### PR TITLE
:broom: Fix warnings for unused assignments

### DIFF
--- a/pallets/subtensor/src/block_step.rs
+++ b/pallets/subtensor/src/block_step.rs
@@ -100,7 +100,7 @@ impl<T: Config> Pallet<T> {
             let emission_tuples_this_block: Vec<(T::AccountId, u64)> = Self::epoch( netuid, emission_to_drain );
                 
             // --- 6. Check that the emission does not exceed the allowed total.
-            let emission_sum: u128 = emission_tuples_this_block.iter().map( |(h,e)| *e as u128 ).sum();
+            let emission_sum: u128 = emission_tuples_this_block.iter().map( |(_account_id, e)| *e as u128 ).sum();
             if emission_sum > emission_to_drain as u128 { continue } // Saftey check.
 
             // --- 7. Sink the emission tuples onto the already loaded.

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1529,7 +1529,7 @@ impl<T: Config + Send + Sync + TypeInfo> SignedExtension for SubtensorSignedExte
 		who: &Self::AccountId,
 		call: &Self::Call,
 		_info: &DispatchInfoOf<Self::Call>,
-		len: usize,
+		_len: usize,
 	) -> TransactionValidity {
 		match call.is_sub_type() {
 			Some(Call::set_weights{netuid, ..}) => {
@@ -1606,13 +1606,13 @@ impl<T: Config + Send + Sync + TypeInfo> SignedExtension for SubtensorSignedExte
 
 	fn post_dispatch(
         maybe_pre: Option<Self::Pre>,
-        info: &DispatchInfoOf<Self::Call>,
-        post_info: &PostDispatchInfoOf<Self::Call>,
-        len: usize,
-        result: &dispatch::DispatchResult,
+        _info: &DispatchInfoOf<Self::Call>,
+        _post_info: &PostDispatchInfoOf<Self::Call>,
+        _len: usize,
+        _result: &dispatch::DispatchResult,
     ) -> Result<(), TransactionValidityError> {
 
-		if let Some((call_type, transaction_fee, who)) = maybe_pre {
+		if let Some((call_type, _transaction_fee, _who)) = maybe_pre {
 			match call_type {
 				CallType::SetWeights => {
 					log::debug!("Not Implemented!");


### PR DESCRIPTION
Nothing special here, just added some under-scores (`_`) to make `cargo {build,check,test,etc}` operations happier