### PR TITLE
:broom: Fix spelling and documentation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,19 +139,19 @@ to store different chain databases, as a different folder will be created per di
 is ran. The following commands shows how to use a newly created folder as our db base path.
 
 ```bash
-// Create a folder to use as the db base path
-$ mkdir my-chain-state
+# Create a folder to use as the db base path
+mkdir my-chain-state
 
-// Use of that folder to store the chain state
-$ ./target/release/node-template --dev --base-path ./my-chain-state/
+# Use of that folder to store the chain state
+./target/release/node-template --dev --base-path ./my-chain-state/
 
-// Check the folder structure created inside the base path after running the chain
-$ ls ./my-chain-state
-chains
-$ ls ./my-chain-state/chains/
-dev
-$ ls ./my-chain-state/chains/dev
-db keystore network
+# Check the folder structure created inside the base path after running the chain
+ls ./my-chain-state
+#> chains
+ls ./my-chain-state/chains/
+#> dev
+ls ./my-chain-state/chains/dev
+#> db keystore network
 ```
 
 ### Connect with Polkadot-JS Apps Front-end

--- a/pallets/subtensor/src/block_step.rs
+++ b/pallets/subtensor/src/block_step.rs
@@ -126,7 +126,7 @@ impl<T: Config> Pallet<T> {
     pub fn emit_inflation_through_hotkey_account( hotkey: &T::AccountId, emission: u64) {
         
         // --- 1. Check if the hotkey is a delegate. If not, we simply pass the stake through to the 
-        // coldkye - hotkey account as normal.
+        // coldkey - hotkey account as normal.
         if !Self::hotkey_is_delegate( hotkey ) { 
             Self::increase_stake_on_hotkey_account( &hotkey, emission ); 
             return; 
@@ -185,7 +185,7 @@ impl<T: Config> Pallet<T> {
         return proportional_emission.to_num::<u64>();
     }
 
-    // Returns the delegated stake 'take' assigend to this key. (If exists, otherwise 0)
+    // Returns the delegated stake 'take' assigned to this key. (If exists, otherwise 0)
     //
     pub fn calculate_delegate_proportional_take( hotkey: &T::AccountId, emission: u64 ) -> u64 {
         if Self::hotkey_is_delegate( hotkey ) {
@@ -197,7 +197,7 @@ impl<T: Config> Pallet<T> {
         }
     }
 
-    // Adjusts the network difficulties/burns of every active network. Reseting state parameters.
+    // Adjusts the network difficulties/burns of every active network. Resetting state parameters.
     //
     pub fn adjust_registration_terms_for_networks( ) {
         
@@ -248,7 +248,7 @@ impl<T: Config> Pallet<T> {
                         Self::set_burn( netuid, Self::adjust_burn( netuid, current_burn, registrations_this_interval, target_registrations_this_interval ) );
                     } else {
                         // D. There are not enough registrations this interval and most of them are burn registrations
-                        // this triggers a decrease in the pow difficutly
+                        // this triggers a decrease in the pow difficulty
                         // pow_difficulty ++ 
                         Self::set_difficulty( netuid, Self::adjust_difficulty( netuid, current_difficulty, registrations_this_interval, target_registrations_this_interval ) );
                     }
@@ -266,8 +266,8 @@ impl<T: Config> Pallet<T> {
         }
     }
 
-    // Performs the difficutly adjustment by multiplying the current difficulty by the ratio ( reg_actual + reg_target / reg_target * reg_target )
-    // We use I110F18 to avoid any overflows on u64. Also min_difficulty and max_difficutly bound the range.
+    // Performs the difficulty adjustment by multiplying the current difficulty by the ratio ( reg_actual + reg_target / reg_target * reg_target )
+    // We use I110F18 to avoid any overflows on u64. Also min_difficulty and max_difficulty bound the range.
     //
     pub fn adjust_difficulty( 
         netuid: u16,


### PR DESCRIPTION
This set of changes _shouldn't_ change current execution behaviors, as it only touches documentation and comments