### PR TITLE
Custom rpc return vec u8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1656,6 +1656,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethbloom"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11da94e443c60508eb62cf256243a64da87304c2802ac2528847f79d750007ef"
+dependencies = [
+ "crunchy",
+ "fixed-hash 0.7.0",
+ "impl-rlp",
+ "impl-serde 0.3.2",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2827b94c556145446fcce834ca86b7abf0c39a805883fe20e72c5bfdb5a0dc6"
+dependencies = [
+ "ethbloom",
+ "fixed-hash 0.7.0",
+ "impl-rlp",
+ "impl-serde 0.3.2",
+ "primitive-types 0.11.1",
+ "uint",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1752,6 +1779,18 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "scale-info",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
+dependencies = [
+ "byteorder",
+ "rand 0.8.5",
+ "rustc-hex",
+ "static_assertions",
 ]
 
 [[package]]
@@ -2661,6 +2700,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "impl-serde"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3125,7 +3182,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "lru",
+ "lru 0.8.1",
  "prost",
  "prost-build",
  "prost-codec",
@@ -3578,6 +3635,15 @@ dependencies = [
 
 [[package]]
 name = "lru"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
+name = "lru"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
@@ -3905,6 +3971,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndarray"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "rawpointer",
+]
+
+[[package]]
 name = "netlink-packet-core"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4053,6 +4132,8 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "scale-info",
+ "serde_json",
+ "smallvec",
  "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
@@ -4375,17 +4456,24 @@ dependencies = [
  "frame-support",
  "frame-system",
  "log",
+ "ndarray",
+ "pallet-balances",
  "pallet-transaction-payment",
  "parity-scale-codec",
+ "parity-util-mem",
+ "rand 0.8.5",
  "scale-info",
  "serde",
  "serde-tuple-vec-map",
  "serde_bytes",
+ "serde_json",
  "serde_with",
  "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-std",
+ "sp-tracing",
+ "sp-version",
  "substrate-fixed",
 ]
 
@@ -4516,6 +4604,35 @@ name = "parity-send-wrapper"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9777aa91b8ad9dd5aaa04a9b6bcb02c7f1deb952fca5a66034d5e63afc5c6f"
+
+[[package]]
+name = "parity-util-mem"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c32561d248d352148124f036cac253a644685a21dc9fea383eb4907d7bd35a8f"
+dependencies = [
+ "cfg-if",
+ "ethereum-types",
+ "hashbrown",
+ "impl-trait-for-tuples",
+ "lru 0.7.8",
+ "parity-util-mem-derive",
+ "parking_lot 0.12.1",
+ "primitive-types 0.11.1",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
+name = "parity-util-mem-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
+dependencies = [
+ "proc-macro2",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "parity-wasm"
@@ -4847,13 +4964,26 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
+dependencies = [
+ "fixed-hash 0.7.0",
+ "impl-codec",
+ "impl-rlp",
+ "impl-serde 0.3.2",
+ "uint",
+]
+
+[[package]]
+name = "primitive-types"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
 dependencies = [
- "fixed-hash",
+ "fixed-hash 0.8.0",
  "impl-codec",
- "impl-serde",
+ "impl-serde 0.4.0",
  "scale-info",
  "uint",
 ]
@@ -5329,6 +5459,16 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rustc-hex",
 ]
 
 [[package]]
@@ -5811,7 +5951,7 @@ name = "sc-executor"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
- "lru",
+ "lru 0.8.1",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sc-executor-common",
@@ -5960,7 +6100,7 @@ dependencies = [
  "ip_network",
  "libp2p",
  "log",
- "lru",
+ "lru 0.8.1",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "pin-project",
@@ -6040,7 +6180,7 @@ dependencies = [
  "futures-timer",
  "libp2p",
  "log",
- "lru",
+ "lru 0.8.1",
  "sc-network-common",
  "sc-peerset",
  "sp-runtime",
@@ -6080,7 +6220,7 @@ dependencies = [
  "futures",
  "libp2p",
  "log",
- "lru",
+ "lru 0.8.1",
  "mockall",
  "parity-scale-codec",
  "prost",
@@ -7000,7 +7140,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.3
 dependencies = [
  "futures",
  "log",
- "lru",
+ "lru 0.8.1",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sp-api",
@@ -7073,14 +7213,14 @@ dependencies = [
  "futures",
  "hash-db",
  "hash256-std-hasher",
- "impl-serde",
+ "impl-serde 0.4.0",
  "lazy_static",
  "libsecp256k1",
  "log",
  "merlin",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "primitive-types",
+ "primitive-types 0.12.1",
  "rand 0.8.5",
  "regex",
  "scale-info",
@@ -7310,7 +7450,7 @@ dependencies = [
  "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "primitive-types",
+ "primitive-types 0.12.1",
  "sp-externalities",
  "sp-runtime-interface-proc-macro",
  "sp-std",
@@ -7388,7 +7528,7 @@ name = "sp-storage"
 version = "7.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
- "impl-serde",
+ "impl-serde 0.4.0",
  "parity-scale-codec",
  "ref-cast",
  "serde",
@@ -7457,7 +7597,7 @@ dependencies = [
  "hash-db",
  "hashbrown",
  "lazy_static",
- "lru",
+ "lru 0.8.1",
  "memory-db",
  "nohash-hasher",
  "parity-scale-codec",
@@ -7476,7 +7616,7 @@ name = "sp-version"
 version = "5.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
- "impl-serde",
+ "impl-serde 0.4.0",
  "parity-scale-codec",
  "parity-wasm",
  "scale-info",
@@ -7984,6 +8124,15 @@ dependencies = [
  "unicode-normalization",
  "wasm-bindgen",
  "zeroize",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4466,7 +4466,6 @@ dependencies = [
  "serde",
  "serde-tuple-vec-map",
  "serde_bytes",
- "serde_json",
  "serde_with",
  "sp-core",
  "sp-io",

--- a/pallets/subtensor/Cargo.toml
+++ b/pallets/subtensor/Cargo.toml
@@ -33,6 +33,7 @@ log = { version = "0.4.14", default-features = false }
 substrate-fixed = { git = 'https://github.com/encointer/substrate-fixed.git', tag = "v0.5.9" }
 pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.37" }
 ndarray = { version = "0.15.0", default-features = false }
+serde_json = { version = "1.0.85", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.37", features = ["std"] }

--- a/pallets/subtensor/Cargo.toml
+++ b/pallets/subtensor/Cargo.toml
@@ -33,7 +33,6 @@ log = { version = "0.4.14", default-features = false }
 substrate-fixed = { git = 'https://github.com/encointer/substrate-fixed.git', tag = "v0.5.9" }
 pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.37" }
 ndarray = { version = "0.15.0", default-features = false }
-serde_json = { version = "1.0.85", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.37", features = ["std"] }

--- a/pallets/subtensor/rpc/src/lib.rs
+++ b/pallets/subtensor/rpc/src/lib.rs
@@ -8,7 +8,7 @@ use jsonrpsee::{
 use sp_blockchain::HeaderBackend;
 use sp_runtime::{
 	generic::BlockId,
-	traits::{Block as BlockT},
+	traits::{Block as BlockT}
 };
 use std::sync::Arc;
 
@@ -16,30 +16,25 @@ use std::sync::Arc;
 use sp_api::ProvideRuntimeApi;
 
 pub use subtensor_custom_rpc_runtime_api::DelegateInfoRuntimeApi;
-use pallet_subtensor::delegate_info::DelegateInfo as DelegateInfoStruct;
-
 pub use subtensor_custom_rpc_runtime_api::NeuronInfoRuntimeApi;
-use pallet_subtensor::neuron_info::NeuronInfo as NeuronInfoStruct;
-
 pub use subtensor_custom_rpc_runtime_api::SubnetInfoRuntimeApi;
-use pallet_subtensor::subnet_info::SubnetInfo as SubnetInfoStruct;
 
 #[rpc(client, server)]
 pub trait SubtensorCustomApi<BlockHash> {
 	#[method(name = "delegateInfo_getDelegates")]
-	fn get_delegates(&self, at: Option<BlockHash>) -> RpcResult<Vec<DelegateInfoStruct>>;
+	fn get_delegates(&self, at: Option<BlockHash>) -> RpcResult<Vec<u8>>;
 	#[method(name = "delegateInfo_getDelegate")]
-	fn get_delegate(&self, delegate_account_vec: Vec<u8>, at: Option<BlockHash>) -> RpcResult<Option<DelegateInfoStruct>>;
+	fn get_delegate(&self, delegate_account_vec: Vec<u8>, at: Option<BlockHash>) -> RpcResult<Vec<u8>>;
 
 	#[method(name = "neuronInfo_getNeurons")]
-	fn get_neurons(&self, netuid: u16, at: Option<BlockHash>) -> RpcResult<Vec<NeuronInfoStruct>>;
+	fn get_neurons(&self, netuid: u16, at: Option<BlockHash>) -> RpcResult<Vec<u8>>;
 	#[method(name = "neuronInfo_getNeuron")]
-	fn get_neuron(&self, netuid: u16, uid: u16, at: Option<BlockHash>) -> RpcResult<Option<NeuronInfoStruct>>;
+	fn get_neuron(&self, netuid: u16, uid: u16, at: Option<BlockHash>) -> RpcResult<Vec<u8>>;
 
 	#[method(name = "subnetInfo_getSubnetInfo")]
-	fn get_subnet_info(&self, netuid: u16, at: Option<BlockHash>) -> RpcResult<Option<SubnetInfoStruct>>;
+	fn get_subnet_info(&self, netuid: u16, at: Option<BlockHash>) -> RpcResult<Vec<u8>>;
 	#[method(name = "subnetInfo_getSubnetsInfo")]
-	fn get_subnets_info(&self, at: Option<BlockHash>) -> RpcResult<Vec<Option<SubnetInfoStruct>>>;
+	fn get_subnets_info(&self, at: Option<BlockHash>) -> RpcResult<Vec<u8>>;
 }
 
 pub struct SubtensorCustom<C, P> {
@@ -80,7 +75,7 @@ where
 	fn get_delegates(
 		&self,
 		at: Option<<Block as BlockT>::Hash>
-	) -> RpcResult<Vec<DelegateInfoStruct>> {
+	) -> RpcResult<Vec<u8>> {
 		let api = self.client.runtime_api();
 		let at = BlockId::hash(at.unwrap_or_else(|| self.client.info().best_hash));
 
@@ -90,6 +85,8 @@ where
 				"Unable to get delegates info.",
 				Some(e.to_string()),
 			)).into()
+		}).map(|info| {
+			info.body
 		})
 	}
 
@@ -97,7 +94,7 @@ where
 		&self,
 		delegate_account_vec: Vec<u8>,
 		at: Option<<Block as BlockT>::Hash>
-	) -> RpcResult<Option<DelegateInfoStruct>> {
+	) -> RpcResult<Vec<u8>> {
 		let api = self.client.runtime_api();
 		let at = BlockId::hash(at.unwrap_or_else(|| self.client.info().best_hash));
 
@@ -107,6 +104,8 @@ where
 				"Unable to get delegate info.",
 				Some(e.to_string()),
 			)).into()
+		}).map(|info| {
+			info.body
 		})
 	}
 
@@ -114,7 +113,7 @@ where
 		&self,
 		netuid: u16,
 		at: Option<<Block as BlockT>::Hash>
-	) -> RpcResult<Vec<NeuronInfoStruct>> {
+	) -> RpcResult<Vec<u8>> {
 		let api = self.client.runtime_api();
 		let at = BlockId::hash(at.unwrap_or_else(|| self.client.info().best_hash));
 
@@ -124,6 +123,8 @@ where
 				"Unable to get neurons info.",
 				Some(e.to_string()),
 			)).into()
+		}).map(|info| {
+			info.body
 		})
 	}
 
@@ -131,7 +132,7 @@ where
 		&self,
 		netuid: u16,
 		uid: u16, at: Option<<Block as BlockT>::Hash>
-	) -> RpcResult<Option<NeuronInfoStruct>> {
+	) -> RpcResult<Vec<u8>> {
 		let api = self.client.runtime_api();
 		let at = BlockId::hash(at.unwrap_or_else(|| self.client.info().best_hash));
 
@@ -141,10 +142,12 @@ where
 				"Unable to get neuron info.",
 				Some(e.to_string()),
 			)).into()
+		}).map(|info| {
+			info.body
 		})
 	}
 	
-	fn get_subnet_info(&self, netuid: u16, at: Option<<Block as BlockT>::Hash>) -> RpcResult<Option<SubnetInfoStruct>> {
+	fn get_subnet_info(&self, netuid: u16, at: Option<<Block as BlockT>::Hash>) -> RpcResult<Vec<u8>> {
 		let api = self.client.runtime_api();
 		let at = BlockId::hash(at.unwrap_or_else(||
 			// If the block hash is not supplied assume the best block.
@@ -156,13 +159,15 @@ where
 				"Unable to get subnet info.",
 				Some(e.to_string()),
 			)).into()
+		}).map(|info| {
+			info.body
 		})
 	}
 
 	fn get_subnets_info(
 		&self,
 		at: Option<<Block as BlockT>::Hash>
-	) -> RpcResult<Vec<Option<SubnetInfoStruct>>> {
+	) -> RpcResult<Vec<u8>> {
 		let api = self.client.runtime_api();
 		let at = BlockId::hash(at.unwrap_or_else(||
 			// If the block hash is not supplied assume the best block.
@@ -174,6 +179,8 @@ where
 			"Unable to get subnets info.",
 			Some(e.to_string()),
 			)).into()
+		}).map(|info| {
+			info.body
 		})
 	}
 }

--- a/pallets/subtensor/rpc/src/lib.rs
+++ b/pallets/subtensor/rpc/src/lib.rs
@@ -85,8 +85,6 @@ where
 				"Unable to get delegates info.",
 				Some(e.to_string()),
 			)).into()
-		}).map(|info| {
-			info.body
 		})
 	}
 
@@ -104,8 +102,6 @@ where
 				"Unable to get delegate info.",
 				Some(e.to_string()),
 			)).into()
-		}).map(|info| {
-			info.body
 		})
 	}
 
@@ -123,8 +119,6 @@ where
 				"Unable to get neurons info.",
 				Some(e.to_string()),
 			)).into()
-		}).map(|info| {
-			info.body
 		})
 	}
 
@@ -142,8 +136,6 @@ where
 				"Unable to get neuron info.",
 				Some(e.to_string()),
 			)).into()
-		}).map(|info| {
-			info.body
 		})
 	}
 	
@@ -159,8 +151,6 @@ where
 				"Unable to get subnet info.",
 				Some(e.to_string()),
 			)).into()
-		}).map(|info| {
-			info.body
 		})
 	}
 
@@ -179,8 +169,6 @@ where
 			"Unable to get subnets info.",
 			Some(e.to_string()),
 			)).into()
-		}).map(|info| {
-			info.body
 		})
 	}
 }

--- a/pallets/subtensor/runtime-api/src/lib.rs
+++ b/pallets/subtensor/runtime-api/src/lib.rs
@@ -1,7 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-use pallet_subtensor::delegate_info::DelegateInfo as DelegateInfoStruct;
-use pallet_subtensor::neuron_info::NeuronInfo as NeuronInfoStruct;
-use pallet_subtensor::subnet_info::SubnetInfo as SubnetInfoStruct;
+use pallet_subtensor::InfoResponse;
 extern crate alloc;
 use alloc::vec::Vec;
 
@@ -9,17 +7,17 @@ use alloc::vec::Vec;
 // src/neuron_info.rs, src/subnet_info.rs, and src/delegate_info.rs
 sp_api::decl_runtime_apis! {
 	pub trait DelegateInfoRuntimeApi {
-		fn get_delegates() -> Vec<DelegateInfoStruct>;
-		fn get_delegate( delegate_account_vec: Vec<u8> ) -> Option<DelegateInfoStruct>;
+		fn get_delegates() -> InfoResponse;
+		fn get_delegate( delegate_account_vec: Vec<u8> ) -> InfoResponse;
 	}
 
 	pub trait NeuronInfoRuntimeApi {
-		fn get_neurons(netuid: u16) -> Vec<NeuronInfoStruct>;
-		fn get_neuron(netuid: u16, uid: u16) -> Option<NeuronInfoStruct>;
+		fn get_neurons(netuid: u16) -> InfoResponse;
+		fn get_neuron(netuid: u16, uid: u16) -> InfoResponse;
 	}
 
 	pub trait SubnetInfoRuntimeApi {
-		fn get_subnet_info(netuid: u16) -> Option<SubnetInfoStruct>;
-		fn get_subnets_info() -> Vec<Option<SubnetInfoStruct>>;
+		fn get_subnet_info(netuid: u16) -> InfoResponse;
+		fn get_subnets_info() -> InfoResponse;
 	}
 }

--- a/pallets/subtensor/runtime-api/src/lib.rs
+++ b/pallets/subtensor/runtime-api/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-use pallet_subtensor::InfoResponse;
 extern crate alloc;
 use alloc::vec::Vec;
 
@@ -7,17 +6,17 @@ use alloc::vec::Vec;
 // src/neuron_info.rs, src/subnet_info.rs, and src/delegate_info.rs
 sp_api::decl_runtime_apis! {
 	pub trait DelegateInfoRuntimeApi {
-		fn get_delegates() -> InfoResponse;
-		fn get_delegate( delegate_account_vec: Vec<u8> ) -> InfoResponse;
+		fn get_delegates() -> Vec<u8>;
+		fn get_delegate( delegate_account_vec: Vec<u8> ) -> Vec<u8>;
 	}
 
 	pub trait NeuronInfoRuntimeApi {
-		fn get_neurons(netuid: u16) -> InfoResponse;
-		fn get_neuron(netuid: u16, uid: u16) -> InfoResponse;
+		fn get_neurons(netuid: u16) -> Vec<u8>;
+		fn get_neuron(netuid: u16, uid: u16) -> Vec<u8>;
 	}
 
 	pub trait SubnetInfoRuntimeApi {
-		fn get_subnet_info(netuid: u16) -> InfoResponse;
-		fn get_subnets_info() -> InfoResponse;
+		fn get_subnet_info(netuid: u16) -> Vec<u8>;
+		fn get_subnets_info() -> Vec<u8>;
 	}
 }

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -72,11 +72,12 @@ pub mod subnet_info;
 pub mod pallet {
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
-	use frame_support::traits::{Currency};
+	use frame_support::traits::Currency;
 	use frame_support::sp_std::vec;
 	use serde::{Serialize, Deserialize};
 	use serde_with::{serde_as, DisplayFromStr};
 	use frame_support::inherent::Vec;
+	use scale_info::prelude::string::String;
 
 
 	#[pallet::pallet]
@@ -180,6 +181,11 @@ pub mod pallet {
 				id: v.clone()
 			}
 		}
+	}
+
+	#[derive(Decode, Encode, Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
+	pub struct InfoResponse {
+		pub body: Vec<u8> // Return all custom RPCs in this format
 	}
 
 	// ============================

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -183,11 +183,6 @@ pub mod pallet {
 		}
 	}
 
-	#[derive(Decode, Encode, Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
-	pub struct InfoResponse {
-		pub body: Vec<u8> // Return all custom RPCs in this format
-	}
-
 	// ============================
 	// ==== Staking + Accounts ====
 	// ============================

--- a/pallets/subtensor/src/neuron_info.rs
+++ b/pallets/subtensor/src/neuron_info.rs
@@ -43,98 +43,37 @@ impl<T: Config> Pallet<T> {
             let uid = uid;
             let netuid = netuid;
 
-            let _hotkey = Self::get_hotkey_for_net_and_uid(netuid, uid);
-            let hotkey;
-            if _hotkey.is_err() {
-                break;
+            let _neuron = Self::get_neuron_subnet_exists(netuid, uid);
+            let neuron;
+            if _neuron.is_none() {
+                break; // No more neurons
             } else {
                 // No error, hotkey was registered
-                hotkey = _hotkey.expect("Hotkey should exist");
+                neuron = _neuron.expect("Neuron should exist");
             }
 
-            let axon_info = Self::get_axon_info( &hotkey.clone() );
-
-            let prometheus_info = Self::get_prometheus_info( &hotkey.clone() );
-
-            
-            let coldkey = Owner::<T>::get( hotkey.clone() ).clone();
-            
-            let active = Self::get_active_for_uid( netuid, uid as u16 );
-            let rank = Self::get_rank_for_uid( netuid, uid as u16 );
-            let emission = Self::get_emission_for_uid( netuid, uid as u16 );
-            let incentive = Self::get_incentive_for_uid( netuid, uid as u16 );
-            let consensus = Self::get_consensus_for_uid( netuid, uid as u16 );
-            let trust = Self::get_trust_for_uid( netuid, uid as u16 );
-            let validator_trust = Self::get_validator_trust_for_uid( netuid, uid as u16 );
-            let dividends = Self::get_dividends_for_uid( netuid, uid as u16 );
-            let pruning_score = Self::get_pruning_score_for_uid( netuid, uid as u16 );
-            let last_update = Self::get_last_update_for_uid( netuid, uid as u16 );
-            let validator_permit = Self::get_validator_permit_for_uid( netuid, uid as u16 );
-
-            let weights = vec_fixed_proportions_to_u16(Self::get_weights(netuid)[uid as usize]);
-            let bonds = vec_fixed_proportions_to_u16(Self::get_bonds(netuid)[uid as usize]);
-            
-            let mut stakes = Vec::<(DeAccountId, u64)>::new();
-            for ( coldkey, stake ) in < Stake<T> as IterableStorageDoubleMap<T::AccountId, T::AccountId, u64> >::iter_prefix( hotkey.clone() ) {
-                stakes.push( (coldkey.clone().encode().into(), stake) );
-            }
-
-            let stake = stakes;
-
-            let neuron = NeuronInfo {
-                hotkey: hotkey.clone().encode().into(),
-                coldkey: coldkey.clone().encode().into(),
-                uid,
-                netuid,
-                active,
-                axon_info,
-                prometheus_info,
-                stake,
-                rank,
-                emission,
-                incentive,
-                consensus,
-                trust,
-                validator_trust,
-                dividends,
-                last_update,
-                validator_permit,
-                weights,
-                bonds,
-                pruning_score
-            };
-            
             neurons.push( neuron );
         }
         neurons
 	}
 
-    pub fn get_neuron(netuid: u16, uid: u16) -> Option<NeuronInfo> {
-        if !Self::if_subnet_exist(netuid) {
+    fn get_neuron_subnet_exists(netuid: u16, uid: u16) -> Option<NeuronInfo> {
+        let _hotkey = Self::get_hotkey_for_net_and_uid(netuid, uid);
+        let hotkey;
+        if _hotkey.is_err() {
             return None;
-        }
-
-
-        let hotkey = Keys::<T>::get( netuid, uid as u16 ).clone();
-
-        let axon_ = Axons::<T>::get( hotkey.clone() );
-        let axon_info;
-        if axon_.is_some() {
-            axon_info = axon_.unwrap();
         } else {
-            axon_info = AxonInfo::default();
+            // No error, hotkey was registered
+            hotkey = _hotkey.expect("Hotkey should exist");
         }
 
-        let promo_ = Prometheus::<T>::get( hotkey.clone() );
-        let prometheus_info;
-        if promo_.is_some() {
-            prometheus_info = promo_.unwrap();
-        } else {
-            prometheus_info = PrometheusInfo::default();
-        }
+        let axon_info = Self::get_axon_info( &hotkey.clone() );
 
-        let coldkey = Owner::<T>::get( hotkey.clone() ).clone();        
+        let prometheus_info = Self::get_prometheus_info( &hotkey.clone() );
 
+        
+        let coldkey = Owner::<T>::get( hotkey.clone() ).clone();
+        
         let active = Self::get_active_for_uid( netuid, uid as u16 );
         let rank = Self::get_rank_for_uid( netuid, uid as u16 );
         let emission = Self::get_emission_for_uid( netuid, uid as u16 );
@@ -147,8 +86,11 @@ impl<T: Config> Pallet<T> {
         let last_update = Self::get_last_update_for_uid( netuid, uid as u16 );
         let validator_permit = Self::get_validator_permit_for_uid( netuid, uid as u16 );
 
-        let weights = Weights::<T>::get( netuid, uid as u16 );
-        let bonds = Bonds::<T>::get( netuid, uid as u16 );
+        let weights = Self::get_weights(netuid)[uid as usize].iter()
+            .map(|x| fixed_proportion_to_u16(*x)).collect::<Vec<u16>>();
+        
+        let bonds = Self::get_bonds(netuid)[uid as usize].iter()
+            .map(|x| fixed_proportion_to_u16(*x)).collect::<Vec<u16>>();
         
         let mut stakes = Vec::<(DeAccountId, u64)>::new();
         for ( coldkey, stake ) in < Stake<T> as IterableStorageDoubleMap<T::AccountId, T::AccountId, u64> >::iter_prefix( hotkey.clone() ) {
@@ -181,6 +123,15 @@ impl<T: Config> Pallet<T> {
         };
         
         return Some(neuron);
+    }
+
+    pub fn get_neuron(netuid: u16, uid: u16) -> Option<NeuronInfo> {
+        if !Self::if_subnet_exist(netuid) {
+            return None;
+        }
+
+        let neuron = Self::get_neuron_subnet_exists(netuid, uid);
+        neuron
 	}
 }
 

--- a/pallets/subtensor/src/subnet_info.rs
+++ b/pallets/subtensor/src/subnet_info.rs
@@ -38,25 +38,25 @@ impl<T: Config> Pallet<T> {
             return None;
         }
 
-        let rho = <Rho<T>>::get(netuid);
-        let kappa = <Kappa<T>>::get(netuid);
-        let difficulty = <Difficulty<T>>::get(netuid);
-        let immunity_period = <ImmunityPeriod<T>>::get(netuid);
-        let validator_batch_size = <ValidatorBatchSize<T>>::get(netuid);
-        let validator_sequence_length = <ValidatorSequenceLength<T>>::get(netuid);
-        let validator_epochs_per_reset = <ValidatorEpochsPerReset<T>>::get(netuid);
-        let validator_epoch_length = <ValidatorEpochLen<T>>::get(netuid);
-        let max_allowed_validators = <MaxAllowedValidators<T>>::get(netuid);
-        let min_allowed_weights = <MinAllowedWeights<T>>::get(netuid);
-        let max_weights_limit = <MaxWeightsLimit<T>>::get(netuid);
-        let scaling_law_power = <ScalingLawPower<T>>::get(netuid);
-        let synergy_scaling_law_power = <SynergyScalingLawPower<T>>::get(netuid);
-        let subnetwork_n = <SubnetworkN<T>>::get(netuid);
-        let max_allowed_uids = <MaxAllowedUids <T>>::get(netuid);
-        let blocks_since_last_step = <BlocksSinceLastStep <T>>::get(netuid);
-        let tempo = <Tempo <T>>::get(netuid);
+        let rho = Self::get_rho(netuid);
+        let kappa = Self::get_kappa(netuid);
+        let difficulty = Self::get_difficulty_as_u64(netuid);
+        let immunity_period = Self::get_immunity_period(netuid);
+        let validator_batch_size = Self::get_validator_batch_size(netuid);
+        let validator_sequence_length = Self::get_validator_sequence_length(netuid);
+        let validator_epochs_per_reset = Self::get_validator_epochs_per_reset(netuid);
+        let validator_epoch_length = Self::get_validator_epoch_length(netuid);
+        let max_allowed_validators = Self::get_max_allowed_validators(netuid);
+        let min_allowed_weights = Self::get_min_allowed_weights(netuid);
+        let max_weights_limit = Self::get_max_weight_limit(netuid);
+        let scaling_law_power = Self::get_scaling_law_power(netuid);
+        let synergy_scaling_law_power = Self::get_synergy_scaling_law_power(netuid);
+        let subnetwork_n = Self::get_subnetwork_n(netuid);
+        let max_allowed_uids = Self::get_max_allowed_uids(netuid);
+        let blocks_since_last_step = Self::get_blocks_since_last_step(netuid);
+        let tempo = Self::get_tempo(netuid);
         let network_modality = <NetworkModality <T>>::get(netuid);
-        let emission_values = <EmissionValues <T>>::get(netuid);
+        let emission_values = Self::get_emission_value(netuid);
 
 
         let mut network_connect: Vec<[u16; 2]> = Vec::<[u16; 2]>::new();

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -21,6 +21,7 @@ subtensor-custom-rpc-runtime-api = { version = "0.0.2", path = "../pallets/subte
 smallvec = "1.6.1"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
+serde_json = { version = "1.0.85", default-features = false, features = ["alloc"] }
 
 pallet-aura = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }
 pallet-balances = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.37" }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -685,7 +685,7 @@ impl_runtime_apis! {
 				}
 			} else {
 				InfoResponse {
-					body: "null".to_owned().as_bytes().to_vec(),
+					body: vec![],
 				}
 			}
 		}
@@ -707,7 +707,7 @@ impl_runtime_apis! {
 				}
 			} else {
 				InfoResponse {
-					body: "null".to_owned().as_bytes().to_vec(),
+					body: vec![],
 				}
 			}
 		}
@@ -722,7 +722,7 @@ impl_runtime_apis! {
 				}
 			} else {
 				InfoResponse {
-					body: "null".to_owned().as_bytes().to_vec(),
+					body: vec![]
 				}
 			}
 		}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -12,7 +12,6 @@ use pallet_grandpa::{
 
 use frame_support::pallet_prelude::Get;
 
-use pallet_subtensor::InfoResponse;
 use smallvec::smallvec;
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
@@ -30,7 +29,6 @@ use sp_std::prelude::*;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
-use serde_json as serde_json;
 
 // A few exports that help ease life for downstream crates.
 pub use frame_support::{
@@ -670,68 +668,56 @@ impl_runtime_apis! {
 	}
 
 	impl subtensor_custom_rpc_runtime_api::DelegateInfoRuntimeApi<Block> for Runtime {
-		fn get_delegates() -> InfoResponse {
+		fn get_delegates() -> Vec<u8> {
 			let result = SubtensorModule::get_delegates();
-			InfoResponse {
-				body: serde_json::to_string(&result).unwrap().as_bytes().to_vec(),
-			}
+			serde_json::to_string(&result).expect("Could not convert DelegateInfo list to JSON")
+				.as_bytes().to_vec()
 		}
 
-		fn get_delegate(delegate_account_vec: Vec<u8>) -> InfoResponse {
+		fn get_delegate(delegate_account_vec: Vec<u8>) -> Vec<u8> {
 			let result = SubtensorModule::get_delegate(delegate_account_vec);
 			if result.is_some() {
-				InfoResponse {
-					body: serde_json::to_string(&result).unwrap().as_bytes().to_vec(),
-				}
+				serde_json::to_string(&result).expect("Could not convert DelegateInfo to JSON")
+					.as_bytes().to_vec()
 			} else {
-				InfoResponse {
-					body: vec![],
-				}
+				vec![]
 			}
 		}
 	}
 
 	impl subtensor_custom_rpc_runtime_api::NeuronInfoRuntimeApi<Block> for Runtime {
-		fn get_neurons(netuid: u16) -> InfoResponse {
+		fn get_neurons(netuid: u16) -> Vec<u8> {
 			let result = SubtensorModule::get_neurons(netuid);
-			InfoResponse {
-				body: serde_json::to_string(&result).unwrap().as_bytes().to_vec(),
-			}
+			serde_json::to_string(&result).expect("Could not convert NeuronInfo Vec to JSON")
+				.as_bytes().to_vec()
 		}
 
-		fn get_neuron(netuid: u16, uid: u16) -> InfoResponse {
+		fn get_neuron(netuid: u16, uid: u16) -> Vec<u8> {
 			let result = SubtensorModule::get_neuron(netuid, uid);
 			if result.is_some() {
-				InfoResponse {
-					body: serde_json::to_string(&result).unwrap().as_bytes().to_vec(),
-				}
+				serde_json::to_string(&result).expect("Could not convert NeuronInfo to JSON")
+					.as_bytes().to_vec()
 			} else {
-				InfoResponse {
-					body: vec![],
-				}
+				vec![]
 			}
 		}
 	}
 
 	impl subtensor_custom_rpc_runtime_api::SubnetInfoRuntimeApi<Block> for Runtime {
-		fn get_subnet_info(netuid: u16) -> InfoResponse {
+		fn get_subnet_info(netuid: u16) -> Vec<u8> {
 			let result = SubtensorModule::get_subnet_info(netuid);
 			if result.is_some() {
-				InfoResponse {
-					body: serde_json::to_string(&result).unwrap().as_bytes().to_vec(),
-				}
+				serde_json::to_string(&result).expect("Could not convert SubnetInfo to JSON")
+					.as_bytes().to_vec()
 			} else {
-				InfoResponse {
-					body: vec![]
-				}
+				vec![]
 			}
 		}
 
-		fn get_subnets_info() -> InfoResponse {
+		fn get_subnets_info() -> Vec<u8> {
 			let result = SubtensorModule::get_subnets_info();
-			InfoResponse {
-				body: serde_json::to_string(&result).unwrap().as_bytes().to_vec(),
-			}
+			serde_json::to_string(&result).expect("Could not convert SubnetInfo list to JSON")
+				.as_bytes().to_vec()
 		}
 	}
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -12,6 +12,7 @@ use pallet_grandpa::{
 
 use frame_support::pallet_prelude::Get;
 
+use pallet_subtensor::InfoResponse;
 use smallvec::smallvec;
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
@@ -24,10 +25,12 @@ use sp_runtime::{
 	transaction_validity::{TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult, MultiSignature,
 };
+
 use sp_std::prelude::*;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
+use serde_json as serde_json;
 
 // A few exports that help ease life for downstream crates.
 pub use frame_support::{
@@ -667,32 +670,68 @@ impl_runtime_apis! {
 	}
 
 	impl subtensor_custom_rpc_runtime_api::DelegateInfoRuntimeApi<Block> for Runtime {
-		fn get_delegates() -> Vec<pallet_subtensor::delegate_info::DelegateInfo> {
-			SubtensorModule::get_delegates()
+		fn get_delegates() -> InfoResponse {
+			let result = SubtensorModule::get_delegates();
+			InfoResponse {
+				body: serde_json::to_string(&result).unwrap().as_bytes().to_vec(),
+			}
 		}
 
-		fn get_delegate(delegate_account_vec: Vec<u8>) -> Option<pallet_subtensor::delegate_info::DelegateInfo> {
-			SubtensorModule::get_delegate(delegate_account_vec)
+		fn get_delegate(delegate_account_vec: Vec<u8>) -> InfoResponse {
+			let result = SubtensorModule::get_delegate(delegate_account_vec);
+			if result.is_some() {
+				InfoResponse {
+					body: serde_json::to_string(&result).unwrap().as_bytes().to_vec(),
+				}
+			} else {
+				InfoResponse {
+					body: "null".to_owned().as_bytes().to_vec(),
+				}
+			}
 		}
 	}
 
 	impl subtensor_custom_rpc_runtime_api::NeuronInfoRuntimeApi<Block> for Runtime {
-		fn get_neurons(netuid: u16) -> Vec<pallet_subtensor::neuron_info::NeuronInfo> {
-			SubtensorModule::get_neurons(netuid)
+		fn get_neurons(netuid: u16) -> InfoResponse {
+			let result = SubtensorModule::get_neurons(netuid);
+			InfoResponse {
+				body: serde_json::to_string(&result).unwrap().as_bytes().to_vec(),
+			}
 		}
 
-		fn get_neuron(netuid: u16, uid: u16) -> Option<pallet_subtensor::neuron_info::NeuronInfo> {
-			SubtensorModule::get_neuron(netuid, uid)
+		fn get_neuron(netuid: u16, uid: u16) -> InfoResponse {
+			let result = SubtensorModule::get_neuron(netuid, uid);
+			if result.is_some() {
+				InfoResponse {
+					body: serde_json::to_string(&result).unwrap().as_bytes().to_vec(),
+				}
+			} else {
+				InfoResponse {
+					body: "null".to_owned().as_bytes().to_vec(),
+				}
+			}
 		}
 	}
 
 	impl subtensor_custom_rpc_runtime_api::SubnetInfoRuntimeApi<Block> for Runtime {
-		fn get_subnet_info(netuid: u16) -> Option<pallet_subtensor::subnet_info::SubnetInfo> {
-			SubtensorModule::get_subnet_info(netuid)
+		fn get_subnet_info(netuid: u16) -> InfoResponse {
+			let result = SubtensorModule::get_subnet_info(netuid);
+			if result.is_some() {
+				InfoResponse {
+					body: serde_json::to_string(&result).unwrap().as_bytes().to_vec(),
+				}
+			} else {
+				InfoResponse {
+					body: "null".to_owned().as_bytes().to_vec(),
+				}
+			}
 		}
 
-		fn get_subnets_info() -> Vec<Option<pallet_subtensor::subnet_info::SubnetInfo>> {
-			SubtensorModule::get_subnets_info()
+		fn get_subnets_info() -> InfoResponse {
+			let result = SubtensorModule::get_subnets_info();
+			InfoResponse {
+				body: serde_json::to_string(&result).unwrap().as_bytes().to_vec(),
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR changes the response format of the custom RPCs to a `Vec<u8>`.  
This should allow us to upgrade the format of the responses more flexibly, inside of the runtime, provided we update the client-decoding to match.  
## New RPC responses
### Node (server) -side
We essentially do 
```rust
serde_json::to_string(&result).unwrap().as_bytes().to_vec()
```
to get a `Vec<u8>` (utf-8) of a JSON representation for the result.  
### Python Client-side 
Then, we do 
```python
result: List[int] = json_body['result']
as_bytes = bytes(result)
as_json_str = as_bytes.decode('utf-8')
as_json: Dict[str, Any] = json.loads(as_json_str)
return as_json
```