### PR TITLE
[BIT-635] Use active_stake for consensus

### DIFF
--- a/pallets/subtensor/src/epoch.rs
+++ b/pallets/subtensor/src/epoch.rs
@@ -124,7 +124,7 @@ impl<T: Config> Pallet<T> {
 
         // Clip weights at majority consensus
         let kappa: I32F32 = Self::get_float_kappa( netuid );  // consensus majority ratio, e.g. 51%.
-        let consensus: Vec<I32F32> = weighted_median_col( &stake, &weights, kappa );
+        let consensus: Vec<I32F32> = weighted_median_col( &active_stake, &weights, kappa );
         inplace_col_clip( &mut weights, &consensus );
         let validator_trust: Vec<I32F32> = row_sum( &weights );
 
@@ -367,7 +367,7 @@ impl<T: Config> Pallet<T> {
 
         // Clip weights at majority consensus
         let kappa: I32F32 = Self::get_float_kappa( netuid );  // consensus majority ratio, e.g. 51%.
-        let consensus: Vec<I32F32> = weighted_median_col_sparse( &stake, &weights, n, kappa );
+        let consensus: Vec<I32F32> = weighted_median_col_sparse( &active_stake, &weights, n, kappa );
         log::trace!( "C: {:?}", &consensus );
 
         weights = col_clip_sparse( &weights, &consensus );


### PR DESCRIPTION
### [BIT-635] Use active_stake for consensus

[BIT-635]: https://opentensor.atlassian.net/browse/BIT-635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ