### PR TITLE
Custom rpc scale codec

### DIFF
--- a/pallets/subtensor/src/delegate_info.rs
+++ b/pallets/subtensor/src/delegate_info.rs
@@ -5,13 +5,14 @@ use frame_support::pallet_prelude::{Decode, Encode};
 extern crate alloc;
 use alloc::vec::Vec;
 use sp_core::hexdisplay::AsBytesRef;
+use codec::Compact;
 
 
 #[derive(Decode, Encode, PartialEq, Eq, Clone, Debug)]
 pub struct DelegateInfo<T: Config> {
     delegate_ss58: T::AccountId,
-    take: u16,
-    nominators: Vec<(T::AccountId, u64)>, // map of nominator_ss58 to stake amount
+    take: Compact<u16>,
+    nominators: Vec<(T::AccountId, Compact<u64>)>, // map of nominator_ss58 to stake amount
     owner_ss58: T::AccountId
 }
 
@@ -22,18 +23,22 @@ impl<T: Config> Pallet<T> {
         }
 
         let delegate: AccountIdOf<T> = T::AccountId::decode( &mut delegate_account_vec.as_bytes_ref() ).unwrap();
+        // Check delegate exists
+        if !<Delegates<T>>::contains_key( delegate.clone() ) {
+            return None;
+        }
 
-        let mut nominators = Vec::<(T::AccountId, u64)>::new();
+        let mut nominators = Vec::<(T::AccountId, Compact<u64>)>::new();
 
         for ( nominator, stake ) in < Stake<T> as IterableStorageDoubleMap<T::AccountId, T::AccountId, u64> >::iter_prefix( delegate.clone() ) {
-            nominators.push( ( nominator.clone(), stake ) );
+            nominators.push( ( nominator.clone(), stake.into() ) );
         }
 
         let owner = <Owner<T>>::get( delegate.clone() );
 
         return Some( DelegateInfo {
             delegate_ss58: delegate.clone(),
-            take: <Delegates<T>>::get( delegate.clone() ),
+            take: <Delegates<T>>::get( delegate.clone() ).into(),
             nominators,
             owner_ss58: owner.clone()
         });
@@ -42,16 +47,16 @@ impl<T: Config> Pallet<T> {
     pub fn get_delegates() -> Vec<DelegateInfo<T>> {
         let mut delegates = Vec::<DelegateInfo<T>>::new();
         for ( delegate, take ) in < Delegates<T> as IterableStorageMap<T::AccountId, u16> >::iter() {
-            let mut nominators = Vec::<(T::AccountId, u64)>::new();
+            let mut nominators = Vec::<(T::AccountId, Compact<u64>)>::new();
             for ( nominator, stake ) in < Stake<T> as IterableStorageDoubleMap<T::AccountId, T::AccountId, u64> >::iter_prefix( delegate.clone() ) {
-                nominators.push( ( nominator.clone(), stake ) );
+                nominators.push( ( nominator.clone(), stake.into() ) );
             }
 
             let owner = <Owner<T>>::get( delegate.clone() );
 
             delegates.push( DelegateInfo {
                 delegate_ss58: delegate.clone(),
-                take,
+                take: take.into(),
                 nominators,
                 owner_ss58: owner.clone()
             });

--- a/pallets/subtensor/src/delegate_info.rs
+++ b/pallets/subtensor/src/delegate_info.rs
@@ -1,6 +1,5 @@
 use super::*;
 use frame_support::IterableStorageDoubleMap;
-use serde::{Serialize, Deserialize};
 use frame_support::storage::IterableStorageMap;
 use frame_support::pallet_prelude::{Decode, Encode};
 extern crate alloc;
@@ -8,54 +7,53 @@ use alloc::vec::Vec;
 use sp_core::hexdisplay::AsBytesRef;
 
 
-#[derive(Decode, Encode, Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
-#[serde(deny_unknown_fields)]
-pub struct DelegateInfo {
-    delegate_ss58: DeAccountId,
+#[derive(Decode, Encode, PartialEq, Eq, Clone, Debug)]
+pub struct DelegateInfo<T: Config> {
+    delegate_ss58: T::AccountId,
     take: u16,
-    nominators: Vec<(DeAccountId, u64)>, // map of nominator_ss58 to stake amount
-    owner_ss58: DeAccountId
+    nominators: Vec<(T::AccountId, u64)>, // map of nominator_ss58 to stake amount
+    owner_ss58: T::AccountId
 }
 
 impl<T: Config> Pallet<T> {
-	pub fn get_delegate( delegate_account_vec: Vec<u8> ) -> Option<DelegateInfo> {
+	pub fn get_delegate( delegate_account_vec: Vec<u8> ) -> Option<DelegateInfo<T>> {
         if delegate_account_vec.len() != 32 {
             return None;
         }
 
         let delegate: AccountIdOf<T> = T::AccountId::decode( &mut delegate_account_vec.as_bytes_ref() ).unwrap();
 
-        let mut nominators = Vec::<(DeAccountId, u64)>::new();
+        let mut nominators = Vec::<(T::AccountId, u64)>::new();
 
         for ( nominator, stake ) in < Stake<T> as IterableStorageDoubleMap<T::AccountId, T::AccountId, u64> >::iter_prefix( delegate.clone() ) {
-            nominators.push( ( nominator.clone().encode().into(), stake ) );
+            nominators.push( ( nominator.clone(), stake ) );
         }
 
         let owner = <Owner<T>>::get( delegate.clone() );
 
         return Some( DelegateInfo {
-            delegate_ss58: delegate.clone().encode().into(),
+            delegate_ss58: delegate.clone(),
             take: <Delegates<T>>::get( delegate.clone() ),
             nominators,
-            owner_ss58: owner.clone().encode().into()
+            owner_ss58: owner.clone()
         });
 	}
 
-    pub fn get_delegates() -> Vec<DelegateInfo> {
-        let mut delegates = Vec::<DelegateInfo>::new();
+    pub fn get_delegates() -> Vec<DelegateInfo<T>> {
+        let mut delegates = Vec::<DelegateInfo<T>>::new();
         for ( delegate, take ) in < Delegates<T> as IterableStorageMap<T::AccountId, u16> >::iter() {
-            let mut nominators = Vec::<(DeAccountId, u64)>::new();
+            let mut nominators = Vec::<(T::AccountId, u64)>::new();
             for ( nominator, stake ) in < Stake<T> as IterableStorageDoubleMap<T::AccountId, T::AccountId, u64> >::iter_prefix( delegate.clone() ) {
-                nominators.push( ( nominator.clone().encode().into(), stake ) );
+                nominators.push( ( nominator.clone(), stake ) );
             }
 
             let owner = <Owner<T>>::get( delegate.clone() );
 
             delegates.push( DelegateInfo {
-                delegate_ss58: delegate.clone().encode().into(),
+                delegate_ss58: delegate.clone(),
                 take,
                 nominators,
-                owner_ss58: owner.clone().encode().into()
+                owner_ss58: owner.clone()
             });
         }
 

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -169,20 +169,6 @@ pub mod pallet {
 
 	pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
 
-	#[derive(Decode, Encode, Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
-	pub struct DeAccountId { // allows us to de/serialize the account id as a u8 vec
-		#[serde(with = "serde_bytes")]
-		id: Vec<u8>
-	}
-
-	impl From<Vec<u8>> for DeAccountId {
-		fn from(v: Vec<u8>) -> Self {
-			DeAccountId {
-				id: v.clone()
-			}
-		}
-	}
-
 	// ============================
 	// ==== Staking + Accounts ====
 	// ============================
@@ -321,12 +307,10 @@ pub mod pallet {
 	// --- Struct for Axon.
 	pub type AxonInfoOf = AxonInfo;
 	
-	#[serde_as]
-	#[derive(Encode, Decode, Default, TypeInfo, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+	#[derive(Encode, Decode, Default, TypeInfo, Clone, PartialEq, Eq, Debug)]
     pub struct AxonInfo {
 		pub block: u64, // --- Axon serving block.
         pub version: u32, // --- Axon version
-		#[serde_as(as = "DisplayFromStr")] // serialize as string, deserialize from string
         pub ip: u128, // --- Axon u128 encoded ip address of type v6 or v4.
         pub port: u16, // --- Axon u16 encoded port.
         pub ip_type: u8, // --- Axon ip type, 4 for ipv4 and 6 for ipv6.
@@ -337,12 +321,10 @@ pub mod pallet {
 
 	// --- Struct for Prometheus.
 	pub type PrometheusInfoOf = PrometheusInfo;
-	#[serde_as]
-	#[derive(Encode, Decode, Default, TypeInfo, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+	#[derive(Encode, Decode, Default, TypeInfo, Clone, PartialEq, Eq, Debug)]
 	pub struct PrometheusInfo {
 		pub block: u64, // --- Prometheus serving block.
         pub version: u32, // --- Prometheus version.
-		#[serde_as(as = "DisplayFromStr")] // serialize as string, deserialize from string
         pub ip: u128, // --- Prometheus u128 encoded ip address of type v6 or v4.
         pub port: u16, // --- Prometheus u16 encoded port.
         pub ip_type: u8, // --- Prometheus ip type, 4 for ipv4 and 6 for ipv6.

--- a/pallets/subtensor/src/neuron_info.rs
+++ b/pallets/subtensor/src/neuron_info.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::math::*;
 use frame_support::storage::IterableStorageDoubleMap;
 use frame_support::pallet_prelude::{Decode, Encode};
 extern crate alloc;
@@ -86,13 +85,11 @@ impl<T: Config> Pallet<T> {
         let validator_permit = Self::get_validator_permit_for_uid( netuid, uid as u16 );
 
         let weights = <Weights<T>>::get(netuid, uid).iter()
-            .filter(|(_, b)| *b > 0)
-            .map(|(i, w)| (i.into(), w.into()))
+            .filter_map(|(i, w)| if *w > 0 { Some((i.into(), w.into())) } else { None })
             .collect::<Vec<(Compact<u16>, Compact<u16>)>>();
         
         let bonds = <Bonds<T>>::get(netuid, uid).iter()
-            .filter(|(_, b)| *b > 0)
-            .map(|(i, b)| (i.into(), b.into()))
+            .filter_map(|(i, b)| if *b > 0 { Some((i.into(), b.into())) } else { None })
             .collect::<Vec<(Compact<u16>, Compact<u16>)>>();
         
         let stake: Vec<(T::AccountId, Compact<u64>)> = < Stake<T> as IterableStorageDoubleMap<T::AccountId, T::AccountId, u64> >::iter_prefix( hotkey.clone() )

--- a/pallets/subtensor/src/neuron_info.rs
+++ b/pallets/subtensor/src/neuron_info.rs
@@ -24,8 +24,8 @@ pub struct NeuronInfo<T: Config> {
     dividends: u16,
     last_update: u64,
     validator_permit: bool,
-    weights: Vec<u16>, // Vec uid to weight
-    bonds: Vec<u16>, // Vec uid to bond
+    weights: Vec<(u16, u16)>, // Vec of (uid, weight)
+    bonds: Vec<(u16, u16)>, // Vec of (uid, bond)
     pruning_score: u16
 }
 
@@ -85,10 +85,16 @@ impl<T: Config> Pallet<T> {
         let validator_permit = Self::get_validator_permit_for_uid( netuid, uid as u16 );
 
         let weights = Self::get_weights(netuid)[uid as usize].iter()
-            .map(|x| fixed_proportion_to_u16(*x)).collect::<Vec<u16>>();
+            .enumerate()
+            .map(|(i, w)| (i as u16, fixed_proportion_to_u16(*w)))
+            .filter(|(_, b)| *b > 0)
+            .collect::<Vec<(u16, u16)>>();
         
         let bonds = Self::get_bonds(netuid)[uid as usize].iter()
-            .map(|x| fixed_proportion_to_u16(*x)).collect::<Vec<u16>>();
+            .enumerate()
+            .map(|(i, b)| (i as u16, fixed_proportion_to_u16(*b)))
+            .filter(|(_, b)| *b > 0)
+            .collect::<Vec<(u16, u16)>>();
         
         let mut stakes = Vec::<(T::AccountId, u64)>::new();
         for ( coldkey, stake ) in < Stake<T> as IterableStorageDoubleMap<T::AccountId, T::AccountId, u64> >::iter_prefix( hotkey.clone() ) {

--- a/pallets/subtensor/src/neuron_info.rs
+++ b/pallets/subtensor/src/neuron_info.rs
@@ -27,7 +27,7 @@ pub struct NeuronInfo<T: Config> {
     validator_permit: bool,
     weights: Vec<(Compact<u16>, Compact<u16>)>, // Vec of (uid, weight)
     bonds: Vec<(Compact<u16>, Compact<u16>)>, // Vec of (uid, bond)
-    pruning_score: u16
+    pruning_score: Compact<u16>,
 }
 
 impl<T: Config> Pallet<T> {

--- a/pallets/subtensor/src/neuron_info.rs
+++ b/pallets/subtensor/src/neuron_info.rs
@@ -95,12 +95,9 @@ impl<T: Config> Pallet<T> {
             .map(|(i, b)| (i.into(), b.into()))
             .collect::<Vec<(Compact<u16>, Compact<u16>)>>();
         
-        let mut stakes = Vec::<(T::AccountId, u64)>::new();
-        for ( coldkey, stake ) in < Stake<T> as IterableStorageDoubleMap<T::AccountId, T::AccountId, u64> >::iter_prefix( hotkey.clone() ) {
-            stakes.push( (coldkey.clone(), stake) );
-        }
-
-        let stake = stakes;
+        let stake: Vec<(T::AccountId, Compact<u64>)> = < Stake<T> as IterableStorageDoubleMap<T::AccountId, T::AccountId, u64> >::iter_prefix( hotkey.clone() )
+            .map(|(coldkey, stake)| (coldkey, stake.into()))
+            .collect();
 
         let neuron = NeuronInfo {
             hotkey: hotkey.clone(),
@@ -110,7 +107,7 @@ impl<T: Config> Pallet<T> {
             active,
             axon_info,
             prometheus_info,
-            stake: stake.into_iter().map(|(k, v)| (k, v.into())).collect(),
+            stake,
             rank: rank.into(),
             emission: emission.into(),
             incentive: incentive.into(),

--- a/pallets/subtensor/src/neuron_info.rs
+++ b/pallets/subtensor/src/neuron_info.rs
@@ -85,16 +85,12 @@ impl<T: Config> Pallet<T> {
         let last_update = Self::get_last_update_for_uid( netuid, uid as u16 );
         let validator_permit = Self::get_validator_permit_for_uid( netuid, uid as u16 );
 
-        let weights = Self::get_weights(netuid)[uid as usize].iter()
-            .enumerate()
-            .map(|(i, w)| (i as u16, fixed_proportion_to_u16(*w)))
+        let weights = <Weights<T>>::get(netuid, uid).iter()
             .filter(|(_, b)| *b > 0)
-            .map(|(i, b)| (i.into(), b.into()))
+            .map(|(i, w)| (i.into(), w.into()))
             .collect::<Vec<(Compact<u16>, Compact<u16>)>>();
         
-        let bonds = Self::get_bonds(netuid)[uid as usize].iter()
-            .enumerate()
-            .map(|(i, b)| (i as u16, fixed_proportion_to_u16(*b)))
+        let bonds = <Bonds<T>>::get(netuid, uid).iter()
             .filter(|(_, b)| *b > 0)
             .map(|(i, b)| (i.into(), b.into()))
             .collect::<Vec<(Compact<u16>, Compact<u16>)>>();

--- a/pallets/subtensor/src/subnet_info.rs
+++ b/pallets/subtensor/src/subnet_info.rs
@@ -1,13 +1,11 @@
 use super::*;
 use frame_support::IterableStorageDoubleMap;
-use serde::{Serialize, Deserialize};
 use frame_support::storage::IterableStorageMap;
 use frame_support::pallet_prelude::{Decode, Encode};
 extern crate alloc;
 use alloc::vec::Vec;
 
-#[derive(Decode, Encode, Serialize, Deserialize, PartialEq, Eq, Clone, Debug)]
-#[serde(deny_unknown_fields)]
+#[derive(Decode, Encode, PartialEq, Eq, Clone, Debug)]
 pub struct SubnetInfo {
     netuid: u16,
     rho: u16,

--- a/pallets/subtensor/src/subnet_info.rs
+++ b/pallets/subtensor/src/subnet_info.rs
@@ -4,30 +4,31 @@ use frame_support::storage::IterableStorageMap;
 use frame_support::pallet_prelude::{Decode, Encode};
 extern crate alloc;
 use alloc::vec::Vec;
+use codec::Compact;
 
 #[derive(Decode, Encode, PartialEq, Eq, Clone, Debug)]
 pub struct SubnetInfo {
-    netuid: u16,
-    rho: u16,
-    kappa: u16,
-    difficulty: u64,
-    immunity_period: u16,
-    validator_batch_size: u16,
-    validator_sequence_length: u16,
-    validator_epochs_per_reset: u16,
-    validator_epoch_length: u16,
-    max_allowed_validators: u16,
-    min_allowed_weights: u16,
-    max_weights_limit: u16,
-    scaling_law_power: u16,
-    synergy_scaling_law_power: u16,
-    subnetwork_n: u16,
-    max_allowed_uids: u16,
-    blocks_since_last_step: u64,
-    tempo: u16,
-    network_modality: u16,
-    network_connect: Vec<[u16; 2]>,
-    emission_values: u64
+    netuid: Compact<u16>,
+    rho: Compact<u16>,
+    kappa: Compact<u16>,
+    difficulty: Compact<u64>,
+    immunity_period: Compact<u16>,
+    validator_batch_size: Compact<u16>,
+    validator_sequence_length: Compact<u16>,
+    validator_epochs_per_reset: Compact<u16>,
+    validator_epoch_length: Compact<u16>,
+    max_allowed_validators: Compact<u16>,
+    min_allowed_weights: Compact<u16>,
+    max_weights_limit: Compact<u16>,
+    scaling_law_power: Compact<u16>,
+    synergy_scaling_law_power: Compact<u16>,
+    subnetwork_n: Compact<u16>,
+    max_allowed_uids: Compact<u16>,
+    blocks_since_last_step: Compact<u64>,
+    tempo: Compact<u16>,
+    network_modality: Compact<u16>,
+    network_connect: Vec<[Compact<u16>; 2]>,
+    emission_values: Compact<u64>
 }
 
 impl<T: Config> Pallet<T> {
@@ -57,34 +58,34 @@ impl<T: Config> Pallet<T> {
         let emission_values = Self::get_emission_value(netuid);
 
 
-        let mut network_connect: Vec<[u16; 2]> = Vec::<[u16; 2]>::new();
+        let mut network_connect: Vec<[Compact<u16>; 2]> = Vec::<[Compact<u16>; 2]>::new();
 
         for ( _netuid_, con_req) in < NetworkConnect<T> as IterableStorageDoubleMap<u16, u16, u16> >::iter_prefix(netuid) {
-            network_connect.push([_netuid_, con_req]);
+            network_connect.push([_netuid_.into(), con_req.into()]);
         }
 
         return Some(SubnetInfo {
-            rho,
-            kappa,
-            difficulty,
-            immunity_period,
-            netuid,
-            validator_batch_size,
-            validator_sequence_length,
-            validator_epochs_per_reset,
-            validator_epoch_length,
-            max_allowed_validators,
-            min_allowed_weights,
-            max_weights_limit,
-            scaling_law_power,
-            synergy_scaling_law_power,
-            subnetwork_n,
-            max_allowed_uids,
-            blocks_since_last_step,
-            tempo,
-            network_modality,
+            rho: rho.into(),
+            kappa: kappa.into(),
+            difficulty: difficulty.into(),
+            immunity_period: immunity_period.into(),
+            netuid: netuid.into(),
+            validator_batch_size: validator_batch_size.into(),
+            validator_sequence_length: validator_sequence_length.into(),
+            validator_epochs_per_reset: validator_epochs_per_reset.into(),
+            validator_epoch_length: validator_epoch_length.into(),
+            max_allowed_validators: max_allowed_validators.into(),
+            min_allowed_weights: min_allowed_weights.into(),
+            max_weights_limit: max_weights_limit.into(),
+            scaling_law_power: scaling_law_power.into(),
+            synergy_scaling_law_power: synergy_scaling_law_power.into(),
+            subnetwork_n: subnetwork_n.into(),
+            max_allowed_uids: max_allowed_uids.into(),
+            blocks_since_last_step: blocks_since_last_step.into(),
+            tempo: tempo.into(),
+            network_modality: network_modality.into(),
             network_connect,
-            emission_values
+            emission_values: emission_values.into()
         })
 	}
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -111,7 +111,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 108,
+	spec_version: 109,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -111,7 +111,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 107,
+	spec_version: 108,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -6,6 +6,7 @@
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
+use codec::Encode;
 use pallet_grandpa::{
 	fg_primitives, AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList,
 };
@@ -110,7 +111,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 104,
+	spec_version: 105,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -670,15 +671,14 @@ impl_runtime_apis! {
 	impl subtensor_custom_rpc_runtime_api::DelegateInfoRuntimeApi<Block> for Runtime {
 		fn get_delegates() -> Vec<u8> {
 			let result = SubtensorModule::get_delegates();
-			serde_json::to_string(&result).expect("Could not convert DelegateInfo list to JSON")
-				.as_bytes().to_vec()
+			result.encode()
 		}
 
 		fn get_delegate(delegate_account_vec: Vec<u8>) -> Vec<u8> {
-			let result = SubtensorModule::get_delegate(delegate_account_vec);
-			if result.is_some() {
-				serde_json::to_string(&result).expect("Could not convert DelegateInfo to JSON")
-					.as_bytes().to_vec()
+			let _result = SubtensorModule::get_delegate(delegate_account_vec);
+			if _result.is_some() {
+				let result = _result.expect("Could not convert DelegateInfo to JSON");
+				result.encode()
 			} else {
 				vec![]
 			}
@@ -688,15 +688,14 @@ impl_runtime_apis! {
 	impl subtensor_custom_rpc_runtime_api::NeuronInfoRuntimeApi<Block> for Runtime {
 		fn get_neurons(netuid: u16) -> Vec<u8> {
 			let result = SubtensorModule::get_neurons(netuid);
-			serde_json::to_string(&result).expect("Could not convert NeuronInfo Vec to JSON")
-				.as_bytes().to_vec()
+			result.encode()
 		}
 
 		fn get_neuron(netuid: u16, uid: u16) -> Vec<u8> {
-			let result = SubtensorModule::get_neuron(netuid, uid);
-			if result.is_some() {
-				serde_json::to_string(&result).expect("Could not convert NeuronInfo to JSON")
-					.as_bytes().to_vec()
+			let _result = SubtensorModule::get_neuron(netuid, uid);
+			if _result.is_some() {
+				let result = _result.expect("Could not convert NeuronInfo to JSON");
+				result.encode()
 			} else {
 				vec![]
 			}
@@ -705,10 +704,10 @@ impl_runtime_apis! {
 
 	impl subtensor_custom_rpc_runtime_api::SubnetInfoRuntimeApi<Block> for Runtime {
 		fn get_subnet_info(netuid: u16) -> Vec<u8> {
-			let result = SubtensorModule::get_subnet_info(netuid);
-			if result.is_some() {
-				serde_json::to_string(&result).expect("Could not convert SubnetInfo to JSON")
-					.as_bytes().to_vec()
+			let _result = SubtensorModule::get_subnet_info(netuid);
+			if _result.is_some() {
+				let result = _result.expect("Could not convert SubnetInfo to JSON");
+				result.encode()
 			} else {
 				vec![]
 			}
@@ -716,8 +715,7 @@ impl_runtime_apis! {
 
 		fn get_subnets_info() -> Vec<u8> {
 			let result = SubtensorModule::get_subnets_info();
-			serde_json::to_string(&result).expect("Could not convert SubnetInfo list to JSON")
-				.as_bytes().to_vec()
+			result.encode()
 		}
 	}
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -111,7 +111,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 105,
+	spec_version: 107,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
This PR modifies the custom RPC encodings to use compact ints and better interates over the storage maps.  
Results in ~1-2s pull of the metagraph with 4096 neurons.  