### PR TITLE
Add neuron info lite RPCs

### DIFF
--- a/pallets/subtensor/rpc/src/lib.rs
+++ b/pallets/subtensor/rpc/src/lib.rs
@@ -26,6 +26,11 @@ pub trait SubtensorCustomApi<BlockHash> {
 	#[method(name = "delegateInfo_getDelegate")]
 	fn get_delegate(&self, delegate_account_vec: Vec<u8>, at: Option<BlockHash>) -> RpcResult<Vec<u8>>;
 
+
+	#[method(name = "neuronInfo_getNeuronsLite")]
+	fn get_neurons_lite(&self, netuid: u16, at: Option<BlockHash>) -> RpcResult<Vec<u8>>;
+	#[method(name = "neuronInfo_getNeuronLite")]
+	fn get_neuron_lite(&self, netuid: u16, uid: u16, at: Option<BlockHash>) -> RpcResult<Vec<u8>>;
 	#[method(name = "neuronInfo_getNeurons")]
 	fn get_neurons(&self, netuid: u16, at: Option<BlockHash>) -> RpcResult<Vec<u8>>;
 	#[method(name = "neuronInfo_getNeuron")]
@@ -100,6 +105,42 @@ where
 			CallError::Custom(ErrorObject::owned(
 				Error::RuntimeError.into(),
 				"Unable to get delegate info.",
+				Some(e.to_string()),
+			)).into()
+		})
+	}
+
+
+	fn get_neurons_lite(
+		&self,
+		netuid: u16,
+		at: Option<<Block as BlockT>::Hash>
+	) -> RpcResult<Vec<u8>> {
+		let api = self.client.runtime_api();
+		let at = at.unwrap_or_else(|| self.client.info().best_hash);
+
+		api.get_neurons_lite(at, netuid).map_err(|e| {
+			CallError::Custom(ErrorObject::owned(
+				Error::RuntimeError.into(),
+				"Unable to get neurons lite info.",
+				Some(e.to_string()),
+			)).into()
+		})
+	}
+
+	fn get_neuron_lite(
+		&self,
+		netuid: u16,
+		uid: u16,
+		at: Option<<Block as BlockT>::Hash>
+	) -> RpcResult<Vec<u8>> {
+		let api = self.client.runtime_api();
+		let at = at.unwrap_or_else(|| self.client.info().best_hash);
+
+		api.get_neuron_lite(at, netuid, uid).map_err(|e| {
+			CallError::Custom(ErrorObject::owned(
+				Error::RuntimeError.into(),
+				"Unable to get neuron lite info.",
 				Some(e.to_string()),
 			)).into()
 		})

--- a/pallets/subtensor/runtime-api/src/lib.rs
+++ b/pallets/subtensor/runtime-api/src/lib.rs
@@ -13,6 +13,8 @@ sp_api::decl_runtime_apis! {
 	pub trait NeuronInfoRuntimeApi {
 		fn get_neurons(netuid: u16) -> Vec<u8>;
 		fn get_neuron(netuid: u16, uid: u16) -> Vec<u8>;
+		fn get_neurons_lite(netuid: u16) -> Vec<u8>;
+		fn get_neuron_lite(netuid: u16, uid: u16) -> Vec<u8>;
 	}
 
 	pub trait SubnetInfoRuntimeApi {

--- a/pallets/subtensor/src/neuron_info.rs
+++ b/pallets/subtensor/src/neuron_info.rs
@@ -29,6 +29,29 @@ pub struct NeuronInfo<T: Config> {
     pruning_score: Compact<u16>,
 }
 
+#[derive(Decode, Encode, PartialEq, Eq, Clone, Debug)]
+pub struct NeuronInfoLite<T: Config> {
+    hotkey: T::AccountId,
+    coldkey: T::AccountId,
+    uid: Compact<u16>,
+    netuid: Compact<u16>,
+    active: bool,
+    axon_info: AxonInfo,
+    prometheus_info: PrometheusInfo,
+    stake: Vec<(T::AccountId, Compact<u64>)>, // map of coldkey to stake on this neuron/hotkey (includes delegations)
+    rank: Compact<u16>,
+    emission: Compact<u64>,
+    incentive: Compact<u16>,
+    consensus: Compact<u16>,
+    trust: Compact<u16>,
+    validator_trust: Compact<u16>,
+    dividends: Compact<u16>,
+    last_update: Compact<u64>,
+    validator_permit: bool,
+    // has no weights or bonds
+    pruning_score: Compact<u16>,
+}
+
 impl<T: Config> Pallet<T> {
 	pub fn get_neurons(netuid: u16) -> Vec<NeuronInfo<T>> {
         if !Self::if_subnet_exist(netuid) {
@@ -130,5 +153,95 @@ impl<T: Config> Pallet<T> {
         let neuron = Self::get_neuron_subnet_exists(netuid, uid);
         neuron
 	}
+
+    fn get_neuron_lite_subnet_exists(netuid: u16, uid: u16) -> Option<NeuronInfoLite<T>> {
+        let _hotkey = Self::get_hotkey_for_net_and_uid(netuid, uid);
+        let hotkey;
+        if _hotkey.is_err() {
+            return None;
+        } else {
+            // No error, hotkey was registered
+            hotkey = _hotkey.expect("Hotkey should exist");
+        }
+
+        let axon_info = Self::get_axon_info( netuid, &hotkey.clone() );
+
+        let prometheus_info = Self::get_prometheus_info( netuid, &hotkey.clone() );
+
+        
+        let coldkey = Owner::<T>::get( hotkey.clone() ).clone();
+        
+        let active = Self::get_active_for_uid( netuid, uid as u16 );
+        let rank = Self::get_rank_for_uid( netuid, uid as u16 );
+        let emission = Self::get_emission_for_uid( netuid, uid as u16 );
+        let incentive = Self::get_incentive_for_uid( netuid, uid as u16 );
+        let consensus = Self::get_consensus_for_uid( netuid, uid as u16 );
+        let trust = Self::get_trust_for_uid( netuid, uid as u16 );
+        let validator_trust = Self::get_validator_trust_for_uid( netuid, uid as u16 );
+        let dividends = Self::get_dividends_for_uid( netuid, uid as u16 );
+        let pruning_score = Self::get_pruning_score_for_uid( netuid, uid as u16 );
+        let last_update = Self::get_last_update_for_uid( netuid, uid as u16 );
+        let validator_permit = Self::get_validator_permit_for_uid( netuid, uid as u16 );
+
+        let stake: Vec<(T::AccountId, Compact<u64>)> = < Stake<T> as IterableStorageDoubleMap<T::AccountId, T::AccountId, u64> >::iter_prefix( hotkey.clone() )
+            .map(|(coldkey, stake)| (coldkey, stake.into()))
+            .collect();
+
+        let neuron = NeuronInfoLite {
+            hotkey: hotkey.clone(),
+            coldkey: coldkey.clone(),
+            uid: uid.into(),
+            netuid: netuid.into(),
+            active,
+            axon_info,
+            prometheus_info,
+            stake,
+            rank: rank.into(),
+            emission: emission.into(),
+            incentive: incentive.into(),
+            consensus: consensus.into(),
+            trust: trust.into(),
+            validator_trust: validator_trust.into(),
+            dividends: dividends.into(),
+            last_update: last_update.into(),
+            validator_permit,
+            pruning_score: pruning_score.into()
+        };
+        
+        return Some(neuron);
+    }    
+
+    pub fn get_neurons_lite(netuid: u16) -> Vec<NeuronInfoLite<T>> {
+         if !Self::if_subnet_exist(netuid) {
+            return Vec::new();
+        }
+
+        let mut neurons: Vec<NeuronInfoLite<T>> = Vec::new();
+        let n = Self::get_subnetwork_n(netuid);
+        for uid in 0..n {
+            let uid = uid;
+
+            let _neuron = Self::get_neuron_lite_subnet_exists(netuid, uid);
+            let neuron;
+            if _neuron.is_none() {
+                break; // No more neurons
+            } else {
+                // No error, hotkey was registered
+                neuron = _neuron.expect("Neuron should exist");
+            }
+
+            neurons.push( neuron );
+        }
+        neurons 
+    }
+
+    pub fn get_neuron_lite(netuid: u16, uid: u16) -> Option<NeuronInfoLite<T>> {
+        if !Self::if_subnet_exist(netuid) {
+            return None;
+        }
+
+        let neuron = Self::get_neuron_lite_subnet_exists(netuid, uid);
+        neuron
+   }
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -111,7 +111,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 109,
+	spec_version: 110,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -692,7 +692,7 @@ impl_runtime_apis! {
 		fn get_delegate(delegate_account_vec: Vec<u8>) -> Vec<u8> {
 			let _result = SubtensorModule::get_delegate(delegate_account_vec);
 			if _result.is_some() {
-				let result = _result.expect("Could not convert DelegateInfo to JSON");
+				let result = _result.expect("Could not get DelegateInfo");
 				result.encode()
 			} else {
 				vec![]
@@ -701,6 +701,21 @@ impl_runtime_apis! {
 	}
 
 	impl subtensor_custom_rpc_runtime_api::NeuronInfoRuntimeApi<Block> for Runtime {
+		fn get_neurons_lite(netuid: u16) -> Vec<u8> {
+			let result = SubtensorModule::get_neurons_lite(netuid);
+			result.encode()
+		}
+
+		fn get_neuron_lite(netuid: u16, uid: u16) -> Vec<u8> {
+			let _result = SubtensorModule::get_neuron_lite(netuid, uid);
+			if _result.is_some() {
+				let result = _result.expect("Could not get NeuronInfoLite");
+				result.encode()
+			} else {
+				vec![]
+			}
+		}
+
 		fn get_neurons(netuid: u16) -> Vec<u8> {
 			let result = SubtensorModule::get_neurons(netuid);
 			result.encode()
@@ -709,7 +724,7 @@ impl_runtime_apis! {
 		fn get_neuron(netuid: u16, uid: u16) -> Vec<u8> {
 			let _result = SubtensorModule::get_neuron(netuid, uid);
 			if _result.is_some() {
-				let result = _result.expect("Could not convert NeuronInfo to JSON");
+				let result = _result.expect("Could not get NeuronInfo");
 				result.encode()
 			} else {
 				vec![]
@@ -721,7 +736,7 @@ impl_runtime_apis! {
 		fn get_subnet_info(netuid: u16) -> Vec<u8> {
 			let _result = SubtensorModule::get_subnet_info(netuid);
 			if _result.is_some() {
-				let result = _result.expect("Could not convert SubnetInfo to JSON");
+				let result = _result.expect("Could not get SubnetInfo");
 				result.encode()
 			} else {
 				vec![]


### PR DESCRIPTION
This adds the NeuronInfoLite RPC methods.  
These are the same as NeuronInfo, but don't include weights or bonds, making their responses faster and smaller.

Requires chain restart.