### PR TITLE
Increased block weights to 4 seconds of compute

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -149,7 +149,7 @@ parameter_types! {
 	// We allow for 2 seconds of compute with a 6 second average block time.
 	pub BlockWeights: frame_system::limits::BlockWeights =
 		frame_system::limits::BlockWeights::with_sensible_defaults(
-			Weight::from_parts(2u64 * WEIGHT_REF_TIME_PER_SECOND, u64::MAX),
+			Weight::from_parts(4u64 * WEIGHT_REF_TIME_PER_SECOND, u64::MAX),
 			NORMAL_DISPATCH_RATIO,
 		);
 	pub BlockLength: frame_system::limits::BlockLength = frame_system::limits::BlockLength


### PR DESCRIPTION
This increases the block weight limit to 4 seconds of compute for a 12 second average block time.