### PR TITLE
[Epoch Improvement] Use only validator stake in epoch

### DIFF
--- a/pallets/subtensor/src/epoch.rs
+++ b/pallets/subtensor/src/epoch.rs
@@ -49,6 +49,7 @@ impl<T: Config> Pallet<T> {
         // ===========
         // == Stake ==
         // ===========
+        
         let mut hotkeys: Vec<(u16, T::AccountId)> = vec![];
         for ( uid_i, hotkey ) in < Keys<T> as IterableStorageDoubleMap<u16, u16, T::AccountId >>::iter_prefix( netuid ) {
             hotkeys.push( (uid_i, hotkey) ); 
@@ -63,14 +64,6 @@ impl<T: Config> Pallet<T> {
         inplace_normalize_64( &mut stake_64 );
         let stake: Vec<I32F32> = vec_fixed64_to_fixed32( stake_64 );
         log::trace!( "S:\n{:?}\n", &stake );
-
-        // Remove inactive stake.
-        let mut active_stake: Vec<I32F32> = stake.clone();
-        inplace_mask_vector( &inactive, &mut active_stake );
-
-        // Normalize active stake.
-        inplace_normalize( &mut active_stake );
-        log::trace!( "S:\n{:?}\n", &active_stake );
 
         // =======================
         // == Validator permits ==
@@ -90,6 +83,22 @@ impl<T: Config> Pallet<T> {
         // Get new validator permits.
         let new_validator_permits: Vec<bool> = is_topk( &stake, max_allowed_validators as usize );
         log::trace!( "new_validator_permits: {:?}", new_validator_permits );
+
+        // ==================
+        // == Active Stake ==
+        // ==================
+
+        let mut active_stake: Vec<I32F32> = stake.clone();
+
+        // Remove inactive stake.
+        inplace_mask_vector( &inactive, &mut active_stake );
+        
+        // Remove non-validator stake.
+        inplace_mask_vector( &validator_forbids, &mut active_stake );
+
+        // Normalize active stake.
+        inplace_normalize( &mut active_stake );
+        log::trace!( "S:\n{:?}\n", &active_stake );
 
         // =============
         // == Weights ==
@@ -305,15 +314,6 @@ impl<T: Config> Pallet<T> {
         // range: I32F32(0, 1)
         log::trace!( "S: {:?}", &stake );
 
-        // Remove inactive stake.
-        let mut active_stake: Vec<I32F32> = stake.clone();
-        inplace_mask_vector( &inactive, &mut active_stake );
-        log::trace!( "S (mask): {:?}", &active_stake );
-
-        // Normalize active stake.
-        inplace_normalize( &mut active_stake );
-        log::trace!( "S (mask+norm): {:?}", &active_stake );
-
         // =======================
         // == Validator permits ==
         // =======================
@@ -332,6 +332,22 @@ impl<T: Config> Pallet<T> {
         // Get new validator permits.
         let new_validator_permits: Vec<bool> = is_topk( &stake, max_allowed_validators as usize );
         log::trace!( "new_validator_permits: {:?}", new_validator_permits );
+
+        // ==================
+        // == Active Stake ==
+        // ==================
+
+        let mut active_stake: Vec<I32F32> = stake.clone();
+
+        // Remove inactive stake.
+        inplace_mask_vector( &inactive, &mut active_stake );
+        
+        // Remove non-validator stake.
+        inplace_mask_vector( &validator_forbids, &mut active_stake );
+
+        // Normalize active stake.
+        inplace_normalize( &mut active_stake );
+        log::trace!( "S:\n{:?}\n", &active_stake );
 
         // =============
         // == Weights ==

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -111,7 +111,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 109,
+	spec_version: 108,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -111,7 +111,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 103,
+	spec_version: 109,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
### [Epoch Improvement] Use only validator stake in epoch

Now explicitly masks out non-validators from active_stake, and does not just rely on masking in the weights:
- Main benefit is that stake-weighted median should now be sparse and much faster, due to non-validator stake giving zero weights being factored out.
- Ensures that the majority (kappa) value is now exact, no longer offset by zero-weighting non-validator stake.