### PR TITLE
[BIT-638] Max-upscale pruning_scores

### DIFF
--- a/pallets/subtensor/src/epoch.rs
+++ b/pallets/subtensor/src/epoch.rs
@@ -215,7 +215,7 @@ impl<T: Config> Pallet<T> {
         let cloned_consensus: Vec<u16> = consensus.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
         let cloned_incentive: Vec<u16> = incentive.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
         let cloned_dividends: Vec<u16> = dividends.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
-        let cloned_pruning_scores: Vec<u16> = pruning_scores.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
+        let cloned_pruning_scores: Vec<u16> = vec_max_upscale_to_u16(&pruning_scores);
         let cloned_validator_trust: Vec<u16> = validator_trust.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
         Active::<T>::insert( netuid, active.clone() );
         Emission::<T>::insert( netuid, cloned_emission );
@@ -485,7 +485,7 @@ impl<T: Config> Pallet<T> {
         let cloned_consensus: Vec<u16> = consensus.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
         let cloned_incentive: Vec<u16> = incentive.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
         let cloned_dividends: Vec<u16> = dividends.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
-        let cloned_pruning_scores: Vec<u16> = pruning_scores.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
+        let cloned_pruning_scores: Vec<u16> = vec_max_upscale_to_u16(&pruning_scores);
         let cloned_validator_trust: Vec<u16> = validator_trust.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
         Active::<T>::insert( netuid, active.clone() );
         Emission::<T>::insert( netuid, cloned_emission );

--- a/pallets/subtensor/src/math.rs
+++ b/pallets/subtensor/src/math.rs
@@ -37,19 +37,24 @@ pub fn vec_u16_proportions_to_fixed( vec: Vec<u16> ) -> Vec<I32F32> { vec.into_i
 pub fn vec_fixed_proportions_to_u16( vec: Vec<I32F32> ) -> Vec<u16> { vec.into_iter().map(|e| fixed_proportion_to_u16(e) ).collect() }
 
 #[allow(dead_code)]
+// Max-upscale vector and convert to u16 so max_value = u16::MAX. Assumes non-negative normalized input.
 pub fn vec_max_upscale_to_u16( vec: &Vec<I32F32> ) -> Vec<u16> {
     let u16_max: I32F32 = I32F32::from_num( u16::MAX );
+    let threshold: I32F32 = I32F32::from_num( 32768 );
     let max_value: Option<&I32F32> = vec.iter().max();
     match max_value {
         Some(val) => {
             if *val == I32F32::from_num( 0 ) {
                 return vec.iter().map(|e: &I32F32| (e * u16_max).to_num::<u16>() ).collect()
             }
-            return vec.iter().map(|e: &I32F32| (e * u16_max / *val).to_num::<u16>() ).collect()
+            if *val > threshold {
+                return vec.iter().map(|e: &I32F32| (e * (u16_max / *val)).round().to_num::<u16>() ).collect()
+            }
+            return vec.iter().map(|e: &I32F32| ((e * u16_max) / *val).round().to_num::<u16>() ).collect()
         },
         None => {
             let sum: I32F32 = vec.iter().sum();
-            return vec.iter().map(|e: &I32F32| (e * u16_max / sum).to_num::<u16>() ).collect()
+            return vec.iter().map(|e: &I32F32| ((e * u16_max) / sum).to_num::<u16>() ).collect()
         }
     }
 }
@@ -863,7 +868,43 @@ mod tests {
         let result: Vec<u16> = vec_max_upscale_to_u16( &vector );
         assert_vec_compare_u16(&result, &target);
         let vector: Vec<I32F32> = vec_to_fixed( &vec![ 0.000001, 0.000006, 0.000007, 0.0001, 0.001, 0.01, 0.1, 0.2, 0.3, 0.4] );
-        let target: Vec<u16> = vec![ 0, 0, 1, 16, 163, 1638, 16383, 32767, 49151, 65535];
+        let target: Vec<u16> = vec![ 0, 1, 1, 16, 164, 1638, 16384, 32768, 49151, 65535];
+        let result: Vec<u16> = vec_max_upscale_to_u16( &vector );
+        assert_vec_compare_u16(&result, &target);
+        let vector: Vec<I32F32> = vec![ I32F32::from_num(16384) ];
+        let target: Vec<u16> = vec![ 65535 ];
+        let result: Vec<u16> = vec_max_upscale_to_u16( &vector );
+        assert_vec_compare_u16(&result, &target);
+        let vector: Vec<I32F32> = vec![ I32F32::from_num(32768) ];
+        let target: Vec<u16> = vec![ 65535 ];
+        let result: Vec<u16> = vec_max_upscale_to_u16( &vector );
+        assert_vec_compare_u16(&result, &target);
+        let vector: Vec<I32F32> = vec![ I32F32::from_num(32769) ];
+        let target: Vec<u16> = vec![ 65535 ];
+        let result: Vec<u16> = vec_max_upscale_to_u16( &vector );
+        assert_vec_compare_u16(&result, &target);
+        let vector: Vec<I32F32> = vec![ I32F32::from_num(65535) ];
+        let target: Vec<u16> = vec![ 65535 ];
+        let result: Vec<u16> = vec_max_upscale_to_u16( &vector );
+        assert_vec_compare_u16(&result, &target);
+        let vector: Vec<I32F32> = vec![ I32F32::max_value() ];
+        let target: Vec<u16> = vec![ 65535 ];
+        let result: Vec<u16> = vec_max_upscale_to_u16( &vector );
+        assert_vec_compare_u16(&result, &target);
+        let vector: Vec<I32F32> = vec_to_fixed( &vec![ 0., 1., 65535. ] );
+        let target: Vec<u16> = vec![ 0, 1, 65535 ];
+        let result: Vec<u16> = vec_max_upscale_to_u16( &vector );
+        assert_vec_compare_u16(&result, &target);
+        let vector: Vec<I32F32> = vec_to_fixed( &vec![ 0., 0.5, 1., 1.5, 2., 32768. ] );
+        let target: Vec<u16> = vec![ 0, 1, 2, 3, 4, 65535 ];
+        let result: Vec<u16> = vec_max_upscale_to_u16( &vector );
+        assert_vec_compare_u16(&result, &target);
+        let vector: Vec<I32F32> = vec_to_fixed( &vec![ 0., 0.5, 1., 1.5, 2., 32768., 32769. ] );
+        let target: Vec<u16> = vec![ 0, 1, 2, 3, 4, 65533, 65535 ];
+        let result: Vec<u16> = vec_max_upscale_to_u16( &vector );
+        assert_vec_compare_u16(&result, &target);
+        let vector: Vec<I32F32> = vec![ I32F32::from_num(0), I32F32::from_num(1), I32F32::from_num(32768), I32F32::from_num(32769), I32F32::max_value() ];
+        let target: Vec<u16> = vec![ 0, 0, 1, 1, 65535 ];
         let result: Vec<u16> = vec_max_upscale_to_u16( &vector );
         assert_vec_compare_u16(&result, &target);
     }

--- a/pallets/subtensor/src/math.rs
+++ b/pallets/subtensor/src/math.rs
@@ -48,7 +48,8 @@ pub fn vec_max_upscale_to_u16( vec: &Vec<I32F32> ) -> Vec<u16> {
             return vec.iter().map(|e: &I32F32| (e * u16_max / *val).to_num::<u16>() ).collect()
         },
         None => {
-            return vec.iter().map(|e: &I32F32| (e * u16_max).to_num::<u16>() ).collect()
+            let sum: I32F32 = vec.iter().sum();
+            return vec.iter().map(|e: &I32F32| (e * u16_max / sum).to_num::<u16>() ).collect()
         }
     }
 }

--- a/pallets/subtensor/tests/epoch.rs
+++ b/pallets/subtensor/tests/epoch.rs
@@ -667,7 +667,8 @@ fn test_active_stake() {
 			D: [0.55, 0.4499999997, 0, 0]
 			nE: [0.275, 0.2249999999, 0.25, 0.25]
 			E: [274999999, 224999999, 250000000, 250000000]
-			P: [0.275, 0.2249999999, 0.25, 0.25] */
+			P: [0.275, 0.2249999999, 0.25, 0.25]
+			P (u16): [65535, 53619, 59577, 59577] */
 		let bonds = SubtensorModule::get_bonds( netuid );
 		assert_eq!( SubtensorModule::get_dividends_for_uid( netuid, 0 ), 36044 ); // Note D = floor((0.5 * 0.9 + 0.1) * 65_535)
 		assert_eq!( SubtensorModule::get_emission_for_uid( netuid, 0 ), 274999999 ); // Note E = 0.5 * 0.55 * 1_000_000_000 = 275_000_000 (discrepancy)
@@ -710,7 +711,8 @@ fn test_active_stake() {
 			D: [0.5450041203, 0.4549958794, 0, 0]
 			nE: [0.27250206, 0.2274979397, 0.25, 0.25]
 			E: [272502060, 227497939, 250000000, 250000000]
-			P: [0.27250206, 0.2274979397, 0.25, 0.25] */
+			P: [0.27250206, 0.2274979397, 0.25, 0.25]
+			P (u16): [65535, 54711, 60123, 60123] */
 		let bonds = SubtensorModule::get_bonds( netuid );
 		assert_eq!( SubtensorModule::get_dividends_for_uid( netuid, 0 ), 35716 ); // Note D = floor((0.55 * 0.9 + 0.5 * 0.1) * 65_535)
 		assert_eq!( SubtensorModule::get_emission_for_uid( netuid, 0 ), 272502060 ); // Note E = 0.5 * (0.55 * 0.9 + 0.5 * 0.1) * 1_000_000_000 = 272_500_000 (discrepancy)
@@ -787,7 +789,7 @@ fn test_outdated_weights() {
 			nE: [0.25, 0.25, 0.3333333333, 0.1666666665]
 			E: [250000000, 250000000, 333333333, 166666666]
 			P: [0.25, 0.25, 0.3333333333, 0.1666666665]
-			n: 4 */
+			P (u16): [49151, 49151, 65535, 32767] */
 
 		// === Dereg server2 at uid3 (least emission) + register new key over uid3
 		let new_key: u64 = n as u64; // register a new key while at max capacity, which means the least incentive uid will be deregistered
@@ -831,7 +833,8 @@ fn test_outdated_weights() {
 			D: [0.5, 0.5, 0, 0]
 			nE: [0.25, 0.25, 0.5, 0]
 			E: [250000000, 250000000, 500000000, 0]
-			P: [0.25, 0.25, 0.5, 0] */
+			P: [0.25, 0.25, 0.5, 0]
+			P (u16): [32767, 32767, 65535, 0] */
 		let bonds = SubtensorModule::get_bonds( netuid );
 		assert_eq!( SubtensorModule::get_dividends_for_uid( netuid, 0 ), 32767 ); // Note D = floor(0.5 * 65_535)
 		assert_eq!( SubtensorModule::get_emission_for_uid( netuid, 0 ), 250000000 ); // Note E = 0.5 * 0.5 * 1_000_000_000 = 249311245

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -111,7 +111,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 114,
+	spec_version: 116,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
Currently `pruning_scores` are a u16 quantization of normalized emission, which is problematic given ~4096 values and a Pareto distribution of emissions. Currently finney has a max emission of ~11% and a min non-zero emission of ~0.0002% (0.000002), but the lowest u16 quantity is 1/2^16 = 0.000015 (0.0015%).

The purpose of `pruning_scores` is to make relative comparisons during registration to determine the neuron to replace, which has the lowest `pruning_score`. Therefore, it doesn't have to be normalized, so this PR proposes max-upscaling where `max(pruning_scores) = u16::MAX`. So scale scores relative to the max score, so 0.0002/11 = 0.000018 (> 0.000015 u16 min quantity).

Assumes that `pruning_scores` is used only for relative comparison, and doesn't have to be normalized.