### PR TITLE
Fix some tests, change mock balance to u64, add staking test

### DIFF
--- a/pallets/subtensor/tests/epoch.rs
+++ b/pallets/subtensor/tests/epoch.rs
@@ -111,7 +111,7 @@ fn init_run_epochs(netuid: u16, n: u16, validators: &Vec<u16>, servers: &Vec<u16
 			stake = if validators.contains(&key) { stake_per_validator } else { 0 }; // only validators receive stake
 		}
 		// let stake: u128 = 1; // alternative test: all nodes receive stake, should be same outcome, except stake
-		SubtensorModule::add_balance_to_coldkey_account( &(key as u64), stake as u128 );
+		SubtensorModule::add_balance_to_coldkey_account( &(key as u64), stake );
 		SubtensorModule::append_neuron( netuid, &(key as u64), 0 );
 		SubtensorModule::increase_stake_on_coldkey_hotkey_account( &(key as u64), &(key as u64), stake as u64 );
 	}
@@ -324,7 +324,7 @@ fn test_1_graph() {
 		let stake_amount: u64 = 1;
 		add_network(netuid, u16::MAX - 1, 0); // set higher tempo to avoid built-in epoch, then manual epoch instead
 		SubtensorModule::set_max_allowed_uids( netuid, 1 ); 
-		SubtensorModule::add_balance_to_coldkey_account( &coldkey, stake_amount as u128 );
+		SubtensorModule::add_balance_to_coldkey_account( &coldkey, stake_amount );
  		SubtensorModule::increase_stake_on_coldkey_hotkey_account( &coldkey, &hotkey, stake_amount );
 		 SubtensorModule::append_neuron( netuid, &hotkey, 0 );
 		assert_eq!( SubtensorModule::get_subnetwork_n(netuid), 1 );
@@ -599,7 +599,7 @@ fn test_active_stake() {
 
 		// === Register [validator1, validator2, server1, server2]
 		for key in 0..n as u64 {
-			SubtensorModule::add_balance_to_coldkey_account( &key, stake as u128 );
+			SubtensorModule::add_balance_to_coldkey_account( &key, stake );
 			let (nonce, work): (u64, Vec<u8>) = SubtensorModule::create_work_for_block_number( netuid, block_number, key * 1_000_000);
 			assert_ok!(SubtensorModule::register(<<Test as Config>::RuntimeOrigin>::signed(key), netuid, block_number, nonce, work, key, key));
 			SubtensorModule::increase_stake_on_coldkey_hotkey_account( &key, &key, stake );
@@ -741,7 +741,7 @@ fn test_outdated_weights() {
 
 		// === Register [validator1, validator2, server1, server2]
 		for key in 0..n as u64 {
-			SubtensorModule::add_balance_to_coldkey_account( &key, stake as u128 );
+			SubtensorModule::add_balance_to_coldkey_account( &key, stake );
 			let (nonce, work): (u64, Vec<u8>) = SubtensorModule::create_work_for_block_number( netuid, block_number, key * 1_000_000);
 			assert_ok!(SubtensorModule::register(<<Test as Config>::RuntimeOrigin>::signed(key), netuid, block_number, nonce, work, key, key));
 			SubtensorModule::increase_stake_on_coldkey_hotkey_account( &key, &key, stake );
@@ -860,7 +860,7 @@ fn test_zero_weights() {
 			assert_ok!(SubtensorModule::register(<<Test as Config>::RuntimeOrigin>::signed(key), netuid, block_number, nonce, work, key, key));
 		}
 		for validator in 0..(n/2) as u64 {
-			SubtensorModule::add_balance_to_coldkey_account( &validator, stake as u128 );
+			SubtensorModule::add_balance_to_coldkey_account( &validator, stake );
 			SubtensorModule::increase_stake_on_coldkey_hotkey_account( &validator, &validator, stake );
 		}
 		assert_eq!(SubtensorModule::get_subnetwork_n(netuid), n);
@@ -984,7 +984,7 @@ fn test_validator_permits() {
 			
 					// === Register [validator1, validator2, server1, server2]
 					for key in 0..network_n as u64 {
-						SubtensorModule::add_balance_to_coldkey_account( &key, stake[key as usize] as u128 );
+						SubtensorModule::add_balance_to_coldkey_account( &key, stake[key as usize] );
 						let (nonce, work): (u64, Vec<u8>) = SubtensorModule::create_work_for_block_number( netuid, block_number, key * 1_000_000);
 						assert_ok!(SubtensorModule::register(<<Test as Config>::RuntimeOrigin>::signed(key), netuid, block_number, nonce, work, key, key));
 						SubtensorModule::increase_stake_on_coldkey_hotkey_account( &key, &key, stake[key as usize] );
@@ -1004,7 +1004,7 @@ fn test_validator_permits() {
 
 					// === Increase server stake above validators
 					for server in &servers {
-						SubtensorModule::add_balance_to_coldkey_account( &(*server as u64), 2*network_n as u128 );
+						SubtensorModule::add_balance_to_coldkey_account( &(*server as u64), 2*network_n as u64 );
 						SubtensorModule::increase_stake_on_coldkey_hotkey_account( &(*server as u64), &(*server as u64), 2*network_n as u64 );
 					}
 

--- a/pallets/subtensor/tests/mock.rs
+++ b/pallets/subtensor/tests/mock.rs
@@ -44,7 +44,7 @@ pub type AccountId = u64;
 
 // Balance of an account.
 #[allow(dead_code)]
-pub type Balance = u128;
+pub type Balance = u64;
 
 // An index to a block.
 #[allow(dead_code)]

--- a/pallets/subtensor/tests/mock.rs
+++ b/pallets/subtensor/tests/mock.rs
@@ -203,7 +203,7 @@ pub fn test_ext_with_balances(balances : Vec<(u64, u128)>) -> sp_io::TestExterna
 		.build_storage::<Test>()
 		.unwrap();
 
-	pallet_balances::GenesisConfig::<Test> { balances }
+	pallet_balances::GenesisConfig::<Test> { balances: balances.iter().map(|(a, b)| (*a, *b as u64)).collect::<Vec<(u64, u64)>>()  }
 		.assimilate_storage(&mut t)
 		.unwrap();
 

--- a/pallets/subtensor/tests/neuron_info.rs
+++ b/pallets/subtensor/tests/neuron_info.rs
@@ -25,7 +25,7 @@ fn test_get_neuron_some() {
         let tempo: u16 = 2;
         let modality: u16 = 2;
 
-        let uid: u16 = 42;
+        let uid: u16 = 0;
         let hotkey0: u64 = 0;
         let coldkey0: u64 = 0;
 

--- a/pallets/subtensor/tests/registration.rs
+++ b/pallets/subtensor/tests/registration.rs
@@ -223,8 +223,9 @@ fn test_registration_too_many_registrations_per_interval() {
 		SubtensorModule::set_max_registrations_per_block( netuid, 11 );
 		assert_eq!( SubtensorModule::get_max_registrations_per_block(netuid), 11 );
 
-		SubtensorModule::set_target_registrations_per_interval( netuid, 10 );
-		assert_eq!( SubtensorModule::get_target_registrations_per_interval(netuid), 9 );
+		SubtensorModule::set_target_registrations_per_interval( netuid, 3 );
+		assert_eq!( SubtensorModule::get_target_registrations_per_interval(netuid), 3 );
+		// Then the max is 3 * 3 = 9
 
 		let block_number: u64 = 0;
 		let (nonce0, work0): (u64, Vec<u8>) = SubtensorModule::create_work_for_block_number( netuid, block_number, 3942084);
@@ -237,13 +238,13 @@ fn test_registration_too_many_registrations_per_interval() {
 		let (nonce7, work7): (u64, Vec<u8>) = SubtensorModule::create_work_for_block_number( netuid, block_number, 6923424);
 		let (nonce8, work8): (u64, Vec<u8>) = SubtensorModule::create_work_for_block_number( netuid, block_number, 124242);
 		let (nonce9, work9): (u64, Vec<u8>) = SubtensorModule::create_work_for_block_number( netuid, block_number, 153453);
-		let (nonce10, work10): (u64, Vec<u8>) = SubtensorModule::create_work_for_block_number( netuid, block_number, 345923888);
 		assert_eq!( SubtensorModule::get_difficulty_as_u64(netuid), 10000 );
 
 		//add network
 		add_network(netuid, tempo, 0);
 		
 		// Subscribe and check extrinsic output
+		// Try 10 registrations, this is less than the max per block, but more than the max per interval
 		assert_ok!(SubtensorModule::register(<<Test as Config>::RuntimeOrigin>::signed(0), netuid, block_number, nonce0, work0, 0, 0));
 		assert_eq!( SubtensorModule::get_registrations_this_interval(netuid), 1 );
 		assert_ok!(SubtensorModule::register(<<Test as Config>::RuntimeOrigin>::signed(1), netuid, block_number, nonce1, work1, 1, 1));
@@ -262,9 +263,7 @@ fn test_registration_too_many_registrations_per_interval() {
 		assert_eq!( SubtensorModule::get_registrations_this_interval(netuid), 8 );
 		assert_ok!(SubtensorModule::register(<<Test as Config>::RuntimeOrigin>::signed(8), netuid, block_number, nonce8, work8, 8, 8));
 		assert_eq!( SubtensorModule::get_registrations_this_interval(netuid), 9 );
-		assert_ok!(SubtensorModule::register(<<Test as Config>::RuntimeOrigin>::signed(9), netuid, block_number, nonce9, work9, 9, 9));
-		assert_eq!( SubtensorModule::get_registrations_this_interval(netuid), 10 );
-		let result = SubtensorModule::register(<<Test as Config>::RuntimeOrigin>::signed(10), netuid, block_number, nonce10, work10, 10, 10);
+		let result = SubtensorModule::register(<<Test as Config>::RuntimeOrigin>::signed(9), netuid, block_number, nonce9, work9, 9, 9);
 		assert_eq!( result, Err(Error::<Test>::TooManyRegistrationsThisInterval.into()) );
 	});
 }

--- a/pallets/subtensor/tests/registration.rs
+++ b/pallets/subtensor/tests/registration.rs
@@ -221,7 +221,7 @@ fn test_registration_too_many_registrations_per_interval() {
 		let netuid: u16 = 1;
 		let tempo: u16 = 13;
 		SubtensorModule::set_max_registrations_per_block( netuid, 11 );
-		assert_eq!( SubtensorModule::get_max_registrations_per_block(netuid), 10 );
+		assert_eq!( SubtensorModule::get_max_registrations_per_block(netuid), 11 );
 
 		SubtensorModule::set_target_registrations_per_interval( netuid, 10 );
 		assert_eq!( SubtensorModule::get_target_registrations_per_interval(netuid), 9 );

--- a/pallets/subtensor/tests/serving.rs
+++ b/pallets/subtensor/tests/serving.rs
@@ -132,12 +132,15 @@ fn test_axon_serving_rate_limit_exceeded() {
                 let placeholder2: u8 = 0;
                 add_network(netuid, tempo, modality);
                 register_ok_neuron( netuid, hotkey_account_id, 66, 0);
+                run_to_block(1); // Go to block 1
                 // No issue on multiple
                 assert_ok!(SubtensorModule::serve_axon(<<Test as Config>::RuntimeOrigin>::signed(hotkey_account_id), netuid, version, ip, port, ip_type, protocol, placeholder1, placeholder2));
                 assert_ok!(SubtensorModule::serve_axon(<<Test as Config>::RuntimeOrigin>::signed(hotkey_account_id), netuid, version, ip, port, ip_type, protocol, placeholder1, placeholder2));
                 assert_ok!(SubtensorModule::serve_axon(<<Test as Config>::RuntimeOrigin>::signed(hotkey_account_id), netuid, version, ip, port, ip_type, protocol, placeholder1, placeholder2));
                 assert_ok!(SubtensorModule::serve_axon(<<Test as Config>::RuntimeOrigin>::signed(hotkey_account_id), netuid, version, ip, port, ip_type, protocol, placeholder1, placeholder2));    
                 SubtensorModule::set_serving_rate_limit( netuid, 2 );
+                run_to_block(2); // Go to block 2
+                // Needs to be 2 blocks apart, we are only 1 block apart
                 assert_eq!(SubtensorModule::serve_axon(<<Test as Config>::RuntimeOrigin>::signed(hotkey_account_id), netuid, version, ip, port, ip_type, protocol, placeholder1, placeholder2), Err(Error::<Test>::ServingRateLimitExceeded.into()) );    
         });
 }
@@ -227,12 +230,14 @@ fn test_prometheus_serving_rate_limit_exceeded() {
                 let modality: u16 = 0;
                 add_network(netuid, tempo, modality);
                 register_ok_neuron( netuid, hotkey_account_id, 66, 0);
+                run_to_block(1); // Go to block 1
                 // No issue on multiple
                 assert_ok!(SubtensorModule::serve_prometheus(<<Test as Config>::RuntimeOrigin>::signed(hotkey_account_id), netuid, version, ip, port, ip_type));
                 assert_ok!(SubtensorModule::serve_prometheus(<<Test as Config>::RuntimeOrigin>::signed(hotkey_account_id), netuid, version, ip, port, ip_type));
                 assert_ok!(SubtensorModule::serve_prometheus(<<Test as Config>::RuntimeOrigin>::signed(hotkey_account_id), netuid, version, ip, port, ip_type));
                 assert_ok!(SubtensorModule::serve_prometheus(<<Test as Config>::RuntimeOrigin>::signed(hotkey_account_id), netuid, version, ip, port, ip_type));    
                 SubtensorModule::set_serving_rate_limit( netuid, 1 );
+                // Same block, need 1 block to pass
                 assert_eq!(SubtensorModule::serve_prometheus(<<Test as Config>::RuntimeOrigin>::signed(hotkey_account_id), netuid, version, ip, port, ip_type), Err(Error::<Test>::ServingRateLimitExceeded.into()) );    
         });
 }

--- a/pallets/subtensor/tests/staking.rs
+++ b/pallets/subtensor/tests/staking.rs
@@ -1,4 +1,4 @@
-use frame_support::{assert_ok};
+use frame_support::{assert_ok, traits::Currency};
 use frame_system::{Config};
 mod mock;
 use mock::*;
@@ -170,6 +170,114 @@ fn test_add_stake_err_not_enough_belance() {
 	});
 }
 
+#[test]
+fn test_add_stake_total_balance_no_change() {
+	// When we add stake, the total balance of the coldkey account should not change
+	//    this is because the stake should be part of the coldkey account balance (reserved/locked)
+	new_test_ext().execute_with(|| {
+		let hotkey_account_id = 551337;
+		let coldkey_account_id = 51337;
+        let netuid : u16 = 1;
+		let tempo: u16 = 13;
+		let start_nonce: u64 = 0;
+
+		//add network
+		add_network(netuid, tempo, 0);
+		
+		// Register neuron
+		register_ok_neuron( netuid, hotkey_account_id, coldkey_account_id, start_nonce);
+
+		// Give it some $$$ in his coldkey balance
+		let initial_balance = 10000;
+		SubtensorModule::add_balance_to_coldkey_account( &coldkey_account_id, initial_balance );
+
+		// Check we have zero staked before transfer
+		let initial_stake = SubtensorModule::get_total_stake_for_hotkey(&hotkey_account_id);
+		assert_eq!(initial_stake, 0);
+
+		// Check total balance is equal to initial balance
+		let initial_total_balance = Balances::total_balance(&coldkey_account_id);
+		assert_eq!(initial_total_balance, initial_balance);
+
+		// Also total stake should be zero
+		assert_eq!(SubtensorModule::get_total_stake(), 0);
+
+		// Stake to hotkey account, and check if the result is ok
+		assert_ok!(SubtensorModule::add_stake(<<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id), hotkey_account_id, 10000));
+
+		// Check if stake has increased
+		let new_stake = SubtensorModule::get_total_stake_for_hotkey(&hotkey_account_id);
+		assert_eq!(new_stake, 10000);
+
+		// Check if free balance has decreased
+		let new_free_balance = SubtensorModule::get_coldkey_balance(&coldkey_account_id);
+		assert_eq!(new_free_balance, 0);
+
+		// Check if total stake has increased accordingly.
+		assert_eq!(SubtensorModule::get_total_stake(), 10000);
+
+		// Check if total balance has remained the same. (no fee, includes reserved/locked balance)
+		let total_balance = Balances::total_balance(&coldkey_account_id);
+		assert_eq!(total_balance, initial_total_balance);
+	});
+}
+
+#[test]
+fn test_add_stake_total_issuance_no_change() {
+	// When we add stake, the total issuance of the balances pallet should not change
+	//    this is because the stake should be part of the coldkey account balance (reserved/locked)
+	new_test_ext().execute_with(|| {
+		let hotkey_account_id = 561337;
+		let coldkey_account_id = 61337;
+        let netuid : u16 = 1;
+		let tempo: u16 = 13;
+		let start_nonce: u64 = 0;
+
+		//add network
+		add_network(netuid, tempo, 0);
+		
+		// Register neuron
+		register_ok_neuron( netuid, hotkey_account_id, coldkey_account_id, start_nonce);
+
+		// Give it some $$$ in his coldkey balance
+		let initial_balance = 10000;
+		SubtensorModule::add_balance_to_coldkey_account( &coldkey_account_id, initial_balance );
+
+		// Check we have zero staked before transfer
+		let initial_stake = SubtensorModule::get_total_stake_for_hotkey(&hotkey_account_id);
+		assert_eq!(initial_stake, 0);
+
+		// Check total balance is equal to initial balance
+		let initial_total_balance = Balances::total_balance(&coldkey_account_id);
+		assert_eq!(initial_total_balance, initial_balance);
+
+		// Check total issuance is equal to initial balance
+		let initial_total_issuance = Balances::total_issuance();
+		assert_eq!(initial_total_issuance, initial_balance);
+
+		// Also total stake should be zero
+		assert_eq!(SubtensorModule::get_total_stake(), 0);
+
+		// Stake to hotkey account, and check if the result is ok
+		assert_ok!(SubtensorModule::add_stake(<<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id), hotkey_account_id, 10000));
+
+		// Check if stake has increased
+		let new_stake = SubtensorModule::get_total_stake_for_hotkey(&hotkey_account_id);
+		assert_eq!(new_stake, 10000);
+
+		// Check if free balance has decreased
+		let new_free_balance = SubtensorModule::get_coldkey_balance(&coldkey_account_id);
+		assert_eq!(new_free_balance, 0);
+
+		// Check if total stake has increased accordingly.
+		assert_eq!(SubtensorModule::get_total_stake(), 10000);
+
+		// Check if total issuance has remained the same. (no fee, includes reserved/locked balance)
+		let total_issuance = Balances::total_issuance();
+		assert_eq!(total_issuance, initial_total_issuance);
+	});
+}
+
 // /***********************************************************
 // 	staking::remove_stake() tests
 // ************************************************************/
@@ -272,6 +380,96 @@ fn test_remove_stake_no_enough_stake() {
 
 		let result = SubtensorModule::remove_stake(<<Test as Config>::RuntimeOrigin>::signed(coldkey_id), hotkey_id, amount);
 		assert_eq!(result, Err(Error::<Test>::NotEnoughStaketoWithdraw.into()));
+	});
+}
+
+#[test]
+fn test_remove_stake_total_balance_no_change() {
+	// When we remove stake, the total balance of the coldkey account should not change
+	//    this is because the stake should be part of the coldkey account balance (reserved/locked)
+	//    then the removed stake just becomes free balance
+	new_test_ext().execute_with(|| {
+		let hotkey_account_id = 571337;
+		let coldkey_account_id = 71337;
+        let netuid : u16 = 1;
+		let tempo: u16 = 13;
+		let start_nonce: u64 = 0;
+		let amount = 10000;
+
+		//add network
+		add_network(netuid, tempo, 0);
+		
+		// Register neuron
+		register_ok_neuron( netuid, hotkey_account_id, coldkey_account_id, start_nonce);
+
+		// Some basic assertions
+		assert_eq!(SubtensorModule::get_total_stake(), 0);
+		assert_eq!(SubtensorModule::get_total_stake_for_hotkey(&hotkey_account_id), 0);
+		assert_eq!(SubtensorModule::get_coldkey_balance(&coldkey_account_id), 0);
+		let initial_total_balance = Balances::total_balance(&coldkey_account_id);
+		assert_eq!(initial_total_balance, 0);
+
+		// Give the neuron some stake to remove
+		SubtensorModule::increase_stake_on_hotkey_account(&hotkey_account_id, amount);
+
+		// Do the magic
+		assert_ok!(SubtensorModule::remove_stake(<<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id), hotkey_account_id, amount));
+
+		assert_eq!(SubtensorModule::get_coldkey_balance(&coldkey_account_id), amount);
+		assert_eq!(SubtensorModule::get_total_stake_for_hotkey(&hotkey_account_id), 0);
+		assert_eq!(SubtensorModule::get_total_stake(), 0);
+
+		// Check total balance is equal to the added stake. Even after remove stake (no fee, includes reserved/locked balance)
+		let total_balance = Balances::total_balance(&coldkey_account_id);
+		assert_eq!(total_balance, amount);
+	});
+}
+
+#[test]
+fn test_remove_stake_total_issuance_no_change() {
+	// When we remove stake, the total issuance of the balances pallet should not change
+	//    this is because the stake should be part of the coldkey account balance (reserved/locked)
+	//    then the removed stake just becomes free balance
+	new_test_ext().execute_with(|| {
+		let hotkey_account_id = 581337;
+		let coldkey_account_id = 81337;
+        let netuid : u16 = 1;
+		let tempo: u16 = 13;
+		let start_nonce: u64 = 0;
+		let amount = 10000;
+
+		//add network
+		add_network(netuid, tempo, 0);
+		
+		// Register neuron
+		register_ok_neuron( netuid, hotkey_account_id, coldkey_account_id, start_nonce);
+
+		// Some basic assertions
+		assert_eq!(SubtensorModule::get_total_stake(), 0);
+		assert_eq!(SubtensorModule::get_total_stake_for_hotkey(&hotkey_account_id), 0);
+		assert_eq!(SubtensorModule::get_coldkey_balance(&coldkey_account_id), 0);
+		let initial_total_balance = Balances::total_balance(&coldkey_account_id);
+		assert_eq!(initial_total_balance, 0);
+		let inital_total_issuance = Balances::total_issuance();
+		assert_eq!(inital_total_issuance, 0);
+
+		// Give the neuron some stake to remove
+		SubtensorModule::increase_stake_on_hotkey_account(&hotkey_account_id, amount);
+
+		let total_issuance_after_stake = Balances::total_issuance();
+
+		// Do the magic
+		assert_ok!(SubtensorModule::remove_stake(<<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id), hotkey_account_id, amount));
+
+		assert_eq!(SubtensorModule::get_coldkey_balance(&coldkey_account_id), amount);
+		assert_eq!(SubtensorModule::get_total_stake_for_hotkey(&hotkey_account_id), 0);
+		assert_eq!(SubtensorModule::get_total_stake(), 0);
+
+		// Check if total issuance is equal to the added stake, even after remove stake (no fee, includes reserved/locked balance)
+		// Should also be equal to the total issuance after adding stake
+		let total_issuance = Balances::total_issuance();
+		assert_eq!(total_issuance, total_issuance_after_stake);
+		assert_eq!(total_issuance, amount);
 	});
 }
 

--- a/pallets/subtensor/tests/staking.rs
+++ b/pallets/subtensor/tests/staking.rs
@@ -215,7 +215,7 @@ fn test_remove_stake_ok_no_emission() {
 		// Do the magic
 		assert_ok!(SubtensorModule::remove_stake(<<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id), hotkey_account_id, amount));
 
-		assert_eq!(SubtensorModule::get_coldkey_balance(&coldkey_account_id), amount as u128);
+		assert_eq!(SubtensorModule::get_coldkey_balance(&coldkey_account_id), amount);
 		assert_eq!(SubtensorModule::get_total_stake_for_hotkey(&hotkey_account_id), 0);
 		assert_eq!(SubtensorModule::get_total_stake(), 0);
 	});

--- a/pallets/subtensor/tests/staking.rs
+++ b/pallets/subtensor/tests/staking.rs
@@ -4,7 +4,7 @@ mod mock;
 use mock::*;
 use frame_support::sp_runtime::DispatchError;
 use pallet_subtensor::{Error};
-use frame_support::weights::{GetDispatchInfo, DispatchInfo, DispatchClass, Pays};
+use frame_support::dispatch::{GetDispatchInfo, DispatchInfo, DispatchClass, Pays};
 
 /***********************************************************
 	staking::add_stake() tests

--- a/pallets/subtensor/tests/weights.rs
+++ b/pallets/subtensor/tests/weights.rs
@@ -20,11 +20,10 @@ fn test_set_weights_dispatch_info_ok() {
         let netuid: u16 = 1;
 		let version_key: u64 = 0;
 		let call = RuntimeCall::SubtensorModule(SubtensorCall::set_weights{netuid, dests, weights, version_key});
-		assert_eq!(call.get_dispatch_info(), DispatchInfo {
-			weight: frame_support::weights::Weight::from_ref_time(0),
-			class: DispatchClass::Normal,
-			pays_fee: Pays::No
-		});
+		let dispatch_info = call.get_dispatch_info();
+		
+		assert_eq!(dispatch_info.class, DispatchClass::Normal);
+		assert_eq!(dispatch_info.pays_fee, Pays::No);
 	});
 }
 

--- a/pallets/subtensor/tests/weights.rs
+++ b/pallets/subtensor/tests/weights.rs
@@ -2,7 +2,7 @@ mod mock;
 use mock::*;
 use pallet_subtensor::{Error};
 use frame_system::Config;
-use frame_support::weights::{GetDispatchInfo, DispatchInfo, DispatchClass, Pays};
+use frame_support::dispatch::{GetDispatchInfo, DispatchInfo, DispatchClass, Pays};
 use frame_support::{assert_ok};
 use sp_runtime::DispatchError;
 use substrate_fixed::types::I32F32;


### PR DESCRIPTION
This PR fixes some tests and adds a test for tracking stake in total balance.  
- Mock Balance u128 -> u64 (match prod)
- Fix a few failing tests, that should not have been failing
- Add failing tests for tracking stake in the total issuance and total balance of an account   