### PR TITLE
[BIT-104] Max-upscale weights

### DIFF
--- a/pallets/subtensor/src/epoch.rs
+++ b/pallets/subtensor/src/epoch.rs
@@ -215,7 +215,7 @@ impl<T: Config> Pallet<T> {
         let cloned_consensus: Vec<u16> = consensus.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
         let cloned_incentive: Vec<u16> = incentive.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
         let cloned_dividends: Vec<u16> = dividends.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
-        let cloned_pruning_scores: Vec<u16> = pruning_scores.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
+        let cloned_pruning_scores: Vec<u16> = vec_max_upscale_to_u16(&pruning_scores);
         let cloned_validator_trust: Vec<u16> = validator_trust.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
         Active::<T>::insert( netuid, active.clone() );
         Emission::<T>::insert( netuid, cloned_emission );
@@ -485,7 +485,7 @@ impl<T: Config> Pallet<T> {
         let cloned_consensus: Vec<u16> = consensus.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
         let cloned_incentive: Vec<u16> = incentive.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
         let cloned_dividends: Vec<u16> = dividends.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
-        let cloned_pruning_scores: Vec<u16> = pruning_scores.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
+        let cloned_pruning_scores: Vec<u16> = vec_max_upscale_to_u16(&pruning_scores);
         let cloned_validator_trust: Vec<u16> = validator_trust.iter().map(|xi| fixed_proportion_to_u16(*xi)).collect::<Vec<u16>>();
         Active::<T>::insert( netuid, active.clone() );
         Emission::<T>::insert( netuid, cloned_emission );

--- a/pallets/subtensor/src/math.rs
+++ b/pallets/subtensor/src/math.rs
@@ -836,13 +836,6 @@ mod tests {
         }  
     }
     
-    fn assert_vec_compare_u16(va: &Vec<u16>, vb: &Vec<u16>) {
-        assert!(va.len() == vb.len());
-        for i in 0..va.len(){
-            assert_eq!(va[i], vb[i]);
-        }  
-    }
-    
     fn assert_mat_compare(ma: &Vec<Vec<I32F32>>, mb: &Vec<Vec<I32F32>>, epsilon: I32F32) {
         assert!(ma.len() == mb.len());
         for row in 0..ma.len() {

--- a/pallets/subtensor/tests/epoch.rs
+++ b/pallets/subtensor/tests/epoch.rs
@@ -110,7 +110,7 @@ fn init_run_epochs(netuid: u16, n: u16, validators: &Vec<u16>, servers: &Vec<u16
 		else {
 			stake = if validators.contains(&key) { stake_per_validator } else { 0 }; // only validators receive stake
 		}
-		// let stake: u128 = 1; // alternative test: all nodes receive stake, should be same outcome, except stake
+		// let stake: u64 = 1; // alternative test: all nodes receive stake, should be same outcome, except stake
 		SubtensorModule::add_balance_to_coldkey_account( &(key as u64), stake );
 		SubtensorModule::append_neuron( netuid, &(key as u64), 0 );
 		SubtensorModule::increase_stake_on_coldkey_hotkey_account( &(key as u64), &(key as u64), stake as u64 );
@@ -667,7 +667,8 @@ fn test_active_stake() {
 			D: [0.55, 0.4499999997, 0, 0]
 			nE: [0.275, 0.2249999999, 0.25, 0.25]
 			E: [274999999, 224999999, 250000000, 250000000]
-			P: [0.275, 0.2249999999, 0.25, 0.25] */
+			P: [0.275, 0.2249999999, 0.25, 0.25]
+			P (u16): [65535, 53619, 59577, 59577] */
 		let bonds = SubtensorModule::get_bonds( netuid );
 		assert_eq!( SubtensorModule::get_dividends_for_uid( netuid, 0 ), 36044 ); // Note D = floor((0.5 * 0.9 + 0.1) * 65_535)
 		assert_eq!( SubtensorModule::get_emission_for_uid( netuid, 0 ), 274999999 ); // Note E = 0.5 * 0.55 * 1_000_000_000 = 275_000_000 (discrepancy)
@@ -710,7 +711,8 @@ fn test_active_stake() {
 			D: [0.5450041203, 0.4549958794, 0, 0]
 			nE: [0.27250206, 0.2274979397, 0.25, 0.25]
 			E: [272502060, 227497939, 250000000, 250000000]
-			P: [0.27250206, 0.2274979397, 0.25, 0.25] */
+			P: [0.27250206, 0.2274979397, 0.25, 0.25]
+			P (u16): [65535, 54711, 60123, 60123] */
 		let bonds = SubtensorModule::get_bonds( netuid );
 		assert_eq!( SubtensorModule::get_dividends_for_uid( netuid, 0 ), 35716 ); // Note D = floor((0.55 * 0.9 + 0.5 * 0.1) * 65_535)
 		assert_eq!( SubtensorModule::get_emission_for_uid( netuid, 0 ), 272502060 ); // Note E = 0.5 * (0.55 * 0.9 + 0.5 * 0.1) * 1_000_000_000 = 272_500_000 (discrepancy)
@@ -787,7 +789,7 @@ fn test_outdated_weights() {
 			nE: [0.25, 0.25, 0.3333333333, 0.1666666665]
 			E: [250000000, 250000000, 333333333, 166666666]
 			P: [0.25, 0.25, 0.3333333333, 0.1666666665]
-			n: 4 */
+			P (u16): [49151, 49151, 65535, 32767] */
 
 		// === Dereg server2 at uid3 (least emission) + register new key over uid3
 		let new_key: u64 = n as u64; // register a new key while at max capacity, which means the least incentive uid will be deregistered
@@ -831,7 +833,8 @@ fn test_outdated_weights() {
 			D: [0.5, 0.5, 0, 0]
 			nE: [0.25, 0.25, 0.5, 0]
 			E: [250000000, 250000000, 500000000, 0]
-			P: [0.25, 0.25, 0.5, 0] */
+			P: [0.25, 0.25, 0.5, 0]
+			P (u16): [32767, 32767, 65535, 0] */
 		let bonds = SubtensorModule::get_bonds( netuid );
 		assert_eq!( SubtensorModule::get_dividends_for_uid( netuid, 0 ), 32767 ); // Note D = floor(0.5 * 65_535)
 		assert_eq!( SubtensorModule::get_emission_for_uid( netuid, 0 ), 250000000 ); // Note E = 0.5 * 0.5 * 1_000_000_000 = 249311245
@@ -1004,7 +1007,7 @@ fn test_validator_permits() {
 
 					// === Increase server stake above validators
 					for server in &servers {
-						SubtensorModule::add_balance_to_coldkey_account( &(*server as u64), 2*network_n as u64 );
+						SubtensorModule::add_balance_to_coldkey_account( &(*server as u64), 2 * network_n as u64 );
 						SubtensorModule::increase_stake_on_coldkey_hotkey_account( &(*server as u64), &(*server as u64), 2*network_n as u64 );
 					}
 

--- a/pallets/subtensor/tests/weights.rs
+++ b/pallets/subtensor/tests/weights.rs
@@ -383,12 +383,8 @@ fn test_set_weights_sum_larger_than_u16_max() {
 		assert_ok!(result);
 
 		let all_weights: Vec<Vec<I32F32>> = SubtensorModule::get_weights(netuid);
-		let weights_set: Vec<u16> = all_weights[neuron_uid as usize].iter().map(|x| x.to_bits() as u16).collect();
-
-		// Should sum less than u16 max.
-		assert!(weights_set.iter().map(|x| *x as u64).sum::<u64>() <= (u16::MAX as u64) );
-
-		// Should be normalized to 50% each.
-		assert_eq!(weights_set, vec![u16::MAX/2, u16::MAX/2]);
+		let weights_set: &Vec<I32F32> = &all_weights[neuron_uid as usize];
+		assert_eq!( weights_set[0], I32F32::from_num(1) );
+		assert_eq!( weights_set[1], I32F32::from_num(1) );
 	});
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -111,7 +111,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 115,
+	spec_version: 116,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -111,7 +111,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 116,
+	spec_version: 117,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
### [BIT-104] Max-upscale weights

Now stores max-upscaled u16 weights, instead of normalized u16 weights, to maximize u16 utilization. With max-upscaled u16 weights, we have `max_weight=u16::MAX`. Weight normalization is eventually done in epoch, but weight storage can be unnormalized.