### PR TITLE
Move bench functions

### DIFF
--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -37,6 +37,7 @@ pub enum Subcommand {
 	Revert(sc_cli::RevertCmd),
 
 	// Sub-commands concerned with benchmarking.
+	#[cfg(feature = "runtime-benchmarks")]
 	#[command(subcommand)]
 	Benchmark(frame_benchmarking_cli::BenchmarkCmd),
 

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -1,14 +1,21 @@
 use crate::{
-	benchmarking::{inherent_benchmark_data, RemarkBuilder, TransferKeepAliveBuilder},
 	chain_spec,
 	cli::{Cli, Subcommand},
 	service,
 };
-use frame_benchmarking_cli::{BenchmarkCmd, ExtrinsicFactory, SUBSTRATE_REFERENCE_HARDWARE};
-use node_subtensor_runtime::{Block, EXISTENTIAL_DEPOSIT};
+
+#[cfg(feature = "runtime-benchmarks")]
+pub use crate::benchmarking::{inherent_benchmark_data, RemarkBuilder, TransferKeepAliveBuilder};
+#[cfg(feature = "runtime-benchmarks")]
+pub use frame_benchmarking_cli::{BenchmarkCmd, ExtrinsicFactory, SUBSTRATE_REFERENCE_HARDWARE};
+#[cfg(feature = "runtime-benchmarks")]
+pub use sp_keyring::Sr25519Keyring;
+#[cfg(feature = "runtime-benchmarks")]
+pub use node_subtensor_runtime::EXISTENTIAL_DEPOSIT;
+
+use node_subtensor_runtime::Block;
 use sc_cli::{ChainSpec, RuntimeVersion, SubstrateCli};
 use sc_service::PartialComponents;
-use sp_keyring::Sr25519Keyring;
 
 impl SubstrateCli for Cli {
 	fn impl_name() -> String {
@@ -105,6 +112,7 @@ pub fn run() -> sc_cli::Result<()> {
 				Ok((cmd.run(client, backend, Some(aux_revert)), task_manager))
 			})
 		},
+		#[cfg(feature = "runtime-benchmarks")]
 		Some(Subcommand::Benchmark(cmd)) => {
 			let runner = cli.create_runner(cmd)?;
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -4,10 +4,11 @@
 mod chain_spec;
 #[macro_use]
 mod service;
-mod benchmarking;
 mod cli;
 mod command;
 mod rpc;
+#[cfg(feature = "runtime-benchmarks")]
+mod benchmarking;
 
 fn main() -> sc_cli::Result<()> {
 	command::run()

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1531,14 +1531,18 @@ pub mod pallet {
 		pub fn sudo_set_total_issuance(origin: OriginFor<T>, total_issuance: u64 ) -> DispatchResult {
 			Self::do_set_total_issuance(origin, total_issuance)
 		}
-		
+
 		#[pallet::call_index(47)]
 		#[pallet::weight((Weight::from_ref_time(49_882_000_000)
 		.saturating_add(T::DbWeight::get().reads(8303))
 		.saturating_add(T::DbWeight::get().writes(110)), DispatchClass::Normal, Pays::No))]
 		pub fn benchmark_epoch_with_weights( _:OriginFor<T> ) -> DispatchResult {
-			Self::epoch( 11, 1_000_000_000 );
-			Ok(())
+			if cfg!(feature = "runtime-benchmarks") {
+				Self::epoch( 11, 1_000_000_000 );
+				Ok(())
+			} else {
+				Err(DispatchError::Other("Benchmarking only."))
+			}
 		} 
 
 		#[pallet::call_index(48)]
@@ -1546,15 +1550,23 @@ pub mod pallet {
 		.saturating_add(T::DbWeight::get().reads(12299 as u64))
 		.saturating_add(T::DbWeight::get().writes(110 as u64)), DispatchClass::Normal, Pays::No))]
 		pub fn benchmark_epoch_without_weights( _:OriginFor<T> ) -> DispatchResult {
-			let _: Vec<(T::AccountId, u64)> = Self::epoch( 11, 1_000_000_000 );
-			Ok(())
+			if cfg!(feature = "runtime-benchmarks") {
+				let _: Vec<(T::AccountId, u64)> = Self::epoch( 11, 1_000_000_000 );
+				Ok(())
+			} else {
+				Err(DispatchError::Other("Benchmarking only."))
+			}
 		} 
 
 		#[pallet::call_index(49)]
 		#[pallet::weight((0, DispatchClass::Normal, Pays::No))]
 		pub fn benchmark_drain_emission( _:OriginFor<T> ) -> DispatchResult {
-			Self::drain_emission( 11 );
-			Ok(())
+			if cfg!(feature = "runtime-benchmarks") {
+				Self::drain_emission( 11 );
+				Ok(())
+			} else {
+				Err(DispatchError::Other("Benchmarking only."))
+			}
 		} 
 	}	
 
@@ -1571,6 +1583,7 @@ pub mod pallet {
 		}
 
 		// Benchmarking functions.
+		#[cfg(feature = "runtime-benchmarks")]
 		pub fn create_network( _: OriginFor<T>, netuid: u16, n: u16, tempo: u16 ) -> DispatchResult {
 			Self::init_new_network( netuid, tempo, 1 );
 			Self::set_max_allowed_uids( netuid, n );
@@ -1584,6 +1597,7 @@ pub mod pallet {
 			Ok(())
 		}
 
+		#[cfg(feature = "runtime-benchmarks")]
 		pub fn create_network_with_weights( _: OriginFor<T>, netuid: u16, n: u16, tempo: u16, n_vals: u16, n_weights: u16 ) -> DispatchResult {
 			Self::init_new_network( netuid, tempo, 1 );
 			Self::set_max_allowed_uids( netuid, n );

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -610,7 +610,8 @@ pub mod pallet {
 		TooManyUids, // ---- Thrown when the caller attempts to set weights with more uids than allowed.
 		TxRateLimitExceeded, // --- Thrown when a transactor exceeds the rate limit for transactions.
 		RegistrationDisabled, // --- Thrown when registration is disabled
-		TooManyRegistrationsThisInterval // --- Thrown when registration attempt exceeds allowed in interval
+		TooManyRegistrationsThisInterval, // --- Thrown when registration attempt exceeds allowed in interval
+		BenchmarkingOnly, // --- Thrown when a function is only available for benchmarking
 	}
 
 	// ==================
@@ -1537,12 +1538,10 @@ pub mod pallet {
 		.saturating_add(T::DbWeight::get().reads(8303))
 		.saturating_add(T::DbWeight::get().writes(110)), DispatchClass::Normal, Pays::No))]
 		pub fn benchmark_epoch_with_weights( _:OriginFor<T> ) -> DispatchResult {
-			if cfg!(feature = "runtime-benchmarks") {
-				Self::epoch( 11, 1_000_000_000 );
-				Ok(())
-			} else {
-				Err(DispatchError::Other("Benchmarking only."))
-			}
+			ensure!( cfg!(feature = "runtime-benchmarks"), Error::<T>::BenchmarkingOnly );
+		
+			Self::epoch( 11, 1_000_000_000 );
+			Ok(())
 		} 
 
 		#[pallet::call_index(48)]
@@ -1550,23 +1549,19 @@ pub mod pallet {
 		.saturating_add(T::DbWeight::get().reads(12299 as u64))
 		.saturating_add(T::DbWeight::get().writes(110 as u64)), DispatchClass::Normal, Pays::No))]
 		pub fn benchmark_epoch_without_weights( _:OriginFor<T> ) -> DispatchResult {
-			if cfg!(feature = "runtime-benchmarks") {
-				let _: Vec<(T::AccountId, u64)> = Self::epoch( 11, 1_000_000_000 );
-				Ok(())
-			} else {
-				Err(DispatchError::Other("Benchmarking only."))
-			}
+			ensure!( cfg!(feature = "runtime-benchmarks"), Error::<T>::BenchmarkingOnly );
+
+			let _: Vec<(T::AccountId, u64)> = Self::epoch( 11, 1_000_000_000 );
+			Ok(())
 		} 
 
 		#[pallet::call_index(49)]
 		#[pallet::weight((0, DispatchClass::Normal, Pays::No))]
 		pub fn benchmark_drain_emission( _:OriginFor<T> ) -> DispatchResult {
-			if cfg!(feature = "runtime-benchmarks") {
-				Self::drain_emission( 11 );
-				Ok(())
-			} else {
-				Err(DispatchError::Other("Benchmarking only."))
-			}
+			ensure!( cfg!(feature = "runtime-benchmarks"), Error::<T>::BenchmarkingOnly );
+		
+			Self::drain_emission( 11 );
+			Ok(())
 		} 
 	}	
 

--- a/pallets/subtensor/tests/benchmarking.rs
+++ b/pallets/subtensor/tests/benchmarking.rs
@@ -1,0 +1,60 @@
+use pallet_subtensor::Error;
+use frame_support::assert_ok;
+use frame_system::Config;
+use crate::mock::*;
+
+mod mock;
+
+/********************************************
+	test benchmarking extrinsics are enabled/disabled with flag
+*********************************************/
+
+#[test]
+fn test_benchmark_epoch_with_weights() {
+	new_test_ext().execute_with(|| {
+        let result = SubtensorModule::benchmark_epoch_with_weights(<<Test as Config>::RuntimeOrigin>::root());
+
+        if cfg!(feature = "runtime-benchmarks") {
+            // benchmarking enabled
+            assert_ok!(result);
+        } else {
+            // benchmarking disabled
+            // check error
+            assert_eq!(result, Err(Error::<Test>::InvalidEmissionValues.into()));
+        }
+	});
+}
+
+#[test]
+fn test_benchmark_epoch_without_weights() {
+	new_test_ext().execute_with(|| {
+        let result = SubtensorModule::benchmark_epoch_without_weights(<<Test as Config>::RuntimeOrigin>::root());
+
+        if cfg!(feature = "runtime-benchmarks") {
+            // benchmarking enabled
+            assert_ok!(result);
+        } else {
+            // benchmarking disabled
+            // check error
+            assert_eq!(result, Err(Error::<Test>::InvalidEmissionValues.into()));
+        }
+	});
+}
+
+#[test]
+fn test_benchmark_drain_emission() {
+	new_test_ext().execute_with(|| {
+        let result = SubtensorModule::benchmark_drain_emission(<<Test as Config>::RuntimeOrigin>::root());
+
+        if cfg!(feature = "runtime-benchmarks") {
+            // benchmarking enabled
+            assert_ok!(result);
+        } else {
+            // benchmarking disabled
+            // check error
+            assert_eq!(result, Err(Error::<Test>::InvalidEmissionValues.into()));
+        }
+	});
+}
+    
+    


### PR DESCRIPTION
This PR disables extrinsics related to benchmarking by returning an error if the feature is off.  

Note: Need to compile new runtime with feature flag missing `runtime-benchmarks`  