### PR TITLE
Publish Git Tag (+ Rust target) as GitHub Release

### DIFF
--- a/.github/workflows/publish-tag.yml
+++ b/.github/workflows/publish-tag.yml
@@ -1,0 +1,102 @@
+name: Rust build, benchmarks, and tests
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+##
+on:
+  ##
+  # Run when a semantic version is tagged
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+##
+# Environment variables shared for all targets
+env:
+  CARGO_TERM_COLOR: always
+  RELEASE: true
+  RELEASE_NAME: release
+  RUSTFLAGS: -A warnings
+  RUST_BACKTRACE: full
+  SKIP_WASM_BUILD: 1
+  VERBOSE: ${{ github.events.input.verbose }}
+
+##
+# Test and build and publish
+jobs:
+  check:
+    name: Tests and publishes targeting ${{ matrix.rust-target }} for OS ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    ##
+    # Define multiple targets for builds and tests
+    strategy:
+      matrix:
+        rust-branch:
+          - stable
+
+        rust-target:
+          - x86_64-unknown-linux-gnu
+          - x86_64-apple-darwin
+
+        os:
+          - ubuntu-latest
+          - macos-latest
+
+        include:
+          - os: ubuntu-latest
+          - os: macos-latest
+
+    ##
+    # Environment variables specific to each target
+    env:
+      RUSTV: ${{ matrix.rust-branch }}
+      RUST_BIN_DIR: target/${{ matrix.rust-target }}/release
+      TARGET: ${{ matrix.rust-target }}
+
+    ##
+    steps:
+      - name: Check-out repository under $GITHUB_WORKSPACE
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          sudo apt update &&
+          sudo apt install -y git clang curl libssl-dev llvm libudev-dev protobuf-compiler
+
+      - name: Install Rust ${{ matrix.rust-branch }}
+        uses: actions-rs/toolchain@v1.0.6
+        with:
+          toolchain: ${{ matrix.rust-branch }}
+          profile: minimal
+
+      - name: Utilize Rust shared cached
+        uses: Swatinem/rust-cache@v2.2.1
+        with:
+          key: ${{ matrix.os }}-${{ env.RUST_BIN_DIR }}
+
+      - name: Run tests
+        run: |
+          cargo test --tests
+
+      - name: Build executable
+        run: |
+          cargo build --release
+
+      ## TODO: double-check `artifacts` path(s) be correct
+      # :warning: values for the following must always match;
+      #   - RUST_BIN_DIR
+      #   - target/${{ matrix.rust-target }}/release/node-subtensor
+      - name: Create Release
+        uses: ncipollo/release-action@v1.12.0
+        with:
+          allowUpdates: false
+          artifactErrorsFailBuild: true
+          bodyFile: CHANGELOG.md
+          makeLatest: true
+          tag: ${{ github.ref }}-${{ matrix.rust-target }}
+          name: Release ${{ github.ref }} for ${{ matrix.rust-target }}
+          artifacts: 'raw_spec.json,raw_spec_finney.json,target/${{ matrix.rust-target }}/release/node-subtensor'
+


### PR DESCRIPTION
:warning:s

- `artifacts` paths will require updating after Finney
- `bodyFile` path will need populated, and edited for every Git Tag