### PR TITLE
Modify new reg code

### DIFF
--- a/pallets/subtensor/src/registration.rs
+++ b/pallets/subtensor/src/registration.rs
@@ -454,9 +454,9 @@ impl<T: Config> Pallet<T> {
     pub fn hash_block_and_hotkey( block_hash_bytes: &[u8], hotkey: &T::AccountId ) -> H256 {
         // Get the public key from the account id.
         let hotkey_pubkey: MultiAddress<T::AccountId, ()> = MultiAddress::Id( hotkey.clone() );
-
         let binding = hotkey_pubkey.encode();
-        let hotkey_bytes: &[u8] = binding.as_slice();
+        // Skip extra 0th byte.
+        let hotkey_bytes: &[u8] = binding[1..].as_ref();
         let full_bytes: &[u8; 64] = &[
             block_hash_bytes[0], block_hash_bytes[1], block_hash_bytes[2], block_hash_bytes[3],
             block_hash_bytes[4], block_hash_bytes[5], block_hash_bytes[6], block_hash_bytes[7],
@@ -480,6 +480,7 @@ impl<T: Config> Pallet<T> {
         ];
         let keccak_256_seal_hash_vec: [u8; 32] = keccak_256 ( full_bytes );
         let seal_hash: H256 = H256::from_slice( &keccak_256_seal_hash_vec );
+
         return seal_hash;
     }
 

--- a/pallets/subtensor/src/registration.rs
+++ b/pallets/subtensor/src/registration.rs
@@ -3,12 +3,10 @@ use frame_support::{ pallet_prelude::DispatchResult};
 use sp_std::convert::TryInto;
 use sp_core::{H256, U256};
 use crate::system::ensure_root;
-use sp_io::hashing::sha2_256;
-use sp_io::hashing::{keccak_512, keccak_256};
+use sp_io::hashing::{sha2_256, keccak_256};
 use frame_system::{ensure_signed};
 use sp_std::vec::Vec;
 use substrate_fixed::types::I32F32;
-use sp_core::H512;
 
 const LOG_TARGET: &'static str = "runtime::subtensor::registration";
 
@@ -452,7 +450,7 @@ impl<T: Config> Pallet<T> {
         return hash_as_vec
     }
 
-    pub fn hash_block_and_hotkey( block_hash_bytes: &[u8], hotkey: &T::AccountId ) -> H512 {
+    pub fn hash_block_and_hotkey( block_hash_bytes: &[u8], hotkey: &T::AccountId ) -> H256 {
         let binding = hotkey.encode();
         let hotkey_bytes: &[u8] = binding.as_slice();
         let full_bytes: &[u8; 64] = &[
@@ -476,8 +474,8 @@ impl<T: Config> Pallet<T> {
             hotkey_bytes[24], hotkey_bytes[25], hotkey_bytes[26], hotkey_bytes[27],
             hotkey_bytes[28], hotkey_bytes[29], hotkey_bytes[30], hotkey_bytes[31],
         ];
-        let keccak_512_seal_hash_vec: [u8; 64] = keccak_512 ( full_bytes );
-        let seal_hash: H512 = H512::from_slice( &keccak_512_seal_hash_vec );
+        let keccak_256_seal_hash_vec: [u8; 32] = keccak_256 ( full_bytes );
+        let seal_hash: H256 = H256::from_slice( &keccak_256_seal_hash_vec );
         return seal_hash;
     }
 

--- a/pallets/subtensor/src/registration.rs
+++ b/pallets/subtensor/src/registration.rs
@@ -1,7 +1,11 @@
+use core::ops::Add;
+
 use super::*;
 use frame_support::{ pallet_prelude::DispatchResult};
+use pallet_balances::AccountData;
+use sp_runtime::MultiAddress;
 use sp_std::convert::TryInto;
-use sp_core::{H256, U256};
+use sp_core::{H256, U256, sr25519, Public};
 use crate::system::ensure_root;
 use sp_io::hashing::{sha2_256, keccak_256};
 use frame_system::{ensure_signed};
@@ -451,7 +455,10 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn hash_block_and_hotkey( block_hash_bytes: &[u8], hotkey: &T::AccountId ) -> H256 {
-        let binding = hotkey.encode();
+        // Get the public key from the account id.
+        let hotkey_pubkey: MultiAddress<T::AccountId, ()> = MultiAddress::Id( hotkey.clone() );
+
+        let binding = hotkey_pubkey.encode();
         let hotkey_bytes: &[u8] = binding.as_slice();
         let full_bytes: &[u8; 64] = &[
             block_hash_bytes[0], block_hash_bytes[1], block_hash_bytes[2], block_hash_bytes[3],

--- a/pallets/subtensor/src/registration.rs
+++ b/pallets/subtensor/src/registration.rs
@@ -1,11 +1,8 @@
-use core::ops::Add;
-
 use super::*;
 use frame_support::{ pallet_prelude::DispatchResult};
-use pallet_balances::AccountData;
 use sp_runtime::MultiAddress;
 use sp_std::convert::TryInto;
-use sp_core::{H256, U256, sr25519, Public};
+use sp_core::{H256, U256};
 use crate::system::ensure_root;
 use sp_io::hashing::{sha2_256, keccak_256};
 use frame_system::{ensure_signed};


### PR DESCRIPTION
- use 256-bit keccak because we only use the first 32 bytes
- grab the public key from the account id before hash