### PR TITLE
Allow for newer version_keys >= WeightsVersionKey

### DIFF
--- a/pallets/subtensor/src/weights.rs
+++ b/pallets/subtensor/src/weights.rs
@@ -136,7 +136,7 @@ impl<T: Config> Pallet<T> {
     pub fn check_version_key( netuid: u16, version_key: u64) -> bool {
         let network_version_key: u64 = WeightsVersionKey::<T>::get( netuid );
         log::info!("check_version_key( network_version_key:{:?}, version_key:{:?} )", network_version_key, version_key );
-        return network_version_key == 0 || version_key == network_version_key;
+        return network_version_key == 0 || version_key >= network_version_key;
     }
 
     // Checks if the neuron has set weights within the weights_set_rate_limit.

--- a/pallets/subtensor/tests/weights.rs
+++ b/pallets/subtensor/tests/weights.rs
@@ -82,8 +82,11 @@ fn test_weights_version_key() {
 		assert_ok!( SubtensorModule::set_weights(RuntimeOrigin::signed(hotkey), netuid0, weights_keys.clone(), weight_values.clone(), key0) );
 		assert_ok!( SubtensorModule::set_weights(RuntimeOrigin::signed(hotkey), netuid1, weights_keys.clone(), weight_values.clone(), key1) );
 
+		// validator:20313 >= network:12312 (accepted: validator newer)
+		assert_ok!( SubtensorModule::set_weights(RuntimeOrigin::signed(hotkey), netuid0, weights_keys.clone(), weight_values.clone(), key1) );
+
 		// Setting fails with incorrect keys.
-		assert_eq!( SubtensorModule::set_weights(RuntimeOrigin::signed(hotkey), netuid0, weights_keys.clone(), weight_values.clone(), key1), Err(Error::<Test>::IncorrectNetworkVersionKey.into()) );
+		// validator:12312 < network:20313 (rejected: validator not updated)
 		assert_eq!( SubtensorModule::set_weights(RuntimeOrigin::signed(hotkey), netuid1, weights_keys.clone(), weight_values.clone(), key0), Err(Error::<Test>::IncorrectNetworkVersionKey.into()) );
 	});
 }


### PR DESCRIPTION
### Allow for newer version_keys >= WeightsVersionKey

WeightsVersionKey only needs updating when bittensor code changes validator operation, e.g. changes in measuring neuron performance, score computation, and weight setting.