### PR TITLE
Fix toolchain installation

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,10 +29,7 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           source ~/.cargo/env
-          rustup default stable
-          rustup update nightly
-          rustup update stable
-          rustup target add wasm32-unknown-unknown --toolchain nightly
+          ./scripts/init.sh
 
       - name: Check Build
         run: |

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -4,9 +4,12 @@ set -e
 
 echo "*** Initializing WASM build environment"
 
+# remove old nightlies
+rustup toolchain remove nightly
+
 if ! (( ${#CI_PROJECT_NAME} )) ; then
-   rustup update nightly
+   rustup update nightly-2023-01-18
    rustup update stable
 fi
 
-rustup target add wasm32-unknown-unknown --toolchain nightly
+rustup target add wasm32-unknown-unknown --toolchain nightly-2023-01-18


### PR DESCRIPTION
This PR fixes the toolchain installation script `init.sh` such that it builds the January build (last compatible nightly build) of cargo.

