### PR TITLE
Updating docker-compose.yaml - Using dns for bootnodes address

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,4 +17,15 @@ services:
       - "9933"
     environment:
       - CARGO_HOME=/var/www/node-subtensor/.cargo
-    command: bash -c "./node-subtensor --base-path /tmp/blockchain --chain ./raw_spec.json --rpc-external --ws-external --rpc-cors all --no-mdns --ws-max-connections 10000 --in-peers 500 --out-peers 500 --bootnodes /ip4/198.211.116.226/tcp/30333/ws/p2p/12D3KooWNiCmFH6aQiyqnYP6uU3Vdgv69ZhtsP2vPXPqMi6YEBmU --sync warp"
+    command:
+      - /bin/bash
+      - -c
+      - |
+        ./node-subtensor \
+          --base-path /tmp/blockchain \
+          --chain ./raw_spec.json \
+          --rpc-external --rpc-cors all \
+          --ws-external --no-mdns \
+          --ws-max-connections 10000 --in-peers 500 --out-peers 500 \
+          --bootnodes /dns/bootnode.finney.opentensor.ai/tcp/30333/ws/p2p/12D3KooWNiCmFH6aQiyqnYP6uU3Vdgv69ZhtsP2vPXPqMi6YEBmU \
+          --sync warp


### PR DESCRIPTION
## What is this about?

- Using DNS instead of IP for bootnodes address within docker-compose
- a bit of boyscoutting
  - formatting docker compose command as multiline string