### PR TITLE
:memo: Draft templates for Pull Requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/add-feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/add-feature.md
@@ -1,0 +1,22 @@
+## Description
+
+<!--
+  Expand on the title of your Pull Request
+-->
+
+
+______
+
+
+## Checklist
+
+<!--
+  Please remove or strike-out irrelevant options
+-->
+
+- [ ] Added tests for intended behaviors
+- [ ] Added tests for error and/or panic states
+- [ ] Updated relevant documentation
+- [ ] Tracked `rustfmt` changes
+- [ ] No _new_ compiler warnings
+

--- a/.github/PULL_REQUEST_TEMPLATE/fix-bug.md
+++ b/.github/PULL_REQUEST_TEMPLATE/fix-bug.md
@@ -1,0 +1,21 @@
+## Description
+
+<!--
+  Expand on the title of your Pull Request
+-->
+
+
+______
+
+
+## Checklist
+
+<!--
+  Please remove or strike-out irrelevant options
+-->
+
+- [ ] Updated relevant documentation
+- [ ] Updated relevant tests
+- [ ] Tracked `rustfmt` changes
+- [ ] No _new_ compiler warnings
+


### PR DESCRIPTION
## Description


Added files _should_ allow for choosing a template via [Web-UI][1], or using [query-parameters][2], plus GitHub supports the use of [check-boxes][3] which is nice for drafts/work-in-progress (WiP) status Pull Requests


______


## Checklist

<!--
  Please remove or strike-out irrelevant options
-->

- ~~[ ] Added tests for intended behaviors~~
- ~~[ ] Added tests for error and/or panic states~~
- ~~[ ] Updated relevant documentation~~
- ~~[ ] Tracked `rustfmt` changes~~
- ~~[ ] No _new_ compiler warnings~~


[1]: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
[2]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request
[3]: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/about-task-lists
