### PR TITLE
:bug: Fix looping over recently changed files

### DIFF
--- a/.cargo-husky/hooks/post-commit
+++ b/.cargo-husky/hooks/post-commit
@@ -25,7 +25,7 @@ __hey_listen__() {
 	fi
 }
 
-while read -rd '' _path; do
+while read -r _path; do
 	if rustup run nightly -- rustfmt --check --quiet -- "${_path}" 1>/dev/null 2>&1; then
 		__hey_listen__ "Skipping -> ${_path}"
 		continue 1


### PR DESCRIPTION
:warning: This will cause churn, and may cause conflicts, until everyone is utilizing the same `.rustfmt.toml` configurations!

:notebook: After merging everyone using Git hooks must manually update via something like

```bash
cp .cargo-husky/hooks/post-commit .git/hooks/
```

:warning: Directory/file paths with spaces may make this loop misbehave