### PR TITLE
[BIT-325] Disallow <= 0 in port argument of serve_* functions

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -582,6 +582,7 @@ pub mod pallet {
 		InvalidModality, // --- Thrown when an invalid modality attempted on serve.
 		InvalidIpType, // ---- Thrown when the user tries to serve an axon which is not of type	4 (IPv4) or 6 (IPv6).
 		InvalidIpAddress, // --- Thrown when an invalid IP address is passed to the serve function.
+		InvalidPort, // --- Thrown when an invalid port is passed to the serve function.
 		NotRegistered, // ---- Thrown when the caller requests setting or removing data from a neuron which does not exist in the active set.
 		NonAssociatedColdKey, // ---- Thrown when a stake, unstake or subscribe request is made by a coldkey which is not associated with the hotkey account. 
 		NotEnoughStaketoWithdraw, // ---- Thrown when the caller requests removing more stake then there exists in the staking account. See: fn remove_stake.

--- a/pallets/subtensor/src/serving.rs
+++ b/pallets/subtensor/src/serving.rs
@@ -79,7 +79,7 @@ impl<T: Config> Pallet<T> {
         // --- 4. Get the previous axon information.
         let mut prev_axon = Self::get_axon_info( netuid, &hotkey_id );
         let current_block:u64 = Self::get_current_block_as_u64();
-        ensure!( Self::axon_passes_rate_limit( netuid, &prev_axon, current_block ), Error::<T>::ServingRateLimitExceeded );  
+        ensure!( Self::axon_passes_rate_limit( netuid, &prev_axon, current_block ), Error::<T>::ServingRateLimitExceeded ); 
 
         // --- 6. We insert the axon meta.
         prev_axon.block = Self::get_current_block_as_u64();

--- a/pallets/subtensor/src/serving.rs
+++ b/pallets/subtensor/src/serving.rs
@@ -275,7 +275,7 @@ impl<T: Config> Pallet<T> {
     }
 
 	pub fn validate_axon_data(axon_info: &AxonInfoOf) -> Result<bool, pallet::Error<T>> {
-		if axon_info.port <= 0 {
+		if axon_info.port.clamp(0, u16::MAX) <= 0 {
 			return Err(Error::<T>::InvalidPort);
 		}
 
@@ -283,7 +283,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	pub fn validate_prometheus_data(prom_info: &PrometheusInfoOf) -> Result<bool, pallet::Error<T>> {
-		if prom_info.port <= 0 {
+		if prom_info.port.clamp(0, u16::MAX) <= 0 {
 			return Err(Error::<T>::InvalidPort);
 		}
 

--- a/pallets/subtensor/src/serving.rs
+++ b/pallets/subtensor/src/serving.rs
@@ -90,13 +90,18 @@ impl<T: Config> Pallet<T> {
         prev_axon.protocol = protocol;
         prev_axon.placeholder1 = placeholder1;
         prev_axon.placeholder2 = placeholder2;
+
+		// --- 7. Validate axon data with delegate func
+		let axon_validated = Self::validate_axon_data(&prev_axon);
+		ensure!( axon_validated.is_ok(), axon_validated.err().unwrap_or(Error::<T>::InvalidPort) );
+
         Axons::<T>::insert( netuid, hotkey_id.clone(), prev_axon );
 
-        // --- 7. We deposit axon served event.
+        // --- 8. We deposit axon served event.
         log::info!("AxonServed( hotkey:{:?} ) ", hotkey_id.clone() );
         Self::deposit_event(Event::AxonServed( netuid, hotkey_id ));
 
-        // --- 8. Return is successful dispatch. 
+        // --- 9. Return is successful dispatch. 
         Ok(())
     }
 
@@ -170,13 +175,19 @@ impl<T: Config> Pallet<T> {
         prev_prometheus.ip = ip;
         prev_prometheus.port = port;
         prev_prometheus.ip_type = ip_type;
+
+		// --- 7. Validate prometheus data with delegate func
+		let prom_validated = Self::validate_prometheus_data(&prev_prometheus);
+		ensure!( prom_validated.is_ok(), prom_validated.err().unwrap_or(Error::<T>::InvalidPort) );
+
+		// --- 8. Insert new prometheus data
         Prometheus::<T>::insert( netuid, hotkey_id.clone(), prev_prometheus );
 
-        // --- 7. We deposit prometheus served event.
+        // --- 9. We deposit prometheus served event.
         log::info!("PrometheusServed( hotkey:{:?} ) ", hotkey_id.clone() );
         Self::deposit_event(Event::PrometheusServed( netuid, hotkey_id ));
 
-        // --- 8. Return is successful dispatch. 
+        // --- 10. Return is successful dispatch. 
         Ok(())
     }
 

--- a/pallets/subtensor/src/serving.rs
+++ b/pallets/subtensor/src/serving.rs
@@ -263,5 +263,20 @@ impl<T: Config> Pallet<T> {
         return true;
     }
 
+	pub fn validate_axon_data(axon_info: &AxonInfoOf) -> Result<bool, pallet::Error<T>> {
+		if axon_info.port <= 0 {
+			return Err(Error::<T>::InvalidPort);
+		}
+
+		Ok(true)
+	}
+
+	pub fn validate_prometheus_data(prom_info: &PrometheusInfoOf) -> Result<bool, pallet::Error<T>> {
+		if prom_info.port <= 0 {
+			return Err(Error::<T>::InvalidPort);
+		}
+
+		Ok(true)
+	}
 
 }

--- a/pallets/subtensor/tests/serving.rs
+++ b/pallets/subtensor/tests/serving.rs
@@ -147,6 +147,27 @@ fn test_axon_serving_rate_limit_exceeded() {
 }
 
 #[test]
+fn test_axon_invalid_port() {
+	new_test_ext().execute_with(|| {
+                let hotkey_account_id = U256::from(1);
+                let netuid: u16 = 1;
+                let tempo: u16 = 13;
+                let version: u32 = 2;
+                let ip: u128 = 1676056785;
+                let port: u16 = 0;
+                let ip_type: u8 = 4;
+                let modality: u16 = 0;
+                let protocol: u8 = 0;
+                let placeholder1: u8 = 0;
+                let placeholder2: u8 = 0;
+                add_network(netuid, tempo, modality);
+                register_ok_neuron( netuid, hotkey_account_id, U256::from(66), 0);
+                run_to_block(1); // Go to block 1
+                assert_eq!(SubtensorModule::serve_axon(<<Test as Config>::RuntimeOrigin>::signed(hotkey_account_id), netuid, version, ip, port, ip_type, protocol, placeholder1, placeholder2), Err(Error::<Test>::InvalidPort.into()) );    
+        });
+}
+
+#[test]
 fn test_prometheus_serving_subscribe_ok_dispatch_info_ok() {
 	new_test_ext().execute_with(|| {
 				let netuid: u16 = 1;
@@ -243,6 +264,23 @@ fn test_prometheus_serving_rate_limit_exceeded() {
         });
 }
 
+#[test]
+fn test_prometheus_invalid_port() {
+	new_test_ext().execute_with(|| {
+                let hotkey_account_id = U256::from(1);
+                let netuid: u16 = 1;
+                let tempo: u16 = 13;
+                let version: u32 = 2;
+                let ip: u128 = 1676056785;
+                let port: u16 = 0;
+                let ip_type: u8 = 4;
+                let modality: u16 = 0;
+                add_network(netuid, tempo, modality);
+                register_ok_neuron( netuid, hotkey_account_id, U256::from(66), 0);
+                run_to_block(1); // Go to block 1
+                assert_eq!(SubtensorModule::serve_prometheus(<<Test as Config>::RuntimeOrigin>::signed(hotkey_account_id), netuid, version, ip, port, ip_type), Err(Error::<Test>::InvalidPort.into()) );    
+        });
+}
 
 #[test]
 fn test_serving_is_valid_ip_type_ok_ipv4() {


### PR DESCRIPTION
This addresses issue BIT-326 by creating a new function that delegates input validation for serve_prometheus and serve_axon extrinsics. Execution time shouldn't be impacted by much but still recommend benchmarking once this is merged into main.