### PR TITLE
[BIT-324] Handle DispatchError result using ensure! over panic!

### DIFF
--- a/pallets/subtensor/src/weights.rs
+++ b/pallets/subtensor/src/weights.rs
@@ -85,8 +85,11 @@ impl<T: Config> Pallet<T> {
 
         // --- 7. Get the neuron uid of associated hotkey on network netuid.
         let neuron_uid;
-        match Self::get_uid_for_net_and_hotkey( netuid, &hotkey ) { Ok(k) => neuron_uid = k, Err(e) => panic!("Error: {:?}", e) } 
+		let net_neuron_uid = Self::get_uid_for_net_and_hotkey( netuid, &hotkey );
+		ensure!( net_neuron_uid.is_ok(), net_neuron_uid.err().unwrap_or(Error::<T>::NotRegistered.into()) );
 
+		neuron_uid = net_neuron_uid.unwrap();
+		
         // --- 8. Ensure the uid is not setting weights faster than the weights_set_rate_limit.
         let current_block: u64 = Self::get_current_block_as_u64();
         ensure!( Self::check_rate_limit( netuid, neuron_uid, current_block ), Error::<T>::SettingWeightsTooFast );


### PR DESCRIPTION
This addresses BIT-324, now DispatchError returned in a result from `get_uid_for_net_and_hotkey` is properly handled and thrown using the `ensure!` macro.