### PR TITLE
Add proj toolchain conf, localnet mkdir and peer auto discovery

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "nightly-2023-03-01"
+components = [ "rustfmt" ]
+targets = [ "wasm32-unknown-unknown" ]
+profile = "minimal"

--- a/scripts/localnet.sh
+++ b/scripts/localnet.sh
@@ -6,6 +6,11 @@
 
 FULL_PATH="$SPEC_PATH$CHAIN.json"
 
+if [ ! -d "$SPEC_PATH" ]; then
+  	echo "*** Creating directory ${SPEC_PATH}..."
+	mkdir $SPEC_PATH
+fi
+
 if [[ $BUILD_BINARY == "1" ]]; then
 	echo "*** Building substrate binary..."
 	cargo build --release --features runtime-benchmarks 1>/dev/null
@@ -32,7 +37,8 @@ alice_start=(
 	--rpc-port 9934
 	--validator
 	--rpc-cors=all
-	--execution native
+	--allow-private-ipv4
+	--discover-local
 )
 
 bob_start=(
@@ -44,8 +50,8 @@ bob_start=(
 	--ws-port 9947
 	--rpc-port 9935
 	--validator
-	--execution native
-	--bootnodes "/ip4/127.0.0.1/tcp/30334/p2p/12D3KooWBBUaVWE5SYj3UvnoXojfS8fvPorw5biRDaDQV7XXwCXm"
+	--allow-private-ipv4
+	--discover-local
 )
 
 (trap 'kill 0' SIGINT; ("${alice_start[@]}" 2>&1) & ("${bob_start[@]}" 2>&1))

--- a/scripts/localnet.sh
+++ b/scripts/localnet.sh
@@ -7,7 +7,7 @@
 FULL_PATH="$SPEC_PATH$CHAIN.json"
 
 if [ ! -d "$SPEC_PATH" ]; then
-  	echo "*** Creating directory ${SPEC_PATH}..."
+	echo "*** Creating directory ${SPEC_PATH}..."
 	mkdir $SPEC_PATH
 fi
 


### PR DESCRIPTION
## Description


Ensure all compiles of subtensor are using a consistent toolchain, along with detecting if chainspec folde exists and creating it, and enabling auto-peer discovery for localnet nodes.

______


## Checklist

- [ ] ~Updated relevant documentation~
- [ ] ~Updated relevant tests~
- [ ] ~Tracked `rustfmt` changes~
- [X] No _new_ compiler warnings

