### PR TITLE
remove unused functions in block_step.rs

### DIFF
--- a/pallets/subtensor/src/block_step.rs
+++ b/pallets/subtensor/src/block_step.rs
@@ -162,28 +162,6 @@ impl<T: Config> Pallet<T> {
         Self::increase_stake_on_hotkey_account( &hotkey, server_emission );
     }
 
-    // Increases the stake on the cold - hot pairing by increment while also incrementing other counters.
-    // This function should be called rather than set_stake under account.
-    // 
-    pub fn block_step_increase_stake_on_coldkey_hotkey_account( coldkey: &T::AccountId, hotkey: &T::AccountId, increment: u64 ){
-        TotalColdkeyStake::<T>::mutate( coldkey, | old | old.saturating_add( increment ) );
-        TotalHotkeyStake::<T>::insert( hotkey, TotalHotkeyStake::<T>::get(hotkey).saturating_add( increment ) );
-        Stake::<T>::insert( hotkey, coldkey, Stake::<T>::get( hotkey, coldkey).saturating_add( increment ) );
-        TotalStake::<T>::put( TotalStake::<T>::get().saturating_add( increment ) );
-        TotalIssuance::<T>::put( TotalIssuance::<T>::get().saturating_add( increment ) );
-
-    }
-
-    // Decreases the stake on the cold - hot pairing by the decrement while decreasing other counters.
-    //
-    pub fn block_step_decrease_stake_on_coldkey_hotkey_account( coldkey: &T::AccountId, hotkey: &T::AccountId, decrement: u64 ){
-        TotalColdkeyStake::<T>::mutate( coldkey, | old | old.saturating_sub( decrement ) );
-        TotalHotkeyStake::<T>::insert( hotkey, TotalHotkeyStake::<T>::get(hotkey).saturating_sub( decrement ) );
-        Stake::<T>::insert( hotkey, coldkey, Stake::<T>::get( hotkey, coldkey).saturating_sub( decrement ) );
-        TotalStake::<T>::put( TotalStake::<T>::get().saturating_sub( decrement ) );
-        TotalIssuance::<T>::put( TotalIssuance::<T>::get().saturating_sub( decrement ) );
-    }
-
     // Returns emission awarded to a hotkey as a function of its proportion of the total stake.
     //
     pub fn calculate_stake_proportional_emission( stake: u64, total_stake:u64, emission: u64 ) -> u64 {


### PR DESCRIPTION
Removed the following methods that are not in used.

- block_step_increase_stake_on_coldkey_hotkey_account
- block_step_decrease_stake_on_coldkey_hotkey_account

@S0AndS0 @Rubberbandits @camfairchild 