### PR TITLE
Testnet config

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -69,6 +69,99 @@ struct ColdkeyHotkeys {
 	balances: std::collections::HashMap<String, u64>
 }
 
+pub fn development_config() -> Result<ChainSpec, String> {
+	let path: PathBuf = std::path::PathBuf::from("./snapshot.json");
+
+	let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;
+	
+	// We mmap the file into memory first, as this is *a lot* faster than using
+	// `serde_json::from_reader`. See https://github.com/serde-rs/json/issues/160
+	let file = File::open(&path)
+		.map_err(|e| format!("Error opening genesis file `{}`: {}", path.display(), e))?;
+
+	// SAFETY: `mmap` is fundamentally unsafe since technically the file can change
+	//         underneath us while it is mapped; in practice it's unlikely to be a problem
+	let bytes = unsafe {
+		memmap2::Mmap::map(&file)
+			.map_err(|e| format!("Error mmaping genesis file `{}`: {}", path.display(), e))?
+	};
+
+	let old_state: ColdkeyHotkeys =
+		json::from_slice(&bytes).map_err(|e| format!("Error parsing genesis file: {}", e))?;
+
+	let mut processed_stakes: Vec<(sp_runtime::AccountId32, Vec<(sp_runtime::AccountId32, (u64, u16))>)> = Vec::new();
+	for (coldkey_str, hotkeys) in old_state.stakes.iter() {
+		let coldkey = <sr25519::Public as Ss58Codec>::from_ss58check(&coldkey_str).unwrap();
+		let coldkey_account = sp_runtime::AccountId32::from(coldkey);
+
+		let mut processed_hotkeys: Vec<(sp_runtime::AccountId32, (u64, u16))> = Vec::new();
+
+		for (hotkey_str, amount_uid) in hotkeys.iter() {
+			let (amount, uid) = amount_uid;
+			let hotkey = <sr25519::Public as Ss58Codec>::from_ss58check(&hotkey_str).unwrap();
+			let hotkey_account = sp_runtime::AccountId32::from(hotkey);
+
+			processed_hotkeys.push((hotkey_account, (*amount, *uid)));
+		}
+
+		processed_stakes.push((coldkey_account, processed_hotkeys));
+	}
+
+	let mut balances_issuance: u64 = 0;
+	let mut processed_balances: Vec<(sp_runtime::AccountId32, u64)> = Vec::new();
+	for (key_str, amount) in old_state.balances.iter() {
+		let key = <sr25519::Public as Ss58Codec>::from_ss58check(&key_str).unwrap();
+		let key_account = sp_runtime::AccountId32::from(key);
+
+		processed_balances.push((key_account, *amount));
+		balances_issuance += *amount;
+	}
+
+	let mut properties = sc_service::Properties::new();
+	properties.insert("tokenSymbol".into(), "TAO".into());
+	properties.insert("tokenDecimals".into(), 9.into());
+	properties.insert("ss58Format".into(), 13116.into());
+	
+	Ok(ChainSpec::from_genesis(
+		// Name
+		"Development",
+		// ID
+		"dev",
+		ChainType::Development,
+		move || {
+			testnet_genesis(
+				wasm_binary,
+				// Initial PoA authorities
+				vec![authority_keys_from_seed("Alice")],
+				// Sudo account
+				get_account_id_from_seed::<sr25519::Public>("Alice"),
+				// Pre-funded accounts
+				vec![
+					get_account_id_from_seed::<sr25519::Public>("Alice"),
+					get_account_id_from_seed::<sr25519::Public>("Bob"),
+					get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
+					get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
+				],
+				true,
+				processed_stakes.clone(),
+				processed_balances.clone(),
+				balances_issuance
+			)
+		},
+		// Bootnodes
+		vec![],
+		// Telemetry
+		None,
+		// Protocol ID
+		None,
+		None,
+		// Properties
+		None,
+		// Extensions
+		None,
+	))
+}
+
 pub fn finney_mainnet_config() -> Result<ChainSpec, String> {
 	let path: PathBuf = std::path::PathBuf::from("./snapshot.json");
 	let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;
@@ -250,14 +343,7 @@ pub fn finney_testnet_config() -> Result<ChainSpec, String> {
 				// aura | grandpa
 				vec![
 					// Keys for debug
-					//authority_keys_from_seed("Alice"), authority_keys_from_seed("Bob"),
-					authority_keys_from_ss58("5D5ABUyMsdmJdH7xrsz9vREq5eGXr5pXhHxix2dENQR62dEo", "5H3qMjQjoeZxZ98jzDmoCwbz2sugd5fDN1wrr8Phf49zemKL"),// key 1
-					authority_keys_from_ss58("5GbRc5sNDdhcPAU9suV2g9P5zyK1hjAQ9JHeeadY1mb8kXoM", "5GbkysfaCjK3cprKPhi3CUwaB5xWpBwcfrkzs6FmqHxej8HZ"),// key 1
-					authority_keys_from_ss58("5CoVWwBwXz2ndEChGcS46VfSTb3RMUZzZzAYdBKo263zDhEz", "5HTLp4BvPp99iXtd8YTBZA1sMfzo8pd4mZzBJf7HYdCn2boU"),// key 1
-					authority_keys_from_ss58("5EekcbqupwbgWqF8hWGY4Pczsxp9sbarjDehqk7bdyLhDCwC", "5GAemcU4Pzyfe8DwLwDFx3aWzyg3FuqYUCCw2h4sdDZhyFvE"),// key 1
-					authority_keys_from_ss58("5GgdEQyS5DZzUwKuyucEPEZLxFKGmasUFm1mqM3sx1MRC5RV", "5EibpMomXmgekxcfs25SzFBpGWUsG9Lc8ALNjXN3TYH5Tube"),// key 1
-					authority_keys_from_ss58("5Ek5JLCGk2PuoT1fS23GXiWYUT98HVUBERFQBu5g57sNf44x", "5Gyrc6b2mx1Af6zWJYHdx3gwgtXgZvD9YkcG9uTUPYry4V2a"),// key 1
-					
+					authority_keys_from_seed("Alice"), authority_keys_from_seed("Bob"),
 					], 
 				// Sudo account
 				Ss58Codec::from_ss58check("5GpzQgpiAKHMWNSH3RN4GLf96GVTDct9QxYEFAY7LWcVzTbx").unwrap(), 

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -46,6 +46,7 @@ impl SubstrateCli for Cli {
 		Ok(match id {
 			"local" => Box::new(chain_spec::localnet_config()?),
 			"finney" => Box::new(chain_spec::finney_mainnet_config()?),
+			"dev" => Box::new(chain_spec::development_config()?),
 			"" |"test_finney" => Box::new(chain_spec::finney_testnet_config()?),
 			path =>
 				Box::new(chain_spec::ChainSpec::from_json_file(std::path::PathBuf::from(path))?),


### PR DESCRIPTION
This creates a config for testing subtensor locally. Everything is set up with pre-made accounts and so blocks finalize right away, no need to insert keys and etc. Simply run it with 

```
./target/release/node-subtensor --dev --tmp
```

`--dev` will specify this localized testnet setup. 
`--tmp` will ensure the node is ephemeral and all its resources deleted when it's stopped.