### PR TITLE
Add BondsPenalty hyperparam

### DIFF
--- a/pallets/subtensor/src/benchmarks.rs
+++ b/pallets/subtensor/src/benchmarks.rs
@@ -365,6 +365,16 @@ benchmarks! {
 
   }: sudo_set_bonds_moving_average(RawOrigin::<AccountIdOf<T>>::Root, netuid, bonds_moving_average)
 
+  benchmark_sudo_set_bonds_penalty {
+    let netuid: u16 = 1;
+    let bonds_penalty: u16 = 100;
+    let tempo: u16 = 1;
+    let modality: u16 = 0;
+
+    assert_ok!( Subtensor::<T>::do_add_network( RawOrigin::Root.into(), netuid.try_into().unwrap(), tempo.into(), modality.into()));
+
+  }: sudo_set_bonds_penalty(RawOrigin::<AccountIdOf<T>>::Root, netuid, bonds_penalty)
+
   benchmark_sudo_set_max_allowed_validators {
     let netuid: u16 = 1;
     let tempo: u16 = 1;

--- a/pallets/subtensor/src/utils.rs
+++ b/pallets/subtensor/src/utils.rs
@@ -404,6 +404,17 @@ impl<T: Config> Pallet<T> {
         Ok(())
     }
 
+    pub fn get_bonds_penalty( netuid: u16 ) -> u16 { BondsPenalty::<T>::get( netuid ) }
+    pub fn set_bonds_penalty( netuid: u16, bonds_penalty: u16 ) { BondsPenalty::<T>::insert( netuid, bonds_penalty ); }
+    pub fn do_sudo_set_bonds_penalty( origin:T::RuntimeOrigin, netuid: u16, bonds_penalty: u16 ) -> DispatchResult {
+        ensure_root( origin )?;
+        ensure!(Self::if_subnet_exist(netuid), Error::<T>::NetworkDoesNotExist);
+        Self::set_bonds_penalty( netuid, bonds_penalty );
+        log::info!("BondsPenaltySet( netuid: {:?} bonds_penalty: {:?} ) ", netuid, bonds_penalty );
+        Self::deposit_event( Event::BondsPenaltySet( netuid, bonds_penalty ) );
+        Ok(())
+    }
+
     pub fn get_max_registrations_per_block( netuid: u16 ) -> u16 { MaxRegistrationsPerBlock::<T>::get( netuid ) }
     pub fn set_max_registrations_per_block( netuid: u16, max_registrations_per_block: u16 ) { MaxRegistrationsPerBlock::<T>::insert( netuid, max_registrations_per_block ); }
     pub fn do_sudo_set_max_registrations_per_block(

--- a/pallets/subtensor/tests/epoch.rs
+++ b/pallets/subtensor/tests/epoch.rs
@@ -155,9 +155,11 @@ fn init_run_epochs(
     random_weights: bool,
     random_seed: u64,
     sparse: bool,
+    bonds_penalty: u16
 ) {
     // === Create the network
     add_network(netuid, u16::MAX - 1, 0); // set higher tempo to avoid built-in epoch, then manual epoch instead
+    SubtensorModule::set_bonds_penalty(netuid, bonds_penalty);
 
     // === Register uids
     SubtensorModule::set_max_allowed_uids(netuid, n);
@@ -408,21 +410,25 @@ fn test_consensus_guarantees() {
     let epochs: u16 = 1;
     let interleave = 2;
     log::info!("test_consensus_guarantees ({network_n:?}, {validators_n:?} validators)");
-    for (major_stake, major_weight, minor_weight, weight_stddev) in vec![
-        (0.51, 1., 1., 0.001),
-        (0.51, 0.03, 0., 0.001),
-        (0.51, 0.51, 0.49, 0.001),
-        (0.51, 0.51, 1., 0.001),
-        (0.51, 0.61, 0.8, 0.1),
-        (0.6, 0.67, 0.65, 0.2),
-        (0.6, 0.74, 0.77, 0.4),
-        (0.6, 0.76, 0.8, 0.4),
-        (0.6, 0.76, 1., 0.4),
-        (0.6, 0.92, 1., 0.4),
-        (0.6, 0.94, 1., 0.4),
-        (0.65, 0.78, 0.85, 0.6),
-        (0.7, 0.81, 0.85, 0.8),
-        (0.7, 0.83, 0.85, 1.),
+    for (major_stake, major_weight, minor_weight, weight_stddev, bonds_penalty) in vec![
+        (0.51, 1., 1., 0.001, u16::MAX),
+        (0.51, 0.03, 0., 0.001, u16::MAX),
+        (0.51, 0.51, 0.49, 0.001, u16::MAX),
+        (0.51, 0.51, 1., 0.001, u16::MAX),
+        (0.51, 0.61, 0.8, 0.1, u16::MAX),
+        (0.6, 0.67, 0.65, 0.2, u16::MAX),
+        (0.6, 0.74, 0.77, 0.4, u16::MAX),
+        (0.6, 0.76, 0.8, 0.4, u16::MAX),
+        (0.6, 0.73, 1., 0.4, u16::MAX), // bonds_penalty = 100%
+        (0.6, 0.74, 1., 0.4, 55800), // bonds_penalty = 85%
+        (0.6, 0.76, 1., 0.4, 43690), // bonds_penalty = 66%
+        (0.6, 0.78, 1., 0.4, 21845), // bonds_penalty = 33%
+        (0.6, 0.79, 1., 0.4, 0), // bonds_penalty = 0%
+        (0.6, 0.92, 1., 0.4, u16::MAX),
+        (0.6, 0.94, 1., 0.4, u16::MAX),
+        (0.65, 0.78, 0.85, 0.6, u16::MAX),
+        (0.7, 0.81, 0.85, 0.8, u16::MAX),
+        (0.7, 0.83, 0.85, 1., u16::MAX),
     ] {
         let (
             validators,
@@ -460,6 +466,7 @@ fn test_consensus_guarantees() {
                 false,
                 0,
                 false,
+                bonds_penalty
             );
 
             let mut major_emission: I64F64 = I64F64::from_num(0);
@@ -689,6 +696,7 @@ fn test_512_graph() {
                     false,
                     0,
                     false,
+                    u16::MAX
                 );
                 let bonds = SubtensorModule::get_bonds(netuid);
                 for uid in validators {
@@ -734,95 +742,99 @@ fn test_512_graph_random_weights() {
     let epochs: u16 = 1;
     log::info!("test_{network_n:?}_graph_random_weights ({validators_n:?} validators)");
     for interleave in 0..3 {
+        // server-self weight off/on
         for server_self in vec![false, true] {
-            // server-self weight off/on
-            let (validators, servers) = distribute_nodes(
-                validators_n as usize,
-                network_n as usize,
-                interleave as usize,
-            );
-            let server: usize = servers[0] as usize;
-            let validator: usize = validators[0] as usize;
-            let (mut rank, mut incentive, mut dividend, mut emission, mut bondv, mut bonds): (
-                Vec<u16>,
-                Vec<u16>,
-                Vec<u16>,
-                Vec<u64>,
-                Vec<I32F32>,
-                Vec<I32F32>,
-            ) = (vec![], vec![], vec![], vec![], vec![], vec![]);
-
-            // Dense epoch
-            new_test_ext().execute_with(|| {
-                init_run_epochs(
-                    netuid,
-                    network_n,
-                    &validators,
-                    &servers,
-                    epochs,
-                    1,
-                    server_self,
-                    &vec![],
-                    false,
-                    &vec![],
-                    false,
-                    true,
-                    interleave as u64,
-                    false,
+            for bonds_penalty in vec![0, u16::MAX/2, u16::MAX] {
+                let (validators, servers) = distribute_nodes(
+                    validators_n as usize,
+                    network_n as usize,
+                    interleave as usize,
                 );
+                let server: usize = servers[0] as usize;
+                let validator: usize = validators[0] as usize;
+                let (mut rank, mut incentive, mut dividend, mut emission, mut bondv, mut bonds): (
+                    Vec<u16>,
+                    Vec<u16>,
+                    Vec<u16>,
+                    Vec<u64>,
+                    Vec<I32F32>,
+                    Vec<I32F32>,
+                ) = (vec![], vec![], vec![], vec![], vec![], vec![]);
 
-                let bond = SubtensorModule::get_bonds(netuid);
-                for uid in 0..network_n {
-                    rank.push(SubtensorModule::get_rank_for_uid(netuid, uid));
-                    incentive.push(SubtensorModule::get_incentive_for_uid(netuid, uid));
-                    dividend.push(SubtensorModule::get_dividends_for_uid(netuid, uid));
-                    emission.push(SubtensorModule::get_emission_for_uid(netuid, uid));
-                    bondv.push(bond[uid as usize][validator]);
-                    bonds.push(bond[uid as usize][server]);
-                }
-            });
+                // Dense epoch
+                new_test_ext().execute_with(|| {
+                    init_run_epochs(
+                        netuid,
+                        network_n,
+                        &validators,
+                        &servers,
+                        epochs,
+                        1,
+                        server_self,
+                        &vec![],
+                        false,
+                        &vec![],
+                        false,
+                        true,
+                        interleave as u64,
+                        false,
+                        bonds_penalty
+                    );
 
-            // Sparse epoch (same random seed as dense)
-            new_test_ext().execute_with(|| {
-                init_run_epochs(
-                    netuid,
-                    network_n,
-                    &validators,
-                    &servers,
-                    epochs,
-                    1,
-                    server_self,
-                    &vec![],
-                    false,
-                    &vec![],
-                    false,
-                    true,
-                    interleave as u64,
-                    true,
-                );
-                // Assert that dense and sparse epoch results are equal
-                let bond = SubtensorModule::get_bonds(netuid);
-                for uid in 0..network_n {
-                    assert_eq!(
-                        SubtensorModule::get_rank_for_uid(netuid, uid),
-                        rank[uid as usize]
+                    let bond = SubtensorModule::get_bonds(netuid);
+                    for uid in 0..network_n {
+                        rank.push(SubtensorModule::get_rank_for_uid(netuid, uid));
+                        incentive.push(SubtensorModule::get_incentive_for_uid(netuid, uid));
+                        dividend.push(SubtensorModule::get_dividends_for_uid(netuid, uid));
+                        emission.push(SubtensorModule::get_emission_for_uid(netuid, uid));
+                        bondv.push(bond[uid as usize][validator]);
+                        bonds.push(bond[uid as usize][server]);
+                    }
+                });
+
+                // Sparse epoch (same random seed as dense)
+                new_test_ext().execute_with(|| {
+                    init_run_epochs(
+                        netuid,
+                        network_n,
+                        &validators,
+                        &servers,
+                        epochs,
+                        1,
+                        server_self,
+                        &vec![],
+                        false,
+                        &vec![],
+                        false,
+                        true,
+                        interleave as u64,
+                        true,
+                        bonds_penalty
                     );
-                    assert_eq!(
-                        SubtensorModule::get_incentive_for_uid(netuid, uid),
-                        incentive[uid as usize]
-                    );
-                    assert_eq!(
-                        SubtensorModule::get_dividends_for_uid(netuid, uid),
-                        dividend[uid as usize]
-                    );
-                    assert_eq!(
-                        SubtensorModule::get_emission_for_uid(netuid, uid),
-                        emission[uid as usize]
-                    );
-                    assert_eq!(bond[uid as usize][validator], bondv[uid as usize]);
-                    assert_eq!(bond[uid as usize][server], bonds[uid as usize]);
-                }
-            });
+                    // Assert that dense and sparse epoch results are equal
+                    let bond = SubtensorModule::get_bonds(netuid);
+                    for uid in 0..network_n {
+                        assert_eq!(
+                            SubtensorModule::get_rank_for_uid(netuid, uid),
+                            rank[uid as usize]
+                        );
+                        assert_eq!(
+                            SubtensorModule::get_incentive_for_uid(netuid, uid),
+                            incentive[uid as usize]
+                        );
+                        assert_eq!(
+                            SubtensorModule::get_dividends_for_uid(netuid, uid),
+                            dividend[uid as usize]
+                        );
+                        assert_eq!(
+                            SubtensorModule::get_emission_for_uid(netuid, uid),
+                            emission[uid as usize]
+                        );
+                        assert_eq!(bond[uid as usize][validator], bondv[uid as usize]);
+                        assert_eq!(bond[uid as usize][server], bonds[uid as usize]);
+                    }
+                });
+            }
         }
     }
 }
@@ -863,6 +875,7 @@ fn test_4096_graph() {
                     false,
                     0,
                     true,
+                    u16::MAX
                 );
                 assert_eq!(SubtensorModule::get_total_stake(), 21_000_000_000_000_000);
                 let bonds = SubtensorModule::get_bonds(netuid);
@@ -930,6 +943,7 @@ fn test_16384_graph_sparse() {
             false,
             0,
             true,
+            u16::MAX
         );
         let bonds = SubtensorModule::get_bonds(netuid);
         for uid in validators {
@@ -983,6 +997,7 @@ fn test_bonds() {
 		SubtensorModule::set_max_registrations_per_block( netuid, n );
 		SubtensorModule::set_target_registrations_per_interval(netuid, n);
 		SubtensorModule::set_weights_set_rate_limit( netuid, 0 );
+        SubtensorModule::set_bonds_penalty(netuid, u16::MAX);
 
 		// === Register [validator1, validator2, validator3, validator4, server1, server2, server3, server4]
 		for key in 0..n as u64 {
@@ -1479,6 +1494,7 @@ fn test_outdated_weights() {
         SubtensorModule::set_max_allowed_uids(netuid, n);
         SubtensorModule::set_weights_set_rate_limit(netuid, 0);
         SubtensorModule::set_max_registrations_per_block(netuid, n + 1); // should be n, but RegistrationsThisBlock is not reset (TODO: Saeideh)
+        SubtensorModule::set_bonds_penalty(netuid, u16::MAX);
 
         // === Register [validator1, validator2, server1, server2]
         for key in 0..n as u64 {
@@ -2014,6 +2030,7 @@ fn _map_consensus_guarantees() {
     let epochs: u16 = 1;
     let interleave = 0;
     let weight_stddev: I32F32 = fixed(0.4);
+    let bonds_penalty: u16 = u16::MAX;
     println!("[");
     for _major_stake in vec![0.51, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 0.99] {
         let major_stake: I32F32 = I32F32::from_num(_major_stake);
@@ -2043,7 +2060,7 @@ fn _map_consensus_guarantees() {
                 );
 
                 new_test_ext().execute_with(|| {
-					init_run_epochs(netuid, network_n, &validators, &servers, epochs, 1, true, &stake, true, &weights, true, false, 0, true);
+					init_run_epochs(netuid, network_n, &validators, &servers, epochs, 1, true, &stake, true, &weights, true, false, 0, true, bonds_penalty);
 
 					let mut major_emission: I64F64 = I64F64::from_num(0);
 					let mut minor_emission: I64F64 = I64F64::from_num(0);

--- a/pallets/subtensor/tests/mock.rs
+++ b/pallets/subtensor/tests/mock.rs
@@ -125,6 +125,7 @@ parameter_types! {
     pub const InitialImmunityPeriod: u16 = 2;
     pub const InitialMaxAllowedUids: u16 = 2;
     pub const InitialBondsMovingAverage: u64 = 900_000;
+    pub const InitialBondsPenalty: u16 = 0;
     pub const InitialStakePruningMin: u16 = 0;
     pub const InitialFoundationDistribution: u64 = 0;
     pub const InitialDefaultTake: u16 = 11_796; // 18% honest number.
@@ -332,6 +333,7 @@ impl pallet_subtensor::Config for Test {
     type InitialMaxRegistrationsPerBlock = InitialMaxRegistrationsPerBlock;
     type InitialPruningScore = InitialPruningScore;
     type InitialBondsMovingAverage = InitialBondsMovingAverage;
+    type InitialBondsPenalty = InitialBondsPenalty;
     type InitialMaxAllowedValidators = InitialMaxAllowedValidators;
     type InitialDefaultTake = InitialDefaultTake;
     type InitialWeightsVersionKey = InitialWeightsVersionKey;

--- a/pallets/subtensor/tests/sudo.rs
+++ b/pallets/subtensor/tests/sudo.rs
@@ -28,6 +28,7 @@ fn test_defaults() {
         assert_eq!(SubtensorModule::get_min_allowed_weights(netuid), 0);
         assert_eq!(SubtensorModule::get_adjustment_interval(netuid), 100);
         assert_eq!(SubtensorModule::get_bonds_moving_average(netuid), 900_000);
+        assert_eq!(SubtensorModule::get_bonds_penalty(netuid), 0);
         assert_eq!(SubtensorModule::get_last_adjustment_block(netuid), 0);
         assert_eq!(SubtensorModule::get_last_mechanism_step_block(netuid), 0);
         assert_eq!(SubtensorModule::get_blocks_since_last_step(netuid), 0);
@@ -928,6 +929,42 @@ fn test_sudo_set_bonds_moving_average() {
             to_be_set
         ));
         assert_eq!(SubtensorModule::get_bonds_moving_average(netuid), to_be_set);
+    });
+}
+
+#[test]
+fn test_sudo_set_bonds_penalty() {
+    new_test_ext().execute_with(|| {
+        let netuid: u16 = 1;
+        let to_be_set: u16 = 10;
+        let init_value: u16 = SubtensorModule::get_bonds_penalty(netuid);
+        add_network(netuid, 10, 0);
+        assert_eq!(
+            SubtensorModule::sudo_set_bonds_penalty(
+                <<Test as Config>::RuntimeOrigin>::signed(U256::from(0)),
+                netuid,
+                to_be_set
+            ),
+            Err(DispatchError::BadOrigin.into())
+        );
+        assert_eq!(
+            SubtensorModule::sudo_set_bonds_penalty(
+                <<Test as Config>::RuntimeOrigin>::root(),
+                netuid + 1,
+                to_be_set
+            ),
+            Err(Error::<Test>::NetworkDoesNotExist.into())
+        );
+        assert_eq!(
+            SubtensorModule::get_bonds_penalty(netuid),
+            init_value
+        );
+        assert_ok!(SubtensorModule::sudo_set_bonds_penalty(
+            <<Test as Config>::RuntimeOrigin>::root(),
+            netuid,
+            to_be_set
+        ));
+        assert_eq!(SubtensorModule::get_bonds_penalty(netuid), to_be_set);
     });
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -575,6 +575,7 @@ parameter_types! {
     pub const SubtensorInitialMaxRegistrationsPerBlock: u16 = 1;
     pub const SubtensorInitialPruningScore : u16 = u16::MAX;
     pub const SubtensorInitialBondsMovingAverage: u64 = 900_000;
+    pub const SubtensorInitialBondsPenalty: u16 = 0;
     pub const SubtensorInitialDefaultTake: u16 = 11_796; // 18% honest number.
     pub const SubtensorInitialWeightsVersionKey: u64 = 0;
     pub const SubtensorInitialMinDifficulty: u64 = 10_000_000;
@@ -600,6 +601,7 @@ impl pallet_subtensor::Config for Runtime {
     type InitialKappa = SubtensorInitialKappa;
     type InitialMaxAllowedUids = SubtensorInitialMaxAllowedUids;
     type InitialBondsMovingAverage = SubtensorInitialBondsMovingAverage;
+    type InitialBondsPenalty = SubtensorInitialBondsPenalty;
     type InitialIssuance = SubtensorInitialIssuance;
     type InitialMinAllowedWeights = SubtensorInitialMinAllowedWeights;
     type InitialEmissionValue = SubtensorInitialEmissionValue;


### PR DESCRIPTION
### Add BondsPenalty hyperparam

Given recent issues with (partially) blacklisted validators getting poor dividends, we've been exploring the possibility of adjusting the validation bonds penalty to improve their dividends.

**Bonds penalty**: Weight higher than consensus gets clipped, and bonds calculated from this then also get clipped, which means dividends get clipped. Cabal that sets weights on its own poor servers have their bonds cut and receive less dividends.
**Validation advantage**: Setting weight on the highest performing servers, means that dividends will be relatively better. Cabal that sets weights on its own poor servers will get less dividends because those servers get less incentive.

**Suggestion**: Adjust bonds penalty per netuid, with a default zero penalty, keep validation advantage.
**Expected result**: Partially blacklisted validators that set more weights on a fewer set of servers will enjoy full bonds on those, instead of getting bonds cut like when validation penalty applies.

**Security guarantees**:
A foremost concern is how this will affect the consensus security guarantees, so we simulate that as part of the subtensor integration tests with the `_map_consensus_guarantees()` function, and do a comparison with/without bonds penalty.
We observe as slight erosion of guarantees, at one point quantified as a 73% -> 79% honest utility increase required @ 60% honest stake to retain at least 60% emission. This is acceptable given that we gain significant alleviation of poor dividends due to blacklisting.