### PR TITLE
Update `TotalStake` in genesis handler

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -949,6 +949,9 @@ pub mod pallet {
                     // Update total issuance value
                     TotalIssuance::<T>::put(TotalIssuance::<T>::get().saturating_add(*stake));
 
+                    // Update total stake value
+                    TotalStake::<T>::put(TotalStake::<T>::get().saturating_add(*stake));
+
                     Stake::<T>::insert(hotkey.clone(), coldkey.clone(), stake);
 
                     next_uid += 1;


### PR DESCRIPTION
`TotalStake` is not updated in genesis handler, so the value returned by `api.query.subtensorModule.totalStake()` is not correct.