### PR TITLE
Re-enable faucet with conditional compilation

### DIFF
--- a/pallets/subtensor/Cargo.toml
+++ b/pallets/subtensor/Cargo.toml
@@ -53,6 +53,6 @@ sp-core = { git = "https://github.com/paritytech/substrate", default-features = 
 [features]
 default = ["std"]
 std = ["codec/std", "frame-benchmarking/std", "frame-support/std", "frame-system/std", "scale-info/std", "pallet-collective/std", "pallet-membership/std"]
-pow-faucet = []
 runtime-benchmarks = ["frame-benchmarking/runtime-benchmarks"]
 try-runtime = ["frame-support/try-runtime"]
+pow-faucet = []

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1948,20 +1948,22 @@ pub mod pallet {
             Self::user_add_network(origin)
         }
 
-        // #[pallet::call_index(60)]
-        // #[pallet::weight((Weight::from_ref_time(91_000_000)
-		// .saturating_add(T::DbWeight::get().reads(27))
-		// .saturating_add(T::DbWeight::get().writes(22)), DispatchClass::Normal, Pays::No))]
-        // pub fn faucet(
-        //     origin: OriginFor<T>,
-        //     block_number: u64,
-        //     nonce: u64,
-        //     work: Vec<u8>,
-        // ) -> DispatchResult {
-        //     ensure!(false, Error::<T>::FaucetDisabled);
-        //     //Self::do_faucet(origin, block_number, nonce, work)
-        //     Ok(())
-        // }
+        #[pallet::call_index(60)]
+        #[pallet::weight((Weight::from_ref_time(91_000_000)
+		.saturating_add(T::DbWeight::get().reads(27))
+		.saturating_add(T::DbWeight::get().writes(22)), DispatchClass::Normal, Pays::No))]
+        pub fn faucet(
+            origin: OriginFor<T>,
+            block_number: u64,
+            nonce: u64,
+            work: Vec<u8>,
+        ) -> DispatchResult {
+            if cfg!(feature = "pow-faucet") {
+                return Self::do_faucet(origin, block_number, nonce, work);
+            }
+            
+            Err(Error::<T>::FaucetDisabled.into())
+        }
 
         #[pallet::call_index(61)]
         #[pallet::weight((Weight::from_ref_time(70_000_000)

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -72,7 +72,7 @@ substrate-wasm-builder = { version = "5.0.0-dev", git = "https://github.com/pari
 
 [features]
 default = ["std"]
-pow-faucet = []
+pow-faucet = ["pallet-subtensor/pow-faucet"]
 std = [
 	"frame-try-runtime?/std",
 	"frame-system-benchmarking?/std",


### PR DESCRIPTION
This PR allows the faucet to be **explicitly** enabled via the compiler flag `pow-faucet` for usage on the testnet without a different codebase.