### PR TITLE
Allow swap of hotkeys on registered coldkeys

### DIFF
--- a/pallets/subtensor/src/benchmarks.rs
+++ b/pallets/subtensor/src/benchmarks.rs
@@ -547,4 +547,31 @@ benchmarks! {
 	Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), amoun_to_be_staked.unwrap());
 	assert_ok!(Subtensor::<T>::register_network(RawOrigin::Signed(coldkey.clone()).into()));
   }: dissolve_network(RawOrigin::Signed(coldkey), 1)
+
+  swap_hotkey {
+	let seed: u32 = 1;
+	let coldkey: T::AccountId = account("Alice", 0, seed);
+	let old_hotkey: T::AccountId = account("Bob", 0, seed);
+	let new_hotkey: T::AccountId = account("Charlie", 0, seed);
+
+	let netuid = 1u16;
+	Subtensor::<T>::init_new_network(netuid, 100);
+	Subtensor::<T>::set_min_burn(netuid, 1);
+	Subtensor::<T>::set_max_burn(netuid, 1);
+	Subtensor::<T>::set_target_registrations_per_interval(netuid, 256);
+	Subtensor::<T>::set_max_registrations_per_block(netuid, 256);
+
+	let max_uids = Subtensor::<T>::get_max_allowed_uids(netuid) as u32;
+	for i in 0..max_uids - 1 {
+		let coldkey: T::AccountId = account("Axon", 0, i);
+		let hotkey: T::AccountId = account("Hotkey", 0, i);
+
+		Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), Subtensor::<T>::u64_to_balance(10_000_000_000).unwrap());
+		assert_ok!(Subtensor::<T>::burned_register(RawOrigin::Signed(coldkey).into(), netuid, hotkey));
+	}
+
+	Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), Subtensor::<T>::u64_to_balance(10_000_000_000).unwrap());
+
+	assert_ok!(Subtensor::<T>::burned_register(RawOrigin::Signed(coldkey.clone()).into(), netuid, old_hotkey.clone()));
+  }: _(RawOrigin::Signed(coldkey), old_hotkey, new_hotkey)
 }

--- a/pallets/subtensor/src/benchmarks.rs
+++ b/pallets/subtensor/src/benchmarks.rs
@@ -561,17 +561,18 @@ benchmarks! {
 	Subtensor::<T>::set_target_registrations_per_interval(netuid, 256);
 	Subtensor::<T>::set_max_registrations_per_block(netuid, 256);
 
+	Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), Subtensor::<T>::u64_to_balance(10_000_000_000).unwrap());
+	assert_ok!(Subtensor::<T>::burned_register(RawOrigin::Signed(coldkey.clone()).into(), netuid, old_hotkey.clone()));
+	assert_ok!(Subtensor::<T>::become_delegate(RawOrigin::Signed(coldkey.clone()).into(), old_hotkey.clone()));
+
 	let max_uids = Subtensor::<T>::get_max_allowed_uids(netuid) as u32;
 	for i in 0..max_uids - 1 {
 		let coldkey: T::AccountId = account("Axon", 0, i);
 		let hotkey: T::AccountId = account("Hotkey", 0, i);
 
 		Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), Subtensor::<T>::u64_to_balance(10_000_000_000).unwrap());
-		assert_ok!(Subtensor::<T>::burned_register(RawOrigin::Signed(coldkey).into(), netuid, hotkey));
+		assert_ok!(Subtensor::<T>::burned_register(RawOrigin::Signed(coldkey.clone()).into(), netuid, hotkey));
+		assert_ok!(Subtensor::<T>::add_stake(RawOrigin::Signed(coldkey).into(), old_hotkey.clone(), 1_000_000_000));
 	}
-
-	Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), Subtensor::<T>::u64_to_balance(10_000_000_000).unwrap());
-
-	assert_ok!(Subtensor::<T>::burned_register(RawOrigin::Signed(coldkey.clone()).into(), netuid, old_hotkey.clone()));
   }: _(RawOrigin::Signed(coldkey), old_hotkey, new_hotkey)
 }

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -915,6 +915,7 @@ pub mod pallet {
         OperationNotPermittedonRootSubnet,
         StakeTooLowForRoot, // --- Thrown when a hotkey attempts to join the root subnet with too little stake
         AllNetworksInImmunity, // --- Thrown when all subnets are in the immunity period
+        NotEnoughBalance,
     }
 
     // ==================

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1523,7 +1523,7 @@ pub mod pallet {
 
         #[pallet::call_index(69)]
         #[pallet::weight((0, DispatchClass::Operational, Pays::No))]
-        pub fn swap_hotkey(origin: OriginFor<T>, hotkey: T::AccountId, new_hotkey: T::AccountId) -> DispatchResult {
+        pub fn swap_hotkey(origin: OriginFor<T>, hotkey: T::AccountId, new_hotkey: T::AccountId) -> DispatchResultWithPostInfo {
             Self::do_swap_hotkey(origin, &hotkey, &new_hotkey)
         }
 

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -855,6 +855,7 @@ pub mod pallet {
         NetworkMinLockCostSet(u64), // Event created when the network minimum locking cost is set.
         SubnetLimitSet(u16), // Event created when the maximum number of subnets is set
         NetworkLockCostReductionIntervalSet(u64), // Event created when the lock cost reduction is set
+        HotkeySwapped{coldkey: T::AccountId, old_hotkey: T::AccountId, new_hotkey: T::AccountId} // Event created when a hotkey is swapped 
     }
 
     // Errors inform users that something went wrong.
@@ -1518,6 +1519,12 @@ pub mod pallet {
             hotkey: T::AccountId,
         ) -> DispatchResult {
             Self::do_burned_registration(origin, netuid, hotkey)
+        }
+
+        #[pallet::call_index(69)]
+        #[pallet::weight((0, DispatchClass::Operational, Pays::No))]
+        pub fn swap_hotkey(origin: OriginFor<T>, hotkey: T::AccountId, new_hotkey: T::AccountId) -> DispatchResult {
+            Self::do_swap_hotkey(origin, &hotkey, &new_hotkey)
         }
 
         #[pallet::call_index(8)]

--- a/pallets/subtensor/src/registration.rs
+++ b/pallets/subtensor/src/registration.rs
@@ -762,4 +762,31 @@ impl<T: Config> Pallet<T> {
         let vec_work: Vec<u8> = Self::hash_to_vec(work);
         return (nonce, vec_work);
     }
+
+    pub fn do_swap_hotkey(origin: T::RuntimeOrigin, hotkey: &T::AccountId, new_hotkey: &T::AccountId) -> DispatchResult {
+        let coldkey = ensure_signed(origin)?;
+        ensure!(Self::coldkey_owns_hotkey(&coldkey, hotkey), Error::<T>::NonAssociatedColdKey);
+
+        let total_hotkey_stake = TotalHotkeyStake::<T>::take(hotkey);
+        TotalHotkeyStake::<T>::insert(new_hotkey, total_hotkey_stake);
+
+        let delegate_take = Delegates::<T>::take(hotkey);
+        Delegates::<T>::insert(new_hotkey, delegate_take);
+
+        // Stake -- have to search for every occurance of hotkey regardless of coldkey
+        // IsNetworkMember -- update every hotkey+netuid pair
+
+        let last_tx = LastTxBlock::<T>::take(hotkey);
+        LastTxBlock::<T>::insert(new_hotkey, last_tx);
+
+        // Axons -- update every netuid+hotkey pair -- take + insert
+
+        // Uids -- update every netuid+hotkey pair -- take + insert
+
+        // Keys -- update every netuid+uid to new hotkey -- use mutate
+
+        // LoadedEmission -- find hotkey in tuple vector, mutate tuple
+
+        Ok(())
+    }
 }

--- a/pallets/subtensor/src/registration.rs
+++ b/pallets/subtensor/src/registration.rs
@@ -783,7 +783,18 @@ impl<T: Config> Pallet<T> {
 
         weight.saturating_accrue(T::DbWeight::get().reads((TotalNetworks::<T>::get() + 1u16) as u64));
 
-        // Pay TAO?
+        let swap_cost = 1_000_000_000u64;
+        let swap_cost_as_balance = Self::u64_to_balance(swap_cost).unwrap();
+        ensure!(
+            Self::can_remove_balance_from_coldkey_account(&coldkey, swap_cost_as_balance),
+            Error::<T>::NotEnoughBalance
+        );
+        ensure!(
+            Self::remove_balance_from_coldkey_account(&coldkey, swap_cost_as_balance)
+                == true,
+            Error::<T>::BalanceWithdrawalError
+        );
+        Self::burn_tokens(swap_cost);
 
         Owner::<T>::remove(old_hotkey);
         Owner::<T>::insert(new_hotkey, coldkey.clone());

--- a/pallets/subtensor/tests/registration.rs
+++ b/pallets/subtensor/tests/registration.rs
@@ -1,7 +1,7 @@
 use frame_support::traits::Currency;
 
 use crate::mock::*;
-use frame_support::assert_ok;
+use frame_support::{assert_ok, assert_err};
 use frame_support::dispatch::{DispatchClass, DispatchInfo, GetDispatchInfo, Pays};
 use frame_support::sp_runtime::DispatchError;
 use frame_system::Config;
@@ -1569,5 +1569,121 @@ fn test_registration_disabled() {
             coldkey_account_id,
         );
         assert_eq!(result, Err(Error::<Test>::RegistrationDisabled.into()));
+    });
+}
+
+#[test]
+fn test_hotkey_swap_ok() {
+    new_test_ext().execute_with(|| {
+        let netuid: u16 = 1;
+        let tempo: u16 = 13;
+        let hotkey_account_id = U256::from(1);
+        let burn_cost = 1000;
+        let coldkey_account_id = U256::from(667); 
+
+        SubtensorModule::set_burn(netuid, burn_cost);
+        add_network(netuid, tempo, 0);
+
+        // Give it some $$$ in his coldkey balance
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, 10000);
+
+        // Subscribe and check extrinsic output
+        assert_ok!(SubtensorModule::burned_register(
+            <<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id),
+            netuid,
+            hotkey_account_id
+        ));
+
+        let new_hotkey = U256::from(1337);
+        assert_ok!(SubtensorModule::swap_hotkey(<<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id), hotkey_account_id, new_hotkey));
+        assert_ne!(SubtensorModule::get_owning_coldkey_for_hotkey(&hotkey_account_id), coldkey_account_id);
+        assert_eq!(SubtensorModule::get_owning_coldkey_for_hotkey(&new_hotkey), coldkey_account_id);
+    });
+}
+
+#[test]
+fn test_hotkey_swap_not_owner() {
+    new_test_ext().execute_with(|| {
+        let netuid: u16 = 1;
+        let tempo: u16 = 13;
+        let hotkey_account_id = U256::from(1);
+        let burn_cost = 1000;
+        let coldkey_account_id = U256::from(2);
+        let not_owner_coldkey = U256::from(3);
+
+        SubtensorModule::set_burn(netuid, burn_cost);
+        add_network(netuid, tempo, 0);
+
+        // Give it some $$$ in his coldkey balance
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, 10000);
+
+        // Subscribe and check extrinsic output
+        assert_ok!(SubtensorModule::burned_register(
+            <<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id),
+            netuid,
+            hotkey_account_id
+        ));
+
+        let new_hotkey = U256::from(4);
+        assert_err!(SubtensorModule::swap_hotkey(<<Test as Config>::RuntimeOrigin>::signed(not_owner_coldkey), hotkey_account_id, new_hotkey), Error::<Test>::NonAssociatedColdKey);
+    });
+}
+
+#[test]
+fn test_hotkey_swap_same_key() {
+    new_test_ext().execute_with(|| {
+        let netuid: u16 = 1;
+        let tempo: u16 = 13;
+        let hotkey_account_id = U256::from(1);
+        let burn_cost = 1000;
+        let coldkey_account_id = U256::from(2);
+
+        SubtensorModule::set_burn(netuid, burn_cost);
+        add_network(netuid, tempo, 0);
+
+        // Give it some $$$ in his coldkey balance
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, 10000);
+
+        // Subscribe and check extrinsic output
+        assert_ok!(SubtensorModule::burned_register(
+            <<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id),
+            netuid,
+            hotkey_account_id
+        ));
+
+        assert_err!(SubtensorModule::swap_hotkey(<<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id), hotkey_account_id, hotkey_account_id), Error::<Test>::AlreadyRegistered);
+    });
+}
+
+#[test]
+fn test_hotkey_swap_registered_key() {
+    new_test_ext().execute_with(|| {
+        let netuid: u16 = 1;
+        let tempo: u16 = 13;
+        let hotkey_account_id = U256::from(1);
+        let burn_cost = 1000;
+        let coldkey_account_id = U256::from(2);
+
+        SubtensorModule::set_burn(netuid, burn_cost);
+        add_network(netuid, tempo, 0);
+
+        // Give it some $$$ in his coldkey balance
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, 100_000_000_000);
+
+        // Subscribe and check extrinsic output
+        assert_ok!(SubtensorModule::burned_register(
+            <<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id),
+            netuid,
+            hotkey_account_id
+        ));
+
+        let new_hotkey = U256::from(3);
+        assert_ok!(SubtensorModule::burned_register(
+            <<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id),
+            netuid,
+            new_hotkey
+        ));
+
+        assert_err!(SubtensorModule::swap_hotkey(<<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id), hotkey_account_id, new_hotkey), Error::<Test>::AlreadyRegistered);
     });
 }

--- a/pallets/subtensor/tests/registration.rs
+++ b/pallets/subtensor/tests/registration.rs
@@ -1585,7 +1585,7 @@ fn test_hotkey_swap_ok() {
         add_network(netuid, tempo, 0);
 
         // Give it some $$$ in his coldkey balance
-        SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, 10000);
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, 10_000_000_000);
 
         // Subscribe and check extrinsic output
         assert_ok!(SubtensorModule::burned_register(


### PR DESCRIPTION
This PR enables any registered miner/validator to swap their hotkey on the fly, transferring all data from the old hotkey to the new, including delegated stake.