### PR TITLE
Refactor subnet pruning mechanism

### DIFF
--- a/pallets/subtensor/src/root.rs
+++ b/pallets/subtensor/src/root.rs
@@ -603,7 +603,7 @@ impl<T: Config> Pallet<T> {
         // --- 4. Determine the netuid to register.
         let netuid_to_register: u16 = {
             log::debug!("subnet count: {:?}\nmax subnets: {:?}", Self::get_num_subnets(), Self::get_max_subnets());
-            if Self::get_num_subnets() - 1 < Self::get_max_subnets() { // We subtract one because we don't want root subnet to count towards total
+            if Self::get_num_subnets().saturating_sub(1) < Self::get_max_subnets() { // We subtract one because we don't want root subnet to count towards total
                 let mut next_available_netuid = 0;
                 loop {
                     next_available_netuid += 1;
@@ -905,52 +905,38 @@ impl<T: Config> Pallet<T> {
     // 		- The uid of the network to be pruned.
     //
     pub fn get_subnet_to_prune() -> u16 {
-        let mut min_score = 1;
-        let mut min_score_in_immunity_period = u64::MAX;
-        let mut uid_with_min_score = 1;
-        let mut uid_with_min_score_in_immunity_period: u16 = 1;
+        let mut netuids: Vec<u16> = vec![];
+        let current_block = Self::get_current_block_as_u64();
 
-        // Iterate over all networks
-        for netuid in 1..TotalNetworks::<T>::get() - 1 { // Don't count root netuid
-            let emission_value: u64 = Self::get_emission_value(netuid);
-            let block_at_registration: u64 = Self::get_network_registered_block(netuid);
-            let current_block: u64 = Self::get_current_block_as_u64();
-            let immunity_period: u64 = Self::get_network_immunity_period();
+        // Even if we don't have a root subnet, this still works
+        for netuid in NetworksAdded::<T>::iter_keys_from(NetworksAdded::<T>::hashed_key_for(0)) {
+            if current_block.saturating_sub(Self::get_network_registered_block(netuid)) < Self::get_network_immunity_period() {
+                continue
+            }
 
-            // Check if the network is in the immunity period
-            if min_score == emission_value {
-                if current_block.saturating_sub(block_at_registration) < immunity_period {
-                    //neuron is in immunity period
-                    if min_score_in_immunity_period > emission_value {
-                        min_score_in_immunity_period = emission_value;
-                        uid_with_min_score_in_immunity_period = netuid;
-                    }
-                } else {
-                    min_score = emission_value;
-                    uid_with_min_score = netuid;
-                }
-            }
-            // Find min emission value.
-            else if min_score > emission_value {
-                if current_block.saturating_sub(block_at_registration) < immunity_period {
-                    // network is in immunity period
-                    if min_score_in_immunity_period > emission_value {
-                        min_score_in_immunity_period = emission_value;
-                        uid_with_min_score_in_immunity_period = netuid;
-                    }
-                } else {
-                    min_score = emission_value;
-                    uid_with_min_score = netuid;
-                }
-            }
+            // This iterator seems to return them in order anyways, so no need to sort by key
+            netuids.push(netuid);
         }
-        // If all networks are in the immunity period, return the one with the minimum emission value.
-        if min_score == 1 {
-            // all networks are in immunity period
-            return 0;
-        } else {
-            return uid_with_min_score;
-        }
+
+        // Now we sort by emission, and then by subnet.
+        netuids.sort_by(|a, b| {
+            use sp_std::cmp::Ordering;
+
+            match Self::get_emission_value(*b).cmp(&Self::get_emission_value(*a)) {
+                Ordering::Equal => {
+                    if Self::get_network_registered_block(*b) < Self::get_network_registered_block(*a) {
+                        Ordering::Less
+                    } else {
+                        Ordering::Equal
+                    }
+                },
+                v => v
+            }
+        });
+
+        log::info!("{:?}", netuids);
+
+        return 0
     }
 
     pub fn get_network_registered_block(netuid: u16) -> u64 {

--- a/pallets/subtensor/src/root.rs
+++ b/pallets/subtensor/src/root.rs
@@ -897,8 +897,7 @@ impl<T: Config> Pallet<T> {
     }
 
     // This function is used to determine which subnet to prune when the total number of networks has reached the limit.
-    // It iterates over all the networks and finds the one with the minimum emission value that is not in the immunity period.
-    // If all networks are in the immunity period, it returns the one with the minimum emission value.
+    // It iterates over all the networks and finds the oldest subnet with the minimum emission value that is not in the immunity period.
     //
     // # Returns:
     // 	* 'u16':

--- a/pallets/subtensor/src/root.rs
+++ b/pallets/subtensor/src/root.rs
@@ -918,7 +918,7 @@ impl<T: Config> Pallet<T> {
             netuids.push(netuid);
         }
 
-        // Now we sort by emission, and then by subnet.
+        // Now we sort by emission, and then by subnet creation time.
         netuids.sort_by(|a, b| {
             use sp_std::cmp::Ordering;
 

--- a/pallets/subtensor/src/root.rs
+++ b/pallets/subtensor/src/root.rs
@@ -936,7 +936,10 @@ impl<T: Config> Pallet<T> {
 
         log::info!("{:?}", netuids);
 
-        return 0
+        match netuids.last() {
+            Some(netuid) => *netuid,
+            None => 0
+        }
     }
 
     pub fn get_network_registered_block(netuid: u16) -> u64 {

--- a/pallets/subtensor/tests/root.rs
+++ b/pallets/subtensor/tests/root.rs
@@ -533,3 +533,36 @@ fn test_network_pruning() {
         assert_eq!(SubtensorModule::get_total_issuance(), 585_930_498);
     });
 }
+
+#[test]
+fn test_network_prune_results() {
+    new_test_ext().execute_with(|| {
+        migration::migrate_create_root_network::<Test>();
+
+        SubtensorModule::set_network_immunity_period(3);
+        SubtensorModule::set_network_min_lock(0);
+        SubtensorModule::set_network_rate_limit(0);
+
+        let owner: U256 = U256::from(0);
+        SubtensorModule::add_balance_to_coldkey_account(&owner, 1_000_000_000_000_000);
+
+        assert_ok!(SubtensorModule::register_network(
+            <<Test as Config>::RuntimeOrigin>::signed(owner)
+        ));
+        step_block(3);
+
+        assert_ok!(SubtensorModule::register_network(
+            <<Test as Config>::RuntimeOrigin>::signed(owner)
+        ));
+        step_block(3);
+
+        assert_ok!(SubtensorModule::register_network(
+            <<Test as Config>::RuntimeOrigin>::signed(owner)
+        ));
+        step_block(3);
+
+        SubtensorModule::set_emission_values(&vec![1u16, 2u16, 3u16], vec![5u64, 4u64, 4u64]);
+
+        SubtensorModule::get_subnet_to_prune()
+    });
+}

--- a/pallets/subtensor/tests/root.rs
+++ b/pallets/subtensor/tests/root.rs
@@ -561,8 +561,16 @@ fn test_network_prune_results() {
         ));
         step_block(3);
 
+        // lowest emission
         SubtensorModule::set_emission_values(&vec![1u16, 2u16, 3u16], vec![5u64, 4u64, 4u64]);
+        assert_eq!(SubtensorModule::get_subnet_to_prune(), 2u16);
 
-        SubtensorModule::get_subnet_to_prune()
+        // equal emission, creation date
+        SubtensorModule::set_emission_values(&vec![1u16, 2u16, 3u16], vec![5u64, 5u64, 4u64]);
+        assert_eq!(SubtensorModule::get_subnet_to_prune(), 3u16);
+
+        // equal emission, creation date
+        SubtensorModule::set_emission_values(&vec![1u16, 2u16, 3u16], vec![4u64, 5u64, 5u64]);
+        assert_eq!(SubtensorModule::get_subnet_to_prune(), 1u16);
     });
 }


### PR DESCRIPTION
Subnet pruning previously selected the last UID with the lowest emission score, which would end up removing any network outside of it's immunity period but hadn't gained any emission. This resulted in freshly created networks being pruned first, rather than older ones that still hadn't gained any emission.

This refactor now sorts subnets by emission value and BlockRegisteredAt, giving us the oldest subnet with the lowest emission value.