### PR TITLE
remove stake records with value 0

### DIFF
--- a/pallets/subtensor/src/block_step.rs
+++ b/pallets/subtensor/src/block_step.rs
@@ -307,11 +307,17 @@ impl<T: Config> Pallet<T> {
             hotkey,
             TotalHotkeyStake::<T>::get(hotkey).saturating_sub(decrement),
         );
-        Stake::<T>::insert(
-            hotkey,
-            coldkey,
-            Stake::<T>::get(hotkey, coldkey).saturating_sub(decrement),
-        );
+        let stake = Stake::<T>::get(hotkey, coldkey).saturating_sub(decrement);
+        if (stake == 0) {
+            Stake::<T>::remove(hotkey, coldkey);
+        }
+        else {
+            Stake::<T>::insert(
+                hotkey,
+                coldkey,
+                stake,
+            );
+        }
         TotalStake::<T>::put(TotalStake::<T>::get().saturating_sub(decrement));
         TotalIssuance::<T>::put(TotalIssuance::<T>::get().saturating_sub(decrement));
     }


### PR DESCRIPTION
This is the definition of the storage item `Stake`.

```rust
#[pallet::storage] // --- DMAP ( hot, cold ) --> stake | Returns the stake under a coldkey prefixed by hotkey.
pub type Stake<T: Config> = StorageDoubleMap<
    _,
    Blake2_128Concat,
    T::AccountId,
    Identity,
    T::AccountId,
    u64,
    ValueQuery,
    DefaultAccountTake<T>,
>;
```

I have run a simple script to get all the records of this storage item and it showed that more than 60% of the records are having value 0.
```bash
33234 out of 53273 items are zero
```
It is defined with the option `ValueQuery`, with default value `0`, so we don't need to keep these records.