### PR TITLE
chore: plug GRANDPA proveFinality RPC to standalone node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4182,6 +4182,7 @@ dependencies = [
  "sc-consensus-aura",
  "sc-executor",
  "sc-finality-grandpa",
+ "sc-finality-grandpa-rpc",
  "sc-keystore",
  "sc-rpc",
  "sc-rpc-api",
@@ -6312,6 +6313,26 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "substrate-prometheus-endpoint",
+ "thiserror",
+]
+
+[[package]]
+name = "sc-finality-grandpa-rpc"
+version = "0.10.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
+dependencies = [
+ "finality-grandpa",
+ "futures",
+ "jsonrpsee",
+ "log",
+ "parity-scale-codec",
+ "sc-client-api",
+ "sc-finality-grandpa",
+ "sc-rpc",
+ "serde",
+ "sp-blockchain",
+ "sp-core",
+ "sp-runtime",
  "thiserror",
 ]
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -38,6 +38,7 @@ sp-consensus-aura = { version = "0.10.0-dev", git = "https://github.com/parityte
 sp-consensus = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.39" }
 sc-consensus = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.39" }
 sc-finality-grandpa = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.39" }
+sc-finality-grandpa-rpc = { version = "0.10.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.39" }
 sp-finality-grandpa = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.39" }
 sc-client-api = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.39" }
 sp-runtime = { version = "7.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.39" }

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -8,27 +8,46 @@
 use std::sync::Arc;
 
 use jsonrpsee::RpcModule;
-use node_subtensor_runtime::{opaque::Block, AccountId, Balance, Index};
+use node_subtensor_runtime::{opaque::Block, AccountId, Balance, BlockNumber, Index, Hash};
 use sc_transaction_pool_api::TransactionPool;
 use sp_api::ProvideRuntimeApi;
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
+use sc_finality_grandpa::FinalityProofProvider;
 
 pub use sc_rpc_api::DenyUnsafe;
 
+/// Dependencies for GRANDPA
+pub struct GrandpaDeps<B> {
+    /// Voting round info.
+    pub shared_voter_state: sc_finality_grandpa::SharedVoterState,
+    /// Authority set info.
+    pub shared_authority_set: sc_finality_grandpa::SharedAuthoritySet<Hash, BlockNumber>,
+    /// Receives notifications about justification events from Grandpa.
+    pub justification_stream: sc_finality_grandpa::GrandpaJustificationStream<Block>,
+    /// Executor to drive the subscription manager in the Grandpa RPC handler.
+    pub subscription_executor: sc_rpc::SubscriptionTaskExecutor,
+    /// Finality proof provider.
+    pub finality_provider: Arc<FinalityProofProvider<B, Block>>,
+}
+
 /// Full client dependencies.
-pub struct FullDeps<C, P> {
+pub struct FullDeps<C, P, B> {
     /// The client instance to use.
     pub client: Arc<C>,
     /// Transaction pool instance.
     pub pool: Arc<P>,
     /// Whether to deny unsafe calls
     pub deny_unsafe: DenyUnsafe,
+    /// Grandpa block import setup.
+    pub grandpa: GrandpaDeps<B>,
+    /// Backend used by the node.
+    pub backend: Arc<B>,
 }
 
 /// Instantiate all full RPC extensions.
-pub fn create_full<C, P>(
-    deps: FullDeps<C, P>,
+pub fn create_full<C, P, B>(
+    deps: FullDeps<C, P, B>,
 ) -> Result<RpcModule<()>, Box<dyn std::error::Error + Send + Sync>>
 where
     C: ProvideRuntimeApi<Block>,
@@ -41,17 +60,21 @@ where
     C::Api: subtensor_custom_rpc_runtime_api::NeuronInfoRuntimeApi<Block>,
     C::Api: subtensor_custom_rpc_runtime_api::SubnetInfoRuntimeApi<Block>,
     C::Api: subtensor_custom_rpc_runtime_api::SubnetRegistrationRuntimeApi<Block>,
+    B: sc_client_api::Backend<Block> + Send + Sync + 'static,
     P: TransactionPool + 'static,
 {
     use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
     use substrate_frame_rpc_system::{System, SystemApiServer};
     use subtensor_custom_rpc::{SubtensorCustom, SubtensorCustomApiServer};
+    use sc_finality_grandpa_rpc::{Grandpa, GrandpaApiServer};
 
     let mut module = RpcModule::new(());
     let FullDeps {
         client,
         pool,
         deny_unsafe,
+        grandpa,
+        backend: _,
     } = deps;
 
     // Custom RPC methods for Paratensor
@@ -59,6 +82,25 @@ where
 
     module.merge(System::new(client.clone(), pool.clone(), deny_unsafe).into_rpc())?;
     module.merge(TransactionPayment::new(client).into_rpc())?;
+
+    let GrandpaDeps {
+        shared_voter_state,
+        shared_authority_set,
+        justification_stream,
+        subscription_executor,
+        finality_provider,
+    } = grandpa;
+
+    module.merge(
+        Grandpa::new(
+            subscription_executor,
+            shared_authority_set.clone(),
+            shared_voter_state,
+            justification_stream,
+            finality_provider,
+        )
+            .into_rpc(),
+    )?;
 
     // Extend this RPC with a custom API by using the following syntax.
     // `YourRpcStruct` should have a reference to a client, which is needed


### PR DESCRIPTION
## Context
t3rn rangers, client-side binaries, feeds the headers out of any relaychain/standalone GRANDPA-based chain into a t3rn parachian. Ranger expects the rpc.grandpa.proveFinality to be there, which is usually hooked into Relay chains. 

I've seen that Grandpa pallet is plugged into Bittensor at https://polkadot.js.org/apps/?rpc=wss%253A%252F%252Fentrypoint-finney.opentensor.ai%253A443# so that's very good. Just that RPC methods allowing proving finality aren't connected to subtensor. 

## Description

This PR connects GRANDPA RPC to subtensor nodes. Following GRANDPA RPCs are now available: 
- grandpa_proveFinality
- grandpa_roundState
- grandpa_subscribeJustifications
- grandpa_unsubscribeJustifications

<img width="1749" alt="Screenshot 2024-01-10 at 10 52 37" src="https://github.com/opentensor/subtensor/assets/6909553/9d837ca4-b532-4669-8f10-33fd13f3ce79">

    
    
    
 