### PR TITLE
Add missing dockercompose definitions for subtensor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,19 +25,37 @@ RUN apt-get update && apt-get install -y curl build-essential protobuf-compiler 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-RUN mkdir -p /subtensor
-WORKDIR /subtensor
-COPY . .
+RUN mkdir -p /subtensor && \
+    mkdir /subtensor/scripts
+
+# Scripts
+COPY ./scripts/init.sh /subtensor/scripts/
+
+# Capture dependencies
+COPY Cargo.lock Cargo.toml /subtensor/
+
+# Specs
+COPY ./snapshot.json /subtensor/snapshot.json
+COPY ./raw_spec.json /subtensor/raw_spec.json
+COPY ./raw_testspec.json /subtensor/raw_testspec.json
+
+# Copy our sources
+COPY ./integration-tests /subtensor/integration-tests
+COPY ./node /subtensor/node
+COPY ./pallets /subtensor/pallets
+COPY ./runtime /subtensor/runtime
 
 # Update to nightly toolchain
-RUN ./scripts/init.sh
+COPY rust-toolchain.toml /subtensor/
+RUN /subtensor/scripts/init.sh
 
 # Cargo build
+WORKDIR /subtensor
 RUN cargo build --release --features runtime-benchmarks --locked
 EXPOSE 30333 9933 9944
 
-FROM $BASE_IMAGE
-COPY --from=builder /subtensor/snapshot.json /
-COPY --from=builder /subtensor/target/release/node-subtensor /
-COPY --from=builder /subtensor/raw_spec.json .
 
+FROM builder AS subtensor
+
+COPY --from=builder /subtensor/snapshot.json /
+COPY --from=builder /subtensor/target/release/node-subtensor /usr/local/bin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,18 @@
-version: "3.2"
+version: '3.8'
+
+volumes:
+  mainnet-lite-volume:
+  mainnet-archive-volume:
+  testnet-lite-volume:
+  testnet-archive-volume:
 
 services:
-  node-subtensor:
-    container_name: node-subtensor
-    image: opentensor/subtensor:latest
+  common: &common
+    #image: opentensor/subtensor:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: subtensor
     cpu_count: 4
     mem_limit: 40000000000
     memswap_limit: 80000000000
@@ -17,15 +26,75 @@ services:
       - "9933"
     environment:
       - CARGO_HOME=/var/www/node-subtensor/.cargo
+
+  mainnet-lite:
+    <<: *common
+    container_name: subtensor-mainnet-lite
+    volumes:
+      - mainnet-lite-volume:/tmp/blockchain
     command:
       - /bin/bash
       - -c
       - |
-        ./node-subtensor \
+        node-subtensor \
           --base-path /tmp/blockchain \
-          --chain ./raw_spec.json \
+          --chain /subtensor/raw_spec.json \
           --rpc-external --rpc-cors all \
           --ws-external --no-mdns \
           --ws-max-connections 10000 --in-peers 500 --out-peers 500 \
           --bootnodes /dns/bootnode.finney.opentensor.ai/tcp/30333/ws/p2p/12D3KooWRwbMb85RWnT8DSXSYMWQtuDwh4LJzndoRrTDotTR5gDC \
           --sync warp
+
+  mainnet-archive:
+    <<: *common
+    container_name: subtensor-mainnet-archive
+    volumes:
+      - mainnet-archive-volume:/tmp/blockchain
+    command:
+      - /bin/bash
+      - -c
+      - |
+        node-subtensor \
+          --base-path /tmp/blockchain \
+          --chain /subtensor/raw_spec.json \
+          --rpc-external --rpc-cors all \
+          --ws-external --no-mdns \
+          --ws-max-connections 10000 --in-peers 500 --out-peers 500 \
+          --bootnodes /dns/bootnode.finney.opentensor.ai/tcp/30333/ws/p2p/12D3KooWRwbMb85RWnT8DSXSYMWQtuDwh4LJzndoRrTDotTR5gDC \
+          --pruning=archive
+
+  testnet-lite:
+    <<: *common
+    container_name: subtensor-testnet-lite
+    volumes:
+      - testnet-lite-volume:/tmp/blockchain
+    command:
+      - /bin/bash
+      - -c
+      - |
+        node-subtensor \
+          --base-path /tmp/blockchain \
+          --chain /subtensor/raw_testspec.json \
+          --rpc-external --rpc-cors all \
+          --ws-external --no-mdns \
+          --ws-max-connections 10000 --in-peers 500 --out-peers 500 \
+          --bootnodes /dns/bootnode.test.finney.opentensor.ai/tcp/30333/ws/p2p/12D3KooWQawexXodtsPEymJUX1X2eKzjNq6s8MvzEWtKwJ6mLmzy \
+          --sync warp
+
+  testnet-archive:
+    <<: *common
+    container_name: subtensor-testnet-archive
+    volumes:
+      - testnet-archive-volume:/tmp/blockchain
+    command:
+      - /bin/bash
+      - -c
+      - |
+        node-subtensor \
+          --base-path /tmp/blockchain \
+          --chain /subtensor/raw_testspec.json \
+          --rpc-external --rpc-cors all \
+          --ws-external --no-mdns \
+          --ws-max-connections 10000 --in-peers 500 --out-peers 500 \
+          --bootnodes /dns/bootnode.test.finney.opentensor.ai/tcp/30333/ws/p2p/12D3KooWQawexXodtsPEymJUX1X2eKzjNq6s8MvzEWtKwJ6mLmzy \
+          --pruning=archive

--- a/docs/running-subtensor-locally.md
+++ b/docs/running-subtensor-locally.md
@@ -1,0 +1,78 @@
+# Running subtensor locally
+
+- [Running docker](#running-docker)
+- [Compiling your own binary](#compiling-your-own-binary)
+
+## Running docker
+
+### Install git
+`sudo apt install git`
+
+### Install Docker Engine
+ You can follow Docker's [oficial installation guides](https://docs.docker.com/engine/install/)
+
+### Run node-subtensor container
+```bash
+git clone https://github.com/opentensor/subtensor.git
+cd subtensor
+# to run a lite node on the mainnet:
+docker compose up -d mainnet-lite # to run a lite node on the mainnet
+# or mainnet archive node: docker compose up -d mainnet-archive
+# or testnet lite node:    docker compose up -d testnet-lite
+# or testnet archive node: docker compose up -d testnet-archive
+```
+
+## Compiling your own binary
+### Requirements
+```bash
+sudo apt install build-essential git make clang libssl-dev llvm libudev-dev protobuf-compiler -y
+```
+
+### Install Rust
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup-init.sh
+chmod +x rustup-init.sh
+./rustup-init.sh # you can select default options in the prompts you will be given
+source "$HOME/.cargo/env"
+```
+
+### Rustup update
+```bash
+rustup default stable && \
+ rustup update && \
+ rustup update nightly && \
+ rustup target add wasm32-unknown-unknown --toolchain nightly
+```
+
+### Compiling
+```bash
+git clone https://github.com/opentensor/subtensor.git
+cd subtensor
+cargo build --release --features runtime-benchmarks
+```
+
+### Running the node
+#### Lite node
+```bash
+./target/release/node-subtensor \
+  --base-path /tmp/blockchain \
+  --chain ./raw_spec.json \
+  --rpc-external --rpc-cors all \
+  --ws-external --no-mdns \
+  --ws-max-connections 10000 --in-peers 500 --out-peers 500 \
+  --bootnodes /dns/bootnode.finney.opentensor.ai/tcp/30333/ws/p2p/12D3KooWRwbMb85RWnT8DSXSYMWQtuDwh4LJzndoRrTDotTR5gDC \
+  --sync warp
+``` 
+
+#### Archive node
+```bash
+
+./target/release/node-subtensor \
+  --base-path /tmp/blockchain \
+  --chain ./raw_spec.json \
+  --rpc-external --rpc-cors all \
+  --ws-external --no-mdns \
+  --ws-max-connections 10000 --in-peers 500 --out-peers 500 \
+  --bootnodes /dns/bootnode.finney.opentensor.ai/tcp/30333/ws/p2p/12D3KooWRwbMb85RWnT8DSXSYMWQtuDwh4LJzndoRrTDotTR5gDC \
+  --pruning=archive
+``` 


### PR DESCRIPTION
- Added docker compose defs for subtensor nodes:
  - mainnet-lite
  - mainnet-archive
  - testnet-lite
  - testnet-archive
- Modify Dockerfile to add just the needed files to the container
- Added documentation to run subtensor locally with docker or compiling it. 