### PR TITLE
Add the proxy pallet to the runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4231,6 +4231,7 @@ dependencies = [
  "pallet-membership",
  "pallet-multisig",
  "pallet-preimage",
+ "pallet-proxy",
  "pallet-registry",
  "pallet-scheduler",
  "pallet-subtensor",
@@ -4632,6 +4633,21 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-proxy"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
  "sp-io",
  "sp-runtime",
  "sp-std",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -56,6 +56,7 @@ pallet-membership = {version = "4.0.0-dev", default-features = false, git = "htt
 
 # Multisig
 pallet-multisig = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.39" }
+pallet-proxy = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.39"}
 
 # Scheduler pallet
 pallet-scheduler = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.39" }
@@ -106,6 +107,8 @@ std = [
 	"pallet-scheduler/std",
 	"pallet-preimage/std",
 	"pallet-commitments/std",
+	"pallet-proxy/std",
+	"subtensor-custom-rpc-runtime-api/std",
 	"sp-api/std",
 	"sp-block-builder/std",
 	"sp-consensus-aura/std",
@@ -138,7 +141,8 @@ runtime-benchmarks = [
 	"pallet-membership/runtime-benchmarks",
 	"pallet-registry/runtime-benchmarks",
 	"pallet-commitments/runtime-benchmarks",
-	"pallet-admin-utils/runtime-benchmarks"
+	"pallet-admin-utils/runtime-benchmarks",
+	"pallet-proxy/runtime-benchmarks",
 ]
 try-runtime = [
 	"frame-try-runtime/try-runtime",
@@ -159,4 +163,5 @@ try-runtime = [
 	"pallet-multisig/try-runtime",
 	"pallet-scheduler/try-runtime",
 	"pallet-preimage/try-runtime",
+	"pallet-proxy/try-runtime",
 ]


### PR DESCRIPTION
## Description

This PR adds parity's [proxy pallet](https://github.com/paritytech/polkadot-sdk/tree/master/substrate/frame/proxy) to the runtime. The Proxy Pallet introduces a pivotal functionality within Subtensor, empowering users to establish a proxy account for another, enhancing both security and usability in key management. This versatile feature allows users to configure proxies with distinct privileges through the ProxyType. Presently, two essential proxy types have been incorporated:

Any: This proxy type grants the proxy account the authority to execute any extrinsic on behalf of the associated account, offering comprehensive control.

Staking: Specifically designed for managing staking capabilities, this proxy type restricts the proxy account to executing `add_stake` and `remove_stake` extrinsics for the associated account. It proves invaluable for scenarios where a hotkey is employed to oversee staking activities for a cold wallet.

New ProxyTypes can be added in the future to add more fine-grained control over the proxy account's privileges. 
