### PR TITLE
Automatically set 0 to deregistered subnets

### DIFF
--- a/docs/running-subtensor-locally.md
+++ b/docs/running-subtensor-locally.md
@@ -2,6 +2,7 @@
 
 - [Running docker](#running-docker)
 - [Compiling your own binary](#compiling-your-own-binary)
+- [Running on cloud](#running-on-cloud)
 
 ## Running docker
 
@@ -71,3 +72,9 @@ sudo ./scripts/run/subtensor.sh -e docker --network testnet --node-type lite
 ```bash
 sudo ./scripts/run/subtensor.sh -e docker --network testnet --node-type archive
 ```
+
+## Running on cloud
+
+We have not tested these installation scripts on any cloud service. In addition, if you are using Runpod cloud service, then note that this service is already [containerized](https://docs.runpod.io/pods/overview). Hence, the only option available to you is to [compile from source](#method-1-by-compiling-the-source-code) but these scripts have not been tested on Runpod.
+
+

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -861,7 +861,7 @@ pub mod pallet {
         PowRegistrationAllowed(u16, bool), // --- Event created when POW registration is allowed/disallowed for a subnet.
         TempoSet(u16, u16),             // --- Event created when setting tempo on a network
         RAORecycledForRegistrationSet(u16, u64), // Event created when setting the RAO recycled for registration.
-        WeightsMinStake(u64),
+        WeightsMinStake(u64),           // --- Event created when min stake is set for validators to set weights.
         SenateRequiredStakePercentSet(u64), // Event created when setting the minimum required stake amount for senate registration.
         AdjustmentAlphaSet(u16, u64), // Event created when setting the adjustment alpha on a subnet.
         Faucet(T::AccountId, u64), // Event created when the facuet it called on the test net.

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1666,7 +1666,6 @@ pub mod pallet {
             if Uids::<T>::contains_key(netuid, &hotkey) {
                 let uid = Self::get_uid_for_net_and_hotkey(netuid, &hotkey.clone()).unwrap();
                 let stake = Self::get_total_stake_for_hotkey(&hotkey);
-                if stake <= 20_000_000_000_000_000 { return 0; } // Blacklist weights transactions for low stake peers.
                 let current_block_number: u64 = Self::get_current_block_as_u64();
                 let default_priority: u64 =
                     current_block_number - Self::get_last_update_for_uid(netuid, uid as u16);

--- a/pallets/subtensor/src/root.rs
+++ b/pallets/subtensor/src/root.rs
@@ -823,7 +823,7 @@ impl<T: Config> Pallet<T> {
         let _ = Keys::<T>::clear_prefix(netuid, u32::max_value(), None);
         let _ = Bonds::<T>::clear_prefix(netuid, u32::max_value(), None);
       
-        // --- 3. Iterate over stored weights and fill the matrix.
+        // --- 9. Iterate over stored weights and fill the matrix.
         for (uid_i, weights_i) in
         <Weights<T> as IterableStorageDoubleMap<u16, u16, Vec<(u16, u16)>>>::iter_prefix(
             Self::get_root_netuid(),
@@ -844,7 +844,7 @@ impl<T: Config> Pallet<T> {
             Weights::<T>::insert(Self::get_root_netuid(), uid_i, modified_weights);
         }
 
-        // --- 9. Remove various network-related parameters.
+        // --- 10. Remove various network-related parameters.
         Rank::<T>::remove(netuid);
         Trust::<T>::remove(netuid);
         Active::<T>::remove(netuid);
@@ -857,7 +857,7 @@ impl<T: Config> Pallet<T> {
         ValidatorPermit::<T>::remove(netuid);
         ValidatorTrust::<T>::remove(netuid);
 
-        // --- 10. Erase network parameters.
+        // --- 11. Erase network parameters.
         Tempo::<T>::remove(netuid);
         Kappa::<T>::remove(netuid);
         Difficulty::<T>::remove(netuid);
@@ -871,7 +871,7 @@ impl<T: Config> Pallet<T> {
         POWRegistrationsThisInterval::<T>::remove(netuid);
         BurnRegistrationsThisInterval::<T>::remove(netuid);
 
-        // --- 11. Add the balance back to the owner.
+        // --- 12. Add the balance back to the owner.
         Self::add_balance_to_coldkey_account(&owner_coldkey, reserved_amount_as_bal.unwrap());
         Self::set_subnet_locked_balance(netuid, 0);
         SubnetOwner::<T>::remove(netuid);

--- a/pallets/subtensor/src/root.rs
+++ b/pallets/subtensor/src/root.rs
@@ -830,15 +830,12 @@ impl<T: Config> Pallet<T> {
         )
         {
             // Create a new vector to hold modified weights.
-            let mut modified_weights = Vec::new();
-            // Iterate over each weight entry in `weights_i` to potentially update it.
-            for (subnet_id, weight) in weights_i.iter() {
+            let mut modified_weights = weights_i.clone();
+            // Iterate over each weight entry to potentially update it.
+            for (subnet_id, weight) in modified_weights.iter_mut() {
                 if subnet_id == &netuid {
-                    // If the condition matches, modify the weight as needed and push it to the new vector.
-                    modified_weights.push((*subnet_id, 0)); // Set weight to 0 for the matching subnet_id.
-                } else {
-                    // For all other entries, just copy them to the new vector.
-                    modified_weights.push((*subnet_id, *weight));
+                    // If the condition matches, modify the weight
+                    *weight = 0; // Set weight to 0 for the matching subnet_id.
                 }
             }
             Weights::<T>::insert(Self::get_root_netuid(), uid_i, modified_weights);

--- a/pallets/subtensor/src/root.rs
+++ b/pallets/subtensor/src/root.rs
@@ -625,6 +625,7 @@ impl<T: Config> Pallet<T> {
 
                 Self::remove_network(netuid_to_prune);
                 log::debug!("remove_network: {:?}", netuid_to_prune,);
+                Self::deposit_event(Event::NetworkRemoved(netuid));
                 netuid_to_prune
             }
         };

--- a/pallets/subtensor/src/root.rs
+++ b/pallets/subtensor/src/root.rs
@@ -625,7 +625,6 @@ impl<T: Config> Pallet<T> {
 
                 Self::remove_network(netuid_to_prune);
                 log::debug!("remove_network: {:?}", netuid_to_prune,);
-                Self::deposit_event(Event::NetworkRemoved(netuid_to_prune));
                 netuid_to_prune
             }
         };

--- a/pallets/subtensor/src/root.rs
+++ b/pallets/subtensor/src/root.rs
@@ -178,7 +178,7 @@ impl<T: Config> Pallet<T> {
     //
     // # Returns:
     // A 2D vector ('Vec<Vec<I32F32>>') where each entry [i][j] represents the weight of subnetwork
-    // 'j' with according to the preferences of key. 'j' within the root network.
+    // 'j' with according to the preferences of key. Validator 'i' within the root network.
     //
     pub fn get_root_weights() -> Vec<Vec<I64F64>> {
         // --- 0. The number of validators on the root network.
@@ -853,7 +853,9 @@ impl<T: Config> Pallet<T> {
         // --- 11. Add the balance back to the owner.
         Self::add_balance_to_coldkey_account(&owner_coldkey, reserved_amount_as_bal.unwrap());
         Self::set_subnet_locked_balance(netuid, 0);
-        SubnetOwner::<T>::remove(netuid);
+
+        // --- 12. Set its weight to 0 from all validators
+        Weights::<T>::remove(0, netuid);
     }
 
     // This function calculates the lock cost for a network based on the last lock amount, minimum lock cost, last lock block, and current block.

--- a/pallets/subtensor/src/root.rs
+++ b/pallets/subtensor/src/root.rs
@@ -961,7 +961,7 @@ impl<T: Config> Pallet<T> {
             }
         });
 
-        log::info!("{:?}", netuids);
+        log::info!("Netuids Order: {:?}", netuids);
 
         match netuids.last() {
             Some(netuid) => *netuid,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -121,7 +121,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 170,
+    spec_version: 142,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -121,7 +121,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 142,
+    spec_version: 169,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -121,7 +121,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 169,
+    spec_version: 170,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -121,7 +121,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 141,
+    spec_version: 142,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
This will ensure that when subnets are deregistered, its weights are automagically set to 0. 