### PR TITLE
Weights min stake

### DIFF
--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -701,6 +701,16 @@ pub mod pallet {
 			T::Subtensor::set_rao_recycled(netuid, rao_recycled);
 			Ok(())
 		}
+
+		#[pallet::call_index(42)]
+		#[pallet::weight((0, DispatchClass::Operational, Pays::No))]
+		pub fn sudo_set_weights_min_stake( origin: OriginFor<T>, min_stake: u64 ) -> DispatchResult 
+		{
+			ensure_root(origin)?;
+			T::Subtensor::set_weights_min_stake(min_stake);
+			Ok(())
+		}
+
     }
 }
 
@@ -785,4 +795,5 @@ pub trait SubtensorInterface<AccountId, Balance, RuntimeOrigin>
 	fn set_adjustment_interval(netuid: u16, adjustment_interval: u16);
 	fn set_weights_set_rate_limit(netuid: u16, weights_set_rate_limit: u64);
 	fn init_new_network(netuid: u16, tempo: u16);
+	fn set_weights_min_stake(min_stake: u64);
 }

--- a/pallets/admin-utils/tests/mock.rs
+++ b/pallets/admin-utils/tests/mock.rs
@@ -478,6 +478,11 @@ impl pallet_admin_utils::SubtensorInterface<AccountId, Balance, RuntimeOrigin> f
     {
         SubtensorModule::init_new_network(netuid, tempo);
     }
+
+    fn set_weights_min_stake( min_stake: u64 )
+    {
+        SubtensorModule::set_weights_min_stake( min_stake );
+    }
 }
 
 impl pallet_admin_utils::Config for Test {

--- a/pallets/admin-utils/tests/tests.rs
+++ b/pallets/admin-utils/tests/tests.rs
@@ -684,6 +684,34 @@ fn test_sudo_set_max_allowed_validators() {
     });
 }
 
+
+#[test]
+fn test_sudo_set_weights_min_stake() {
+    new_test_ext().execute_with(|| {
+        let to_be_set: u64 = 10;
+        let init_value: u64 = SubtensorModule::get_weights_min_stake();
+        assert_eq!(
+            AdminUtils::sudo_set_weights_min_stake(
+                <<Test as Config>::RuntimeOrigin>::signed(U256::from(1)),
+                to_be_set
+            ),
+            Err(DispatchError::BadOrigin.into())
+        );
+        assert_eq!(
+            SubtensorModule::get_weights_min_stake(),
+            init_value
+        );
+        assert_ok!(AdminUtils::sudo_set_weights_min_stake(
+            <<Test as Config>::RuntimeOrigin>::root(),
+            to_be_set
+        ));
+        assert_eq!(
+            SubtensorModule::get_weights_min_stake(),
+            to_be_set
+        );
+    });
+}
+
 #[test]
 fn test_sudo_set_bonds_moving_average() {
     new_test_ext().execute_with(|| {

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1687,21 +1687,21 @@ pub mod pallet {
 
         pub fn checked_allowed_register( netuid: u16 ) -> bool {
             if netuid == Self::get_root_netuid() {
-                return false
+                return false;
             }
             if !Self::if_subnet_exist(netuid) {
-                return false
+                return false;
             }
             if !Self::get_network_registration_allowed(netuid) {
-                return false
+                return false;
             }
             if Self::get_registrations_this_block(netuid) >= Self::get_max_registrations_per_block(netuid) {
-                return false
+                return false;
             }
             if Self::get_registrations_this_interval(netuid) >= Self::get_target_registrations_per_interval(netuid) * 3 {
-                return false
+                return false;
             }
-            return true
+            true
         }
     }
 }
@@ -1749,7 +1749,7 @@ where
     }
 
     pub fn check_weights_min_stake( who: &T::AccountId ) -> bool {
-        return Pallet::<T>::check_weights_min_stake(who);
+        Pallet::<T>::check_weights_min_stake(who)
     }
 
     pub fn u64_to_balance(

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -886,6 +886,7 @@ pub mod pallet {
         NotRegistered, // ---- Thrown when the caller requests setting or removing data from a neuron which does not exist in the active set.
         NonAssociatedColdKey, // ---- Thrown when a stake, unstake or subscribe request is made by a coldkey which is not associated with the hotkey account.
         NotEnoughStaketoWithdraw, // ---- Thrown when the caller requests removing more stake than there exists in the staking account. See: fn remove_stake.
+        NotEnoughStakeToSetWeights, // ---- Thrown when the caller requests to set weights but has less than WeightsMinStake
         NotEnoughBalanceToStake, //  ---- Thrown when the caller requests adding more stake than there exists in the cold key account. See: fn add_stake
         BalanceWithdrawalError, // ---- Thrown when the caller tries to add stake, but for some reason the requested amount could not be withdrawn from the coldkey account.
         NoValidatorPermit, // ---- Thrown when the caller attempts to set non-self weights without being a permitted validator.

--- a/pallets/subtensor/src/utils.rs
+++ b/pallets/subtensor/src/utils.rs
@@ -133,6 +133,10 @@ impl<T: Config> Pallet<T> {
             ValidatorPermit::<T>::insert(netuid, updated_validator_permit);
         }
     }
+    pub fn set_weights_min_stake( min_stake: u64 ) {
+        WeightsMinStake::<T>::put( min_stake );
+        Self::deposit_event(Event::WeightsMinStake(min_stake));
+    }
 
     pub fn get_rank_for_uid(netuid: u16, uid: u16) -> u16 {
         let vec = Rank::<T>::get(netuid);
@@ -221,6 +225,9 @@ impl<T: Config> Pallet<T> {
         } else {
             return false;
         }
+    }
+    pub fn get_weights_min_stake( ) -> u64 {
+        WeightsMinStake::<T>::get()
     }
 
     // ============================

--- a/pallets/subtensor/src/weights.rs
+++ b/pallets/subtensor/src/weights.rs
@@ -113,7 +113,7 @@ impl<T: Config> Pallet<T> {
         // --- 6. Check to see if the hotkey has enought stake to set weights.
         ensure!(
             Self::get_total_stake_for_hotkey(&hotkey) >= Self::get_weights_min_stake(),
-            Error::<T>::NotEnoughStaketoWithdraw
+            Error::<T>::NotEnoughStakeToSetWeights
         );
 
         // --- 7. Ensure version_key is up-to-date.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -996,6 +996,11 @@ impl pallet_admin_utils::SubtensorInterface<AccountId, <pallet_balances::Pallet<
     {
         SubtensorModule::init_new_network(netuid, tempo);
     }
+    
+    fn set_weights_min_stake(min_stake: u64)
+    {
+        SubtensorModule::set_weights_min_stake(min_stake);
+    }
 }
 
 impl pallet_admin_utils::Config for Runtime {


### PR DESCRIPTION
This PR adds a check into the signed extension for pallet subtensor which blocks calls to set weights when the caller has less stake than predefined WeightsMinStake value. 

