### PR TITLE
Set activity fix for miners in metagraph

### DIFF
--- a/pallets/subtensor/src/weights.rs
+++ b/pallets/subtensor/src/weights.rs
@@ -181,15 +181,22 @@ impl<T: Config> Pallet<T> {
         // --- 17. Set the activity for the weights on this network.
         Self::set_last_update_for_uid(netuid, neuron_uid, current_block);
 
-        // --- 18. Emit the tracking event.
+        // --- 18. Set the activity for the minors on this network.
+        for &uid in uids.iter() {
+            // Ensure we don't redo the update for neuron_uid
+            if uid != neuron_uid {
+                Self::set_last_update_for_uid(netuid, uid, current_block);
+            }
+        }
+        // --- 19. Emit the tracking event.
         log::info!(
-            "WeightsSet( netuid:{:?}, neuron_uid:{:?} )",
+            "WeightsSet( netuid:{:?}, neuron_uids:{:?} )",
             netuid,
-            neuron_uid
+            uids
         );
         Self::deposit_event(Event::WeightsSet(netuid, neuron_uid));
 
-        // --- 19. Return ok.
+        // --- 20. Return ok.
         Ok(())
     }
 


### PR DESCRIPTION
Since miners don't set weights anymore, the value of the last 'UPDATE' value in the metagraph remains untouched for miners. The current 'set_weights' function correctly updates the weights for the uids but only updates the activity value in the graph for the validator itself. As a result, the last block updated for those miners in the list of uids for set_weights remains untouched and keeps growing. This raises 2 problem:
  
  1) This lack of activity update for the miners results in miner codes constantly trying to sync with the metagraph since the logic is to update if the miner is behind by a certain threshold.
  2) Lack of updates on the last block will also affect the monitoring websites such as taostats where they suggest that the last updated block should not grow and as a result, this might confuse the users.