### PR TITLE
Adds new power to Subnet owners.

### DIFF
--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -228,7 +228,7 @@ pub mod pallet {
 		))]
 		pub fn sudo_set_adjustment_alpha(origin: OriginFor<T>, netuid: u16, adjustment_alpha: u64) -> DispatchResult 
 		{
-			ensure_root(origin)?;
+			T::Subtensor::ensure_subnet_owner_or_root(origin, netuid)?;
 
 			ensure!(
 				T::Subtensor::if_subnet_exist(netuid),
@@ -324,7 +324,7 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::sudo_set_kappa())]
 		pub fn sudo_set_kappa(origin: OriginFor<T>, netuid: u16, kappa: u16) -> DispatchResult 
 		{
-			ensure_root(origin)?;
+			T::Subtensor::ensure_subnet_owner_or_root(origin, netuid)?;
 	
 			ensure!(
 				T::Subtensor::if_subnet_exist(netuid),
@@ -339,7 +339,7 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::sudo_set_rho())]
 		pub fn sudo_set_rho(origin: OriginFor<T>, netuid: u16, rho: u16) -> DispatchResult 
 		{
-			ensure_root(origin)?;
+			T::Subtensor::ensure_subnet_owner_or_root(origin, netuid)?;
 	
 			ensure!(
 				T::Subtensor::if_subnet_exist(netuid),
@@ -469,7 +469,7 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::sudo_set_difficulty())]
 		pub fn sudo_set_difficulty(origin: OriginFor<T>, netuid: u16, difficulty: u64) -> DispatchResult 
 		{
-			ensure_root(origin)?;
+			T::Subtensor::ensure_subnet_owner_or_root(origin, netuid)?;
 			ensure!(
 				T::Subtensor::if_subnet_exist(netuid),
 				Error::<T>::NetworkDoesNotExist
@@ -511,7 +511,7 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::sudo_set_bonds_moving_average())]
 		pub fn sudo_set_bonds_moving_average(origin: OriginFor<T>, netuid: u16, bonds_moving_average: u64) -> DispatchResult 
 		{
-			ensure_root(origin)?;
+			T::Subtensor::ensure_subnet_owner_or_root(origin, netuid)?;
 	
 			ensure!(
 				T::Subtensor::if_subnet_exist(netuid),

--- a/pallets/admin-utils/tests/tests.rs
+++ b/pallets/admin-utils/tests/tests.rs
@@ -621,7 +621,7 @@ fn test_sudo_set_difficulty() {
         let init_value: u64 = SubtensorModule::get_difficulty_as_u64(netuid);
         assert_eq!(
             AdminUtils::sudo_set_difficulty(
-                <<Test as Config>::RuntimeOrigin>::signed(U256::from(0)),
+                <<Test as Config>::RuntimeOrigin>::signed(U256::from(1)),
                 netuid,
                 to_be_set
             ),

--- a/pallets/subtensor/src/root.rs
+++ b/pallets/subtensor/src/root.rs
@@ -724,7 +724,7 @@ impl<T: Config> Pallet<T> {
         Self::set_max_weight_limit(netuid, u16::MAX);
         Self::set_adjustment_interval(netuid, 360);
         Self::set_target_registrations_per_interval(netuid, 1);
-        Self::set_adjustment_alpha(netuid, 58000);
+        Self::set_adjustment_alpha(netuid, 17_893_341_751_498_265_066); // 18_446_744_073_709_551_615 * 0.97 = 17_893_341_751_498_265_066
         Self::set_immunity_period(netuid, 5000);
         Self::set_min_burn(netuid, 1);
         Self::set_min_difficulty(netuid, u64::MAX);

--- a/pallets/subtensor/tests/block_step.rs
+++ b/pallets/subtensor/tests/block_step.rs
@@ -14,6 +14,7 @@ fn test_loaded_emission() {
         let emission: Vec<u64> = vec![1000000000];
         add_network(netuid, tempo, 0);
         SubtensorModule::set_max_allowed_uids(netuid, n);
+        SubtensorModule::set_adjustment_alpha(netuid, 58000); // Set to old value.
         SubtensorModule::set_emission_values( &netuids, emission);
         for i in 0..n {
             SubtensorModule::append_neuron(netuid, &U256::from(i), 0);
@@ -174,6 +175,7 @@ fn test_burn_adjustment() {
         add_network(netuid, tempo, 0);
         SubtensorModule::set_burn(netuid, burn_cost);
         SubtensorModule::set_adjustment_interval(netuid, adjustment_interval);
+        SubtensorModule::set_adjustment_alpha(netuid, 58000); // Set to old value.
         SubtensorModule::set_target_registrations_per_interval(
             netuid,
             target_registrations_per_interval,
@@ -220,6 +222,7 @@ fn test_burn_adjustment_with_moving_average() {
         add_network(netuid, tempo, 0);
         SubtensorModule::set_burn(netuid, burn_cost);
         SubtensorModule::set_adjustment_interval(netuid, adjustment_interval);
+        SubtensorModule::set_adjustment_alpha(netuid, 58000); // Set to old value.
         SubtensorModule::set_target_registrations_per_interval(
             netuid,
             target_registrations_per_interval,
@@ -277,6 +280,7 @@ fn test_burn_adjustment_case_a() {
         SubtensorModule::set_difficulty(netuid, start_diff);
         SubtensorModule::set_min_difficulty(netuid, start_diff);
         SubtensorModule::set_adjustment_interval(netuid, adjustment_interval);
+        SubtensorModule::set_adjustment_alpha(netuid, 58000); // Set to old value.
         SubtensorModule::set_target_registrations_per_interval(
             netuid,
             target_registrations_per_interval,
@@ -368,6 +372,7 @@ fn test_burn_adjustment_case_b() {
         SubtensorModule::set_burn(netuid, burn_cost);
         SubtensorModule::set_difficulty(netuid, start_diff);
         SubtensorModule::set_adjustment_interval(netuid, adjustment_interval);
+        SubtensorModule::set_adjustment_alpha(netuid, 58000); // Set to old value.
         SubtensorModule::set_target_registrations_per_interval(
             netuid,
             target_registrations_per_interval,
@@ -449,6 +454,7 @@ fn test_burn_adjustment_case_c() {
         SubtensorModule::set_burn(netuid, burn_cost);
         SubtensorModule::set_difficulty(netuid, start_diff);
         SubtensorModule::set_adjustment_interval(netuid, adjustment_interval);
+        SubtensorModule::set_adjustment_alpha(netuid, 58000); // Set to old value.
         SubtensorModule::set_target_registrations_per_interval(
             netuid,
             target_registrations_per_interval,
@@ -541,6 +547,7 @@ fn test_burn_adjustment_case_d() {
         SubtensorModule::set_difficulty(netuid, start_diff);
         SubtensorModule::set_min_difficulty(netuid, 1);
         SubtensorModule::set_adjustment_interval(netuid, adjustment_interval);
+        SubtensorModule::set_adjustment_alpha(netuid, 58000); // Set to old value.
         SubtensorModule::set_target_registrations_per_interval(
             netuid,
             target_registrations_per_interval,
@@ -624,6 +631,7 @@ fn test_burn_adjustment_case_e() {
         SubtensorModule::set_difficulty(netuid, start_diff);
         SubtensorModule::set_min_difficulty(netuid, 1);
         SubtensorModule::set_adjustment_interval(netuid, adjustment_interval);
+        SubtensorModule::set_adjustment_alpha(netuid, 58000); // Set to old value.
         SubtensorModule::set_target_registrations_per_interval(
             netuid,
             target_registrations_per_interval,
@@ -698,6 +706,7 @@ fn test_burn_adjustment_case_f() {
         SubtensorModule::set_difficulty(netuid, start_diff);
         SubtensorModule::set_min_difficulty(netuid, start_diff);
         SubtensorModule::set_adjustment_interval(netuid, adjustment_interval);
+        SubtensorModule::set_adjustment_alpha(netuid, 58000); // Set to old value.
         SubtensorModule::set_target_registrations_per_interval(
             netuid,
             target_registrations_per_interval,
@@ -771,6 +780,7 @@ fn test_burn_adjustment_case_e_zero_registrations() {
         SubtensorModule::set_difficulty(netuid, start_diff);
         SubtensorModule::set_min_difficulty(netuid, 1);
         SubtensorModule::set_adjustment_interval(netuid, adjustment_interval);
+        SubtensorModule::set_adjustment_alpha(netuid, 58000); // Set to old value.
         SubtensorModule::set_target_registrations_per_interval(
             netuid,
             target_registrations_per_interval,

--- a/pallets/subtensor/tests/difficulty.rs
+++ b/pallets/subtensor/tests/difficulty.rs
@@ -15,6 +15,7 @@ fn test_registration_difficulty_adjustment() {
         assert_eq!(SubtensorModule::get_difficulty_as_u64(netuid), 10000); // Check initial difficulty.
         assert_eq!(SubtensorModule::get_last_adjustment_block(netuid), 0); // Last adjustment block starts at 0.
         assert_eq!(SubtensorModule::get_registrations_this_block(netuid), 0); // No registrations this block.
+        SubtensorModule::set_adjustment_alpha(netuid, 58000);
         SubtensorModule::set_target_registrations_per_interval(netuid, 2);
         SubtensorModule::set_adjustment_interval(netuid,100);
         assert_eq!(

--- a/pallets/subtensor/tests/registration.rs
+++ b/pallets/subtensor/tests/registration.rs
@@ -215,6 +215,7 @@ fn test_burn_adjustment() {
         add_network(netuid, tempo, 0);
         SubtensorModule::set_burn(netuid, burn_cost);
         SubtensorModule::set_adjustment_interval(netuid, adjustment_interval);
+        SubtensorModule::set_adjustment_alpha(netuid, 58000); // Set to old value.
         SubtensorModule::set_target_registrations_per_interval(
             netuid,
             target_registrations_per_interval,


### PR DESCRIPTION
- Changes default registration adjustment_alpha to 0.97
- Allows owners to set adjustment_alpha
- Allows owners to set rho
- Allows owners to set kappa
- Allows owners to set bonds moving average