### PR TITLE
Remove profile section in runtime/Cargo.toml

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -12,9 +12,6 @@ repository = "https://github.com/opentensor/subtensor/"
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
-[profile.test]
-opt-level = 3
-
 [dependencies]
 pallet-subtensor = { version = "4.0.0-dev", default-features = false, path = "../pallets/subtensor" }
 subtensor-custom-rpc-runtime-api = { version = "0.0.2", path = "../pallets/subtensor/runtime-api", default-features = false }


### PR DESCRIPTION
Since they're not gonna be read and are overridden by the top-level `Cargo.toml` anyway, let's go ahead and remove the `profile` section.