### PR TITLE
Adjust Multi-Sig Deposit

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -476,9 +476,9 @@ impl pallet_sudo::Config for Runtime {
 parameter_types! {
     // One storage item; key size is 32 + sizeof(AccountId) = 64; value is size 4 + sizeof((BlockNumber, Balance, AccountId)) = 56;
 	// = 120 bytes total.
-    pub const DepositBase: Balance = (1) as Balance * 2_000 * 10_000 + (120 as Balance) * 100 * 10_000;
+    pub const DepositBase: Balance = (1) as Balance * 200 * 1_000 + (120 as Balance) * 300 * 1_000;
     // Additional storage item size of 32 bytes.
-    pub const DepositFactor: Balance = (0) as Balance * 2_000 * 10_000 + (32 as Balance) * 100 * 10_000;
+    pub const DepositFactor: Balance = (0) as Balance * 200 * 1_000 + (32 as Balance) * 300 * 1_000;
     pub const MaxSignatories: u32 = 100;
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -474,8 +474,9 @@ impl pallet_sudo::Config for Runtime {
 }
 
 parameter_types! {
-    // One storage item; key size is 32; value is size 4+4+16+32 bytes = 56 bytes.
-    pub const DepositBase: Balance = (1) as Balance * 2_000 * 10_000 + (88 as Balance) * 100 * 10_000;
+    // One storage item; key size is 32 + sizeof(AccountId) = 64; value is size 4 + sizeof((BlockNumber, Balance, AccountId)) = 56;
+	// = 120 bytes total.
+    pub const DepositBase: Balance = (1) as Balance * 2_000 * 10_000 + (120 as Balance) * 100 * 10_000;
     // Additional storage item size of 32 bytes.
     pub const DepositFactor: Balance = (0) as Balance * 2_000 * 10_000 + (32 as Balance) * 100 * 10_000;
     pub const MaxSignatories: u32 = 100;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -475,7 +475,7 @@ impl pallet_sudo::Config for Runtime {
 
 parameter_types! {
     // One storage item; key size is 32 + sizeof(AccountId) = 64; value is size 4 + sizeof((BlockNumber, Balance, AccountId)) = 56;
-	// = 120 bytes total.
+    // = 120 bytes total.
     pub const DepositBase: Balance = (1) as Balance * 200 * 1_000 + (120 as Balance) * 300 * 1_000;
     // Additional storage item size of 32 bytes.
     pub const DepositFactor: Balance = (0) as Balance * 200 * 1_000 + (32 as Balance) * 300 * 1_000;


### PR DESCRIPTION
This PR affects the multi-sig deposit in two ways:
1. Fixes the deposit base calculation to match the multi-sig pallet comments ([link](https://github.com/paritytech/substrate/blob/89a50c7106a4bb3eca42a584122a9c97e9286144/frame/multisig/src/lib.rs#L120-L128))
2. Lowers the deposit base by adjusting the constant terms 
    - e.g. `0.172` for a `2/2` multi-sig becomes `0.0476` 
        - and `0.0572` after the first change