### PR TITLE
add zero check when stake

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -968,6 +968,7 @@ pub mod pallet {
         StakeTooLowForRoot, // --- Thrown when a hotkey attempts to join the root subnet with too little stake
         AllNetworksInImmunity, // --- Thrown when all subnets are in the immunity period
         NotEnoughBalance,
+        StakeAmountIsZero, // -- Thrown when add stake amount is zero
     }
 
     // ==================

--- a/pallets/subtensor/tests/staking.rs
+++ b/pallets/subtensor/tests/staking.rs
@@ -456,6 +456,24 @@ fn test_add_stake_rate_limit_exceeded() {
     });
 }
 
+#[test]
+fn test_add_stake_err_stake_amount_is_zero() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey_account_id = U256::from(435445);
+        let hotkey_account_id = U256::from(54544);
+        let amount = 0;
+
+        assert_eq!(
+            SubtensorModule::add_stake(
+                <<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id),
+                hotkey_account_id,
+                amount
+            ),
+            Err(Error::<Test>::StakeAmountIsZero.into())
+        );
+    });
+}
+
 // /***********************************************************
 // 	staking::remove_stake() tests
 // ************************************************************/


### PR DESCRIPTION
When checking the status of network, found out lots of stake with 0 records. We can avoid it via checking the stake amount