### PR TITLE
Fixing README and subtensor node install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ Requirements:
 
 ## For Subnet Development 
 
-For subnet incentive mechanism development and testing, you will need to run a local subtensor node. Follow the detailed step-by-step instructions provided in the document [Running subtensor locally](./docs/running-subtensor-locally.md) to run either a lite node or an archive node. Also see the [**Subtensor Nodes** section in Bittensor Developer Documentation](https://docs.bittensor.com/subtensor-nodes).
+If you are developing and testing subnet incentive mechanism, you will need to run a local subtensor node. Follow the detailed step-by-step instructions provided in the document [Running subtensor locally](./docs/running-subtensor-locally.md) to run either a lite node or an archive node. Also see the [**Subtensor Nodes** section in Bittensor Developer Documentation](https://docs.bittensor.com/subtensor-nodes).
+
+### Lite node vs Archive node
+
+For an explanation of lite node, archive node and how you can run your local subtensor node in these modes, see [Lite node vs archive node](https://docs.bittensor.com/subtensor-nodes#lite-node-vs-archive-node) section on [Bittensor Developer Docs](https://docs.bittensor.com/).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 This repository contains Bittensor's substrate-chain. Subtensor contains the trusted logic which:
 
 1. Runs Bittensor's [consensus mechanism](./docs/consensus.md);
-2. Advertises neuron information, IPs, etc.; and
+2. Advertises neuron information, IPs, etc., and
 3. Facilitates value transfer via TAO.
 
 ## System Requirements
@@ -42,15 +42,25 @@ Requirements:
 * Subtensor needs access to the public internet
 * Subtensor runs on ipv4
 * Subtensor listens on the following ports:
-1) 9944 - Websocket. This port is used by bittensor. It only accepts connections from localhost. Make sure this port is firewalled off from the public domain.
-2) 9933 - RPC. This port is opened, but not used.
-3) 30333 - p2p socket. This port accepts connections from other subtensor nodes. Make sure your firewall(s) allow incoming traffic to this port.
+  1) 9944 - Websocket. This port is used by bittensor. It only accepts connections from localhost. Make sure this port is firewalled off from the public domain.
+  2) 9933 - RPC. This port is opened, but not used.
+  3) 30333 - p2p socket. This port accepts connections from other subtensor nodes. Make sure your firewall(s) allow incoming traffic to this port.
 * It is assumed your default outgoing traffic policy is ACCEPT. If not, make sure outbound traffic to port 30333 is allowed.
+
+---
+
+## For Subnet Development 
+
+For subnet incentive mechanism development and testing, you will need to run a local subtensor node. Follow the detailed step-by-step instructions provided in the document [Running subtensor locally](./docs/running-subtensor-locally.md) to run either a lite node or an archive node. Also see the [**Subtensor Nodes** section in Bittensor Developer Documentation](https://docs.bittensor.com/subtensor-nodes).
+
+---
+
+## For Subtensor Development
 
 ### Installation
 First, complete the [basic Rust setup instructions](./docs/rust-setup.md).
 
-### Run
+**Build and Run**
 
 Use Rust's native `cargo` command to build and launch the template node:
 
@@ -58,14 +68,19 @@ Use Rust's native `cargo` command to build and launch the template node:
 cargo run --release -- --dev
 ```
 
-### Build
+**Build only**
 
-The `cargo run` command will perform an initial build. Use the following command to build the node
+The above `cargo run` command will perform an initial build and launch the node. Use the following command to build the node
 without launching it:
 
 ```sh
 cargo build --release
 ```
+
+<!--
+
+/** When I ran "cargo doc" it gave me a bunch of errors. And when I did "cargo doc --open" it gave same bunch of errors, and did not open. Also, I don't think the binary is "subtensor". It is "node-subtensor". We should uncomment this section after testing and validating and fixing this section.
+*/
 
 ### Embedded Docs
 
@@ -75,10 +90,11 @@ subcommands:
 ```sh
 ./target/release/subtensor -h
 ```
+-->
 
-## Run
+## Other ways to launch the node
 
-The provided `cargo run` command will launch a temporary node and its state will be discarded after
+The above `cargo run` command will launch a temporary node and its state will be discarded after
 you terminate the process. After the project has been built, there are other ways to launch the
 node.
 
@@ -148,7 +164,7 @@ Running code coverage
 bash scripts/code-coverage.sh
 ```
 
-> Note; above requires `cargo-tarpaulin` is installed to the host, eg. `cargo install cargo-tarpaulin`
+> Note: They above requires `cargo-tarpaulin` is installed to the host, eg. `cargo install cargo-tarpaulin`
 > Development chain means that the state of our chain will be in a tmp folder while the nodes are
 > running. Also, **alice** account will be authority and sudo account as declared in the
 > [genesis state](https://github.com/substrate-developer-hub/substrate-node-template/blob/main/node/src/chain_spec.rs#L49).
@@ -158,10 +174,10 @@ bash scripts/code-coverage.sh
 > - Alice//stash
 > - Bob//stash
 
-In case of being interested in maintaining the chain' state between runs a base path must be added
+If we want to maintain the chain state between runs, a base path must be added
 so the db can be stored in the provided folder instead of a temporal one. We could use this folder
 to store different chain databases, as a different folder will be created per different chain that
-is ran. The following commands shows how to use a newly created folder as our db base path.
+is ran. The following commands show how to use a newly created folder as our db base path:
 
 ```bash
 # Create a folder to use as the db base path
@@ -179,7 +195,7 @@ ls ./my-chain-state/chains/dev
 #> db keystore network
 ```
 
-### Connect with Polkadot-JS Apps Front-end
+**Connect with Polkadot-JS Apps Front-end**
 
 Once the node template is running locally, you can connect it with **Polkadot-JS Apps** front-end
 to interact with your chain. [Click
@@ -196,7 +212,7 @@ If you want to see the multi-node consensus algorithm in action, refer to our
 A Substrate project such as this consists of a number of components that are spread across a few
 directories.
 
-### Node
+### Node Capabilities 
 
 A blockchain node is an application that allows users to participate in a blockchain network.
 Substrate-based blockchain nodes expose a number of capabilities:
@@ -210,7 +226,9 @@ Substrate-based blockchain nodes expose a number of capabilities:
   [Web3 Foundation research](https://research.web3.foundation/en/latest/polkadot/NPoS/index.html).
 - RPC Server: A remote procedure call (RPC) server is used to interact with Substrate nodes.
 
-There are several files in the `node` directory - take special note of the following:
+**Directory structure**
+
+There are several files in the [`node`](./node/) directory. Make a note of the following important files: 
 
 - [`chain_spec.rs`](./node/src/chain_spec.rs): A
   [chain specification](https://docs.substrate.io/main-docs/build/chain-spec/) is a
@@ -228,11 +246,13 @@ There are several files in the `node` directory - take special note of the follo
   and other [consensus mechanisms](https://docs.substrate.io/main-docs/fundamentals/consensus/#default-consensus-models)
   such as Aura for block authoring and GRANDPA for finality.
 
+### CLI help
+
 After the node has been [built](#build), refer to the embedded documentation to learn more about the
 capabilities and configuration parameters that it exposes:
 
 ```shell
-./target/release/node-template --help
+./target/release/node-subtensor --help
 ```
 
 ### Runtime
@@ -278,6 +298,7 @@ A FRAME pallet is compromised of a number of blockchain primitives:
 - Config: The `Config` configuration interface is used to define the types and parameters upon
   which a FRAME pallet depends.
 
+<!--
 ### Run in Docker
 
 First, install [Docker](https://docs.docker.com/get-docker/) and
@@ -304,9 +325,9 @@ by appending your own. A few useful ones are as follow.
 # Check whether the code is compilable
 ./scripts/docker_run.sh cargo check
 ```
+-->
 
-
-## 6. License
+## License
 The MIT License (MIT)
 Copyright © 2021 Yuma Rao
 
@@ -317,5 +338,5 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
-## 7. Acknowledgments
+## Acknowledgments
 **parralax**

--- a/docs/running-subtensor-locally.md
+++ b/docs/running-subtensor-locally.md
@@ -202,4 +202,4 @@ To run an archive node connected to the testchain, execute the below command:
 ``` 
 
 ## Running on cloud
-We have not tested these installation scripts on any cloud service. In addition, if you are using Runpod cloud service, then note that this service is already [containerized](https://docs.runpod.io/pods/overview). Hence, the only option available to you is to compile from the source, as described in the above [Compiling your own binary](#compiling-your-own-binary) section. Note that these scripts have not been tested on Runpod.
+We have not tested these installation scripts on any cloud service. In addition, if you are using Runpod cloud service, then note that this service is already [containerized](https://docs.runpod.io/pods/overview). Hence, the only option available to you is to compile from the source, as described in the above [Method 2: Using Source Code](#method-2-using-source-code) section. Note that these scripts have not been tested on Runpod.

--- a/docs/running-subtensor-locally.md
+++ b/docs/running-subtensor-locally.md
@@ -1,77 +1,205 @@
-# Running subtensor locally
+# Running subtensor node locally
 
-- [Running docker](#running-docker)
-- [Compiling your own binary](#compiling-your-own-binary)
-- [Running on cloud](#running-on-cloud)
+- [Method 1: Using Docker](#method-1-using-docker)
+- [Method 2: Using Source Code](#method-2-using-source-code)
+- [Running on Cloud](#running-on-cloud)
 
-## Running docker
+## Method 1: Using Docker
 
-### Install git
-`sudo apt install git`
+To run a subtensor node with Docker, follow the below steps.
 
-### Install Docker Engine
- You can follow Docker's [oficial installation guides](https://docs.docker.com/engine/install/)
+If you are already running a subtensor node using Docker, then go directly to [Step 5 Prepare to Run](#step-5-prepare-to-run) to restart the Docker container. The below steps 1 through 4 are for first time users only.
 
-### Run node-subtensor container
+### Step 1: Install git
+
+Make sure you installed `git` on your machine. See [GitHub docs](https://docs.github.com/en/get-started).
+
+### Step 2: Install Docker
+
+Follow Docker's [official installation guides](https://docs.docker.com/engine/install/) and install Docker.
+
+**Run Docker first**
+Before you proceed, make sure that Docker is running.
+
+### Step 3: Clone the subtensor repo
+
+Clone the subtensor repo:
+
 ```bash
 git clone https://github.com/opentensor/subtensor.git
+```
+
+### Step 4: Go into subtensor directory
+
+Then `cd` into the subtensor directory:
+
+```bash
 cd subtensor
-# to run a lite node on the mainnet:
+```
+
+### Step 5: Prepare to run
+
+Execute the below three commands in this order:
+
+Make sure you are on the `main` branch. If not, switch to it:
+
+```bash
+git checkout main
+```
+
+Pull the latest `main` branch contents:
+
+```bash
+git pull
+```
+
+Stop the currently running Docker containers:
+
+```bash
+docker compose down --volumes
+```
+
+### Run a lite node on mainchain
+
+To run a lite node connected to the Bittensor mainchain, run the below command.
+
+```bash
 sudo ./scripts/run/subtensor.sh -e docker --network mainnet --node-type lite
-# or mainnet archive node: sudo ./scripts/run/subtensor.sh -e docker --network mainnet --node-type archive
-# or testnet lite node:    sudo ./scripts/run/subtensor.sh -e docker --network testnet --node-type lite
-# or testnet archive node: sudo ./scripts/run/subtensor.sh -e docker --network testnet --node-type archive
 ```
 
-## Compiling your own binary
-### Requirements
-```bash
-sudo apt install build-essential git make clang libssl-dev llvm libudev-dev protobuf-compiler -y
-```
+### Run an archive node on mainchain
 
-### Install Rust
-```bash
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup-init.sh
-chmod +x rustup-init.sh
-./rustup-init.sh # you can select default options in the prompts you will be given
-source "$HOME/.cargo/env"
-```
+To run an archive node connected to the Bittensor mainchain, run the below command.
 
-### Rustup update
-```bash
-rustup default stable && \
- rustup update && \
- rustup update nightly && \
- rustup target add wasm32-unknown-unknown --toolchain nightly
-```
-
-### Compiling
-```bash
-git clone https://github.com/opentensor/subtensor.git
-cd subtensor
-cargo build --release --features runtime-benchmarks
-```
-
-### Running the node
-#### Mainnet / Lite node
-```bash
-sudo ./scripts/run/subtensor.sh -e binary --network mainnet --node-type lite
-``` 
-
-#### Mainnet / Archive node
 ```bash
 sudo ./scripts/run/subtensor.sh -e docker --network mainnet --node-type archive
 ```
 
-#### Testnet / Lite node
+### Run a lite node on testchain
+
+To run a lite node connected to the Bittensor testchain, run the below command.
+
 ```bash
 sudo ./scripts/run/subtensor.sh -e docker --network testnet --node-type lite
 ```
 
-#### Testnet / Archive node
+### Run an archive node on testchain
+
+To run an archive node connected to the Bittensor testchain, run the below command.
+
 ```bash
 sudo ./scripts/run/subtensor.sh -e docker --network testnet --node-type archive
 ```
+
+---
+
+## Method 2: Using Source Code
+
+To install and run a subtensor node by compiling the source code, follow the below steps.
+
+## Install basic packages
+
+Install the basic requirements by running the below commands on a Linux terminal.
+
+```bash title="On Linux"
+sudo apt-get update 
+sudo apt install build-essential
+sudo apt-get install clang
+sudo apt-get install curl 
+sudo apt-get install git 
+sudo apt-get install make
+sudo apt install --assume-yes git clang curl libssl-dev protobuf-compiler
+sudo apt install --assume-yes git clang curl libssl-dev llvm libudev-dev make protobuf-compiler
+```
+
+## Install Rust
+
+Next, install Rust and update the environment by running the following commands:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source ~/.cargo/env
+```
+
+Next, install Rust toolchain:
+
+```bash
+rustup default stable
+rustup update
+rustup target add wasm32-unknown-unknown
+rustup toolchain install nightly
+rustup target add --toolchain nightly wasm32-unknown-unknown
+```
+
+## Compile subtensor code 
+
+Next, to compile the subtensor source code, follow the below steps:
+
+Clone the subtensor repo:
+
+```bash
+git clone https://github.com/opentensor/subtensor.git
+```
+
+`cd` into the subtensor directory:
+
+```bash
+cd subtensor
+```
+
+Make sure you are on the `main` branch. If not, switch to it:
+
+```bash
+git checkout main
+```
+
+Remove previous chain state:
+
+```bash
+rm -rf /tmp/blockchain 
+```
+
+Install subtensor by compiling with `cargo`:
+
+```bash
+cargo build --release --features=runtime-benchmarks
+```
+
+## Run the subtensor node
+
+You can now run the public subtensor node either as a lite node or as an archive node. See below:
+
+### Lite node on mainchain 
+
+To run a lite node connected to the mainchain, execute the below command (note the `--sync=warp` flag which runs the subtensor node in lite mode):
+
+```bash title="With --sync=warp setting, for lite node"
+./target/release/node-subtensor --chain raw_spec.json --base-path /tmp/blockchain --sync=warp --execution wasm --wasm-execution compiled --port 30333 --max-runtime-instances 64 --rpc-max-response-size 2048 --rpc-cors all --rpc-port 9933 --ws-port 9944 --bootnodes /ip4/13.58.175.193/tcp/30333/p2p/12D3KooWDe7g2JbNETiKypcKT1KsCEZJbTzEHCn8hpd4PHZ6pdz5 --ws-max-connections 16000 --no-mdns --in-peers 8000 --out-peers 8000 --prometheus-external --rpc-external --ws-external
+``` 
+
+### Archive node on mainchain
+
+To run an archive node connected to the mainchain, execute the below command (note the `--sync=full` which syncs the node to the full chain and `--pruning archive` flags, which disables the node's automatic pruning of older historical data):
+
+```bash title="With --sync=full and --pruning archive setting, for archive node"
+./target/release/node-subtensor --chain raw_spec.json --base-path /tmp/blockchain --sync=full --pruning archive --execution wasm --wasm-execution compiled --port 30333 --max-runtime-instances 64 --rpc-max-response-size 2048 --rpc-cors all --rpc-port 9933 --ws-port 9944 --bootnodes /ip4/13.58.175.193/tcp/30333/p2p/12D3KooWDe7g2JbNETiKypcKT1KsCEZJbTzEHCn8hpd4PHZ6pdz5 --ws-max-connections 16000 --no-mdns --in-peers 8000 --out-peers 8000 --prometheus-external --rpc-external --ws-external
+``` 
+
+### Lite node on testchain 
+
+To run a lite node connected to the testchain, execute the below command:
+
+```bash title="With bootnodes set to testnet and --sync=warp setting, for lite node."
+./target/release/node-subtensor --chain raw_spec.json --base-path /tmp/blockchain --sync=warp --execution wasm --wasm-execution compiled --port 30333 --max-runtime-instances 64 --rpc-max-response-size 2048 --rpc-cors all --rpc-port 9933 --ws-port 9944 --bootnodes /dns/bootnode.test.finney.opentensor.ai/tcp/30333/p2p/12D3KooWDe7g2JbNETiKypcKT1KsCEZJbTzEHCn8hpd4PHZ6pdz5 --ws-max-connections 16000 --no-mdns --in-peers 8000 --out-peers 8000 --prometheus-external --rpc-external --ws-external
+``` 
+
+### Archive node on testchain
+
+To run an archive node connected to the testchain, execute the below command:
+
+```bash title="With bootnodes set to testnet and --sync=full and --pruning archive setting, for archive node"
+./target/release/node-subtensor --chain raw_spec.json --base-path /tmp/blockchain --sync=full --pruning archive --execution wasm --wasm-execution compiled --port 30333 --max-runtime-instances 64 --rpc-max-response-size 2048 --rpc-cors all --rpc-port 9933 --ws-port 9944 --bootnodes /dns/bootnode.test.finney.opentensor.ai/tcp/30333/p2p/12D3KooWDe7g2JbNETiKypcKT1KsCEZJbTzEHCn8hpd4PHZ6pdz5 --ws-max-connections 16000 --no-mdns --in-peers 8000 --out-peers 8000 --prometheus-external --rpc-external --ws-external
+``` 
 
 ## Running on cloud
 We have not tested these installation scripts on any cloud service. In addition, if you are using Runpod cloud service, then note that this service is already [containerized](https://docs.runpod.io/pods/overview). Hence, the only option available to you is to compile from the source, as described in the above [Compiling your own binary](#compiling-your-own-binary) section. Note that these scripts have not been tested on Runpod.


### PR DESCRIPTION
This PR makes the below fixes to the Markdown documents in this repo. These fixes are identified in: https://github.com/opentensor/subtensor/issues/310

- Added a link in the README to the `./docs/running-subtensor-locally.md` doc.
- Commented out the "Embedded Docs" section in the README because when I tested it, it did not work (line 84 of README).
- Distinguished the README doc sections to better identify running subtensor for subnet purposes vs running subtensor for development purposes.
- Updated the instructions in the `./docs/running-subtensor-locally.md` doc.
- General cleanups to enhance readability.