### PR TITLE
set root weights with coldkey

### DIFF
--- a/pallets/subtensor/src/benchmarks.rs
+++ b/pallets/subtensor/src/benchmarks.rs
@@ -72,7 +72,7 @@ benchmarks! {
       weights.push(id.clone());
     }
 
-  }: set_weights(RawOrigin::Signed( signer.clone() ), netuid, dests, weights, version_key)
+  }: set_weights(RawOrigin::Signed( signer.clone() ), netuid, signer.clone(), dests, weights, version_key)
 
 
   benchmark_become_delegate {

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1270,11 +1270,12 @@ pub mod pallet {
         pub fn set_weights(
             origin: OriginFor<T>,
             netuid: u16,
+            hotkey: T::AccountId,
             dests: Vec<u16>,
             weights: Vec<u16>,
             version_key: u64,
         ) -> DispatchResult {
-            Self::do_set_weights(origin, netuid, dests, weights, version_key)
+            Self::do_set_weights(origin, netuid, hotkey, dests, weights, version_key)
         }
 
         // --- Sets the key as a delegate.

--- a/pallets/subtensor/src/staking.rs
+++ b/pallets/subtensor/src/staking.rs
@@ -181,7 +181,8 @@ impl<T: Config> Pallet<T> {
         );
 
         // --- 8. Ensure the remove operation from the coldkey is a success.
-        let actual_amount_to_stake = Self::remove_balance_from_coldkey_account(&coldkey, stake_as_balance.unwrap())?;
+        let actual_amount_to_stake =
+            Self::remove_balance_from_coldkey_account(&coldkey, stake_as_balance.unwrap())?;
 
         // --- 9. If we reach here, add the balance to the hotkey.
         Self::increase_stake_on_coldkey_hotkey_account(&coldkey, &hotkey, actual_amount_to_stake);
@@ -190,11 +191,7 @@ impl<T: Config> Pallet<T> {
         Self::set_last_tx_block(&coldkey, block);
 
         // --- 10. Emit the staking event.
-        Self::set_stakes_this_interval_for_hotkey(
-            &hotkey,
-            stakes_this_interval + 1,
-            block,
-        );
+        Self::set_stakes_this_interval_for_hotkey(&hotkey, stakes_this_interval + 1, block);
         log::info!(
             "StakeAdded( hotkey:{:?}, stake_to_be_added:{:?} )",
             hotkey,
@@ -308,11 +305,7 @@ impl<T: Config> Pallet<T> {
         Self::set_last_tx_block(&coldkey, block);
 
         // --- 10. Emit the unstaking event.
-        Self::set_stakes_this_interval_for_hotkey(
-            &hotkey,
-            unstakes_this_interval + 1,
-            block,
-        );
+        Self::set_stakes_this_interval_for_hotkey(&hotkey, unstakes_this_interval + 1, block);
         log::info!(
             "StakeRemoved( hotkey:{:?}, stake_to_be_removed:{:?} )",
             hotkey,
@@ -508,7 +501,7 @@ impl<T: Config> Pallet<T> {
         input: u64,
     ) -> Option<
         <<T as Config>::Currency as fungible::Inspect<<T as frame_system::Config>::AccountId>>::Balance,
-    > {
+    >{
         input.try_into().ok()
     }
 
@@ -537,19 +530,21 @@ impl<T: Config> Pallet<T> {
         }
 
         // This bit is currently untested. @todo
-        let can_withdraw = T::Currency::can_withdraw(
-            &coldkey,
-            amount,
-        )
-        .into_result(false)
-        .is_ok();
+        let can_withdraw = T::Currency::can_withdraw(&coldkey, amount)
+            .into_result(false)
+            .is_ok();
         can_withdraw
     }
 
     pub fn get_coldkey_balance(
         coldkey: &T::AccountId,
-    ) -> <<T as Config>::Currency as fungible::Inspect<<T as system::Config>::AccountId>>::Balance {
-        return T::Currency::reducible_balance(&coldkey, Preservation::Expendable, Fortitude::Polite);
+    ) -> <<T as Config>::Currency as fungible::Inspect<<T as system::Config>::AccountId>>::Balance
+    {
+        return T::Currency::reducible_balance(
+            &coldkey,
+            Preservation::Expendable,
+            Fortitude::Polite,
+        );
     }
 
     #[must_use = "Balance must be used to preserve total issuance of token"]
@@ -557,23 +552,27 @@ impl<T: Config> Pallet<T> {
         coldkey: &T::AccountId,
         amount: <<T as Config>::Currency as fungible::Inspect<<T as system::Config>::AccountId>>::Balance,
     ) -> Result<u64, DispatchError> {
-        let amount_u64: u64 = amount.try_into().map_err(|_| Error::<T>::CouldNotConvertToU64)?;
+        let amount_u64: u64 = amount
+            .try_into()
+            .map_err(|_| Error::<T>::CouldNotConvertToU64)?;
 
         if amount_u64 == 0 {
             return Ok(0);
         }
 
         let credit = T::Currency::withdraw(
-                &coldkey,
-                amount,
-                Precision::BestEffort,
-                Preservation::Preserve,
-                Fortitude::Polite,
-            )
-            .map_err(|_| Error::<T>::BalanceWithdrawalError)?
-            .peek();
+            &coldkey,
+            amount,
+            Precision::BestEffort,
+            Preservation::Preserve,
+            Fortitude::Polite,
+        )
+        .map_err(|_| Error::<T>::BalanceWithdrawalError)?
+        .peek();
 
-        let credit_u64: u64 = credit.try_into().map_err(|_| Error::<T>::CouldNotConvertToU64)?;
+        let credit_u64: u64 = credit
+            .try_into()
+            .map_err(|_| Error::<T>::CouldNotConvertToU64)?;
 
         if credit_u64 == 0 {
             return Err(Error::<T>::BalanceWithdrawalError.into());

--- a/pallets/subtensor/tests/root.rs
+++ b/pallets/subtensor/tests/root.rs
@@ -207,11 +207,17 @@ fn test_root_set_weights() {
 
         // Set weights into diagonal matrix.
         for i in 0..n {
+            let hotkey = U256::from(i);
+            let coldkey = U256::from(i);
+
+            SubtensorModule::create_account_if_non_existent(&coldkey, &hotkey);
+
             let uids: Vec<u16> = vec![i as u16];
             let values: Vec<u16> = vec![1];
             assert_ok!(SubtensorModule::set_weights(
-                <<Test as Config>::RuntimeOrigin>::signed(U256::from(i)),
+                <<Test as Config>::RuntimeOrigin>::signed(coldkey),
                 root_netuid,
+                hotkey,
                 uids,
                 values,
                 0,
@@ -321,12 +327,23 @@ fn test_root_set_weights_out_of_order_netuids() {
         let subnets = SubtensorModule::get_all_subnet_netuids();
         // Set weights into diagonal matrix.
         for (i, netuid) in subnets.iter().enumerate() {
-            let uids: Vec<u16> = vec![*netuid];
+            let hotkey = U256::from(i);
+            let coldkey = U256::from(i);
 
+            // Cannot register neuron for root
+            if *netuid == 0 {
+                SubtensorModule::create_account_if_non_existent(&coldkey, &hotkey);
+            } else {
+                SubtensorModule::set_network_pow_registration_allowed(*netuid, true);
+                register_ok_neuron(*netuid, hotkey, coldkey, 0);
+            }
+
+            let uids: Vec<u16> = vec![*netuid];
             let values: Vec<u16> = vec![1];
             assert_ok!(SubtensorModule::set_weights(
-                <<Test as Config>::RuntimeOrigin>::signed(U256::from(i)),
+                <<Test as Config>::RuntimeOrigin>::signed(coldkey),
                 root_netuid,
+                hotkey,
                 uids,
                 values,
                 0,
@@ -504,8 +521,9 @@ fn test_network_pruning() {
             ));
             assert!(SubtensorModule::get_uid_for_net_and_hotkey(root_netuid, &hot).is_ok());
             assert_ok!(SubtensorModule::set_weights(
-                <<Test as Config>::RuntimeOrigin>::signed(hot),
+                <<Test as Config>::RuntimeOrigin>::signed(cold),
                 root_netuid,
+                hot,
                 uids,
                 values,
                 0
@@ -640,8 +658,9 @@ fn test_weights_after_network_pruning() {
         log::info!("values set: {:?}", values);
         log::info!("In netuid: {:?}", root_netuid);
         assert_ok!(SubtensorModule::set_weights(
-            <<Test as Config>::RuntimeOrigin>::signed(hot),
+            <<Test as Config>::RuntimeOrigin>::signed(cold),
             root_netuid,
+            hot,
             uids,
             values,
             0


### PR DESCRIPTION
This PR changes the requirement from signing root weights with a hot key to using a cold key instead.