### PR TITLE
Fixes bootnode ID for docker containers

### DIFF
--- a/scripts/run/subtensor.sh
+++ b/scripts/run/subtensor.sh
@@ -12,7 +12,7 @@ function run_command()
 
     # Different command options by network and node type
     MAINNET_BOOTNODE='--bootnodes /dns/bootnode.finney.opentensor.ai/tcp/30333/ws/p2p/12D3KooWRwbMb85RWnT8DSXSYMWQtuDwh4LJzndoRrTDotTR5gDC'
-    TESTNET_BOOTNODE='--bootnodes /dns/bootnode.test.finney.opentensor.ai/tcp/30333/ws/p2p/12D3KooWRwbMb85RWnT8DSXSYMWQtuDwh4LJzndoRrTDotTR5gDC'
+    TESTNET_BOOTNODE='--bootnodes /dns/bootnode.test.finney.opentensor.ai/tcp/30333/ws/p2p/12D3KooWPM4mLcKJGtyVtkggqdG84zWrd7Rij6PGQDoijh1X86Vr'
     NODE_TYPE_ARCHIVE='--pruning=archive'
     NODE_TYPE_LITE='--sync warp'
 


### PR DESCRIPTION
Currently new docker test nodes will fail because they are trying to connect to the test boot node but using the wrong node key, this PR fixes that.