### PR TITLE
Align chain flag in test nodes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 volumes:
   mainnet-lite-volume:
@@ -74,7 +74,7 @@ services:
       - |
         node-subtensor \
           --base-path /tmp/blockchain \
-          --chain raw_testspec.json \
+          --chain raw_spec.json \
           --rpc-external --rpc-cors all \
           --ws-external --no-mdns \
           --ws-max-connections 10000 --in-peers 500 --out-peers 500 \
@@ -92,7 +92,7 @@ services:
       - |
         node-subtensor \
           --base-path /tmp/blockchain \
-          --chain raw_testspec.json \
+          --chain raw_spec.json \
           --rpc-external --rpc-cors all \
           --ws-external --no-mdns \
           --ws-max-connections 10000 --in-peers 500 --out-peers 500 \


### PR DESCRIPTION
Of these places with test node configuration:

- **subtensor/docker-compose** (raw_testspec)
- **subtensor/scripts/run/subtensor.sh** (raw_spec)
- **subtensor/docs/running-subtensor-locally.md** (raw_spec)
- **developer-docs/docs/subtensor-nodes/using-source.md** (raw_spec)

Only the docker-compose.yml would set chain to raw_testspec.json instead of raw_spec.json. This aligns the docker-compose to the rest. Let me know if it's actually the 3 other places that should be aligned to the docker-compose.yml instead.