### PR TITLE
Add set_root_weights()

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1317,8 +1317,6 @@ pub mod pallet {
         // 		- The network version key to check if the validator is up to date.
         //
         // # Event:
-        // 	* 'WeightVecNotEqualSize':
-        // 		- Attempting to set weights with uids not of same length.
         //
         // 	* WeightsSet;
         // 		- On successfully setting the weights on chain.

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -987,7 +987,6 @@ pub mod pallet {
         NoNeuronIdAvailable, // -- Thrown when no neuron id is available
         /// Thrown a stake would be below the minimum threshold for nominator validations
         NomStakeBelowMinimumThreshold,
-
     }
 
     // ==================

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -984,6 +984,7 @@ pub mod pallet {
         AllNetworksInImmunity, // --- Thrown when all subnets are in the immunity period
         NotEnoughBalance,
         NotRootSubnet,
+        IsRoot,
         NoNeuronIdAvailable, // -- Thrown when no neuron id is available
         /// Thrown a stake would be below the minimum threshold for nominator validations
         NomStakeBelowMinimumThreshold,

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -968,6 +968,7 @@ pub mod pallet {
         StakeTooLowForRoot, // --- Thrown when a hotkey attempts to join the root subnet with too little stake
         AllNetworksInImmunity, // --- Thrown when all subnets are in the immunity period
         NotEnoughBalance,
+        NotRootSubnet,
     }
 
     // ==================
@@ -1275,6 +1276,83 @@ pub mod pallet {
             version_key: u64,
         ) -> DispatchResult {
             Self::do_set_weights(origin, netuid, dests, weights, version_key)
+        }
+
+        // # Args:
+        // 	* `origin`: (<T as frame_system::Config>Origin):
+        // 		- The caller, a hotkey who wishes to set their weights.
+        //
+        // 	* `netuid` (u16):
+        // 		- The network uid we are setting these weights on.
+        //
+        // 	* `hotkey` (T::AccountId):
+        // 		- The hotkey associated with the operation and the calling coldkey.
+        //
+        // 	* `dests` (Vec<u16>):
+        // 		- The edge endpoint for the weight, i.e. j for w_ij.
+        //
+        // 	* 'weights' (Vec<u16>):
+        // 		- The u16 integer encoded weights. Interpreted as rational
+        // 		values in the range [0,1]. They must sum to in32::MAX.
+        //
+        // 	* 'version_key' ( u64 ):
+        // 		- The network version key to check if the validator is up to date.
+        //
+        // # Event:
+        // 	* 'WeightVecNotEqualSize':
+        // 		- Attempting to set weights with uids not of same length.
+        //
+        // 	* WeightsSet;
+        // 		- On successfully setting the weights on chain.
+        //
+        // # Raises:
+        //
+        // 	* NonAssociatedColdKey;
+        // 		- Attempting to set weights on a non-associated cold key.
+        //
+        // 	* 'NetworkDoesNotExist':
+        // 		- Attempting to set weights on a non-existent network.
+        //
+        // 	* 'NotRootSubnet':
+        // 		- Attempting to set weights on a subnet that is not the root network.
+        //
+        // 	* 'WeightVecNotEqualSize':
+        // 		- Attempting to set weights with uids not of same length.
+        //
+        // 	* 'InvalidUid':
+        // 		- Attempting to set weights with invalid uids.
+        //
+        // 	* 'NotRegistered':
+        // 		- Attempting to set weights from a non registered account.
+        //
+        // 	* 'NotSettingEnoughWeights':
+        // 		- Attempting to set weights with fewer weights than min.
+        //
+        //  * 'IncorrectNetworkVersionKey':
+        //      - Attempting to set weights with the incorrect network version key.
+        //
+        //  * 'SettingWeightsTooFast':
+        //      - Attempting to set weights too fast.
+        //
+        // 	* 'NotSettingEnoughWeights':
+        // 		- Attempting to set weights with fewer weights than min.
+        //
+        // 	* 'MaxWeightExceeded':
+        // 		- Attempting to set weights with max value exceeding limit.
+        //
+        #[pallet::call_index(8)]
+        #[pallet::weight((Weight::from_parts(10_151_000_000, 0)
+		.saturating_add(T::DbWeight::get().reads(4104))
+		.saturating_add(T::DbWeight::get().writes(2)), DispatchClass::Normal, Pays::No))]
+        pub fn set_root_weights(
+            origin: OriginFor<T>,
+            netuid: u16,
+            hotkey: T::AccountId,
+            dests: Vec<u16>,
+            weights: Vec<u16>,
+            version_key: u64,
+        ) -> DispatchResult {
+            Self::do_set_root_weights(origin, netuid, hotkey, dests, weights, version_key)
         }
 
         // --- Sets the key as a delegate.
@@ -1834,6 +1912,18 @@ where
     ) -> TransactionValidity {
         match call.is_sub_type() {
             Some(Call::set_weights { netuid, .. }) => {
+                if Self::check_weights_min_stake(who) {
+                    let priority: u64 = Self::get_priority_set_weights(who, *netuid);
+                    Ok(ValidTransaction {
+                        priority: priority,
+                        longevity: 1,
+                        ..Default::default()
+                    })
+                } else {
+                    return Err(InvalidTransaction::Call.into());
+                }
+            }
+            Some(Call::set_root_weights { netuid, .. }) => {
                 if Self::check_weights_min_stake(who) {
                     let priority: u64 = Self::get_priority_set_weights(who, *netuid);
                     Ok(ValidTransaction {

--- a/pallets/subtensor/src/root.rs
+++ b/pallets/subtensor/src/root.rs
@@ -639,16 +639,7 @@ impl<T: Config> Pallet<T> {
         );
 
         // --- 10. Get the neuron uid of associated hotkey on network netuid.
-        let neuron_uid;
-        let net_neuron_uid = Self::get_uid_for_net_and_hotkey(netuid, &hotkey);
-        ensure!(
-            net_neuron_uid.is_ok(),
-            net_neuron_uid
-                .err()
-                .unwrap_or(Error::<T>::NotRegistered.into())
-        );
-
-        neuron_uid = net_neuron_uid.unwrap();
+        let neuron_uid = Self::get_uid_for_net_and_hotkey(netuid, &hotkey)?;
 
         // --- 11. Ensure the uid is not setting weights faster than the weights_set_rate_limit.
         let current_block: u64 = Self::get_current_block_as_u64();

--- a/pallets/subtensor/src/root.rs
+++ b/pallets/subtensor/src/root.rs
@@ -605,10 +605,7 @@ impl<T: Config> Pallet<T> {
         );
 
         // --- 4. Check that this is the root network.
-        ensure!(
-            netuid == Self::get_root_netuid(),
-            Error::<T>::NotRootSubnet
-        );
+        ensure!(netuid == Self::get_root_netuid(), Error::<T>::NotRootSubnet);
 
         // --- 5. Check that the length of uid list and value list are equal for this network.
         ensure!(

--- a/pallets/subtensor/src/root.rs
+++ b/pallets/subtensor/src/root.rs
@@ -577,6 +577,135 @@ impl<T: Config> Pallet<T> {
         Ok(())
     }
 
+    pub fn do_set_root_weights(
+        origin: T::RuntimeOrigin,
+        netuid: u16,
+        hotkey: T::AccountId,
+        uids: Vec<u16>,
+        values: Vec<u16>,
+        version_key: u64,
+    ) -> dispatch::DispatchResult {
+        // --- 1. Check the caller's signature. This is the coldkey of a registered account.
+        let coldkey = ensure_signed(origin)?;
+        log::info!(
+            "do_set_root_weights( origin:{:?} netuid:{:?}, uids:{:?}, values:{:?})",
+            coldkey,
+            netuid,
+            uids,
+            values
+        );
+
+        // --- 2. Check that the signer coldkey owns the hotkey
+        ensure!(
+            Self::coldkey_owns_hotkey(&coldkey, &hotkey)
+                && Self::get_owning_coldkey_for_hotkey(&hotkey) == coldkey,
+            Error::<T>::NonAssociatedColdKey
+        );
+
+        // --- 3. Check to see if this is a valid network.
+        ensure!(
+            Self::if_subnet_exist(netuid),
+            Error::<T>::NetworkDoesNotExist
+        );
+
+        // --- 4. Check that this is the root network.
+        ensure!(
+            netuid == Self::get_root_netuid(),
+            Error::<T>::NotRootSubnet
+        );
+
+        // --- 5. Check that the length of uid list and value list are equal for this network.
+        ensure!(
+            Self::uids_match_values(&uids, &values),
+            Error::<T>::WeightVecNotEqualSize
+        );
+
+        // --- 6. Check to see if the number of uids is within the max allowed uids for this network.
+        // For the root network this number is the number of subnets.
+        ensure!(
+            !Self::contains_invalid_root_uids(&uids),
+            Error::<T>::InvalidUid
+        );
+
+        // --- 7. Check to see if the hotkey is registered to the passed network.
+        ensure!(
+            Self::is_hotkey_registered_on_network(netuid, &hotkey),
+            Error::<T>::NotRegistered
+        );
+
+        // --- 8. Check to see if the hotkey has enough stake to set weights.
+        ensure!(
+            Self::get_total_stake_for_hotkey(&hotkey) >= Self::get_weights_min_stake(),
+            Error::<T>::NotEnoughStakeToSetWeights
+        );
+
+        // --- 9. Ensure version_key is up-to-date.
+        ensure!(
+            Self::check_version_key(netuid, version_key),
+            Error::<T>::IncorrectNetworkVersionKey
+        );
+
+        // --- 10. Get the neuron uid of associated hotkey on network netuid.
+        let neuron_uid;
+        let net_neuron_uid = Self::get_uid_for_net_and_hotkey(netuid, &hotkey);
+        ensure!(
+            net_neuron_uid.is_ok(),
+            net_neuron_uid
+                .err()
+                .unwrap_or(Error::<T>::NotRegistered.into())
+        );
+
+        neuron_uid = net_neuron_uid.unwrap();
+
+        // --- 11. Ensure the uid is not setting weights faster than the weights_set_rate_limit.
+        let current_block: u64 = Self::get_current_block_as_u64();
+        ensure!(
+            Self::check_rate_limit(netuid, neuron_uid, current_block),
+            Error::<T>::SettingWeightsTooFast
+        );
+
+        // --- 12. Ensure the passed uids contain no duplicates.
+        ensure!(!Self::has_duplicate_uids(&uids), Error::<T>::DuplicateUids);
+
+        // --- 13. Ensure that the weights have the required length.
+        ensure!(
+            Self::check_length(netuid, neuron_uid, &uids, &values),
+            Error::<T>::NotSettingEnoughWeights
+        );
+
+        // --- 14. Max-upscale the weights.
+        let max_upscaled_weights: Vec<u16> = vec_u16_max_upscale_to_u16(&values);
+
+        // --- 15. Ensure the weights are max weight limited
+        ensure!(
+            Self::max_weight_limited(netuid, neuron_uid, &uids, &max_upscaled_weights),
+            Error::<T>::MaxWeightExceeded
+        );
+
+        // --- 16. Zip weights for sinking to storage map.
+        let mut zipped_weights: Vec<(u16, u16)> = vec![];
+        for (uid, val) in uids.iter().zip(max_upscaled_weights.iter()) {
+            zipped_weights.push((*uid, *val))
+        }
+
+        // --- 17. Set weights under netuid, uid double map entry.
+        Weights::<T>::insert(netuid, neuron_uid, zipped_weights);
+
+        // --- 18. Set the activity for the weights on this network.
+        Self::set_last_update_for_uid(netuid, neuron_uid, current_block);
+
+        // --- 19. Emit the tracking event.
+        log::info!(
+            "RootWeightsSet( netuid:{:?}, neuron_uid:{:?} )",
+            netuid,
+            neuron_uid
+        );
+        Self::deposit_event(Event::WeightsSet(netuid, neuron_uid));
+
+        // --- 20. Return ok.
+        Ok(())
+    }
+
     pub fn do_vote_root(
         origin: T::RuntimeOrigin,
         hotkey: &T::AccountId,

--- a/pallets/subtensor/src/weights.rs
+++ b/pallets/subtensor/src/weights.rs
@@ -76,6 +76,7 @@ impl<T: Config> Pallet<T> {
             values
         );
 
+        // --- Check that the netuid is not the root network.
         ensure!(netuid != Self::get_root_netuid(), Error::<T>::IsRoot);
 
         // --- 2. Check that the length of uid list and value list are equal for this network.

--- a/pallets/subtensor/src/weights.rs
+++ b/pallets/subtensor/src/weights.rs
@@ -76,6 +76,8 @@ impl<T: Config> Pallet<T> {
             values
         );
 
+        ensure!(netuid != Self::get_root_netuid(), Error::<T>::IsRoot);
+
         // --- 2. Check that the length of uid list and value list are equal for this network.
         ensure!(
             Self::uids_match_values(&uids, &values),
@@ -89,19 +91,10 @@ impl<T: Config> Pallet<T> {
         );
 
         // --- 4. Check to see if the number of uids is within the max allowed uids for this network.
-        // For the root network this number is the number of subnets.
-        if netuid == Self::get_root_netuid() {
-            // --- 4.a. Ensure that the passed uids are valid for the network.
-            ensure!(
-                !Self::contains_invalid_root_uids(&uids),
-                Error::<T>::InvalidUid
-            );
-        } else {
-            ensure!(
-                Self::check_len_uids_within_allowed(netuid, &uids),
-                Error::<T>::TooManyUids
-            );
-        }
+        ensure!(
+            Self::check_len_uids_within_allowed(netuid, &uids),
+            Error::<T>::TooManyUids
+        );
 
         // --- 5. Check to see if the hotkey is registered to the passed network.
         ensure!(
@@ -141,23 +134,19 @@ impl<T: Config> Pallet<T> {
         );
 
         // --- 10. Check that the neuron uid is an allowed validator permitted to set non-self weights.
-        if netuid != Self::get_root_netuid() {
-            ensure!(
-                Self::check_validator_permit(netuid, neuron_uid, &uids, &values),
-                Error::<T>::NoValidatorPermit
-            );
-        }
+        ensure!(
+            Self::check_validator_permit(netuid, neuron_uid, &uids, &values),
+            Error::<T>::NoValidatorPermit
+        );
 
         // --- 11. Ensure the passed uids contain no duplicates.
         ensure!(!Self::has_duplicate_uids(&uids), Error::<T>::DuplicateUids);
 
         // --- 12. Ensure that the passed uids are valid for the network.
-        if netuid != Self::get_root_netuid() {
-            ensure!(
-                !Self::contains_invalid_uids(netuid, &uids),
-                Error::<T>::InvalidUid
-            );
-        }
+        ensure!(
+            !Self::contains_invalid_uids(netuid, &uids),
+            Error::<T>::InvalidUid
+        );
 
         // --- 13. Ensure that the weights have the required length.
         ensure!(

--- a/pallets/subtensor/src/weights.rs
+++ b/pallets/subtensor/src/weights.rs
@@ -115,19 +115,8 @@ impl<T: Config> Pallet<T> {
             Error::<T>::IncorrectNetworkVersionKey
         );
 
-        // --- 9. Get the neuron uid of associated hotkey on network netuid.
-
-        let net_neuron_uid = Self::get_uid_for_net_and_hotkey(netuid, &hotkey);
-        ensure!(
-            net_neuron_uid.is_ok(),
-            net_neuron_uid
-                .err()
-                .unwrap_or(Error::<T>::NotRegistered.into())
-        );
-
-        let neuron_uid = net_neuron_uid.unwrap();
-
         // --- 9. Ensure the uid is not setting weights faster than the weights_set_rate_limit.
+        let neuron_uid = Self::get_uid_for_net_and_hotkey(netuid, &hotkey)?;
         let current_block: u64 = Self::get_current_block_as_u64();
         ensure!(
             Self::check_rate_limit(netuid, neuron_uid, current_block),

--- a/pallets/subtensor/tests/weights.rs
+++ b/pallets/subtensor/tests/weights.rs
@@ -1,6 +1,6 @@
 mod mock;
 use frame_support::{
-    assert_ok,
+    assert_err, assert_ok,
     dispatch::{DispatchClass, GetDispatchInfo, Pays},
 };
 use mock::*;
@@ -32,6 +32,29 @@ fn test_set_weights_dispatch_info_ok() {
 
         assert_eq!(dispatch_info.class, DispatchClass::Normal);
         assert_eq!(dispatch_info.pays_fee, Pays::No);
+    });
+}
+
+#[test]
+fn test_set_weights_is_root_error() {
+    new_test_ext(0).execute_with(|| {
+        let root_netuid: u16 = 0;
+
+        let dests = vec![0];
+        let weights = vec![1];
+        let version_key: u64 = 0;
+        let hotkey = U256::from(1);
+
+        assert_err!(
+            SubtensorModule::set_weights(
+                RuntimeOrigin::signed(hotkey),
+                root_netuid,
+                dests.clone(),
+                weights.clone(),
+                version_key,
+            ),
+            Error::<Test>::IsRoot
+        );
     });
 }
 


### PR DESCRIPTION
## Description
  This PR implements a new function `set_root_weights()` for setting root weights with the coldkey.

### Changes
 * Created `set_root_weights` which contains the original logic associated with the root network from `set_weights`.
 * `set_weights` now rejects calls for the root network. 
 * Root specific operations in `set_weights` have been removed.
 * Added & updated associated unit tests. 


## Related Issue(s)
N/A

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

Calls to `set_weights` for the root network will now be rejected. Instead they should call `set_root_weights`. 

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.