### PR TITLE
Add per-subnet takes functionality

### DIFF
--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -111,6 +111,15 @@ pub mod pallet {
             Ok(())
         }
 
+        #[pallet::call_index(46)]
+        #[pallet::weight((0, DispatchClass::Operational, Pays::No))]
+        pub fn sudo_set_delegate_limit(origin: OriginFor<T>, delegate_limit: u32) -> DispatchResult {
+            ensure_root(origin)?;
+            T::Subtensor::set_delegate_limit(delegate_limit);
+            log::info!("TxDelegateLimitSet( set_delegate_limit: {:?} ) ", delegate_limit);
+            Ok(())
+        }
+
         #[pallet::call_index(3)]
         #[pallet::weight(T::WeightInfo::sudo_set_serving_rate_limit())]
         pub fn sudo_set_serving_rate_limit(
@@ -819,6 +828,7 @@ pub trait SubtensorInterface<AccountId, Balance, RuntimeOrigin> {
     fn set_default_take(default_take: u16);
     fn set_tx_rate_limit(rate_limit: u64);
     fn set_tx_delegate_take_rate_limit(rate_limit: u64);
+    fn set_delegate_limit(delegate_limit: u32);
 
     fn set_serving_rate_limit(netuid: u16, rate_limit: u64);
 

--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -104,19 +104,31 @@ pub mod pallet {
 
         #[pallet::call_index(45)]
         #[pallet::weight((0, DispatchClass::Operational, Pays::No))]
-        pub fn sudo_set_tx_delegate_take_rate_limit(origin: OriginFor<T>, tx_rate_limit: u64) -> DispatchResult {
+        pub fn sudo_set_tx_delegate_take_rate_limit(
+            origin: OriginFor<T>,
+            tx_rate_limit: u64,
+        ) -> DispatchResult {
             ensure_root(origin)?;
             T::Subtensor::set_tx_delegate_take_rate_limit(tx_rate_limit);
-            log::info!("TxRateLimitDelegateTakeSet( tx_delegate_take_rate_limit: {:?} ) ", tx_rate_limit);
+            log::info!(
+                "TxRateLimitDelegateTakeSet( tx_delegate_take_rate_limit: {:?} ) ",
+                tx_rate_limit
+            );
             Ok(())
         }
 
         #[pallet::call_index(46)]
         #[pallet::weight((0, DispatchClass::Operational, Pays::No))]
-        pub fn sudo_set_delegate_limit(origin: OriginFor<T>, delegate_limit: u32) -> DispatchResult {
+        pub fn sudo_set_delegate_limit(
+            origin: OriginFor<T>,
+            delegate_limit: u32,
+        ) -> DispatchResult {
             ensure_root(origin)?;
             T::Subtensor::set_delegate_limit(delegate_limit);
-            log::info!("TxDelegateLimitSet( set_delegate_limit: {:?} ) ", delegate_limit);
+            log::info!(
+                "TxDelegateLimitSet( set_delegate_limit: {:?} ) ",
+                delegate_limit
+            );
             Ok(())
         }
 

--- a/pallets/admin-utils/tests/tests.rs
+++ b/pallets/admin-utils/tests/tests.rs
@@ -960,11 +960,17 @@ fn test_sudo_set_tx_delegate_take_rate_limit() {
             ),
             Err(DispatchError::BadOrigin.into())
         );
-        assert_eq!(SubtensorModule::get_tx_delegate_take_rate_limit(), init_value);
+        assert_eq!(
+            SubtensorModule::get_tx_delegate_take_rate_limit(),
+            init_value
+        );
         assert_ok!(AdminUtils::sudo_set_tx_delegate_take_rate_limit(
             <<Test as Config>::RuntimeOrigin>::root(),
             to_be_set
         ));
-        assert_eq!(SubtensorModule::get_tx_delegate_take_rate_limit(), to_be_set);
+        assert_eq!(
+            SubtensorModule::get_tx_delegate_take_rate_limit(),
+            to_be_set
+        );
     });
 }

--- a/pallets/subtensor/src/block_step.rs
+++ b/pallets/subtensor/src/block_step.rs
@@ -223,7 +223,7 @@ impl<T: Config> Pallet<T> {
         }
 
         // 2. Else the key is a delegate, first compute the delegate take from the emission.
-        let take_proportion: I64F64 = I64F64::from_num(Delegates::<T>::get( delegate, netuid )) / I64F64::from_num(u16::MAX);
+        let take_proportion: I64F64 = I64F64::from_num(DelegatesTake::<T>::get( delegate, netuid )) / I64F64::from_num(u16::MAX);
         let delegate_take: I64F64 = take_proportion * I64F64::from_num( validator_emission );
         let delegate_take_u64: u64 = delegate_take.to_num::<u64>();
         let remaining_validator_emission: u64 = validator_emission - delegate_take_u64;
@@ -301,7 +301,7 @@ impl<T: Config> Pallet<T> {
     pub fn calculate_delegate_proportional_take(hotkey: &T::AccountId, netuid: u16, emission: u64) -> u64 {
         if Self::hotkey_is_delegate(hotkey) {
             let take_proportion: I64F64 =
-                I64F64::from_num(Delegates::<T>::get(hotkey, netuid)) / I64F64::from_num(u16::MAX);
+                I64F64::from_num(DelegatesTake::<T>::get(hotkey, netuid)) / I64F64::from_num(u16::MAX);
             let take_emission: I64F64 = take_proportion * I64F64::from_num(emission);
             return take_emission.to_num::<u64>();
         } else {

--- a/pallets/subtensor/src/delegate_info.rs
+++ b/pallets/subtensor/src/delegate_info.rs
@@ -53,6 +53,8 @@ impl<T: Config> Pallet<T> {
         }
 
         let owner = Self::get_owning_coldkey_for_hotkey(&delegate.clone());
+
+        // Create a vector of tuples (netuid, take). If a take is not set in DelegatesTake, use default value
         let take = NetworksAdded::<T>::iter()
             .filter(|(_, added)| {
                 *added

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -293,8 +293,12 @@ pub mod pallet {
         StorageMap<_, Blake2_128Concat, T::AccountId, T::AccountId, ValueQuery, DefaultAccount<T>>;
     #[pallet::storage] // --- ITEM ( delegate_limit ) --> Maximmu number of nominators per subnet validator
     pub type DelegateLimit<T> = StorageValue<_, u32, ValueQuery, DefaultDelegateLimit<T>>;
-    #[pallet::storage] // --- DMAP ( hot, subnetid ) --> take | Returns the hotkey delegation take by subnet. And signals that this key is open for delegation.
-    pub type Delegates<T: Config> = StorageDoubleMap<
+
+    #[pallet::storage] // --- MAP ( hot, u16 ) --> take | Signals that this key is open for delegation.
+    pub type Delegates<T: Config> =
+        StorageMap<_, Blake2_128Concat, T::AccountId, u16, ValueQuery, DefaultDefaultTake<T>>;
+    #[pallet::storage] // --- DMAP ( hot, subnetid ) --> take | Returns the hotkey delegation take by subnet.
+    pub type DelegatesTake<T: Config> = StorageDoubleMap<
         _,
         Blake2_128Concat,
         T::AccountId,
@@ -1364,9 +1368,6 @@ pub mod pallet {
         // 	* 'hotkey' (T::AccountId):
         // 		- The hotkey we are delegating (must be owned by the coldkey.)
         //
-        //  * 'netuid' (u16):
-        //      - Subnet ID to become delegate for
-        //
         // 	* 'take' (u16):
         // 		- The stake proportion that this hotkey takes from delegations.
         //
@@ -1384,8 +1385,8 @@ pub mod pallet {
         //
         #[pallet::call_index(1)]
         #[pallet::weight((0, DispatchClass::Normal, Pays::No))]
-        pub fn become_delegate(origin: OriginFor<T>, hotkey: T::AccountId, netuid: u16, take: u16) -> DispatchResult {
-            Self::do_become_delegate(origin, hotkey, netuid, take)
+        pub fn become_delegate(origin: OriginFor<T>, hotkey: T::AccountId) -> DispatchResult {
+            Self::do_become_delegate(origin, hotkey, Self::get_default_take())
         }
 
         // --- Allows delegates to decrease its take value.

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -306,7 +306,7 @@ pub mod pallet {
         u16,
         u16,
         ValueQuery,
-        DefaultDefaultTake<T>
+        DefaultDefaultTake<T>,
     >;
     #[pallet::storage] // --- DMAP ( hot, cold ) --> stake | Returns the stake under a coldkey prefixed by hotkey.
     pub type Stake<T: Config> = StorageDoubleMap<
@@ -646,7 +646,8 @@ pub mod pallet {
     #[pallet::storage] // --- ITEM ( tx_rate_limit )
     pub(super) type TxRateLimit<T> = StorageValue<_, u64, ValueQuery, DefaultTxRateLimit<T>>;
     #[pallet::storage] // --- ITEM ( tx_rate_limit )
-    pub(super) type TxDelegateTakeRateLimit<T> = StorageValue<_, u64, ValueQuery, DefaultTxDelegateTakeRateLimit<T>>;
+    pub(super) type TxDelegateTakeRateLimit<T> =
+        StorageValue<_, u64, ValueQuery, DefaultTxDelegateTakeRateLimit<T>>;
     #[pallet::storage] // --- MAP ( key ) --> last_block
     pub(super) type LastTxBlock<T: Config> =
         StorageMap<_, Identity, T::AccountId, u64, ValueQuery, DefaultLastTxBlock<T>>;
@@ -962,7 +963,7 @@ pub mod pallet {
         MinBurnSet(u16, u64),          // --- Event created when setting min burn on a network.
         TxRateLimitSet(u64),           // --- Event created when setting the transaction rate limit.
         TxDelegateTakeRateLimitSet(u64), // --- Event created when setting the delegate take transaction rate limit.
-        Sudid(DispatchResult),         // --- Event created when a sudo call is done.
+        Sudid(DispatchResult),           // --- Event created when a sudo call is done.
         RegistrationAllowed(u16, bool), // --- Event created when registration is allowed/disallowed for a subnet.
         PowRegistrationAllowed(u16, bool), // --- Event created when POW registration is allowed/disallowed for a subnet.
         TempoSet(u16, u16),                // --- Event created when setting tempo on a network
@@ -977,8 +978,8 @@ pub mod pallet {
         NetworkMinLockCostSet(u64),   // Event created when the network minimum locking cost is set.
         SubnetLimitSet(u16),          // Event created when the maximum number of subnets is set
         NetworkLockCostReductionIntervalSet(u64), // Event created when the lock cost reduction is set
-        TakeDecreased( T::AccountId, T::AccountId, u16 ), // Event created when the take for a delegate is decreased.
-        TakeIncreased( T::AccountId, T::AccountId, u16 ), // Event created when the take for a delegate is increased.
+        TakeDecreased(T::AccountId, T::AccountId, u16), // Event created when the take for a delegate is decreased.
+        TakeIncreased(T::AccountId, T::AccountId, u16), // Event created when the take for a delegate is increased.
         HotkeySwapped {
             coldkey: T::AccountId,
             old_hotkey: T::AccountId,
@@ -1424,7 +1425,12 @@ pub mod pallet {
         //
         #[pallet::call_index(65)]
         #[pallet::weight((0, DispatchClass::Normal, Pays::No))]
-        pub fn decrease_take(origin: OriginFor<T>, hotkey: T::AccountId, netuid: u16, take: u16) -> DispatchResult {
+        pub fn decrease_take(
+            origin: OriginFor<T>,
+            hotkey: T::AccountId,
+            netuid: u16,
+            take: u16,
+        ) -> DispatchResult {
             Self::do_decrease_take(origin, hotkey, netuid, take)
         }
 
@@ -1463,7 +1469,12 @@ pub mod pallet {
         //
         #[pallet::call_index(66)]
         #[pallet::weight((0, DispatchClass::Normal, Pays::No))]
-        pub fn increase_take(origin: OriginFor<T>, hotkey: T::AccountId, netuid: u16, take: u16) -> DispatchResult {
+        pub fn increase_take(
+            origin: OriginFor<T>,
+            hotkey: T::AccountId,
+            netuid: u16,
+            take: u16,
+        ) -> DispatchResult {
             Self::do_increase_take(origin, hotkey, netuid, take)
         }
 

--- a/pallets/subtensor/src/migration.rs
+++ b/pallets/subtensor/src/migration.rs
@@ -1,14 +1,12 @@
 use super::*;
 use alloc::collections::BTreeMap;
 use frame_support::{
-    Blake2_128Concat,
     sp_std::vec::Vec,
     storage_alias,
     weights::Weight,
     pallet_prelude::{
         Identity,
         OptionQuery,
-        ValueQuery,
     },
     traits::{ fungible::Inspect as _, Get, GetStorageVersion, StorageVersion },
 };
@@ -549,61 +547,4 @@ pub fn migrate_stake_to_substake<T: Config>() -> Weight {
 
     log::info!("Final weight: {:?}", weight); // Debug print
     weight
-}
-
-pub mod v0_delegates_format {
-    use super::*;
-
-    #[storage_alias]
-    pub(super) type Delegates<T: Config> =
-        StorageMap<Pallet<T>, Blake2_128Concat, <T as frame_system::Config>::AccountId, u16, ValueQuery>;
-}
-
-pub fn migrate_to_v1_delegates<T: Config>() -> Weight {
-    use v0_delegates_format as v0;
-
-    // Check storage version
-    let mut weight = T::DbWeight::get().reads_writes(1, 0);
-
-    // Grab current version
-    let onchain_version = Pallet::<T>::on_chain_storage_version();
-
-    // Only runs if we haven't already updated version to 2.
-    if onchain_version < 2 {
-        info!(
-            target: LOG_TARGET,
-            ">>> Updating the Delegates from V0 to V1. Pallet version: {:?}", onchain_version
-        );
-
-        // We transform the storage values from the old into the new format.
-        // Translate the old storage values into the new format.
-        // Each take from v0 becomes a set of takes for v1, same for each registered subnet
-        let mut counter = 0;
-        v0::Delegates::<T>::iter()
-            .for_each(|(key0, take0)| {
-                weight.saturating_accrue(T::DbWeight::get().reads(1));
-                SubnetworkN::<T>::iter_values()
-                    .for_each(|netid| {
-                        Delegates::<T>::insert(key0.clone(), netid, take0);
-                        weight.saturating_accrue(T::DbWeight::get().writes(1));
-                    });
-
-                counter += 1;
-                if counter % 100 == 0 {
-                    info!(
-                        target: LOG_TARGET,
-                        ">>> Updating the Delegates from V0 to V1: {} keys updated", counter
-                    );
-                }
-            });
-
-        // Update storage version.
-        StorageVersion::new(2).put::<Pallet<T>>(); // Update to version 2 so we don't run this again.
-        weight.saturating_accrue(T::DbWeight::get().writes(1)); // One write to storage version
-
-        weight
-    } else {
-        info!(target: LOG_TARGET_1, "Delegates migration to pallet v2 already done!");
-        Weight::zero()
-    }
 }

--- a/pallets/subtensor/src/registration.rs
+++ b/pallets/subtensor/src/registration.rs
@@ -746,12 +746,19 @@ impl<T: Config> Pallet<T> {
             weight.saturating_accrue(T::DbWeight::get().writes(2));
         }
 
-        for (netuid, delegate_take) in Delegates::<T>::iter_prefix(old_hotkey) {
-            Delegates::<T>::insert(new_hotkey, netuid, delegate_take);
+        if let Ok(delegate_take) = Delegates::<T>::try_get(old_hotkey) {
+            Delegates::<T>::remove(old_hotkey);
+            Delegates::<T>::insert(new_hotkey, delegate_take);
+
+            weight.saturating_accrue(T::DbWeight::get().writes(2));
+        }
+
+        for (netuid, delegate_take) in DelegatesTake::<T>::iter_prefix(old_hotkey) {
+            DelegatesTake::<T>::insert(new_hotkey, netuid, delegate_take);
             weight.saturating_accrue(T::DbWeight::get().reads_writes(1, 1));
         }
         let subnet_limit = SubnetLimit::<T>::get().into();
-        let _ = Delegates::<T>::clear_prefix(old_hotkey, subnet_limit, None);
+        let _ = DelegatesTake::<T>::clear_prefix(old_hotkey, subnet_limit, None);
         weight.saturating_accrue(T::DbWeight::get().writes(subnet_limit.into()));
 
         if let Ok(last_tx) = LastTxBlock::<T>::try_get(old_hotkey) {

--- a/pallets/subtensor/src/root.rs
+++ b/pallets/subtensor/src/root.rs
@@ -660,7 +660,7 @@ impl<T: Config> Pallet<T> {
 
         // --- 13. Force all members on root to become a delegate.
         if !Self::hotkey_is_delegate(&hotkey) {
-            Self::delegate_hotkey(&hotkey, 11_796); // 18% cut defaulted.
+            Self::delegate_hotkey(&hotkey, 0u16, 11_796); // 0 is root ID, 18% cut defaulted.
         }
 
         // --- 14. Update the registration counters for both the block and interval.

--- a/pallets/subtensor/src/root.rs
+++ b/pallets/subtensor/src/root.rs
@@ -660,7 +660,7 @@ impl<T: Config> Pallet<T> {
 
         // --- 13. Force all members on root to become a delegate.
         if !Self::hotkey_is_delegate(&hotkey) {
-            Self::delegate_hotkey(&hotkey, 0u16, 11_796); // 0 is root ID, 18% cut defaulted.
+            Self::delegate_hotkey(&hotkey, 11_796); // 18% cut defaulted.
         }
 
         // --- 14. Update the registration counters for both the block and interval.

--- a/pallets/subtensor/src/staking.rs
+++ b/pallets/subtensor/src/staking.rs
@@ -339,7 +339,7 @@ impl<T: Config> Pallet<T> {
         );
 
         // --- 7. Enforce the nominator limit
-        // let nominator_count: u32 = 0;
+        // let nominator_count: u32 = 0; // TODO: get the number of nominators
         // ensure!(
         //     nominator_count < DelegateLimit::<T>::get(),
         //     Error::<T>::TooManyNominations

--- a/pallets/subtensor/src/subnet_info.rs
+++ b/pallets/subtensor/src/subnet_info.rs
@@ -177,4 +177,8 @@ impl<T: Config> Pallet<T> {
             difficulty: difficulty.into(),
         });
     }
+
+    pub fn get_subnet_limit() -> u16 {
+        SubnetLimit::<T>::get()
+    }
 }

--- a/pallets/subtensor/src/utils.rs
+++ b/pallets/subtensor/src/utils.rs
@@ -668,4 +668,8 @@ impl<T: Config> Pallet<T> {
     pub fn is_subnet_owner(address: &T::AccountId) -> bool {
         SubnetOwner::<T>::iter_values().any(|owner| *address == owner)
     }
+
+    pub fn set_delegate_limit(delegate_limit: u32) {
+        DelegateLimit::<T>::put(delegate_limit);
+    }
 }

--- a/pallets/subtensor/tests/root.rs
+++ b/pallets/subtensor/tests/root.rs
@@ -785,13 +785,11 @@ fn test_issance_bounds() {
         // Simulate 100 halvings convergence to 21M. Note that the total issuance never reaches 21M because of rounding errors.
         // We converge to 20_999_999_989_500_000 (< 1 TAO away).
         let n_halvings: usize = 100;
-        let total_issuance = (0..n_halvings)
-            .into_iter()
-            .fold(0, |total, _| {
-                let block_emission_10_500_000x: u64 =
-                    SubtensorModule::get_block_emission_for_issuance(total).unwrap() * 10_500_000;
-                total + block_emission_10_500_000x
-            });
+        let total_issuance = (0..n_halvings).into_iter().fold(0, |total, _| {
+            let block_emission_10_500_000x: u64 =
+                SubtensorModule::get_block_emission_for_issuance(total).unwrap() * 10_500_000;
+            total + block_emission_10_500_000x
+        });
         assert_eq!(total_issuance, 20_999_999_989_500_000);
     })
 }

--- a/pallets/subtensor/tests/staking.rs
+++ b/pallets/subtensor/tests/staking.rs
@@ -2735,8 +2735,8 @@ fn test_faucet_ok() {
 #[test]
 fn test_delegate_take_limit() {
     new_test_ext(1).execute_with(|| {
-        assert_eq!(InitialDefaultTake::get() >= u16::MAX/2, true);
-        assert_eq!(InitialDefaultTake::get() <= u16::MAX-1, true);
+        assert_eq!(InitialDefaultTake::get() >= u16::MAX / 2, true);
+        assert_eq!(InitialDefaultTake::get() <= u16::MAX - 1, true);
     });
 }
 
@@ -2916,7 +2916,10 @@ fn test_delegate_take_can_be_increased_to_limit() {
             hotkey0,
             InitialDefaultTake::get()
         ));
-        assert_eq!(SubtensorModule::get_hotkey_take(&hotkey0), InitialDefaultTake::get());
+        assert_eq!(
+            SubtensorModule::get_hotkey_take(&hotkey0),
+            InitialDefaultTake::get()
+        );
     });
 }
 
@@ -2944,7 +2947,7 @@ fn test_delegate_take_can_not_be_set_beyond_limit() {
                 SubtensorModule::do_become_delegate(
                     <<Test as Config>::RuntimeOrigin>::signed(coldkey0),
                     hotkey0,
-                    InitialDefaultTake::get()+1
+                    InitialDefaultTake::get() + 1
                 ),
                 Err(Error::<Test>::InvalidTake.into())
             );
@@ -2984,7 +2987,7 @@ fn test_delegate_take_can_not_be_increased_beyond_limit() {
                 SubtensorModule::do_increase_take(
                     <<Test as Config>::RuntimeOrigin>::signed(coldkey0),
                     hotkey0,
-                    InitialDefaultTake::get()+1
+                    InitialDefaultTake::get() + 1
                 ),
                 Err(Error::<Test>::InvalidTake.into())
             );
@@ -3568,6 +3571,5 @@ fn test_rate_limits_enforced_on_increase_take() {
             u16::MAX / 10
         ));
         assert_eq!(SubtensorModule::get_hotkey_take(&hotkey0), u16::MAX / 10);
-
     });
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -640,6 +640,7 @@ parameter_types! {
     pub const SubtensorInitialScalingLawPower: u16 = 50; // 0.5
     pub const SubtensorInitialMaxAllowedValidators: u16 = 128;
     pub const SubtensorInitialTempo: u16 = 99;
+    pub const SubtensorInitialDelegateLimit: u32 = 128; // Limits the number of nominators per subnet validator
     pub const SubtensorInitialDifficulty: u64 = 10_000_000;
     pub const SubtensorInitialAdjustmentInterval: u16 = 100;
     pub const SubtensorInitialAdjustmentAlpha: u64 = 0; // no weight to previous value.
@@ -690,6 +691,7 @@ impl pallet_subtensor::Config for Runtime {
     type InitialValidatorPruneLen = SubtensorInitialValidatorPruneLen;
     type InitialScalingLawPower = SubtensorInitialScalingLawPower;
     type InitialTempo = SubtensorInitialTempo;
+    type InitialDelegateLimit = SubtensorInitialDelegateLimit;
     type InitialDifficulty = SubtensorInitialDifficulty;
     type InitialAdjustmentInterval = SubtensorInitialAdjustmentInterval;
     type InitialAdjustmentAlpha = SubtensorInitialAdjustmentAlpha;
@@ -876,6 +878,10 @@ impl
 
     fn set_tempo(netuid: u16, tempo: u16) {
         SubtensorModule::set_tempo(netuid, tempo);
+    }
+
+    fn set_delegate_limit(limit: u32) {
+        SubtensorModule::set_delegate_limit(limit);
     }
 
     fn set_subnet_owner_cut(subnet_owner_cut: u16) {
@@ -1410,6 +1416,11 @@ impl_runtime_apis! {
 
         fn get_total_subnet_stake( netuid: u16 ) -> Vec<u8> {
             let result = SubtensorModule::get_total_subnet_stake( netuid );
+            result.encode()
+        }
+
+        fn get_all_subnet_stake_info_for_coldkey( coldkey_account_vec: TensorBytes ) -> Vec<u8> {
+            let result = SubtensorModule::get_all_subnet_stake_info_for_coldkey( coldkey_account_vec );
             result.encode()
         }
     }


### PR DESCRIPTION
## Description
Add per-subnet takes for delegation. Validators can validate more than one subnet is stao and will now be able to specify their take specific to subnets.

## Related Issue(s)

- Closes #[315]

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Other (please describe):

## Breaking Change

DelegateInfo struct has changes, which affects RPC runtime APIs that return it. 

### What changed
`DelegateInfo::take` used to be `Compact<u16>`, and now it is contains a vector of (netuid, take) tuples: `Vec<(Compact<u16>, Compact<u16>)>`.

### What RPC endpoints are affected
```
DelegateInfoRuntimeApi::get_delegates
DelegateInfoRuntimeApi::get_delegate
DelegateInfoRuntimeApi::get_delegated
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

n/a

## Additional Notes

n/a