### PR TITLE
fix: account data migration

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1250,7 +1250,7 @@ mod account_data_migration {
                 pallet_balances::Pallet::<Runtime, ()>::ensure_upgraded(&acc);
             }
 
-            log::info!(target: TARGET, "Migrated ✅");
+            log::info!(target: TARGET, "Migrated {} accounts ✅", accounts.len());
 
             // R/W not important for solo chain.
             return <Runtime as frame_system::Config>::DbWeight::get().reads_writes(0u64, 0u64);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1207,10 +1207,12 @@ mod account_data_migration {
 
             for acc in account_ids {
                 // Ensure account exists in storage and decodes.
-                ensure!(
-                    frame_system::pallet::Account::<Runtime>::try_get(&acc).is_ok(),
-                    "account not found"
-                );
+                match frame_system::pallet::Account::<Runtime>::try_get(&acc) {
+                    Ok(d) => {
+                        ensure!(d.data.free > 0 || d.data.reserved > 0, "account has 0 bal");
+                    }
+                    _ => { panic!("account not found") }
+                };
 
                 // Ensure account provider is >0.
                 ensure!(

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1211,7 +1211,9 @@ mod account_data_migration {
                     Ok(d) => {
                         ensure!(d.data.free > 0 || d.data.reserved > 0, "account has 0 bal");
                     }
-                    _ => { panic!("account not found") }
+                    _ => {
+                        panic!("account not found")
+                    }
                 };
 
                 // Ensure account provider is >0.


### PR DESCRIPTION
Adds a new migration that
1. Migrates accounts to v1 format
2. Adds a provider for all accounts if one doesn't exist yet, preventing it from being killed