### PR TITLE
Fix: Remove invalid flag from localnet start script

### DIFF
--- a/scripts/localnet.sh
+++ b/scripts/localnet.sh
@@ -34,8 +34,7 @@ alice_start=(
 	--chain="$FULL_PATH"
 	--alice
 	--port 30334
-	--ws-port 9946
-	--rpc-port 9934
+	--rpc-port 9946
 	--validator
 	--rpc-cors=all
 	--allow-private-ipv4
@@ -48,8 +47,7 @@ bob_start=(
 	--chain="$FULL_PATH"
 	--bob
 	--port 30335
-	--ws-port 9947
-	--rpc-port 9935
+	--rpc-port 9945
 	--validator
 	--allow-private-ipv4
 	--discover-local


### PR DESCRIPTION
## Description
Small fix removing the now invalid —ws-port flag from the localnet.sh start script.

## Related Issue(s)
N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

N/A

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

<img width="553" alt="image" src="https://github.com/opentensor/subtensor/assets/141723589/ee233cd5-6acb-4784-9b1b-c6b9ef0f4f88">


## Additional Notes
Port 9946 is kept given that it's used in the subnet template docs & other documentation with localnet usage.