### PR TITLE
hotfix: minimum nominator stake

### DIFF
--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -53,7 +53,6 @@ pub mod pallet {
     }
 
     #[pallet::event]
-    #[pallet::generate_deposit(pub(super) fn deposit_event)]
     pub enum Event<T: Config> {}
 
     // Errors inform users that something went wrong.
@@ -765,6 +764,27 @@ pub mod pallet {
             T::Subtensor::set_weights_min_stake(min_stake);
             Ok(())
         }
+
+        /// Sets the minimum stake required for nominators, and clears small nominations
+        /// that are below the minimum required stake.
+        #[pallet::call_index(43)]
+        #[pallet::weight((0, DispatchClass::Operational, Pays::No))]
+        pub fn sudo_set_nominator_min_required_stake(
+            origin: OriginFor<T>,
+            // The minimum stake required for nominators.
+            min_stake: u64,
+        ) -> DispatchResult {
+            ensure_root(origin)?;
+            let prev_min_stake = T::Subtensor::get_nominator_min_required_stake();
+            log::trace!("Setting minimum stake to: {}", min_stake);
+            T::Subtensor::set_nominator_min_required_stake(min_stake);
+            if min_stake > prev_min_stake {
+                log::trace!("Clearing small nominations");
+                T::Subtensor::clear_small_nominations();
+                log::trace!("Small nominations cleared");
+            }
+            Ok(())
+        }
     }
 }
 
@@ -853,4 +873,7 @@ pub trait SubtensorInterface<AccountId, Balance, RuntimeOrigin> {
     fn set_weights_set_rate_limit(netuid: u16, weights_set_rate_limit: u64);
     fn init_new_network(netuid: u16, tempo: u16);
     fn set_weights_min_stake(min_stake: u64);
+    fn get_nominator_min_required_stake() -> u64;
+    fn set_nominator_min_required_stake(min_stake: u64);
+    fn clear_small_nominations();
 }

--- a/pallets/admin-utils/tests/mock.rs
+++ b/pallets/admin-utils/tests/mock.rs
@@ -1,5 +1,5 @@
 use frame_support::{
-    parameter_types,
+    assert_ok, parameter_types,
     traits::{Everything, Hooks, StorageMapShim},
     weights,
 };
@@ -436,6 +436,18 @@ impl pallet_admin_utils::SubtensorInterface<AccountId, Balance, RuntimeOrigin> f
     fn set_weights_min_stake(min_stake: u64) {
         SubtensorModule::set_weights_min_stake(min_stake);
     }
+
+    fn set_nominator_min_required_stake(min_stake: u64) {
+        SubtensorModule::set_nominator_min_required_stake(min_stake);
+    }
+
+    fn get_nominator_min_required_stake() -> u64 {
+        SubtensorModule::get_nominator_min_required_stake()
+    }
+
+    fn clear_small_nominations() {
+        SubtensorModule::clear_small_nominations();
+    }
 }
 
 impl pallet_admin_utils::Config for Test {
@@ -466,4 +478,43 @@ pub(crate) fn run_to_block(n: u64) {
         System::on_initialize(System::block_number());
         SubtensorModule::on_initialize(System::block_number());
     }
+}
+
+#[allow(dead_code)]
+pub fn register_ok_neuron(
+    netuid: u16,
+    hotkey_account_id: U256,
+    coldkey_account_id: U256,
+    start_nonce: u64,
+) {
+    let block_number: u64 = SubtensorModule::get_current_block_as_u64();
+    let (nonce, work): (u64, Vec<u8>) = SubtensorModule::create_work_for_block_number(
+        netuid,
+        block_number,
+        start_nonce,
+        &hotkey_account_id,
+    );
+    let result = SubtensorModule::register(
+        <<Test as frame_system::Config>::RuntimeOrigin>::signed(hotkey_account_id),
+        netuid,
+        block_number,
+        nonce,
+        work,
+        hotkey_account_id,
+        coldkey_account_id,
+    );
+    assert_ok!(result);
+    log::info!(
+        "Register ok neuron: netuid: {:?}, coldkey: {:?}, hotkey: {:?}",
+        netuid,
+        hotkey_account_id,
+        coldkey_account_id
+    );
+}
+
+#[allow(dead_code)]
+pub fn add_network(netuid: u16, tempo: u16, _modality: u16) {
+    SubtensorModule::init_new_network(netuid, tempo);
+    SubtensorModule::set_network_registration_allowed(netuid, true);
+    SubtensorModule::set_network_pow_registration_allowed(netuid, true);
 }

--- a/pallets/admin-utils/tests/tests.rs
+++ b/pallets/admin-utils/tests/tests.rs
@@ -8,13 +8,6 @@ use sp_core::U256;
 mod mock;
 use mock::*;
 
-#[allow(dead_code)]
-pub fn add_network(netuid: u16, tempo: u16, modality: u16) {
-    SubtensorModule::init_new_network(netuid, tempo);
-    SubtensorModule::set_network_registration_allowed(netuid, true);
-    SubtensorModule::set_network_pow_registration_allowed(netuid, true);
-}
-
 #[test]
 fn test_sudo_set_default_take() {
     new_test_ext().execute_with(|| {
@@ -883,4 +876,188 @@ fn test_sudo_set_network_pow_registration_allowed() {
             to_be_set
         );
     });
+}
+
+mod sudo_set_nominator_min_required_stake {
+    use super::*;
+
+    #[test]
+    fn can_only_be_called_by_admin() {
+        new_test_ext().execute_with(|| {
+            let to_be_set: u64 = SubtensorModule::get_nominator_min_required_stake() + 5 as u64;
+            assert_eq!(
+                AdminUtils::sudo_set_nominator_min_required_stake(
+                    <<Test as Config>::RuntimeOrigin>::signed(U256::from(0)),
+                    to_be_set
+                ),
+                Err(DispatchError::BadOrigin.into())
+            );
+        });
+    }
+
+    #[test]
+    fn sets_a_lower_value() {
+        new_test_ext().execute_with(|| {
+            let to_be_set: u64 = SubtensorModule::get_nominator_min_required_stake() - 5 as u64;
+            assert_ok!(AdminUtils::sudo_set_nominator_min_required_stake(
+                <<Test as Config>::RuntimeOrigin>::root(),
+                to_be_set
+            ));
+            assert_eq!(
+                SubtensorModule::get_nominator_min_required_stake(),
+                to_be_set
+            );
+        });
+    }
+
+    #[test]
+    fn sets_a_higher_value() {
+        new_test_ext().execute_with(|| {
+            let to_be_set: u64 = SubtensorModule::get_nominator_min_required_stake() + 5 as u64;
+            assert_ok!(AdminUtils::sudo_set_nominator_min_required_stake(
+                <<Test as Config>::RuntimeOrigin>::root(),
+                to_be_set
+            ));
+            assert_eq!(
+                SubtensorModule::get_nominator_min_required_stake(),
+                to_be_set
+            );
+        });
+    }
+
+    #[test]
+    fn clears_staker_nominations_below_min() {
+        new_test_ext().execute_with(|| {
+            System::set_block_number(1);
+
+            // Create accounts.
+            let netuid = 1;
+            let hot1 = U256::from(1);
+            let hot2 = U256::from(2);
+            let cold1 = U256::from(3);
+            let cold2 = U256::from(4);
+
+            SubtensorModule::set_target_stakes_per_interval(10);
+            // Register network.
+            add_network(netuid, 0, 0);
+
+            // Register hot1.
+            register_ok_neuron(netuid, hot1, cold1, 0);
+            assert_ok!(SubtensorModule::do_become_delegate(
+                <<Test as Config>::RuntimeOrigin>::signed(cold1),
+                hot1,
+                0
+            ));
+            assert_eq!(SubtensorModule::get_owning_coldkey_for_hotkey(&hot1), cold1);
+
+            // Register hot2.
+            register_ok_neuron(netuid, hot2, cold2, 0);
+            assert_ok!(SubtensorModule::do_become_delegate(
+                <<Test as Config>::RuntimeOrigin>::signed(cold2),
+                hot2,
+                0
+            ));
+            assert_eq!(SubtensorModule::get_owning_coldkey_for_hotkey(&hot2), cold2);
+
+            // Add stake cold1 --> hot1 (non delegation.)
+            SubtensorModule::add_balance_to_coldkey_account(&cold1, 5);
+            assert_ok!(SubtensorModule::add_stake(
+                <<Test as Config>::RuntimeOrigin>::signed(cold1),
+                hot1,
+                1
+            ));
+            assert_eq!(
+                SubtensorModule::get_stake_for_coldkey_and_hotkey(&cold1, &hot1),
+                1
+            );
+            assert_eq!(Balances::free_balance(cold1), 4);
+
+            // Add stake cold2 --> hot1 (is delegation.)
+            SubtensorModule::add_balance_to_coldkey_account(&cold2, 5);
+            assert_ok!(SubtensorModule::add_stake(
+                <<Test as Config>::RuntimeOrigin>::signed(cold2),
+                hot1,
+                1
+            ));
+            assert_eq!(
+                SubtensorModule::get_stake_for_coldkey_and_hotkey(&cold2, &hot1),
+                1
+            );
+            assert_eq!(Balances::free_balance(cold2), 4);
+
+            // Add stake cold1 --> hot2 (non delegation.)
+            SubtensorModule::add_balance_to_coldkey_account(&cold1, 5);
+            assert_ok!(SubtensorModule::add_stake(
+                <<Test as Config>::RuntimeOrigin>::signed(cold1),
+                hot2,
+                1
+            ));
+            assert_eq!(
+                SubtensorModule::get_stake_for_coldkey_and_hotkey(&cold1, &hot2),
+                1
+            );
+            assert_eq!(Balances::free_balance(cold1), 8);
+
+            // Add stake cold2 --> hot2 (is delegation.)
+            SubtensorModule::add_balance_to_coldkey_account(&cold2, 5);
+            assert_ok!(SubtensorModule::add_stake(
+                <<Test as Config>::RuntimeOrigin>::signed(cold2),
+                hot2,
+                1
+            ));
+            assert_eq!(
+                SubtensorModule::get_stake_for_coldkey_and_hotkey(&cold2, &hot2),
+                1
+            );
+            assert_eq!(Balances::free_balance(cold2), 8);
+
+            // Set min stake to 0 (noop)
+            assert_ok!(AdminUtils::sudo_set_nominator_min_required_stake(
+                <<Test as Config>::RuntimeOrigin>::root(),
+                0u64
+            ));
+            assert_eq!(
+                SubtensorModule::get_stake_for_coldkey_and_hotkey(&cold1, &hot1),
+                1
+            );
+            assert_eq!(
+                SubtensorModule::get_stake_for_coldkey_and_hotkey(&cold1, &hot2),
+                1
+            );
+            assert_eq!(
+                SubtensorModule::get_stake_for_coldkey_and_hotkey(&cold2, &hot1),
+                1
+            );
+            assert_eq!(
+                SubtensorModule::get_stake_for_coldkey_and_hotkey(&cold2, &hot2),
+                1
+            );
+
+            // Set min nomination to 10: should clear (cold2, hot1) and (cold1, hot2).
+            assert_ok!(AdminUtils::sudo_set_nominator_min_required_stake(
+                <<Test as Config>::RuntimeOrigin>::root(),
+                10u64
+            ));
+            assert_eq!(
+                SubtensorModule::get_stake_for_coldkey_and_hotkey(&cold1, &hot1),
+                1
+            );
+            assert_eq!(
+                SubtensorModule::get_stake_for_coldkey_and_hotkey(&cold1, &hot2),
+                0
+            );
+            assert_eq!(
+                SubtensorModule::get_stake_for_coldkey_and_hotkey(&cold2, &hot1),
+                0
+            );
+            assert_eq!(
+                SubtensorModule::get_stake_for_coldkey_and_hotkey(&cold2, &hot2),
+                1
+            );
+
+            // Balances have been added back into accounts.
+            assert_eq!(Balances::free_balance(cold1), 9);
+            assert_eq!(Balances::free_balance(cold2), 9);
+        });
+    }
 }

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -405,7 +405,7 @@ pub mod pallet {
     }
     #[pallet::type_value]
     pub fn DefaultNominatorMinRequiredStake<T: Config>() -> u64 {
-        1_000_000_000 // TODO: Confirm this is the correct amount?
+        0
     }
     #[pallet::type_value]
     pub fn DefaultNetworkMinAllowedUids<T: Config>() -> u16 {
@@ -981,6 +981,8 @@ pub mod pallet {
         StakeTooLowForRoot, // --- Thrown when a hotkey attempts to join the root subnet with too little stake
         AllNetworksInImmunity, // --- Thrown when all subnets are in the immunity period
         NotEnoughBalance,
+        /// Thrown a stake would be below the minimum threshold for nominator validations
+        NomStakeBelowMinimumThreshold,
     }
 
     // ==================

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -404,6 +404,10 @@ pub mod pallet {
         0
     }
     #[pallet::type_value]
+    pub fn DefaultNominatorMinRequiredStake<T: Config>() -> u64 {
+        1_000_000_000 // TODO: Confirm this is the correct amount?
+    }
+    #[pallet::type_value]
     pub fn DefaultNetworkMinAllowedUids<T: Config>() -> u16 {
         T::InitialNetworkMinAllowedUids::get()
     }
@@ -484,6 +488,9 @@ pub mod pallet {
     pub type SubnetOwnerCut<T> = StorageValue<_, u16, ValueQuery, DefaultSubnetOwnerCut<T>>;
     #[pallet::storage] // ITEM( network_rate_limit )
     pub type NetworkRateLimit<T> = StorageValue<_, u64, ValueQuery, DefaultNetworkRateLimit<T>>;
+    #[pallet::storage] // ITEM( nominator_min_required_stake )
+    pub type NominatorMinRequiredStake<T> =
+        StorageValue<_, u64, ValueQuery, DefaultNominatorMinRequiredStake<T>>;
 
     // ==============================
     // ==== Subnetwork Features =====
@@ -1000,8 +1007,6 @@ pub mod pallet {
     #[pallet::genesis_build]
     impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
         fn build(&self) {
-            use crate::MemberManagement;
-
             // Set initial total issuance from balances
             TotalIssuance::<T>::put(self.balances_issuance);
 
@@ -1714,7 +1719,7 @@ pub mod pallet {
         pub fn get_priority_set_weights(hotkey: &T::AccountId, netuid: u16) -> u64 {
             if Uids::<T>::contains_key(netuid, &hotkey) {
                 let uid = Self::get_uid_for_net_and_hotkey(netuid, &hotkey.clone()).unwrap();
-                let stake = Self::get_total_stake_for_hotkey(&hotkey);
+                let _stake = Self::get_total_stake_for_hotkey(&hotkey);
                 let current_block_number: u64 = Self::get_current_block_as_u64();
                 let default_priority: u64 =
                     current_block_number - Self::get_last_update_for_uid(netuid, uid as u16);

--- a/pallets/subtensor/src/migration.rs
+++ b/pallets/subtensor/src/migration.rs
@@ -1,4 +1,5 @@
 use super::*;
+use frame_support::traits::DefensiveResult;
 use frame_support::{
     inherent::Vec,
     pallet_prelude::{Identity, OptionQuery},
@@ -22,30 +23,37 @@ pub mod deprecated_loaded_emission_format {
         StorageMap<Pallet<T>, Identity, u16, Vec<(AccountIdOf<T>, u64)>, OptionQuery>;
 }
 
-
 /// Performs migration to update the total issuance based on the sum of stakes and total balances.
 /// This migration is applicable only if the current storage version is 5, after which it updates the storage version to 6.
 ///
 /// # Returns
 /// Weight of the migration process.
-pub fn migration5_total_issuance<T: Config>( test: bool ) -> Weight {
+pub fn migration5_total_issuance<T: Config>(test: bool) -> Weight {
     let mut weight = T::DbWeight::get().reads(1); // Initialize migration weight
 
     // Execute migration if the current storage version is 5
     if Pallet::<T>::on_chain_storage_version() == StorageVersion::new(5) || test {
         // Calculate the sum of all stake values
-        let stake_sum: u64 = Stake::<T>::iter()
-            .fold(0, |accumulator, (_, _, stake_value)| accumulator.saturating_add(stake_value));
-        weight = weight.saturating_add(T::DbWeight::get().reads_writes(Stake::<T>::iter().count() as u64, 0));
+        let stake_sum: u64 = Stake::<T>::iter().fold(0, |accumulator, (_, _, stake_value)| {
+            accumulator.saturating_add(stake_value)
+        });
+        weight = weight
+            .saturating_add(T::DbWeight::get().reads_writes(Stake::<T>::iter().count() as u64, 0));
 
         // Calculate the sum of all stake values
         let locked_sum: u64 = SubnetLocked::<T>::iter()
-            .fold(0, |accumulator, (_, locked_value)| accumulator.saturating_add(locked_value));
-        weight = weight.saturating_add(T::DbWeight::get().reads_writes(SubnetLocked::<T>::iter().count() as u64, 0));
+            .fold(0, |accumulator, (_, locked_value)| {
+                accumulator.saturating_add(locked_value)
+            });
+        weight = weight.saturating_add(
+            T::DbWeight::get().reads_writes(SubnetLocked::<T>::iter().count() as u64, 0),
+        );
 
         // Retrieve the total balance sum
         let total_balance = T::Currency::total_issuance();
-        let total_balance_sum: u64 = total_balance.try_into().unwrap_or_else(|_| panic!("Conversion must be within range"));
+        let total_balance_sum: u64 = total_balance
+            .try_into()
+            .unwrap_or_else(|_| panic!("Conversion must be within range"));
         weight = weight.saturating_add(T::DbWeight::get().reads(1));
 
         // Compute the total issuance value
@@ -153,8 +161,8 @@ pub fn migrate_create_root_network<T: Config>() -> Weight {
     // Empty senate members entirely, they will be filled by by registrations
     // on the subnet.
     for hotkey_i in T::SenateMembers::members().iter() {
-        T::TriumvirateInterface::remove_votes(&hotkey_i);
-        T::SenateMembers::remove_member(&hotkey_i);
+        T::TriumvirateInterface::remove_votes(&hotkey_i).defensive_ok();
+        T::SenateMembers::remove_member(&hotkey_i).defensive_ok();
 
         weight.saturating_accrue(T::DbWeight::get().reads_writes(2, 2));
     }

--- a/pallets/subtensor/src/registration.rs
+++ b/pallets/subtensor/src/registration.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::system::ensure_root;
 use frame_support::pallet_prelude::{DispatchResult, DispatchResultWithPostInfo};
 use frame_support::storage::IterableStorageDoubleMap;
 use frame_system::ensure_signed;
@@ -401,7 +400,7 @@ impl<T: Config> Pallet<T> {
 
         // --- 5. Add Balance via faucet.
         let balance_to_add: u64 = 100_000_000_000;
-        Self::coinbase( 100_000_000_000 ); // We are creating tokens here from the coinbase.
+        Self::coinbase(100_000_000_000); // We are creating tokens here from the coinbase.
 
         let balance_to_be_added_as_balance = Self::u64_to_balance(balance_to_add);
         Self::add_balance_to_coldkey_account(&coldkey, balance_to_be_added_as_balance.unwrap());

--- a/pallets/subtensor/src/staking.rs
+++ b/pallets/subtensor/src/staking.rs
@@ -167,6 +167,8 @@ impl<T: Config> Pallet<T> {
 
         // --- 7. If this is a nomination stake, check if total stake after adding will be above
         // the minimum required stake.
+
+        // If coldkey is not owner of the hotkey, it's a nomination stake.
         if !Self::coldkey_owns_hotkey(&coldkey, &hotkey) {
             let total_stake_after_add =
                 Stake::<T>::get(&hotkey, &coldkey).saturating_add(stake_to_be_added);
@@ -296,6 +298,8 @@ impl<T: Config> Pallet<T> {
 
         // --- 7. If this is a nomination stake, check if total stake after removing will be above
         // the minimum required stake.
+
+        // If coldkey is not owner of the hotkey, it's a nomination stake.
         if !Self::coldkey_owns_hotkey(&coldkey, &hotkey) {
             let total_stake_after_remove =
                 Stake::<T>::get(&hotkey, &coldkey).saturating_sub(stake_to_be_removed);

--- a/pallets/subtensor/src/staking.rs
+++ b/pallets/subtensor/src/staking.rs
@@ -564,7 +564,7 @@ impl<T: Config> Pallet<T> {
 
     /// Clears small nominations for all accounts.
     ///
-    /// WARN: This is an O(N) operations, where N is the number of staking accounts. It should be
+    /// WARN: This is an O(N) operation, where N is the number of staking accounts. It should be
     /// used with caution.
     pub fn clear_small_nominations() {
         // Loop through all staking accounts to identify and clear nominations below the minimum stake.

--- a/pallets/subtensor/src/utils.rs
+++ b/pallets/subtensor/src/utils.rs
@@ -606,4 +606,12 @@ impl<T: Config> Pallet<T> {
     pub fn is_subnet_owner(address: &T::AccountId) -> bool {
         SubnetOwner::<T>::iter_values().any(|owner| *address == owner)
     }
+
+    pub fn get_nominator_min_required_stake() -> u64 {
+        NominatorMinRequiredStake::<T>::get()
+    }
+
+    pub fn set_nominator_min_required_stake(min_stake: u64) {
+        NominatorMinRequiredStake::<T>::put(min_stake);
+    }
 }

--- a/pallets/subtensor/tests/mock.rs
+++ b/pallets/subtensor/tests/mock.rs
@@ -5,7 +5,6 @@ use frame_support::{
     weights,
 };
 use frame_system as system;
-use frame_system::Config;
 use frame_system::{limits, EnsureNever, EnsureRoot, RawOrigin};
 use sp_core::{Get, H256, U256};
 use sp_runtime::{
@@ -457,7 +456,7 @@ pub fn register_ok_neuron(
 }
 
 #[allow(dead_code)]
-pub fn add_network(netuid: u16, tempo: u16, modality: u16) {
+pub fn add_network(netuid: u16, tempo: u16, _modality: u16) {
     SubtensorModule::init_new_network(netuid, tempo);
     SubtensorModule::set_network_registration_allowed(netuid, true);
     SubtensorModule::set_network_pow_registration_allowed(netuid, true);


### PR DESCRIPTION
Supersedes https://github.com/opentensor/subtensor/pull/345 and https://github.com/opentensor/subtensor/pull/348.

- Creates new `admin-util` call `sudo_set_nominator_min_required_stake`, which clears small nomination stakes
- Updates `add_stake` and `remove_stake` calls to enforce the new nominator minimum stake