### PR TITLE
Update old script arguments --ws-external and --ws-max-connections

### DIFF
--- a/scripts/run/subtensor.sh
+++ b/scripts/run/subtensor.sh
@@ -44,8 +44,8 @@ function run_command()
         --base-path /tmp/blockchain \
         --chain ./raw_spec.json \
         --rpc-external --rpc-cors all \
-        --ws-external --no-mdns \
-        --ws-max-connections 10000 --in-peers 500 --out-peers 500 \
+        --no-mdns \
+        --rpc-max-connections 10000 --in-peers 500 --out-peers 500 \
         $SPECIFIC_OPTIONS
 }
 


### PR DESCRIPTION
## Description
When you run the script `./scripts/run/subtensor.sh`  on the newest version, it throws the error 
```
error: unexpected argument '--ws-external' found                                                                                                                
                                                                                                                                                                
  tip: a similar argument exists: '--rpc-external'                                                                                                              
```
This PR updates the parameters of the script according to info from PR #324 

## Related Issue(s)
PR #324 

## Type of Change
Removed deprecated parameter `--ws-external`. Changed `--ws-max-connections` -> `--rpc-max-connections` 


- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules