### PR TITLE
Feat/limit nominators per delegate

### DIFF
--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -119,15 +119,15 @@ pub mod pallet {
 
         #[pallet::call_index(46)]
         #[pallet::weight((0, DispatchClass::Operational, Pays::No))]
-        pub fn sudo_set_delegate_limit(
+        pub fn sudo_set_nominator_limit(
             origin: OriginFor<T>,
-            delegate_limit: u32,
+            nominator_limit: u32,
         ) -> DispatchResult {
             ensure_root(origin)?;
-            T::Subtensor::set_delegate_limit(delegate_limit);
+            T::Subtensor::set_nominator_limit(nominator_limit);
             log::info!(
-                "TxDelegateLimitSet( set_delegate_limit: {:?} ) ",
-                delegate_limit
+                "TxNominatorLimitSet( set_nominator_limit: {:?} ) ",
+                nominator_limit
             );
             Ok(())
         }
@@ -840,7 +840,7 @@ pub trait SubtensorInterface<AccountId, Balance, RuntimeOrigin> {
     fn set_default_take(default_take: u16);
     fn set_tx_rate_limit(rate_limit: u64);
     fn set_tx_delegate_take_rate_limit(rate_limit: u64);
-    fn set_delegate_limit(delegate_limit: u32);
+    fn set_nominator_limit(nominator_limit: u32);
 
     fn set_serving_rate_limit(netuid: u16, rate_limit: u64);
 

--- a/pallets/admin-utils/tests/mock.rs
+++ b/pallets/admin-utils/tests/mock.rs
@@ -108,6 +108,7 @@ parameter_types! {
     pub const InitialNetworkRateLimit: u64 = 0;
     pub const InitialTargetStakesPerInterval: u16 = 1;
     pub const InitialNominatorLimit: u16 = 128;
+    pub const InitialSubnetOwnerLockPeriod: u64 = 7 * 7200 * 3; // 3 months
 
 }
 
@@ -160,6 +161,7 @@ impl pallet_subtensor::Config for Test {
     type InitialNetworkRateLimit = InitialNetworkRateLimit;
     type InitialTargetStakesPerInterval = InitialTargetStakesPerInterval;
     type InitialNominatorLimit = InitialNominatorLimit;
+    type InitialSubnetOwnerLockPeriod = InitialSubnetOwnerLockPeriod;
 }
 
 impl system::Config for Test {

--- a/pallets/admin-utils/tests/mock.rs
+++ b/pallets/admin-utils/tests/mock.rs
@@ -107,7 +107,7 @@ parameter_types! {
     pub const InitialSubnetLimit: u16 = 10; // Max 10 subnets.
     pub const InitialNetworkRateLimit: u64 = 0;
     pub const InitialTargetStakesPerInterval: u16 = 1;
-    pub const InitialDelegateLimit: u16 = 128;
+    pub const InitialNominatorLimit: u16 = 128;
 
 }
 
@@ -159,7 +159,7 @@ impl pallet_subtensor::Config for Test {
     type InitialSubnetLimit = InitialSubnetLimit;
     type InitialNetworkRateLimit = InitialNetworkRateLimit;
     type InitialTargetStakesPerInterval = InitialTargetStakesPerInterval;
-    type InitialDelegateLimit = InitialDelegateLimit;
+    type InitialNominatorLimit = InitialNominatorLimit;
 }
 
 impl system::Config for Test {
@@ -449,8 +449,8 @@ impl pallet_admin_utils::SubtensorInterface<AccountId, Balance, RuntimeOrigin> f
         SubtensorModule::set_subnet_staking(subnet_staking);
     }
 
-    fn set_delegate_limit(delegate_limit: u32) {
-        SubtensorModule::set_delegate_limit(delegate_limit);
+    fn set_nominator_limit(nominator_limit: u32) {
+        SubtensorModule::set_nominator_limit(nominator_limit);
     }
 }
 

--- a/pallets/subtensor/rpc/src/lib.rs
+++ b/pallets/subtensor/rpc/src/lib.rs
@@ -95,7 +95,7 @@ pub trait SubtensorCustomApi<BlockHash> {
         coldkey_account_vec: TensorBytes,
         at: Option<BlockHash>,
     ) -> RpcResult<Vec<u8>>;
-    #[method(name= "subnetInfo_getTotalStakeForEachSubnet")]
+    #[method(name = "subnetInfo_getTotalStakeForEachSubnet")]
     fn get_total_stake_for_each_subnet(&self, at: Option<BlockHash>) -> RpcResult<Vec<u8>>;
     #[method(name = "dynamicPoolInfo_getDynamicPoolInfo")]
     fn get_dynamic_pool_info(&self, netuid: u16, at: Option<BlockHash>) -> RpcResult<Vec<u8>>;
@@ -511,7 +511,10 @@ where
         })
     }
 
-    fn get_total_stake_for_each_subnet(&self,at:Option<<Block  as  BlockT>::Hash>) -> RpcResult<Vec<u8> > {
+    fn get_total_stake_for_each_subnet(
+        &self,
+        at: Option<<Block as BlockT>::Hash>,
+    ) -> RpcResult<Vec<u8>> {
         let api = self.client.runtime_api();
         let at = at.unwrap_or_else(|| self.client.info().best_hash);
 
@@ -522,6 +525,6 @@ where
                 Some(e.to_string()),
             ))
             .into()
-        })  
+        })
     }
 }

--- a/pallets/subtensor/src/delegate_info.rs
+++ b/pallets/subtensor/src/delegate_info.rs
@@ -258,7 +258,7 @@ impl<T: Config> Pallet<T> {
             .collect()
     }
 
-    pub fn get_delegate_limit() -> u32 {
-        DelegateLimit::<T>::get()
+    pub fn get_nominator_limit() -> u32 {
+        NominatorLimit::<T>::get()
     }
 }

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -162,7 +162,7 @@ pub mod pallet {
         #[pallet::constant] // Initial default delegation take.
         type InitialDefaultTake: Get<u16>;
         #[pallet::constant] // Initial limit on number of nominators per subnet validator
-        type InitialDelegateLimit: Get<u32>;
+        type InitialNominatorLimit: Get<u32>;
         #[pallet::constant] // Initial weights version key.
         type InitialWeightsVersionKey: Get<u64>;
         #[pallet::constant] // Initial serving rate limit.
@@ -219,11 +219,15 @@ pub mod pallet {
         T::InitialDefaultTake::get()
     }
     #[pallet::type_value]
-    pub fn DefaultDelegateLimit<T: Config>() -> u32 {
-        T::InitialDelegateLimit::get()
+    pub fn DefaultNominatorLimit<T: Config>() -> u32 {
+        T::InitialNominatorLimit::get()
     }
     #[pallet::type_value]
     pub fn DefaultZeroU64<T: Config>() -> u64 {
+        0
+    }
+    #[pallet::type_value]
+    pub fn DefaultZeroU32<T: Config>() -> u32 {
         0
     }
     #[pallet::type_value]
@@ -294,8 +298,11 @@ pub mod pallet {
     #[pallet::storage] // --- MAP ( hot ) --> cold | Returns the controlling coldkey for a hotkey.
     pub type Owner<T: Config> =
         StorageMap<_, Blake2_128Concat, T::AccountId, T::AccountId, ValueQuery, DefaultAccount<T>>;
-    #[pallet::storage] // --- ITEM ( delegate_limit ) --> Maximmu number of nominators per subnet validator
-    pub type DelegateLimit<T> = StorageValue<_, u32, ValueQuery, DefaultDelegateLimit<T>>;
+    #[pallet::storage] // --- ITEM ( delegate_limit ) --> Maximum number of nominators per hotkey
+    pub type NominatorLimit<T> = StorageValue<_, u32, ValueQuery, DefaultNominatorLimit<T>>;
+    #[pallet::storage] // --- MAP ( hot ) --> count | Number of nominators per hotkey
+    pub type NominatorCount<T: Config> =
+        StorageMap<_, Identity, T::AccountId, u32, ValueQuery, DefaultZeroU32<T>>;
 
     #[pallet::storage] // --- MAP ( hot, u16 ) --> take | Signals that this key is open for delegation.
     pub type Delegates<T: Config> =
@@ -893,7 +900,7 @@ pub mod pallet {
         StorageMap<_, Identity, u16, Vec<(T::AccountId, u64, u64)>, OptionQuery>;
     #[pallet::storage] // --- DMAP ( netuid ) --> stake_weight
     pub(super) type StakeWeight<T: Config> =
-        StorageMap<_, Identity, u16, Vec<u16>, ValueQuery, EmptyU16Vec<T>>;    
+        StorageMap<_, Identity, u16, Vec<u16>, ValueQuery, EmptyU16Vec<T>>;
     #[pallet::storage] // --- DMAP ( netuid ) --> active
     pub(super) type Active<T: Config> =
         StorageMap<_, Identity, u16, Vec<bool>, ValueQuery, EmptyBoolVec<T>>;

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1310,15 +1310,17 @@ pub mod pallet {
                 "feabaafee293d3b76dae304e2f9d885f77d2b17adab9e17e921b321eccd61c77"
             ];
             weight = weight
-                .saturating_add(migration::migrate_to_v1_separate_emission::<T>())
-                .saturating_add(migration::migrate_to_v2_fixed_total_stake::<T>())
-                .saturating_add(migration::migrate_create_root_network::<T>())
-                .saturating_add(migration::migrate_transfer_ownership_to_foundation::<T>(
+                .saturating_add(migration::migrate_to_v1_separate_emission::<T>())         // v0 -> v1
+                .saturating_add(migration::migrate_to_v2_fixed_total_stake::<T>())         // v1 -> v2
+                .saturating_add(migration::migrate_create_root_network::<T>())             // DOES NOT CHECK VERSION
+                .saturating_add(migration::migrate_transfer_ownership_to_foundation::<T>(  // v2 -> v3
                     hex,
                 ))
-                .saturating_add(migration::migrate_delete_subnet_3::<T>())
-                .saturating_add(migration::migrate_delete_subnet_21::<T>())
-                .saturating_add(migration::migration5_total_issuance::<T>(false));
+                .saturating_add(migration::migrate_delete_subnet_21::<T>())                // v3 -> v4
+                .saturating_add(migration::migrate_delete_subnet_3::<T>())                 // v4 -> v5
+                .saturating_add(migration::migration5_total_issuance::<T>(false))          // DOES NOT CHECK VERSION
+                .saturating_add(migration::migrate_stake_to_substake::<T>())               // v5 -> v6
+                .saturating_add(migration::migrate_nominator_counters::<T>());             // v6 -> v7
 
             return weight;
         }

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1310,17 +1310,18 @@ pub mod pallet {
                 "feabaafee293d3b76dae304e2f9d885f77d2b17adab9e17e921b321eccd61c77"
             ];
             weight = weight
-                .saturating_add(migration::migrate_to_v1_separate_emission::<T>())         // v0 -> v1
-                .saturating_add(migration::migrate_to_v2_fixed_total_stake::<T>())         // v1 -> v2
-                .saturating_add(migration::migrate_create_root_network::<T>())             // DOES NOT CHECK VERSION
-                .saturating_add(migration::migrate_transfer_ownership_to_foundation::<T>(  // v2 -> v3
+                .saturating_add(migration::migrate_to_v1_separate_emission::<T>()) // v0 -> v1
+                .saturating_add(migration::migrate_to_v2_fixed_total_stake::<T>()) // v1 -> v2
+                .saturating_add(migration::migrate_create_root_network::<T>()) // DOES NOT CHECK VERSION
+                .saturating_add(migration::migrate_transfer_ownership_to_foundation::<T>(
+                    // v2 -> v3
                     hex,
                 ))
-                .saturating_add(migration::migrate_delete_subnet_21::<T>())                // v3 -> v4
-                .saturating_add(migration::migrate_delete_subnet_3::<T>())                 // v4 -> v5
-                .saturating_add(migration::migration5_total_issuance::<T>(false))          // DOES NOT CHECK VERSION
-                .saturating_add(migration::migrate_stake_to_substake::<T>())               // v5 -> v6
-                .saturating_add(migration::migrate_nominator_counters::<T>());             // v6 -> v7
+                .saturating_add(migration::migrate_delete_subnet_21::<T>()) // v3 -> v4
+                .saturating_add(migration::migrate_delete_subnet_3::<T>()) // v4 -> v5
+                .saturating_add(migration::migration5_total_issuance::<T>(false)) // DOES NOT CHECK VERSION
+                .saturating_add(migration::migrate_stake_to_substake::<T>()) // v5 -> v6
+                .saturating_add(migration::migrate_nominator_counters::<T>()); // v6 -> v7
 
             return weight;
         }

--- a/pallets/subtensor/src/utils.rs
+++ b/pallets/subtensor/src/utils.rs
@@ -671,8 +671,8 @@ impl<T: Config> Pallet<T> {
         SubnetOwner::<T>::iter_values().any(|owner| *address == owner)
     }
 
-    pub fn set_delegate_limit(delegate_limit: u32) {
-        DelegateLimit::<T>::put(delegate_limit);
+    pub fn set_nominator_limit(nominator_limit: u32) {
+        NominatorLimit::<T>::put(nominator_limit);
     }
 
     pub fn get_subnet_owner_lock_period() -> u64 {

--- a/pallets/subtensor/tests/block_step.rs
+++ b/pallets/subtensor/tests/block_step.rs
@@ -857,8 +857,6 @@ fn test_subnet_staking_emission() {
     });
 }
 
-
-
 #[test]
 fn test_run_coinbase_price_greater_than_1() {
     new_test_ext(1).execute_with(|| {

--- a/pallets/subtensor/tests/dtao.rs
+++ b/pallets/subtensor/tests/dtao.rs
@@ -15,13 +15,13 @@ fn test_add_subnet_stake_ok_no_emission() {
         let coldkey = U256::from(1);
 
         SubtensorModule::add_balance_to_coldkey_account(&coldkey, 100_000_000_000); // 100 TAO.
-        // Check
-        // -- that the lock cost is 100 TAO.
-        // -- that the balance is 100 TAO.
-        // -- that the root pool is empty.
-        // -- that the root alpha pool is empty.
-        // -- that the root price is 1.0.
-        // -- that the root has zero k value.
+                                                                                    // Check
+                                                                                    // -- that the lock cost is 100 TAO.
+                                                                                    // -- that the balance is 100 TAO.
+                                                                                    // -- that the root pool is empty.
+                                                                                    // -- that the root alpha pool is empty.
+                                                                                    // -- that the root price is 1.0.
+                                                                                    // -- that the root has zero k value.
         assert_eq!(SubtensorModule::get_network_lock_cost(), 100_000_000_000); // 100 TAO.
         assert_eq!(
             SubtensorModule::get_coldkey_balance(&coldkey),
@@ -38,7 +38,10 @@ fn test_add_subnet_stake_ok_no_emission() {
         assert_eq!(SubtensorModule::get_pool_k(0), 0);
         assert_eq!(SubtensorModule::is_subnet_dynamic(0), false);
 
-        log::info!("Alpha Outstanding is {:?}", SubtensorModule::get_alpha_outstanding(0));
+        log::info!(
+            "Alpha Outstanding is {:?}",
+            SubtensorModule::get_alpha_outstanding(0)
+        );
         // Register a network with this coldkey + hotkey for a lock cost of 100 TAO.
         step_block(1);
         assert_ok!(SubtensorModule::register_network(
@@ -60,21 +63,39 @@ fn test_add_subnet_stake_ok_no_emission() {
         // -- that the alpha reserve is 100 ALPHA
         // -- that the k factor is 100 TAO * 100 ALPHA.
         // -- that the new network is dynamic
-        assert_eq!( SubtensorModule::get_network_lock_cost(), 200_000_000_000 ); // 200 TAO.
-        // TODO:(sam)Decide how to deal with ED , as this account can only stake 199
-        assert_eq!( SubtensorModule::get_coldkey_balance( &coldkey ), 1 ); // 0 TAO.
-        assert_eq!( SubtensorModule::get_subnet_owner( 1 ), coldkey );
-        assert_eq!( SubtensorModule::get_subnetwork_n( 1 ), 1 );
-        assert_eq!( SubtensorModule::get_hotkey_for_net_and_uid( 1, 0 ).unwrap(), hotkey );
-        assert_eq!( SubtensorModule::get_owning_coldkey_for_hotkey( &hotkey ), coldkey );
-        assert_eq!( SubtensorModule::get_total_stake_for_hotkey_and_subnet( &hotkey, 1), 100_000_000_000 ); // 1 subnets * 100 TAO lock cost.
-        assert_eq!( SubtensorModule::get_total_stake_for_subnet( 1 ), 100_000_000_000 );
-        assert_eq!( SubtensorModule::get_tao_per_alpha_price(1), 1.0 );
-        assert_eq!( SubtensorModule::get_tao_reserve(1), 100_000_000_000 );
-        assert_eq!( SubtensorModule::get_alpha_reserve(1), 100_000_000_000 );
-        assert_eq!( SubtensorModule::get_pool_k(1), 100_000_000_000 * 100_000_000_000 );
-        assert_eq!( SubtensorModule::is_subnet_dynamic(1), true );
-        log::info!("Alpha Outstanding is {:?}", SubtensorModule::get_alpha_outstanding(1));
+        assert_eq!(SubtensorModule::get_network_lock_cost(), 200_000_000_000); // 200 TAO.
+                                                                               // TODO:(sam)Decide how to deal with ED , as this account can only stake 199
+        assert_eq!(SubtensorModule::get_coldkey_balance(&coldkey), 1); // 0 TAO.
+        assert_eq!(SubtensorModule::get_subnet_owner(1), coldkey);
+        assert_eq!(SubtensorModule::get_subnetwork_n(1), 1);
+        assert_eq!(
+            SubtensorModule::get_hotkey_for_net_and_uid(1, 0).unwrap(),
+            hotkey
+        );
+        assert_eq!(
+            SubtensorModule::get_owning_coldkey_for_hotkey(&hotkey),
+            coldkey
+        );
+        assert_eq!(
+            SubtensorModule::get_total_stake_for_hotkey_and_subnet(&hotkey, 1),
+            100_000_000_000
+        ); // 1 subnets * 100 TAO lock cost.
+        assert_eq!(
+            SubtensorModule::get_total_stake_for_subnet(1),
+            100_000_000_000
+        );
+        assert_eq!(SubtensorModule::get_tao_per_alpha_price(1), 1.0);
+        assert_eq!(SubtensorModule::get_tao_reserve(1), 100_000_000_000);
+        assert_eq!(SubtensorModule::get_alpha_reserve(1), 100_000_000_000);
+        assert_eq!(
+            SubtensorModule::get_pool_k(1),
+            100_000_000_000 * 100_000_000_000
+        );
+        assert_eq!(SubtensorModule::is_subnet_dynamic(1), true);
+        log::info!(
+            "Alpha Outstanding is {:?}",
+            SubtensorModule::get_alpha_outstanding(1)
+        );
 
         // Register a new network
         assert_eq!(SubtensorModule::get_network_lock_cost(), 200_000_000_000); // 100 TAO.
@@ -98,21 +119,39 @@ fn test_add_subnet_stake_ok_no_emission() {
         // -- that the alpha reserve is 400 ALPHA
         // -- that the k factor is 200 TAO * 400 ALPHA.
         // -- that the new network is dynamic
-        assert_eq!( SubtensorModule::get_network_lock_cost(), 400_000_000_000 ); // 4 TAO.
-                // TODO:(sam)Decide how to deal with ED , as this account can only stake 199
-        assert_eq!( SubtensorModule::get_coldkey_balance( &coldkey ), 1 ); // 0 TAO.
-        assert_eq!( SubtensorModule::get_subnet_owner( 2 ), coldkey );
-        assert_eq!( SubtensorModule::get_subnetwork_n( 2 ), 1 );
-        assert_eq!( SubtensorModule::get_hotkey_for_net_and_uid( 2, 0 ).unwrap(), hotkey );
-        assert_eq!( SubtensorModule::get_owning_coldkey_for_hotkey( &hotkey ), coldkey );
-        assert_eq!( SubtensorModule::get_total_stake_for_hotkey_and_subnet( &hotkey, 2), 400_000_000_000 ); // 2 subnets * 2 TAO lock cost.
-        assert_eq!( SubtensorModule::get_total_stake_for_subnet( 2 ), 400_000_000_000 );
-        assert_eq!( SubtensorModule::get_tao_per_alpha_price(2), 0.5 );
-        assert_eq!( SubtensorModule::get_tao_reserve(2), 200_000_000_000 );
-        assert_eq!( SubtensorModule::get_alpha_reserve(2), 400_000_000_000 );
-        assert_eq!( SubtensorModule::get_pool_k(2), 200_000_000_000 * 400_000_000_000 );
-        assert_eq!( SubtensorModule::is_subnet_dynamic(2), true );
-        log::info!("Alpha Outstanding is {:?}", SubtensorModule::get_alpha_outstanding(2));
+        assert_eq!(SubtensorModule::get_network_lock_cost(), 400_000_000_000); // 4 TAO.
+                                                                               // TODO:(sam)Decide how to deal with ED , as this account can only stake 199
+        assert_eq!(SubtensorModule::get_coldkey_balance(&coldkey), 1); // 0 TAO.
+        assert_eq!(SubtensorModule::get_subnet_owner(2), coldkey);
+        assert_eq!(SubtensorModule::get_subnetwork_n(2), 1);
+        assert_eq!(
+            SubtensorModule::get_hotkey_for_net_and_uid(2, 0).unwrap(),
+            hotkey
+        );
+        assert_eq!(
+            SubtensorModule::get_owning_coldkey_for_hotkey(&hotkey),
+            coldkey
+        );
+        assert_eq!(
+            SubtensorModule::get_total_stake_for_hotkey_and_subnet(&hotkey, 2),
+            400_000_000_000
+        ); // 2 subnets * 2 TAO lock cost.
+        assert_eq!(
+            SubtensorModule::get_total_stake_for_subnet(2),
+            400_000_000_000
+        );
+        assert_eq!(SubtensorModule::get_tao_per_alpha_price(2), 0.5);
+        assert_eq!(SubtensorModule::get_tao_reserve(2), 200_000_000_000);
+        assert_eq!(SubtensorModule::get_alpha_reserve(2), 400_000_000_000);
+        assert_eq!(
+            SubtensorModule::get_pool_k(2),
+            200_000_000_000 * 400_000_000_000
+        );
+        assert_eq!(SubtensorModule::is_subnet_dynamic(2), true);
+        log::info!(
+            "Alpha Outstanding is {:?}",
+            SubtensorModule::get_alpha_outstanding(2)
+        );
 
         // Let's remove all of our stake from subnet 2.
         // Check:
@@ -124,7 +163,7 @@ fn test_add_subnet_stake_ok_no_emission() {
         // -- that the alpha reserve is 800 ALPHA
         // -- that the k factor is 100 TAO * 400 ALPHA. (unchanged)
         // TODO:(sam)Decide how to deal with ED , free balance will always be 1
-        assert_eq!(Balances::free_balance(coldkey), 1 );
+        assert_eq!(Balances::free_balance(coldkey), 1);
         // We set this to zero , otherwise the alpha calculation is off due to the fact that many tempos will be run
         // over the default lock period (3 months)
         SubtensorModule::set_subnet_owner_lock_period(0);
@@ -137,16 +176,31 @@ fn test_add_subnet_stake_ok_no_emission() {
         ));
         // assert_eq!( Balances::free_balance(coldkey), 100_000_000_000);
         // Rounding to 3 decimal places as the actual value is 0.1249998051747815231  Consider using Arithmetic rounding
-        // Also use more rigour calculation for slippage via K 
-        assert_eq!( format!("{:.3}", SubtensorModule::get_tao_per_alpha_price(2)), "0.125" );
-        assert_eq!( round_to_significant_figures(SubtensorModule::get_tao_reserve(2), 3), 100_000_000_000 );
+        // Also use more rigour calculation for slippage via K
+        assert_eq!(
+            format!("{:.3}", SubtensorModule::get_tao_per_alpha_price(2)),
+            "0.125"
+        );
+        assert_eq!(
+            round_to_significant_figures(SubtensorModule::get_tao_reserve(2), 3),
+            100_000_000_000
+        );
         // Yet another ugly approximation
-        assert_eq!( round_to_significant_figures(SubtensorModule::get_alpha_reserve(2), 2), 800_000_000_000 );
+        assert_eq!(
+            round_to_significant_figures(SubtensorModule::get_alpha_reserve(2), 2),
+            800_000_000_000
+        );
 
-        log::info!("Alpha Reserve is {:?}", SubtensorModule::get_alpha_reserve(2));
+        log::info!(
+            "Alpha Reserve is {:?}",
+            SubtensorModule::get_alpha_reserve(2)
+        );
         log::info!("Tao Reserve is {:?}", SubtensorModule::get_tao_reserve(2));
         // Yet another ugly approximation
-        assert_eq!( SubtensorModule::get_pool_k(2), 200_000_000_000 * 400_000_000_000 );
+        assert_eq!(
+            SubtensorModule::get_pool_k(2),
+            200_000_000_000 * 400_000_000_000
+        );
 
         // Let's run a block step.
         // Check
@@ -212,7 +266,6 @@ fn test_stake_unstake() {
         assert_eq!(SubtensorModule::get_tao_per_alpha_price(1), 4); // Price is increased from the stake operation.
     })
 }
-
 
 fn round_to_significant_figures(num: u64, significant_figures: u32) -> u64 {
     if num == 0 {

--- a/pallets/subtensor/tests/epoch.rs
+++ b/pallets/subtensor/tests/epoch.rs
@@ -4,7 +4,7 @@ use frame_system::Config;
 use rand::{distributions::Uniform, rngs::StdRng, seq::SliceRandom, thread_rng, Rng, SeedableRng};
 use sp_core::U256;
 use std::time::Instant;
-use substrate_fixed::types::{ I32F32, I64F64 };
+use substrate_fixed::types::{I32F32, I64F64};
 mod mock;
 
 #[macro_use]
@@ -2005,7 +2005,7 @@ fn test_validator_permits() {
 fn test_get_stakes_division_by_zero_is_checked() {
     new_test_ext(1).execute_with(|| {
         setup_dynamic_network(1u16, 1u16, 1u16);
-        SubtensorModule::set_alpha_outstanding( 1u16, 0 );
+        SubtensorModule::set_alpha_outstanding(1u16, 0);
 
         let hotkey_tuples = vec![(0u16, U256::from(1))];
         let gsw = SubtensorModule::get_global_stake_weights(&hotkey_tuples);
@@ -2253,7 +2253,6 @@ fn test_lsw_2_subnets_2_hotkeys_2_nominators_uneven_cross_stake() {
     });
 }
 
-
 #[test]
 fn test_get_stakes_subnets_2_hotkeys_2_nominators_uneven_cross_stake_0_global() {
     new_test_ext(1).execute_with(|| {
@@ -2282,7 +2281,7 @@ fn test_get_stakes_subnets_2_hotkeys_2_nominators_uneven_cross_stake_1_global() 
     new_test_ext(1).execute_with(|| {
         setup_dynamic_network(1u16, 1u16, 1u16);
         setup_dynamic_network(2u16, 2u16, 2u16);
-        SubtensorModule::set_global_stake_weight( u16::MAX );
+        SubtensorModule::set_global_stake_weight(u16::MAX);
 
         add_dynamic_stake(1u16, 1u16, 1u16, 100_000_000_000u64);
         add_dynamic_stake(1u16, 1u16, 2u16, 200_000_000_000u64);
@@ -2307,7 +2306,7 @@ fn test_get_stakes_subnets_2_hotkeys_2_nominators_uneven_cross_stake_05_global()
     new_test_ext(1).execute_with(|| {
         setup_dynamic_network(1u16, 1u16, 1u16);
         setup_dynamic_network(2u16, 2u16, 2u16);
-        SubtensorModule::set_global_stake_weight( u16::MAX / 2 );
+        SubtensorModule::set_global_stake_weight(u16::MAX / 2);
 
         add_dynamic_stake(1u16, 1u16, 1u16, 100_000_000_000u64);
         add_dynamic_stake(1u16, 1u16, 2u16, 200_000_000_000u64);

--- a/pallets/subtensor/tests/migration.rs
+++ b/pallets/subtensor/tests/migration.rs
@@ -410,14 +410,8 @@ fn test_migration_init_nominator_counts_two_to_two() {
         pallet_subtensor::migration::migrate_nominator_counters::<Test>();
 
         // Verify that counters are correct
-        assert_eq!(
-            pallet_subtensor::NominatorCount::<Test>::get(&hotkey1),
-            1
-        );
-        assert_eq!(
-            pallet_subtensor::NominatorCount::<Test>::get(&hotkey2),
-            1
-        );
+        assert_eq!(pallet_subtensor::NominatorCount::<Test>::get(&hotkey1), 1);
+        assert_eq!(pallet_subtensor::NominatorCount::<Test>::get(&hotkey2), 1);
     });
 }
 
@@ -451,9 +445,6 @@ fn test_migration_init_nominator_counts_10_to_one() {
         pallet_subtensor::migration::migrate_nominator_counters::<Test>();
 
         // Verify that counters are correct
-        assert_eq!(
-            pallet_subtensor::NominatorCount::<Test>::get(&delegate),
-            10
-        );
+        assert_eq!(pallet_subtensor::NominatorCount::<Test>::get(&delegate), 10);
     });
 }

--- a/pallets/subtensor/tests/mock.rs
+++ b/pallets/subtensor/tests/mock.rs
@@ -156,7 +156,7 @@ parameter_types! {
     pub const InitialSubnetLimit: u16 = 10; // Max 10 subnets.
     pub const InitialNetworkRateLimit: u64 = 0;
     pub const InitialTargetStakesPerInterval: u16 = 2;
-    pub const InitialDelegateLimit: u16 = 128;
+    pub const InitialNominatorLimit: u16 = 128;
     pub const InitialSubnetOwnerLockPeriod: u64 = 7 * 7200 * 3;
 }
 
@@ -357,7 +357,7 @@ impl pallet_subtensor::Config for Test {
     type InitialSubnetLimit = InitialSubnetLimit;
     type InitialNetworkRateLimit = InitialNetworkRateLimit;
     type InitialTargetStakesPerInterval = InitialTargetStakesPerInterval;
-    type InitialDelegateLimit = InitialDelegateLimit;
+    type InitialNominatorLimit = InitialNominatorLimit;
     type InitialSubnetOwnerLockPeriod = InitialSubnetOwnerLockPeriod;
 }
 

--- a/pallets/subtensor/tests/mock.rs
+++ b/pallets/subtensor/tests/mock.rs
@@ -475,23 +475,23 @@ pub fn add_network(netuid: u16, tempo: u16, _modality: u16) {
 }
 
 #[allow(dead_code)]
-pub fn add_dynamic_network(netuid: u16, tempo: u16, cold_id: u16, hot_id: u16 ) {
+pub fn add_dynamic_network(netuid: u16, tempo: u16, cold_id: u16, hot_id: u16) {
     let lock_amount = SubtensorModule::get_network_lock_cost();
-    let coldkey = U256::from( cold_id );
-    let hotkey = U256::from( hot_id );
+    let coldkey = U256::from(cold_id);
+    let hotkey = U256::from(hot_id);
 
     add_network(netuid, tempo, 0);
 
     let initial_tao_reserve: u64 = lock_amount as u64;
     let initial_dynamic_reserve: u64 = lock_amount * SubtensorModule::get_num_subnets() as u64;
     let initial_dynamic_outstanding: u64 = lock_amount * SubtensorModule::get_num_subnets() as u64;
-    let initial_dynamic_k: u128 = ( initial_tao_reserve as u128) * ( initial_dynamic_reserve as u128 );
+    let initial_dynamic_k: u128 = (initial_tao_reserve as u128) * (initial_dynamic_reserve as u128);
 
-    SubtensorModule::set_tao_reserve( netuid, initial_tao_reserve );
-    SubtensorModule::set_alpha_reserve( netuid, initial_dynamic_reserve );
-    SubtensorModule::set_alpha_outstanding( netuid, initial_dynamic_outstanding );
-    SubtensorModule::set_pool_k( netuid, initial_dynamic_k );
-    SubtensorModule::set_subnet_dynamic( netuid ); // Turn on dynamic staking.
+    SubtensorModule::set_tao_reserve(netuid, initial_tao_reserve);
+    SubtensorModule::set_alpha_reserve(netuid, initial_dynamic_reserve);
+    SubtensorModule::set_alpha_outstanding(netuid, initial_dynamic_outstanding);
+    SubtensorModule::set_pool_k(netuid, initial_dynamic_k);
+    SubtensorModule::set_subnet_dynamic(netuid); // Turn on dynamic staking.
 
     SubtensorModule::increase_stake_on_coldkey_hotkey_account(
         &coldkey,
@@ -503,21 +503,21 @@ pub fn add_dynamic_network(netuid: u16, tempo: u16, cold_id: u16, hot_id: u16 ) 
 
 #[allow(dead_code)]
 pub fn setup_dynamic_network(netuid: u16, cold_id: u16, hot_id: u16) {
-    SubtensorModule::set_global_stake_weight( 0 );
-    let hotkey = U256::from( hot_id );
-    add_dynamic_network( netuid, u16::MAX - 1, cold_id, hot_id );
-    SubtensorModule::set_max_allowed_uids( netuid, 1 );
-    SubtensorModule::append_neuron( netuid, &hotkey, 1 );
+    SubtensorModule::set_global_stake_weight(0);
+    let hotkey = U256::from(hot_id);
+    add_dynamic_network(netuid, u16::MAX - 1, cold_id, hot_id);
+    SubtensorModule::set_max_allowed_uids(netuid, 1);
+    SubtensorModule::append_neuron(netuid, &hotkey, 1);
 }
 
 #[allow(dead_code)]
 pub fn add_dynamic_stake(netuid: u16, cold_id: u16, hot_id: u16, amount: u64) {
-    let coldkey = U256::from( cold_id );
-    let hotkey = U256::from( hot_id );
+    let coldkey = U256::from(cold_id);
+    let hotkey = U256::from(hot_id);
 
-    SubtensorModule::add_balance_to_coldkey_account( &coldkey, amount );
+    SubtensorModule::add_balance_to_coldkey_account(&coldkey, amount);
 
-    let dynamic_stake = SubtensorModule::compute_dynamic_stake( netuid, amount );
+    let dynamic_stake = SubtensorModule::compute_dynamic_stake(netuid, amount);
     SubtensorModule::increase_stake_on_coldkey_hotkey_account(
         &coldkey,
         &hotkey,
@@ -528,15 +528,14 @@ pub fn add_dynamic_stake(netuid: u16, cold_id: u16, hot_id: u16, amount: u64) {
 
 #[allow(dead_code)]
 pub fn remove_dynamic_stake(netuid: u16, cold_id: u16, hot_id: u16, amount: u64) {
-    let coldkey = U256::from( cold_id );
-    let hotkey = U256::from( hot_id );
+    let coldkey = U256::from(cold_id);
+    let hotkey = U256::from(hot_id);
 
-    let dynamic_unstake_amount_tao = SubtensorModule::compute_dynamic_unstake( netuid, amount );
+    let dynamic_unstake_amount_tao = SubtensorModule::compute_dynamic_unstake(netuid, amount);
     SubtensorModule::decrease_stake_on_coldkey_hotkey_account(
         &coldkey,
         &hotkey,
         netuid,
         dynamic_unstake_amount_tao,
     );
-
 }

--- a/pallets/subtensor/tests/stake_info.rs
+++ b/pallets/subtensor/tests/stake_info.rs
@@ -415,7 +415,7 @@ fn test_get_total_stake_for_each_subnet_double_stake() {
             ));
 
             // Add stake to another subnet
-            let netuid = ((i+1) % 32 + 1) as u16;
+            let netuid = ((i + 1) % 32 + 1) as u16;
             assert_ok!(SubtensorModule::add_subnet_stake(
                 <<Test as frame_system::Config>::RuntimeOrigin>::signed(coldkey),
                 *hotkey,

--- a/pallets/subtensor/tests/staking.rs
+++ b/pallets/subtensor/tests/staking.rs
@@ -4517,19 +4517,6 @@ fn test_remove_stake_below_nominator_limit_nominates_ok() {
             ));
         }
 
-        // Nominate 11th time - fails
-        let nominator11 = U256::from(11);
-        SubtensorModule::add_balance_to_coldkey_account(&nominator11, 100_000_000_000);
-        assert_err!(
-            SubtensorModule::add_subnet_stake(
-                <<Test as Config>::RuntimeOrigin>::signed(nominator11),
-                delegate,
-                1,
-                1_000_000_000
-            ),
-            Error::<Test>::TooManyNominations
-        );
-
         // Remove one stake - can nominate again
         let nominator1 = U256::from(1);
         assert_ok!(SubtensorModule::remove_subnet_stake(
@@ -4579,20 +4566,7 @@ fn test_partial_remove_stake_nomination_fails() {
             ));
         }
 
-        // Nominate 11th time - fails
-        let nominator11 = U256::from(11);
-        SubtensorModule::add_balance_to_coldkey_account(&nominator11, 100_000_000_000);
-        assert_err!(
-            SubtensorModule::add_subnet_stake(
-                <<Test as Config>::RuntimeOrigin>::signed(nominator11),
-                delegate,
-                1,
-                1_000_000_000
-            ),
-            Error::<Test>::TooManyNominations
-        );
-
-        // Remove one stake - can nominate again
+        // Remove one stake partially - still can't nominate
         let nominator1 = U256::from(1);
         assert_ok!(SubtensorModule::remove_subnet_stake(
             <<Test as Config>::RuntimeOrigin>::signed(nominator1),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -644,7 +644,7 @@ parameter_types! {
     pub const SubtensorInitialScalingLawPower: u16 = 50; // 0.5
     pub const SubtensorInitialMaxAllowedValidators: u16 = 128;
     pub const SubtensorInitialTempo: u16 = 99;
-    pub const SubtensorInitialDelegateLimit: u32 = 128; // Limits the number of nominators per subnet validator
+    pub const SubtensorInitialNominatorLimit: u32 = 128; // Limits the number of nominators per subnet validator
     pub const SubtensorInitialDifficulty: u64 = 10_000_000;
     pub const SubtensorInitialAdjustmentInterval: u16 = 100;
     pub const SubtensorInitialAdjustmentAlpha: u64 = 0; // no weight to previous value.
@@ -696,7 +696,7 @@ impl pallet_subtensor::Config for Runtime {
     type InitialValidatorPruneLen = SubtensorInitialValidatorPruneLen;
     type InitialScalingLawPower = SubtensorInitialScalingLawPower;
     type InitialTempo = SubtensorInitialTempo;
-    type InitialDelegateLimit = SubtensorInitialDelegateLimit;
+    type InitialNominatorLimit = SubtensorInitialNominatorLimit;
     type InitialDifficulty = SubtensorInitialDifficulty;
     type InitialAdjustmentInterval = SubtensorInitialAdjustmentInterval;
     type InitialAdjustmentAlpha = SubtensorInitialAdjustmentAlpha;
@@ -886,8 +886,8 @@ impl
         SubtensorModule::set_tempo(netuid, tempo);
     }
 
-    fn set_delegate_limit(limit: u32) {
-        SubtensorModule::set_delegate_limit(limit);
+    fn set_nominator_limit(limit: u32) {
+        SubtensorModule::set_nominator_limit(limit);
     }
 
     fn set_subnet_owner_cut(subnet_owner_cut: u16) {


### PR DESCRIPTION
## Description
This PR completes the feature of limiting the number of nominators per hotkey. Default value is set to 128, but it can be adjusted via admin extrinsic. Initially the code migrates by initializing counters using Stake state map, so that add_stake transaction don't need to run O(n) counting operation.

## Related Issue(s)

- Closes [Issue #[347]](https://github.com/orgs/opentensor/projects/27/views/1?filterQuery=gzten&pane=issue&itemId=59380692)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

n/a

## Additional Notes

n/a