### PR TITLE
Fix migration order, comment on_runtime_upgrade

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1203,14 +1203,21 @@ pub mod pallet {
                 "feabaafee293d3b76dae304e2f9d885f77d2b17adab9e17e921b321eccd61c77"
             ];
             weight = weight
+                // Initializes storage version (to 1)
                 .saturating_add(migration::migrate_to_v1_separate_emission::<T>())
+                // Storage version v1 -> v2
                 .saturating_add(migration::migrate_to_v2_fixed_total_stake::<T>())
+                // Doesn't check storage version. TODO: Remove after upgrade
                 .saturating_add(migration::migrate_create_root_network::<T>())
+                // Storage version v2 -> v3
                 .saturating_add(migration::migrate_transfer_ownership_to_foundation::<T>(
                     hex,
                 ))
-                .saturating_add(migration::migrate_delete_subnet_3::<T>())
+                // Storage version v3 -> v4
                 .saturating_add(migration::migrate_delete_subnet_21::<T>())
+                // Storage version v4 -> v5
+                .saturating_add(migration::migrate_delete_subnet_3::<T>())
+                // Doesn't check storage version. TODO: Remove after upgrade
                 .saturating_add(migration::migration5_total_issuance::<T>(false));
 
             weight


### PR DESCRIPTION
## Description
This PR is primarily a fix for migration order. `migrate_delete_subnet_21` and `migrate_delete_subnet_3` update to respectively storage versions of 4 and 5, but the `migrate_delete_subnet_3` migration is called first in `on_runtime_upgrade`, so `migrate_delete_subnet_21` will never run.

## Related Issue(s)

n/a

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

n/a

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

n/a

## Additional Notes

n/a