### PR TITLE
Hotfix regs

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1875,7 +1875,7 @@ where
                     Pallet::<T>::get_registrations_this_interval(*netuid);
                 let max_registrations_per_interval =
                     Pallet::<T>::get_target_registrations_per_interval(*netuid);
-                if registrations_this_interval >= max_registrations_per_interval {
+                if registrations_this_interval >= (max_registrations_per_interval * 3) {
                     // If the registration limit for the interval is exceeded, reject the transaction
                     return InvalidTransaction::ExhaustsResources.into();
                 }

--- a/pallets/subtensor/tests/mock.rs
+++ b/pallets/subtensor/tests/mock.rs
@@ -145,7 +145,7 @@ parameter_types! {
     pub const InitialAdjustmentInterval: u16 = 100;
     pub const InitialAdjustmentAlpha: u64 = 0; // no weight to previous value.
     pub const InitialMaxRegistrationsPerBlock: u16 = 3;
-    pub const InitialTargetRegistrationsPerInterval: u16 = 2;
+    pub const InitialTargetRegistrationsPerInterval: u16 = 3;
     pub const InitialPruningScore : u16 = u16::MAX;
     pub const InitialRegistrationRequirement: u16 = u16::MAX; // Top 100%
     pub const InitialMinDifficulty: u64 = 1;

--- a/pallets/subtensor/tests/registration.rs
+++ b/pallets/subtensor/tests/registration.rs
@@ -256,18 +256,18 @@ fn test_burned_registration_under_limit() {
         let netuid: u16 = 1;
         let hotkey_account_id: U256 = U256::from(1);
         let coldkey_account_id = U256::from(667);
-        let who: <Test as frame_system::Config>::AccountId = hotkey_account_id;
-        let block_number: u64 = 0;
+        let who: <Test as frame_system::Config>::AccountId = coldkey_account_id;
+        let burn_cost = 1000;
+        // Set the burn cost
+        SubtensorModule::set_burn(netuid, burn_cost);
 
-        let (nonce, work) = SubtensorModule::create_work_for_block_number(
-            netuid,
-            block_number,
-            129123813,
-            &hotkey_account_id,
-        );
+        add_network(netuid, 13, 0); // Add the network
+                                    // Give it some TAO to the coldkey balance; more than the burn cost
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, burn_cost + 10_000);
 
-        let max_registrants = 2;
-        SubtensorModule::set_target_registrations_per_interval(netuid, max_registrants);
+        let target_registrants = 2;
+        let max_registrants = target_registrants * 3; // Maximum is 3 times the target
+        SubtensorModule::set_target_registrations_per_interval(netuid, target_registrants);
 
         let call_burned_register: pallet_subtensor::Call<Test> =
             pallet_subtensor::Call::burned_register {
@@ -283,21 +283,15 @@ fn test_burned_registration_under_limit() {
             extension.validate(&who, &call_burned_register.into(), &info, 10);
         assert_ok!(burned_register_result);
 
-        add_network(netuid, 13, 0);
         //actually call register
-        assert_ok!(SubtensorModule::register(
-            <<Test as Config>::RuntimeOrigin>::signed(hotkey_account_id),
+        assert_ok!(SubtensorModule::burned_register(
+            <<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id),
             netuid,
-            block_number,
-            nonce,
-            work,
             hotkey_account_id,
-            coldkey_account_id
         ));
 
         let current_registrants = SubtensorModule::get_registrations_this_interval(netuid);
-        let target_registrants = SubtensorModule::get_target_registrations_per_interval(netuid);
-        assert!(current_registrants <= target_registrants);
+        assert!(current_registrants <= max_registrants);
     });
 }
 
@@ -306,11 +300,15 @@ fn test_burned_registration_rate_limit_exceeded() {
     new_test_ext().execute_with(|| {
         let netuid: u16 = 1;
         let hotkey_account_id: U256 = U256::from(1);
-        let who: <Test as frame_system::Config>::AccountId = hotkey_account_id;
-        let max_registrants = 1;
+        let coldkey_account_id = U256::from(667);
+        let who: <Test as frame_system::Config>::AccountId = coldkey_account_id;
 
-        SubtensorModule::set_target_registrations_per_interval(netuid, max_registrants);
-        SubtensorModule::set_registrations_this_interval(netuid, 1);
+        let target_registrants = 1;
+        let max_registrants = target_registrants * 3; // Maximum is 3 times the target
+
+        SubtensorModule::set_target_registrations_per_interval(netuid, target_registrants);
+        // Set the current registrations to the maximum; should not be able to register more
+        SubtensorModule::set_registrations_this_interval(netuid, max_registrants);
 
         let call_burned_register: pallet_subtensor::Call<Test> =
             pallet_subtensor::Call::burned_register {
@@ -332,6 +330,55 @@ fn test_burned_registration_rate_limit_exceeded() {
 
         let current_registrants = SubtensorModule::get_registrations_this_interval(netuid);
         assert!(current_registrants <= max_registrants);
+    });
+}
+
+#[test]
+fn test_burned_registration_rate_allows_burn_adjustment() {
+    // We need to be able to register more than the *target* registrations per interval
+    new_test_ext().execute_with(|| {
+        let netuid: u16 = 1;
+        let hotkey_account_id: U256 = U256::from(1);
+        let coldkey_account_id = U256::from(667);
+        let who: <Test as frame_system::Config>::AccountId = coldkey_account_id;
+
+        let burn_cost = 1000;
+        // Set the burn cost
+        SubtensorModule::set_burn(netuid, burn_cost);
+
+        add_network(netuid, 13, 0); // Add the network
+                                    // Give it some TAO to the coldkey balance; more than the burn cost
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, burn_cost + 10_000);
+
+        let target_registrants = 1; // Target is 1, but we can register more than that, up to some maximum.
+        SubtensorModule::set_target_registrations_per_interval(netuid, target_registrants);
+        // Set the current registrations to above the target; we should be able to register at least 1 more
+        SubtensorModule::set_registrations_this_interval(netuid, target_registrants);
+
+        // Register one more, so the current registrations are above the target
+        let call_burned_register: pallet_subtensor::Call<Test> =
+            pallet_subtensor::Call::burned_register {
+                netuid,
+                hotkey: hotkey_account_id,
+            };
+
+        let info: DispatchInfo =
+            DispatchInfoOf::<<Test as frame_system::Config>::RuntimeCall>::default();
+        let extension = SubtensorSignedExtension::<Test>::new();
+        //does not actually call register
+        let burned_register_result =
+            extension.validate(&who, &call_burned_register.into(), &info, 10);
+        assert_ok!(burned_register_result);
+
+        //actually call register
+        assert_ok!(SubtensorModule::burned_register(
+            <<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id),
+            netuid,
+            hotkey_account_id
+        ));
+
+        let current_registrants = SubtensorModule::get_registrations_this_interval(netuid);
+        assert!(current_registrants > target_registrants); // Should be able to register more than the target
     });
 }
 


### PR DESCRIPTION
## Description
Previous chain upgrade introduced an overly strict signed extension filtering on registrations per interval. The change fixes this to bring the SE to match the code in registrations.rs.
