### PR TITLE
Add increase_take and decrease_take extrinsics, rate limiting, and tests

### DIFF
--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -88,7 +88,7 @@ pub mod pallet {
         #[pallet::weight(T::WeightInfo::sudo_set_default_take())]
         pub fn sudo_set_default_take(origin: OriginFor<T>, default_take: u16) -> DispatchResult {
             ensure_root(origin)?;
-            T::Subtensor::set_default_take(default_take);
+            T::Subtensor::set_max_delegate_take(default_take);
             log::info!("DefaultTakeSet( default_take: {:?} ) ", default_take);
             Ok(())
         }
@@ -800,6 +800,15 @@ pub mod pallet {
             );
             Ok(())
         }
+
+        #[pallet::call_index(46)]
+        #[pallet::weight((0, DispatchClass::Operational, Pays::No))]
+        pub fn sudo_set_min_delegate_take(origin: OriginFor<T>, take: u16) -> DispatchResult {
+            ensure_root(origin)?;
+            T::Subtensor::set_min_delegate_take(take);
+            log::info!("TxMinDelegateTakeSet( tx_min_delegate_take: {:?} ) ", take);
+            Ok(())
+        }
     }
 }
 
@@ -821,7 +830,8 @@ impl<A, M> AuraInterface<A, M> for () {
 ///////////////////////////////////////////
 
 pub trait SubtensorInterface<AccountId, Balance, RuntimeOrigin> {
-    fn set_default_take(default_take: u16);
+    fn set_min_delegate_take(take: u16);
+    fn set_max_delegate_take(take: u16);
     fn set_tx_rate_limit(rate_limit: u64);
     fn set_tx_delegate_take_rate_limit(rate_limit: u64);
 

--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -785,6 +785,21 @@ pub mod pallet {
             }
             Ok(())
         }
+
+        #[pallet::call_index(45)]
+        #[pallet::weight((0, DispatchClass::Operational, Pays::No))]
+        pub fn sudo_set_tx_delegate_take_rate_limit(
+            origin: OriginFor<T>,
+            tx_rate_limit: u64,
+        ) -> DispatchResult {
+            ensure_root(origin)?;
+            T::Subtensor::set_tx_delegate_take_rate_limit(tx_rate_limit);
+            log::info!(
+                "TxRateLimitDelegateTakeSet( tx_delegate_take_rate_limit: {:?} ) ",
+                tx_rate_limit
+            );
+            Ok(())
+        }
     }
 }
 
@@ -808,6 +823,7 @@ impl<A, M> AuraInterface<A, M> for () {
 pub trait SubtensorInterface<AccountId, Balance, RuntimeOrigin> {
     fn set_default_take(default_take: u16);
     fn set_tx_rate_limit(rate_limit: u64);
+    fn set_tx_delegate_take_rate_limit(rate_limit: u64);
 
     fn set_serving_rate_limit(netuid: u16, rate_limit: u64);
 

--- a/pallets/admin-utils/src/weights.rs
+++ b/pallets/admin-utils/src/weights.rs
@@ -34,7 +34,8 @@ use core::marker::PhantomData;
 /// Weight functions needed for `pallet_admin_utils`.
 pub trait WeightInfo {
 	fn swap_authorities(a: u32, ) -> Weight;
-	fn sudo_set_default_take() -> Weight;
+    fn sudo_set_min_delegate_take() -> Weight;
+    fn sudo_set_default_take() -> Weight;
 	fn sudo_set_serving_rate_limit() -> Weight;
 	fn sudo_set_max_difficulty() -> Weight;
 	fn sudo_set_min_difficulty() -> Weight;
@@ -83,6 +84,16 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Storage: SubtensorModule DefaultTake (r:0 w:1)
 	/// Proof Skipped: SubtensorModule DefaultTake (max_values: Some(1), max_size: None, mode: Measured)
 	fn sudo_set_default_take() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `655`
+		//  Estimated: `655`
+		// Minimum execution time: 26_770_000 picoseconds.
+		Weight::from_parts(27_199_000, 655)
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
+	/// Storage: SubtensorModule DefaultTake (r:0 w:1)
+	/// Proof Skipped: SubtensorModule DefaultTake (max_values: Some(1), max_size: None, mode: Measured)
+	fn sudo_set_min_delegate_take() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `655`
 		//  Estimated: `655`
@@ -423,6 +434,16 @@ impl WeightInfo for () {
 	/// Storage: SubtensorModule DefaultTake (r:0 w:1)
 	/// Proof Skipped: SubtensorModule DefaultTake (max_values: Some(1), max_size: None, mode: Measured)
 	fn sudo_set_default_take() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `655`
+		//  Estimated: `655`
+		// Minimum execution time: 26_770_000 picoseconds.
+		Weight::from_parts(27_199_000, 655)
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+	/// Storage: SubtensorModule DefaultTake (r:0 w:1)
+	/// Proof Skipped: SubtensorModule DefaultTake (max_values: Some(1), max_size: None, mode: Measured)
+	fn sudo_set_min_delegate_take() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `655`
 		//  Estimated: `655`

--- a/pallets/admin-utils/tests/mock.rs
+++ b/pallets/admin-utils/tests/mock.rs
@@ -76,6 +76,7 @@ parameter_types! {
     pub const InitialStakePruningMin: u16 = 0;
     pub const InitialFoundationDistribution: u64 = 0;
     pub const InitialDefaultTake: u16 = 11_796; // 18% honest number.
+    pub const InitialMinTake: u16 = 0;
     pub const InitialWeightsVersionKey: u16 = 0;
     pub const InitialServingRateLimit: u64 = 0; // No limit.
     pub const InitialTxRateLimit: u64 = 0; // Disable rate limit for testing
@@ -139,6 +140,7 @@ impl pallet_subtensor::Config for Test {
     type InitialBondsMovingAverage = InitialBondsMovingAverage;
     type InitialMaxAllowedValidators = InitialMaxAllowedValidators;
     type InitialDefaultTake = InitialDefaultTake;
+    type InitialMinTake = InitialMinTake;
     type InitialWeightsVersionKey = InitialWeightsVersionKey;
     type InitialMaxDifficulty = InitialMaxDifficulty;
     type InitialMinDifficulty = InitialMinDifficulty;
@@ -205,8 +207,12 @@ impl pallet_balances::Config for Test {
 pub struct SubtensorIntrf;
 
 impl pallet_admin_utils::SubtensorInterface<AccountId, Balance, RuntimeOrigin> for SubtensorIntrf {
-    fn set_default_take(default_take: u16) {
-        SubtensorModule::set_default_take(default_take);
+    fn set_max_delegate_take(default_take: u16) {
+        SubtensorModule::set_max_delegate_take(default_take);
+    }
+
+    fn set_min_delegate_take(default_take: u16) {
+        SubtensorModule::set_min_delegate_take(default_take);
     }
 
     fn set_tx_rate_limit(rate_limit: u64) {

--- a/pallets/admin-utils/tests/mock.rs
+++ b/pallets/admin-utils/tests/mock.rs
@@ -79,6 +79,7 @@ parameter_types! {
     pub const InitialWeightsVersionKey: u16 = 0;
     pub const InitialServingRateLimit: u64 = 0; // No limit.
     pub const InitialTxRateLimit: u64 = 0; // Disable rate limit for testing
+    pub const InitialTxDelegateTakeRateLimit: u64 = 0; // Disable rate limit for testing
     pub const InitialBurn: u64 = 0;
     pub const InitialMinBurn: u64 = 0;
     pub const InitialMaxBurn: u64 = 1_000_000_000;
@@ -143,6 +144,7 @@ impl pallet_subtensor::Config for Test {
     type InitialMinDifficulty = InitialMinDifficulty;
     type InitialServingRateLimit = InitialServingRateLimit;
     type InitialTxRateLimit = InitialTxRateLimit;
+    type InitialTxDelegateTakeRateLimit = InitialTxDelegateTakeRateLimit;
     type InitialBurn = InitialBurn;
     type InitialMaxBurn = InitialMaxBurn;
     type InitialMinBurn = InitialMinBurn;
@@ -209,6 +211,10 @@ impl pallet_admin_utils::SubtensorInterface<AccountId, Balance, RuntimeOrigin> f
 
     fn set_tx_rate_limit(rate_limit: u64) {
         SubtensorModule::set_tx_rate_limit(rate_limit);
+    }
+
+    fn set_tx_delegate_take_rate_limit(rate_limit: u64) {
+        SubtensorModule::set_tx_delegate_take_rate_limit(rate_limit);
     }
 
     fn set_serving_rate_limit(netuid: u16, rate_limit: u64) {

--- a/pallets/admin-utils/tests/tests.rs
+++ b/pallets/admin-utils/tests/tests.rs
@@ -1087,3 +1087,24 @@ fn test_sudo_set_tx_delegate_take_rate_limit() {
         );
     });
 }
+
+#[test]
+fn test_sudo_set_min_delegate_take() {
+    new_test_ext().execute_with(|| {
+        let to_be_set = u16::MAX / 100;
+        let init_value = SubtensorModule::get_min_delegate_take();
+        assert_eq!(
+            AdminUtils::sudo_set_min_delegate_take(
+                <<Test as Config>::RuntimeOrigin>::signed(U256::from(1)),
+                to_be_set
+            ),
+            Err(DispatchError::BadOrigin.into())
+        );
+        assert_eq!(SubtensorModule::get_min_delegate_take(), init_value);
+        assert_ok!(AdminUtils::sudo_set_min_delegate_take(
+            <<Test as Config>::RuntimeOrigin>::root(),
+            to_be_set
+        ));
+        assert_eq!(SubtensorModule::get_min_delegate_take(), to_be_set);
+    });
+}

--- a/pallets/admin-utils/tests/tests.rs
+++ b/pallets/admin-utils/tests/tests.rs
@@ -1060,3 +1060,24 @@ mod sudo_set_nominator_min_required_stake {
         });
     }
 }
+
+#[test]
+fn test_sudo_set_tx_delegate_take_rate_limit() {
+    new_test_ext().execute_with(|| {
+        let to_be_set: u64 = 10;
+        let init_value: u64 = SubtensorModule::get_tx_delegate_take_rate_limit();
+        assert_eq!(
+            AdminUtils::sudo_set_tx_delegate_take_rate_limit(
+                <<Test as Config>::RuntimeOrigin>::signed(U256::from(1)),
+                to_be_set
+            ),
+            Err(DispatchError::BadOrigin.into())
+        );
+        assert_eq!(SubtensorModule::get_tx_delegate_take_rate_limit(), init_value);
+        assert_ok!(AdminUtils::sudo_set_tx_delegate_take_rate_limit(
+            <<Test as Config>::RuntimeOrigin>::root(),
+            to_be_set
+        ));
+        assert_eq!(SubtensorModule::get_tx_delegate_take_rate_limit(), to_be_set);
+    });
+}

--- a/pallets/admin-utils/tests/tests.rs
+++ b/pallets/admin-utils/tests/tests.rs
@@ -1073,11 +1073,17 @@ fn test_sudo_set_tx_delegate_take_rate_limit() {
             ),
             Err(DispatchError::BadOrigin.into())
         );
-        assert_eq!(SubtensorModule::get_tx_delegate_take_rate_limit(), init_value);
+        assert_eq!(
+            SubtensorModule::get_tx_delegate_take_rate_limit(),
+            init_value
+        );
         assert_ok!(AdminUtils::sudo_set_tx_delegate_take_rate_limit(
             <<Test as Config>::RuntimeOrigin>::root(),
             to_be_set
         ));
-        assert_eq!(SubtensorModule::get_tx_delegate_take_rate_limit(), to_be_set);
+        assert_eq!(
+            SubtensorModule::get_tx_delegate_take_rate_limit(),
+            to_be_set
+        );
     });
 }

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -19,7 +19,6 @@ use codec::{Decode, Encode};
 use frame_support::sp_runtime::transaction_validity::InvalidTransaction;
 use frame_support::sp_runtime::transaction_validity::ValidTransaction;
 use scale_info::TypeInfo;
-use sp_core::Get;
 use sp_runtime::{
     traits::{DispatchInfoOf, Dispatchable, PostDispatchInfoOf, SignedExtension},
     transaction_validity::{TransactionValidity, TransactionValidityError},
@@ -160,6 +159,8 @@ pub mod pallet {
         type InitialMaxAllowedValidators: Get<u16>;
         #[pallet::constant] // Initial default delegation take.
         type InitialDefaultTake: Get<u16>;
+        #[pallet::constant] // Initial minimum delegation take.
+        type InitialMinTake: Get<u16>;
         #[pallet::constant] // Initial weights version key.
         type InitialWeightsVersionKey: Get<u64>;
         #[pallet::constant] // Initial serving rate limit.
@@ -214,6 +215,10 @@ pub mod pallet {
         T::InitialDefaultTake::get()
     }
     #[pallet::type_value]
+    pub fn DefaultMinTake<T: Config>() -> u16 {
+        T::InitialMinTake::get()
+    }
+    #[pallet::type_value]
     pub fn DefaultAccountTake<T: Config>() -> u64 {
         0
     }
@@ -249,7 +254,9 @@ pub mod pallet {
     #[pallet::storage] // --- ITEM ( total_stake )
     pub type TotalStake<T> = StorageValue<_, u64, ValueQuery>;
     #[pallet::storage] // --- ITEM ( default_take )
-    pub type DefaultTake<T> = StorageValue<_, u16, ValueQuery, DefaultDefaultTake<T>>;
+    pub type MaxTake<T> = StorageValue<_, u16, ValueQuery, DefaultDefaultTake<T>>;
+    #[pallet::storage] // --- ITEM ( min_take )
+    pub type MinTake<T> = StorageValue<_, u16, ValueQuery, DefaultMinTake<T>>;
     #[pallet::storage] // --- ITEM ( global_block_emission )
     pub type BlockEmission<T> = StorageValue<_, u64, ValueQuery, DefaultBlockEmission<T>>;
     #[pallet::storage] // --- ITEM ( total_issuance )
@@ -935,6 +942,8 @@ pub mod pallet {
             old_hotkey: T::AccountId,
             new_hotkey: T::AccountId,
         }, // Event created when a hotkey is swapped
+        MaxDelegateTakeSet(u16), // Event emitted when maximum delegate take is set by sudo/admin transaction
+        MinDelegateTakeSet(u16), // Event emitted when minimum delegate take is set by sudo/admin transaction
     }
 
     // Errors inform users that something went wrong.

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -596,7 +596,8 @@ pub mod pallet {
     #[pallet::storage] // --- ITEM ( tx_rate_limit )
     pub(super) type TxRateLimit<T> = StorageValue<_, u64, ValueQuery, DefaultTxRateLimit<T>>;
     #[pallet::storage] // --- ITEM ( tx_rate_limit )
-    pub(super) type TxDelegateTakeRateLimit<T> = StorageValue<_, u64, ValueQuery, DefaultTxDelegateTakeRateLimit<T>>;
+    pub(super) type TxDelegateTakeRateLimit<T> =
+        StorageValue<_, u64, ValueQuery, DefaultTxDelegateTakeRateLimit<T>>;
     #[pallet::storage] // --- MAP ( key ) --> last_block
     pub(super) type LastTxBlock<T: Config> =
         StorageMap<_, Identity, T::AccountId, u64, ValueQuery, DefaultLastTxBlock<T>>;
@@ -912,7 +913,7 @@ pub mod pallet {
         MinBurnSet(u16, u64),          // --- Event created when setting min burn on a network.
         TxRateLimitSet(u64),           // --- Event created when setting the transaction rate limit.
         TxDelegateTakeRateLimitSet(u64), // --- Event created when setting the delegate take transaction rate limit.
-        Sudid(DispatchResult),         // --- Event created when a sudo call is done.
+        Sudid(DispatchResult),           // --- Event created when a sudo call is done.
         RegistrationAllowed(u16, bool), // --- Event created when registration is allowed/disallowed for a subnet.
         PowRegistrationAllowed(u16, bool), // --- Event created when POW registration is allowed/disallowed for a subnet.
         TempoSet(u16, u16),                // --- Event created when setting tempo on a network
@@ -927,8 +928,8 @@ pub mod pallet {
         NetworkMinLockCostSet(u64),   // Event created when the network minimum locking cost is set.
         SubnetLimitSet(u16),          // Event created when the maximum number of subnets is set
         NetworkLockCostReductionIntervalSet(u64), // Event created when the lock cost reduction is set
-        TakeDecreased( T::AccountId, T::AccountId, u16 ), // Event created when the take for a delegate is decreased.
-        TakeIncreased( T::AccountId, T::AccountId, u16 ), // Event created when the take for a delegate is increased.
+        TakeDecreased(T::AccountId, T::AccountId, u16), // Event created when the take for a delegate is decreased.
+        TakeIncreased(T::AccountId, T::AccountId, u16), // Event created when the take for a delegate is increased.
         HotkeySwapped {
             coldkey: T::AccountId,
             old_hotkey: T::AccountId,

--- a/pallets/subtensor/src/staking.rs
+++ b/pallets/subtensor/src/staking.rs
@@ -52,16 +52,8 @@ impl<T: Config> Pallet<T> {
         );
 
         // --- 2. Ensure we are delegating an known key.
-        ensure!(
-            Self::hotkey_account_exists(&hotkey),
-            Error::<T>::NotRegistered
-        );
-
         // --- 3. Ensure that the coldkey is the owner.
-        ensure!(
-            Self::coldkey_owns_hotkey(&coldkey, &hotkey),
-            Error::<T>::NonAssociatedColdKey
-        );
+        Self::do_take_checks(&coldkey, &hotkey)?;
 
         // --- 4. Ensure we are not already a delegate (dont allow changing delegate take.)
         ensure!(
@@ -76,11 +68,19 @@ impl<T: Config> Pallet<T> {
             Error::<T>::TxRateLimitExceeded
         );
 
+        // --- 5.1 Ensure take is within the 0 ..= InitialDefaultTake (18%) range
+        let max_take = T::InitialDefaultTake::get();
+        ensure!(
+            take <= max_take,
+            Error::<T>::InvalidTake
+        );
+
         // --- 6. Delegate the key.
         Self::delegate_hotkey(&hotkey, take);
 
         // Set last block for rate limiting
         Self::set_last_tx_block(&coldkey, block);
+        Self::set_last_tx_block_delegate_take(&coldkey, block);
 
         // --- 7. Emit the staking event.
         log::info!(
@@ -90,6 +90,156 @@ impl<T: Config> Pallet<T> {
             take
         );
         Self::deposit_event(Event::DelegateAdded(coldkey, hotkey, take));
+
+        // --- 8. Ok and return.
+        Ok(())
+    }
+
+    // ---- The implementation for the extrinsic decrease_take
+    //
+    // # Args:
+    // 	* 'origin': (<T as frame_system::Config>::RuntimeOrigin):
+    // 		- The signature of the caller's coldkey.
+    //
+    // 	* 'hotkey' (T::AccountId):
+    // 		- The hotkey we are delegating (must be owned by the coldkey.)
+    //
+    // 	* 'take' (u16):
+    // 		- The stake proportion that this hotkey takes from delegations for subnet ID.
+    //
+    // # Event:
+    // 	* TakeDecreased;
+    // 		- On successfully setting a decreased take for this hotkey.
+    //
+    // # Raises:
+    // 	* 'NotRegistered':
+    // 		- The hotkey we are delegating is not registered on the network.
+    //
+    // 	* 'NonAssociatedColdKey':
+    // 		- The hotkey we are delegating is not owned by the calling coldket.
+    //
+    pub fn do_decrease_take(
+        origin: T::RuntimeOrigin,
+        hotkey: T::AccountId,
+        take: u16,
+    ) -> dispatch::DispatchResult {
+        // --- 1. We check the coldkey signature.
+        let coldkey = ensure_signed(origin)?;
+        log::info!(
+            "do_decrease_take( origin:{:?} hotkey:{:?}, take:{:?} )",
+            coldkey,
+            hotkey,
+            take
+        );
+
+        // --- 2. Ensure we are delegating a known key.
+        //        Ensure that the coldkey is the owner.
+        Self::do_take_checks(&coldkey, &hotkey)?;
+
+        // --- 3. Ensure we are always strictly decreasing, never increasing take
+        if let Ok(current_take) = Delegates::<T>::try_get(&hotkey) {
+            ensure!(
+                take < current_take,
+                Error::<T>::InvalidTake
+            );
+        }
+
+        // --- 4. Set the new take value.
+        Delegates::<T>::insert(hotkey.clone(), take);
+
+        // --- 5. Emit the take value.
+        log::info!(
+            "TakeDecreased( coldkey:{:?}, hotkey:{:?}, take:{:?} )",
+            coldkey,
+            hotkey,
+            take
+        );
+        Self::deposit_event(Event::TakeDecreased(coldkey, hotkey, take));
+
+        // --- 6. Ok and return.
+        Ok(())
+    }
+
+    // ---- The implementation for the extrinsic increase_take
+    //
+    // # Args:
+    // 	* 'origin': (<T as frame_system::Config>::RuntimeOrigin):
+    // 		- The signature of the caller's coldkey.
+    //
+    // 	* 'hotkey' (T::AccountId):
+    // 		- The hotkey we are delegating (must be owned by the coldkey.)
+    //
+    // 	* 'take' (u16):
+    // 		- The stake proportion that this hotkey takes from delegations for subnet ID.
+    //
+    // # Event:
+    // 	* TakeDecreased;
+    // 		- On successfully setting a decreased take for this hotkey.
+    //
+    // # Raises:
+    // 	* 'NotRegistered':
+    // 		- The hotkey we are delegating is not registered on the network.
+    //
+    // 	* 'NonAssociatedColdKey':
+    // 		- The hotkey we are delegating is not owned by the calling coldket.
+    //
+    // 	* 'TxRateLimitExceeded':
+    // 		- Thrown if key has hit transaction rate limit
+    //
+    pub fn do_increase_take(
+        origin: T::RuntimeOrigin,
+        hotkey: T::AccountId,
+        take: u16,
+    ) -> dispatch::DispatchResult {
+        // --- 1. We check the coldkey signature.
+        let coldkey = ensure_signed(origin)?;
+        log::info!(
+            "do_increase_take( origin:{:?} hotkey:{:?}, take:{:?} )",
+            coldkey,
+            hotkey,
+            take
+        );
+
+        // --- 2. Ensure we are delegating a known key.
+        //        Ensure that the coldkey is the owner.
+        Self::do_take_checks(&coldkey, &hotkey)?;
+
+        // --- 3. Ensure we are strinctly increasing take
+        if let Ok(current_take) = Delegates::<T>::try_get(&hotkey) {
+            ensure!(
+                take > current_take,
+                Error::<T>::InvalidTake
+            );
+        }
+
+        // --- 4. Ensure take is within the 0 ..= InitialDefaultTake (18%) range
+        let max_take = T::InitialDefaultTake::get();
+        ensure!(
+            take <= max_take,
+            Error::<T>::InvalidTake
+        );
+
+        // --- 5. Enforce the rate limit (independently on do_add_stake rate limits)
+        let block: u64 = Self::get_current_block_as_u64();
+        ensure!(
+            !Self::exceeds_tx_delegate_take_rate_limit(Self::get_last_tx_block_delegate_take(&coldkey), block),
+            Error::<T>::TxRateLimitExceeded
+        );
+
+        // Set last block for rate limiting
+        Self::set_last_tx_block_delegate_take(&coldkey, block);
+
+        // --- 6. Set the new take value.
+        Delegates::<T>::insert(hotkey.clone(), take);
+
+        // --- 7. Emit the take value.
+        log::info!(
+            "TakeIncreased( coldkey:{:?}, hotkey:{:?}, take:{:?} )",
+            coldkey,
+            hotkey,
+            take
+        );
+        Self::deposit_event(Event::TakeIncreased(coldkey, hotkey, take));
 
         // --- 8. Ok and return.
         Ok(())
@@ -432,6 +582,12 @@ impl<T: Config> Pallet<T> {
     //
     pub fn get_owning_coldkey_for_hotkey(hotkey: &T::AccountId) -> T::AccountId {
         Owner::<T>::get(hotkey)
+    }
+
+    // Returns the hotkey take
+    //
+    pub fn get_hotkey_take(hotkey: &T::AccountId) -> u16 {
+        Delegates::<T>::get(hotkey)
     }
 
     // Returns true if the hotkey account has been created.

--- a/pallets/subtensor/src/staking.rs
+++ b/pallets/subtensor/src/staking.rs
@@ -68,8 +68,10 @@ impl<T: Config> Pallet<T> {
             Error::<T>::TxRateLimitExceeded
         );
 
-        // --- 5.1 Ensure take is within the 0 ..= InitialDefaultTake (18%) range
-        let max_take = T::InitialDefaultTake::get();
+        // --- 5.1 Ensure take is within the min ..= InitialDefaultTake (18%) range
+        let min_take = MinTake::<T>::get();
+        let max_take = MaxTake::<T>::get();
+        ensure!(take >= min_take, Error::<T>::InvalidTake);
         ensure!(take <= max_take, Error::<T>::InvalidTake);
 
         // --- 6. Delegate the key.
@@ -138,6 +140,10 @@ impl<T: Config> Pallet<T> {
             ensure!(take < current_take, Error::<T>::InvalidTake);
         }
 
+        // --- 3.1 Ensure take is within the min ..= InitialDefaultTake (18%) range
+        let min_take = MinTake::<T>::get();
+        ensure!(take >= min_take, Error::<T>::InvalidTake);
+
         // --- 4. Set the new take value.
         Delegates::<T>::insert(hotkey.clone(), take);
 
@@ -203,8 +209,8 @@ impl<T: Config> Pallet<T> {
             ensure!(take > current_take, Error::<T>::InvalidTake);
         }
 
-        // --- 4. Ensure take is within the 0 ..= InitialDefaultTake (18%) range
-        let max_take = T::InitialDefaultTake::get();
+        // --- 4. Ensure take is within the min ..= InitialDefaultTake (18%) range
+        let max_take = MaxTake::<T>::get();
         ensure!(take <= max_take, Error::<T>::InvalidTake);
 
         // --- 5. Enforce the rate limit (independently on do_add_stake rate limits)

--- a/pallets/subtensor/src/staking.rs
+++ b/pallets/subtensor/src/staking.rs
@@ -70,10 +70,7 @@ impl<T: Config> Pallet<T> {
 
         // --- 5.1 Ensure take is within the 0 ..= InitialDefaultTake (18%) range
         let max_take = T::InitialDefaultTake::get();
-        ensure!(
-            take <= max_take,
-            Error::<T>::InvalidTake
-        );
+        ensure!(take <= max_take, Error::<T>::InvalidTake);
 
         // --- 6. Delegate the key.
         Self::delegate_hotkey(&hotkey, take);
@@ -138,10 +135,7 @@ impl<T: Config> Pallet<T> {
 
         // --- 3. Ensure we are always strictly decreasing, never increasing take
         if let Ok(current_take) = Delegates::<T>::try_get(&hotkey) {
-            ensure!(
-                take < current_take,
-                Error::<T>::InvalidTake
-            );
+            ensure!(take < current_take, Error::<T>::InvalidTake);
         }
 
         // --- 4. Set the new take value.
@@ -206,23 +200,20 @@ impl<T: Config> Pallet<T> {
 
         // --- 3. Ensure we are strinctly increasing take
         if let Ok(current_take) = Delegates::<T>::try_get(&hotkey) {
-            ensure!(
-                take > current_take,
-                Error::<T>::InvalidTake
-            );
+            ensure!(take > current_take, Error::<T>::InvalidTake);
         }
 
         // --- 4. Ensure take is within the 0 ..= InitialDefaultTake (18%) range
         let max_take = T::InitialDefaultTake::get();
-        ensure!(
-            take <= max_take,
-            Error::<T>::InvalidTake
-        );
+        ensure!(take <= max_take, Error::<T>::InvalidTake);
 
         // --- 5. Enforce the rate limit (independently on do_add_stake rate limits)
         let block: u64 = Self::get_current_block_as_u64();
         ensure!(
-            !Self::exceeds_tx_delegate_take_rate_limit(Self::get_last_tx_block_delegate_take(&coldkey), block),
+            !Self::exceeds_tx_delegate_take_rate_limit(
+                Self::get_last_tx_block_delegate_take(&coldkey),
+                block
+            ),
             Error::<T>::TxRateLimitExceeded
         );
 

--- a/pallets/subtensor/src/utils.rs
+++ b/pallets/subtensor/src/utils.rs
@@ -288,10 +288,7 @@ impl<T: Config> Pallet<T> {
     // ========================
     // ===== Take checks ======
     // ========================
-    pub fn do_take_checks(
-        coldkey: &T::AccountId,
-        hotkey: &T::AccountId,
-    ) -> Result<(), Error<T>> {
+    pub fn do_take_checks(coldkey: &T::AccountId, hotkey: &T::AccountId) -> Result<(), Error<T>> {
         // Ensure we are delegating a known key.
         ensure!(
             Self::hotkey_account_exists(hotkey),

--- a/pallets/subtensor/src/utils.rs
+++ b/pallets/subtensor/src/utils.rs
@@ -346,11 +346,15 @@ impl<T: Config> Pallet<T> {
         TotalIssuance::<T>::put(TotalIssuance::<T>::get().saturating_add(amount));
     }
     pub fn get_default_take() -> u16 {
-        DefaultTake::<T>::get()
+        // Default to maximum
+        MaxTake::<T>::get()
     }
-    pub fn set_default_take(default_take: u16) {
-        DefaultTake::<T>::put(default_take);
+    pub fn set_max_take(default_take: u16) {
+        MaxTake::<T>::put(default_take);
         Self::deposit_event(Event::DefaultTakeSet(default_take));
+    }
+    pub fn get_min_take() -> u16 {
+        MinTake::<T>::get()
     }
 
     pub fn set_subnet_locked_balance(netuid: u16, amount: u64) {
@@ -379,6 +383,20 @@ impl<T: Config> Pallet<T> {
     pub fn set_tx_delegate_take_rate_limit(tx_rate_limit: u64) {
         TxDelegateTakeRateLimit::<T>::put(tx_rate_limit);
         Self::deposit_event(Event::TxDelegateTakeRateLimitSet(tx_rate_limit));
+    }
+    pub fn set_min_delegate_take(take: u16) {
+        MinTake::<T>::put(take);
+        Self::deposit_event(Event::MinDelegateTakeSet(take));
+    }
+    pub fn set_max_delegate_take(take: u16) {
+        MaxTake::<T>::put(take);
+        Self::deposit_event(Event::MaxDelegateTakeSet(take));
+    }
+    pub fn get_min_delegate_take() -> u16 {
+        MinTake::<T>::get()
+    }
+    pub fn get_max_delegate_take() -> u16 {
+        MaxTake::<T>::get()
     }
 
     pub fn get_serving_rate_limit(netuid: u16) -> u64 {

--- a/pallets/subtensor/tests/mock.rs
+++ b/pallets/subtensor/tests/mock.rs
@@ -123,10 +123,11 @@ parameter_types! {
     pub const InitialBondsMovingAverage: u64 = 900_000;
     pub const InitialStakePruningMin: u16 = 0;
     pub const InitialFoundationDistribution: u64 = 0;
-    pub const InitialDefaultTake: u16 = 11_796; // 18% honest number.
+    pub const InitialDefaultTake: u16 = 32_767; // 50% for tests (18% honest number is used in production (see runtime))
     pub const InitialWeightsVersionKey: u16 = 0;
     pub const InitialServingRateLimit: u64 = 0; // No limit.
     pub const InitialTxRateLimit: u64 = 0; // Disable rate limit for testing
+    pub const InitialTxDelegateTakeRateLimit: u64 = 1; // 1 block take rate limit for testing
     pub const InitialBurn: u64 = 0;
     pub const InitialMinBurn: u64 = 0;
     pub const InitialMaxBurn: u64 = 1_000_000_000;
@@ -153,7 +154,7 @@ parameter_types! {
     pub const InitialNetworkLockReductionInterval: u64 = 2; // 2 blocks.
     pub const InitialSubnetLimit: u16 = 10; // Max 10 subnets.
     pub const InitialNetworkRateLimit: u64 = 0;
-    pub const InitialTargetStakesPerInterval: u16 = 1;
+    pub const InitialTargetStakesPerInterval: u16 = 2;
 }
 
 // Configure collective pallet for council
@@ -339,6 +340,7 @@ impl pallet_subtensor::Config for Test {
     type InitialMinDifficulty = InitialMinDifficulty;
     type InitialServingRateLimit = InitialServingRateLimit;
     type InitialTxRateLimit = InitialTxRateLimit;
+    type InitialTxDelegateTakeRateLimit = InitialTxDelegateTakeRateLimit;
     type InitialBurn = InitialBurn;
     type InitialMaxBurn = InitialMaxBurn;
     type InitialMinBurn = InitialMinBurn;

--- a/pallets/subtensor/tests/mock.rs
+++ b/pallets/subtensor/tests/mock.rs
@@ -123,7 +123,7 @@ parameter_types! {
     pub const InitialBondsMovingAverage: u64 = 900_000;
     pub const InitialStakePruningMin: u16 = 0;
     pub const InitialFoundationDistribution: u64 = 0;
-    pub const InitialDefaultTake: u16 = 32_767; // 50% for tests (18% honest number is used in production (see runtime))
+    pub const InitialDefaultTake: u16 = 11_796; // 18%, same as in production
     pub const InitialWeightsVersionKey: u16 = 0;
     pub const InitialServingRateLimit: u64 = 0; // No limit.
     pub const InitialTxRateLimit: u64 = 0; // Disable rate limit for testing

--- a/pallets/subtensor/tests/mock.rs
+++ b/pallets/subtensor/tests/mock.rs
@@ -124,6 +124,7 @@ parameter_types! {
     pub const InitialStakePruningMin: u16 = 0;
     pub const InitialFoundationDistribution: u64 = 0;
     pub const InitialDefaultTake: u16 = 11_796; // 18%, same as in production
+    pub const InitialMinTake: u16 = 0;
     pub const InitialWeightsVersionKey: u16 = 0;
     pub const InitialServingRateLimit: u64 = 0; // No limit.
     pub const InitialTxRateLimit: u64 = 0; // Disable rate limit for testing
@@ -335,6 +336,7 @@ impl pallet_subtensor::Config for Test {
     type InitialBondsMovingAverage = InitialBondsMovingAverage;
     type InitialMaxAllowedValidators = InitialMaxAllowedValidators;
     type InitialDefaultTake = InitialDefaultTake;
+    type InitialMinTake = InitialMinTake;
     type InitialWeightsVersionKey = InitialWeightsVersionKey;
     type InitialMaxDifficulty = InitialMaxDifficulty;
     type InitialMinDifficulty = InitialMinDifficulty;

--- a/pallets/subtensor/tests/senate.rs
+++ b/pallets/subtensor/tests/senate.rs
@@ -87,11 +87,11 @@ fn test_senate_join_works() {
             coldkey_account_id
         );
 
-        // Lets make this new key a delegate with a 50% take.
+        // Lets make this new key a delegate with a 10% take.
         assert_ok!(SubtensorModule::do_become_delegate(
             <<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id),
             hotkey_account_id,
-            u16::MAX / 2
+            u16::MAX / 10
         ));
 
         let staker_coldkey = U256::from(7);
@@ -156,11 +156,11 @@ fn test_senate_vote_works() {
             coldkey_account_id
         );
 
-        // Lets make this new key a delegate with a 50% take.
+        // Lets make this new key a delegate with a 10% take.
         assert_ok!(SubtensorModule::do_become_delegate(
             <<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id),
             hotkey_account_id,
-            u16::MAX / 2
+            u16::MAX / 10
         ));
 
         let staker_coldkey = U256::from(7);
@@ -324,11 +324,11 @@ fn test_senate_leave_works() {
             coldkey_account_id
         );
 
-        // Lets make this new key a delegate with a 50% take.
+        // Lets make this new key a delegate with a 10% take.
         assert_ok!(SubtensorModule::do_become_delegate(
             <<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id),
             hotkey_account_id,
-            u16::MAX / 2
+            u16::MAX / 10
         ));
 
         let staker_coldkey = U256::from(7);
@@ -394,11 +394,11 @@ fn test_senate_leave_vote_removal() {
             coldkey_account_id
         );
 
-        // Lets make this new key a delegate with a 50% take.
+        // Lets make this new key a delegate with a 10% take.
         assert_ok!(SubtensorModule::do_become_delegate(
             coldkey_origin.clone(),
             hotkey_account_id,
-            u16::MAX / 2
+            u16::MAX / 10
         ));
 
         let staker_coldkey = U256::from(7);
@@ -530,11 +530,11 @@ fn test_senate_not_leave_when_stake_removed() {
             coldkey_account_id
         );
 
-        // Lets make this new key a delegate with a 50% take.
+        // Lets make this new key a delegate with a 10% take.
         assert_ok!(SubtensorModule::do_become_delegate(
             <<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id),
             hotkey_account_id,
-            u16::MAX / 2
+            u16::MAX / 10
         ));
 
         let staker_coldkey = U256::from(7);

--- a/pallets/subtensor/tests/staking.rs
+++ b/pallets/subtensor/tests/staking.rs
@@ -2717,21 +2717,21 @@ fn test_delegate_take_can_be_decreased() {
         add_network(netuid, 0, 0);
         register_ok_neuron(netuid, hotkey0, coldkey0, 124124);
 
-        // Coldkey / hotkey 0 become delegates with 5% take
+        // Coldkey / hotkey 0 become delegates with 10% take
         assert_ok!(SubtensorModule::do_become_delegate(
-            <<Test as Config>::RuntimeOrigin>::signed(coldkey0),
-            hotkey0,
-            u16::MAX / 2
-        ));
-        assert_eq!(SubtensorModule::get_hotkey_take(&hotkey0), u16::MAX / 2);
-
-        // Coldkey / hotkey 0 decreases take to 10%
-        assert_ok!(SubtensorModule::do_decrease_take(
             <<Test as Config>::RuntimeOrigin>::signed(coldkey0),
             hotkey0,
             u16::MAX / 10
         ));
         assert_eq!(SubtensorModule::get_hotkey_take(&hotkey0), u16::MAX / 10);
+
+        // Coldkey / hotkey 0 decreases take to 5%
+        assert_ok!(SubtensorModule::do_decrease_take(
+            <<Test as Config>::RuntimeOrigin>::signed(coldkey0),
+            hotkey0,
+            u16::MAX / 20
+        ));
+        assert_eq!(SubtensorModule::get_hotkey_take(&hotkey0), u16::MAX / 20);
     });
 }
 

--- a/pallets/subtensor/tests/staking.rs
+++ b/pallets/subtensor/tests/staking.rs
@@ -2737,7 +2737,7 @@ fn test_delegate_take_can_be_decreased() {
 
 // Verify delegate take can be decreased
 #[test]
-fn test_can_set_zero_take_ok() {
+fn test_can_set_min_take_ok() {
     new_test_ext(1).execute_with(|| {
         // Make account
         let hotkey0 = U256::from(1);
@@ -2758,11 +2758,11 @@ fn test_can_set_zero_take_ok() {
             u16::MAX / 10
         ));
 
-        // Coldkey / hotkey 0 decreases take to 0%
+        // Coldkey / hotkey 0 decreases take to min
         assert_ok!(SubtensorModule::do_decrease_take(
             <<Test as Config>::RuntimeOrigin>::signed(coldkey0),
             hotkey0,
-            0
+            SubtensorModule::get_min_take()
         ));
         assert_eq!(SubtensorModule::get_hotkey_take(&hotkey0), 0);
     });

--- a/pallets/subtensor/tests/staking.rs
+++ b/pallets/subtensor/tests/staking.rs
@@ -2744,6 +2744,42 @@ fn test_delegate_take_can_be_decreased() {
     });
 }
 
+// Verify delegate take can be decreased
+#[test]
+fn test_can_set_zero_take_ok() {
+    new_test_ext(1).execute_with(|| {
+        // Make account
+        let hotkey0 = U256::from(1);
+        let coldkey0 = U256::from(3);
+
+        // Add balance
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey0, 100000);
+
+        // Register the neuron to a new network
+        let netuid = 1;
+        add_network(netuid, 0, 0);
+        register_ok_neuron(netuid, hotkey0, coldkey0, 124124);
+
+        // Coldkey / hotkey 0 become delegates
+        assert_ok!(SubtensorModule::do_become_delegate(
+            <<Test as Config>::RuntimeOrigin>::signed(coldkey0),
+            hotkey0
+        ));
+
+        // Coldkey / hotkey 0 decreases take to 0%
+        assert_ok!(SubtensorModule::do_decrease_take(
+            <<Test as Config>::RuntimeOrigin>::signed(coldkey0),
+            hotkey0,
+            netuid,
+            0
+        ));
+        assert_eq!(
+            SubtensorModule::get_delegate_take(&hotkey0, netuid),
+            0
+        );
+    });
+}
+
 // Verify delegate take can not be increased with do_decrease_take
 #[test]
 fn test_delegate_take_can_not_be_increased_with_decrease_take() {

--- a/pallets/subtensor/tests/staking.rs
+++ b/pallets/subtensor/tests/staking.rs
@@ -2763,18 +2763,18 @@ fn test_can_set_zero_take_ok() {
         // Coldkey / hotkey 0 become delegates
         assert_ok!(SubtensorModule::do_become_delegate(
             <<Test as Config>::RuntimeOrigin>::signed(coldkey0),
-            hotkey0
+            hotkey0,
+            u16::MAX / 10
         ));
 
         // Coldkey / hotkey 0 decreases take to 0%
         assert_ok!(SubtensorModule::do_decrease_take(
             <<Test as Config>::RuntimeOrigin>::signed(coldkey0),
             hotkey0,
-            netuid,
             0
         ));
         assert_eq!(
-            SubtensorModule::get_delegate_take(&hotkey0, netuid),
+            SubtensorModule::get_last_tx_block_delegate_take(&hotkey0),
             0
         );
     });

--- a/pallets/subtensor/tests/staking.rs
+++ b/pallets/subtensor/tests/staking.rs
@@ -2773,10 +2773,7 @@ fn test_can_set_zero_take_ok() {
             hotkey0,
             0
         ));
-        assert_eq!(
-            SubtensorModule::get_last_tx_block_delegate_take(&hotkey0),
-            0
-        );
+        assert_eq!(SubtensorModule::get_hotkey_take(&hotkey0), 0);
     });
 }
 

--- a/pallets/subtensor/tests/staking.rs
+++ b/pallets/subtensor/tests/staking.rs
@@ -2705,8 +2705,8 @@ fn test_remove_stake_below_minimum_threshold() {
 #[test]
 fn test_delegate_take_limit() {
     new_test_ext(1).execute_with(|| {
-        assert_eq!(InitialDefaultTake::get() >= u16::MAX/2, true);
-        assert_eq!(InitialDefaultTake::get() <= u16::MAX-1, true);
+        assert_eq!(InitialDefaultTake::get() >= u16::MAX / 2, true);
+        assert_eq!(InitialDefaultTake::get() <= u16::MAX - 1, true);
     });
 }
 
@@ -2886,7 +2886,10 @@ fn test_delegate_take_can_be_increased_to_limit() {
             hotkey0,
             InitialDefaultTake::get()
         ));
-        assert_eq!(SubtensorModule::get_hotkey_take(&hotkey0), InitialDefaultTake::get());
+        assert_eq!(
+            SubtensorModule::get_hotkey_take(&hotkey0),
+            InitialDefaultTake::get()
+        );
     });
 }
 
@@ -2914,7 +2917,7 @@ fn test_delegate_take_can_not_be_set_beyond_limit() {
                 SubtensorModule::do_become_delegate(
                     <<Test as Config>::RuntimeOrigin>::signed(coldkey0),
                     hotkey0,
-                    InitialDefaultTake::get()+1
+                    InitialDefaultTake::get() + 1
                 ),
                 Err(Error::<Test>::InvalidTake.into())
             );
@@ -2954,7 +2957,7 @@ fn test_delegate_take_can_not_be_increased_beyond_limit() {
                 SubtensorModule::do_increase_take(
                     <<Test as Config>::RuntimeOrigin>::signed(coldkey0),
                     hotkey0,
-                    InitialDefaultTake::get()+1
+                    InitialDefaultTake::get() + 1
                 ),
                 Err(Error::<Test>::InvalidTake.into())
             );
@@ -3007,6 +3010,5 @@ fn test_rate_limits_enforced_on_increase_take() {
             u16::MAX / 10
         ));
         assert_eq!(SubtensorModule::get_hotkey_take(&hotkey0), u16::MAX / 10);
-
     });
 }

--- a/pallets/subtensor/tests/staking.rs
+++ b/pallets/subtensor/tests/staking.rs
@@ -1638,11 +1638,11 @@ fn test_full_with_delegating() {
             Err(Error::<Test>::NonAssociatedColdKey.into())
         );
 
-        // Lets make this new key a delegate with a 50% take.
+        // Lets make this new key a delegate with a 10% take.
         assert_ok!(SubtensorModule::do_become_delegate(
             <<Test as Config>::RuntimeOrigin>::signed(coldkey2),
             hotkey2,
-            u16::MAX / 2
+            u16::MAX / 10
         ));
 
         // Add nominate some stake.
@@ -1680,16 +1680,16 @@ fn test_full_with_delegating() {
         SubtensorModule::emit_inflation_through_hotkey_account(&hotkey2, 0, 1000);
         assert_eq!(
             SubtensorModule::get_stake_for_coldkey_and_hotkey(&coldkey2, &hotkey2),
-            1_668
-        ); // 1000 + 500 + 500 * (1000/3000) = 1500 + 166.6666666667 = 1,668
+            1_400
+        ); // 1000 + 100 + 900 * (1000/3000) = 1400
         assert_eq!(
             SubtensorModule::get_stake_for_coldkey_and_hotkey(&coldkey1, &hotkey2),
-            1_166
-        ); // 1000 + 500 * (1000/3000) = 1000 + 166.6666666667 = 1166.6
+            1_300
+        ); // 1000 + 900 * (1000/3000) = 1300
         assert_eq!(
             SubtensorModule::get_stake_for_coldkey_and_hotkey(&coldkey0, &hotkey2),
-            1_166
-        ); // 1000 + 500 * (1000/3000) = 1000 + 166.6666666667 = 1166.6
+            1_300
+        ); // 1000 + 900 * (1000/3000) = 1300
         assert_eq!(SubtensorModule::get_total_stake(), 6_500); // before + 1_000 = 5_500 + 1_000 = 6_500
 
         step_block(1);
@@ -1710,7 +1710,7 @@ fn test_full_with_delegating() {
         assert_ok!(SubtensorModule::do_become_delegate(
             <<Test as Config>::RuntimeOrigin>::signed(coldkey3),
             hotkey3,
-            u16::MAX / 2
+            u16::MAX / 10
         )); // Full take.
         assert_ok!(SubtensorModule::add_stake(
             <<Test as Config>::RuntimeOrigin>::signed(coldkey0),
@@ -1748,20 +1748,20 @@ fn test_full_with_delegating() {
         SubtensorModule::emit_inflation_through_hotkey_account(&hotkey3, 0, 1000);
         assert_eq!(
             SubtensorModule::get_stake_for_coldkey_and_hotkey(&coldkey0, &hotkey3),
-            1125
-        ); // 1000 + 50% * 1000 * 1000/4000 = 1125
+            1225
+        ); // 1000 + 90% * 1000 * 1000/4000 = 1225
         assert_eq!(
             SubtensorModule::get_stake_for_coldkey_and_hotkey(&coldkey1, &hotkey3),
-            1125
-        ); // 1000 + 50% * 1000 * 1000/4000 = 1125
+            1225
+        ); // 1000 + 90% * 1000 * 1000/4000 = 1225
         assert_eq!(
             SubtensorModule::get_stake_for_coldkey_and_hotkey(&coldkey2, &hotkey3),
-            1125
-        ); // 1000 + 50% * 1000 * 1000/4000 = 1125
+            1225
+        ); // 1000 + 90% * 1000 * 1000/4000 = 1225
         assert_eq!(
             SubtensorModule::get_stake_for_coldkey_and_hotkey(&coldkey3, &hotkey3),
-            1625
-        ); // 1000 + 125 * 3 + 1000 * 1000/4000 = 1625
+            1325
+        ); // 1000 + 25 * 3 + 1000 * 1000/4000 = 1325
         assert_eq!(SubtensorModule::get_total_stake(), 11_500); // before + 1_000 = 10_500 + 1_000 = 11_500
     });
 }
@@ -2018,11 +2018,11 @@ fn test_full_with_delegating_some_servers() {
 
         assert_eq!(SubtensorModule::get_total_stake(), 5_623); // 4_723 + 900 = 5_623
 
-        // Lets make this new key a delegate with a 50% take.
+        // Lets make this new key a delegate with a 10% take.
         assert_ok!(SubtensorModule::do_become_delegate(
             <<Test as Config>::RuntimeOrigin>::signed(coldkey2),
             hotkey2,
-            u16::MAX / 2
+            u16::MAX / 10
         ));
 
         // Add nominate some stake.
@@ -2062,16 +2062,16 @@ fn test_full_with_delegating_some_servers() {
         SubtensorModule::emit_inflation_through_hotkey_account(&hotkey2, 100, 1000);
         assert_eq!(
             SubtensorModule::get_stake_for_coldkey_and_hotkey(&coldkey2, &hotkey2),
-            1_768
-        ); // 1000 + 100 + 500 + 500 * (1000/3000) = 100 + 1500 + 166.6666666667 ~= 1,768.6666666667
+            1_500
+        ); // 1000 + 100 + 100 + 900 * (1000/3000) = 1000 + 200 + 300 = 1500
         assert_eq!(
             SubtensorModule::get_stake_for_coldkey_and_hotkey(&coldkey1, &hotkey2),
-            1_166
-        ); // 1000 + 500 * (1000/3000) = 1000 + 166.6666666667 = 1166.6
+            1_300
+        ); // 1000 + 900 * (1000/3000) = 1000 + 300 = 1300
         assert_eq!(
             SubtensorModule::get_stake_for_coldkey_and_hotkey(&coldkey0, &hotkey2),
-            1_166
-        ); // 1000 + 500 * (1000/3000) = 1000 + 166.6666666667 = 1166.6
+            1_300
+        ); // 1000 + 900 * (1000/3000) = 1000 + 300 = 1300
         assert_eq!(SubtensorModule::get_total_stake(), 8_823); // 7_723 + 1_100 = 8_823
 
         // Lets emit MORE inflation through this new key with distributed ownership.
@@ -2081,15 +2081,15 @@ fn test_full_with_delegating_some_servers() {
         SubtensorModule::emit_inflation_through_hotkey_account(&hotkey2, 123, 0);
         assert_eq!(
             SubtensorModule::get_stake_for_coldkey_and_hotkey(&coldkey2, &hotkey2),
-            1_891
-        ); // 1_768 + 123 = 1_891
+            1_623
+        ); // 1_500 + 123 = 1_623
         assert_eq!(
             SubtensorModule::get_stake_for_coldkey_and_hotkey(&coldkey1, &hotkey2),
-            1_166
+            1_300
         ); // No change.
         assert_eq!(
             SubtensorModule::get_stake_for_coldkey_and_hotkey(&coldkey0, &hotkey2),
-            1_166
+            1_300
         ); // No change.
         assert_eq!(SubtensorModule::get_total_stake(), 8_946); // 8_823 + 123 = 8_946
     });
@@ -2699,15 +2699,6 @@ fn test_remove_stake_below_minimum_threshold() {
             Error::<Test>::NomStakeBelowMinimumThreshold
         );
     })
-}
-
-// Verify that InitialDefaultTake is between 50% and u16::MAX-1, this is important for other tests
-#[test]
-fn test_delegate_take_limit() {
-    new_test_ext(1).execute_with(|| {
-        assert_eq!(InitialDefaultTake::get() >= u16::MAX / 2, true);
-        assert_eq!(InitialDefaultTake::get() <= u16::MAX - 1, true);
-    });
 }
 
 // Verify delegate take can be decreased

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -786,6 +786,7 @@ parameter_types! {
     pub const SubtensorInitialMinBurn: u64 = 1_000_000_000; // 1 tao
     pub const SubtensorInitialMaxBurn: u64 = 100_000_000_000; // 100 tao
     pub const SubtensorInitialTxRateLimit: u64 = 1000;
+    pub const SubtensorInitialTxDelegateTakeRateLimit: u64 = 216000; // 30 days at 12 seconds per block
     pub const SubtensorInitialRAORecycledForRegistration: u64 = 0; // 0 rao
     pub const SubtensorInitialSenateRequiredStakePercentage: u64 = 1; // 1 percent of total stake
     pub const SubtensorInitialNetworkImmunity: u64 = 7 * 7200;
@@ -835,6 +836,7 @@ impl pallet_subtensor::Config for Runtime {
     type InitialMaxBurn = SubtensorInitialMaxBurn;
     type InitialMinBurn = SubtensorInitialMinBurn;
     type InitialTxRateLimit = SubtensorInitialTxRateLimit;
+    type InitialTxDelegateTakeRateLimit = SubtensorInitialTxDelegateTakeRateLimit;
     type InitialRAORecycledForRegistration = SubtensorInitialRAORecycledForRegistration;
     type InitialSenateRequiredStakePercentage = SubtensorInitialSenateRequiredStakePercentage;
     type InitialNetworkImmunityPeriod = SubtensorInitialNetworkImmunity;
@@ -871,6 +873,10 @@ impl
 
     fn set_tx_rate_limit(rate_limit: u64) {
         SubtensorModule::set_tx_rate_limit(rate_limit);
+    }
+
+    fn set_tx_delegate_take_rate_limit(rate_limit: u64) {
+        SubtensorModule::set_tx_delegate_take_rate_limit(rate_limit);
     }
 
     fn set_serving_rate_limit(netuid: u16, rate_limit: u64) {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -778,6 +778,7 @@ parameter_types! {
     pub const SubtensorInitialPruningScore : u16 = u16::MAX;
     pub const SubtensorInitialBondsMovingAverage: u64 = 900_000;
     pub const SubtensorInitialDefaultTake: u16 = 11_796; // 18% honest number.
+    pub const SubtensorInitialMinTake: u16 = 0;
     pub const SubtensorInitialWeightsVersionKey: u64 = 0;
     pub const SubtensorInitialMinDifficulty: u64 = 10_000_000;
     pub const SubtensorInitialMaxDifficulty: u64 = u64::MAX / 4;
@@ -828,6 +829,7 @@ impl pallet_subtensor::Config for Runtime {
     type InitialPruningScore = SubtensorInitialPruningScore;
     type InitialMaxAllowedValidators = SubtensorInitialMaxAllowedValidators;
     type InitialDefaultTake = SubtensorInitialDefaultTake;
+    type InitialMinTake = SubtensorInitialMinTake;
     type InitialWeightsVersionKey = SubtensorInitialWeightsVersionKey;
     type InitialMaxDifficulty = SubtensorInitialMaxDifficulty;
     type InitialMinDifficulty = SubtensorInitialMinDifficulty;
@@ -867,8 +869,12 @@ impl
         RuntimeOrigin,
     > for SubtensorInterface
 {
-    fn set_default_take(default_take: u16) {
-        SubtensorModule::set_default_take(default_take);
+    fn set_max_delegate_take(max_take: u16) {
+        SubtensorModule::set_max_delegate_take(max_take);
+    }
+
+    fn set_min_delegate_take(max_take: u16) {
+        SubtensorModule::set_min_delegate_take(max_take);
     }
 
     fn set_tx_rate_limit(rate_limit: u64) {


### PR DESCRIPTION
## Description
Added:

- Extrinsic decrease_take in subtensor pallet
- Extrinsic increase_take in subtensor pallet
- Extrinsic sudo_set_tx_rate_limit_delegate_take in admin-utils pallet
- Separate rate limit logic for increasing delegate take (decreasing is not rate limited)
- Unit tests for decreasing and increasing take in misc. corner cases

## Related Issue(s)

- Closes issue [#314](https://github.com/opentensor/subtensor/issues/314)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

