### PR TITLE
hotfix: allow unstake below the min nom threshold when unstaking entire stake

### DIFF
--- a/pallets/subtensor/src/staking.rs
+++ b/pallets/subtensor/src/staking.rs
@@ -1,5 +1,6 @@
 use super::*;
 use frame_support::storage::IterableStorageDoubleMap;
+use sp_runtime::traits::Zero;
 
 impl<T: Config> Pallet<T> {
     // ---- The implementation for the extrinsic become_delegate: signals that this hotkey allows delegated stake.
@@ -305,7 +306,8 @@ impl<T: Config> Pallet<T> {
                 Stake::<T>::get(&hotkey, &coldkey).saturating_sub(stake_to_be_removed);
 
             ensure!(
-                total_stake_after_remove >= NominatorMinRequiredStake::<T>::get(),
+                total_stake_after_remove.is_zero()
+                    || total_stake_after_remove >= NominatorMinRequiredStake::<T>::get(),
                 Error::<T>::NomStakeBelowMinimumThreshold
             );
         }

--- a/pallets/subtensor/tests/staking.rs
+++ b/pallets/subtensor/tests/staking.rs
@@ -2695,5 +2695,12 @@ fn test_remove_stake_below_minimum_threshold() {
             ),
             Error::<Test>::NomStakeBelowMinimumThreshold
         );
+
+        // Nomination stake can still remove their entire stake
+        assert_ok!(SubtensorModule::remove_stake(
+            <<Test as Config>::RuntimeOrigin>::signed(coldkey2),
+            hotkey1,
+            initial_stake
+        ));
     })
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -121,7 +121,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 147,
+    spec_version: 148,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Allow user to unstake below the min nom threshold if they're unstaking their entire stake. 