### PR TITLE
fix: fix slow proxy test

### DIFF
--- a/runtime/tests/pallet_proxy.rs
+++ b/runtime/tests/pallet_proxy.rs
@@ -112,6 +112,10 @@ fn call_add_stake() -> RuntimeCall {
 fn call_register() -> RuntimeCall {
     let block_number: u64 = 1;
     let netuid: u16 = 2;
+
+    // lower diff first
+    SubtensorModule::set_difficulty(netuid, 100);
+
     let (nonce, work): (u64, Vec<u8>) = SubtensorModule::create_work_for_block_number(
         netuid,
         block_number,


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
One of the calls ran during a proxy-pallet test had a long run time (>60s) due to the work hash search.
This PR lowers the difficulty of the test environment to make the runtime much shorter (<0.05s).

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please describe): Test fix

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.
Before:
<img width="663" alt="Screenshot 2024-04-30 at 8 56 52 PM" src="https://github.com/opentensor/subtensor/assets/24501463/a738d142-7c88-415e-9150-5e2dfe116006">
After:
<img width="669" alt="Screenshot 2024-04-30 at 8 57 33 PM" src="https://github.com/opentensor/subtensor/assets/24501463/a86f12af-8590-4249-bf06-b1a289cf2f06">

