### PR TITLE
Fix root subnetwork weights normalization

### DIFF
--- a/pallets/subtensor/src/math.rs
+++ b/pallets/subtensor/src/math.rs
@@ -278,6 +278,18 @@ pub fn inplace_normalize_64(x: &mut Vec<I64F64>) {
     }
 }
 
+// Normalizes (sum to 1 except 0) each row (dim=0) of a I64F64 matrix in-place.
+#[allow(dead_code)]
+pub fn inplace_row_normalize_64(x: &mut [Vec<I64F64>]) {
+    for row in x {
+        let row_sum: I64F64 = row.iter().sum();
+        if row_sum > I64F64::from_num(0.0_f64) {
+            row.iter_mut()
+                .for_each(|x_ij: &mut I64F64| *x_ij /= row_sum);
+        }
+    }
+}
+
 /// Returns x / y for input vectors x and y, if y == 0 return 0.
 #[allow(dead_code)]
 pub fn vecdiv(x: &Vec<I32F32>, y: &Vec<I32F32>) -> Vec<I32F32> {

--- a/pallets/subtensor/src/root.rs
+++ b/pallets/subtensor/src/root.rs
@@ -346,8 +346,12 @@ impl<T: Config> Pallet<T> {
 
         // --- 8. Retrieves the network weights in a 2D Vector format. Weights have shape
         // n x k where is n is the number of registered peers and k is the number of subnets.
-        let weights: Vec<Vec<I64F64>> = Self::get_root_weights();
+        let mut weights: Vec<Vec<I64F64>> = Self::get_root_weights();
         log::debug!("W:\n{:?}\n", &weights);
+
+        // Normalize weights.
+        inplace_row_normalize_64(&mut weights);
+        log::debug!("W(norm):\n{:?}\n", &weights);
 
         // --- 9. Calculates the rank of networks. Rank is a product of weights and stakes.
         // Ranks will have shape k, a score for each subnet.


### PR DESCRIPTION
Summary:

Weights are upscaled to u16 for storage.
Therefore, weight normalization is required after weights extraction from storage.

Detailed explanation of the fix: 

Without re-normalization original validator weights are being distorted by upscaling process before being applied for subnet emissions consensus.
As one of the consequences, it allows validators which set weights uniformly across subnetworks to have bigger emissions impact on subnets vs those validators who have higher variance in the weights they set.

The following example illustrates that.
Let's say:
validator 1 sets equal weights for 4 subnets: 0.25, 0.25, 0.25, 0.25 to sn1, sn2, sn3, sn4
validator 2 sets equal weights for 10 subnets: 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1 to sn 1 .. 10
validator 3 sets variable weights for 3 subnets: 0.75, 0.2, 0.05, to sn1, sn2, sn3

Max upscale to u16 makes these weight vectors to look like this in storage:
validator 1 = 65535, 65535, 65535, 65535, 0, 0, 0, 0, 0, 0, 0, …
validator 2 = 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 0, …
validator 3 = 65535, 17476, 4369, 0, 0, 0, 0, 0, 0, 0, …

Sum of the weights:
Validator 1 has the sum = 262140
Validator 2 has the sum = 655350
Validator 3 has the sum = 87380

As a result, validator weights are distorted for emissions accounting.

E.g. for subnet 2 original weights are:
from validator 1 = 0.25
from validator 2 = 0.1
from validator 3 = 0.2

But for consensus emissions calculation they are accounted as:
from validator 1 = 65535
from validator 2 = 65535
from validator 3 = 17476

It doesn't correlate with original weights.
If we assume equal stakes of these 3 validators, validator 2 with weight 0.1 was able to have 4x bigger impact on subnet 2 rank than validator 3 with weight 0.2.