### PR TITLE
Normalise weights in Root Epoch Calculation

### DIFF
--- a/pallets/subtensor/src/math.rs
+++ b/pallets/subtensor/src/math.rs
@@ -260,6 +260,18 @@ pub fn inplace_normalize_64(x: &mut [I64F64]) {
     x.iter_mut().for_each(|value| *value /= x_sum);
 }
 
+// Normalizes (sum to 1 except 0) each row (dim=0) of a I64F64 matrix in-place.
+#[allow(dead_code)]
+pub fn inplace_row_normalize_64(x: &mut [Vec<I64F64>]) {
+    for row in x {
+        let row_sum: I64F64 = row.iter().sum();
+        if row_sum > I64F64::from_num(0.0_f64) {
+            row.iter_mut()
+                .for_each(|x_ij: &mut I64F64| *x_ij /= row_sum);
+        }
+    }
+}
+
 /// Returns x / y for input vectors x and y, if y == 0 return 0.
 #[allow(dead_code)]
 pub fn vecdiv(x: &[I32F32], y: &[I32F32]) -> Vec<I32F32> {

--- a/pallets/subtensor/src/math.rs
+++ b/pallets/subtensor/src/math.rs
@@ -260,7 +260,7 @@ pub fn inplace_normalize_64(x: &mut [I64F64]) {
     x.iter_mut().for_each(|value| *value /= x_sum);
 }
 
-// Normalizes (sum to 1 except 0) each row (dim=0) of a I64F64 matrix in-place.
+/// Normalizes (sum to 1 except 0) each row (dim=0) of a I64F64 matrix in-place.
 #[allow(dead_code)]
 pub fn inplace_row_normalize_64(x: &mut [Vec<I64F64>]) {
     for row in x {

--- a/pallets/subtensor/src/root.rs
+++ b/pallets/subtensor/src/root.rs
@@ -346,8 +346,12 @@ impl<T: Config> Pallet<T> {
 
         // --- 8. Retrieves the network weights in a 2D Vector format. Weights have shape
         // n x k where is n is the number of registered peers and k is the number of subnets.
-        let weights: Vec<Vec<I64F64>> = Self::get_root_weights();
+        let mut weights: Vec<Vec<I64F64>> = Self::get_root_weights();
         log::debug!("W:\n{:?}\n", &weights);
+
+        // Normalize weights.
+        inplace_row_normalize_64(&mut weights);
+        log::debug!("W(norm):\n{:?}\n", &weights);
 
         // --- 9. Calculates the rank of networks. Rank is a product of weights and stakes.
         // Ranks will have shape k, a score for each subnet.

--- a/pallets/subtensor/src/root.rs
+++ b/pallets/subtensor/src/root.rs
@@ -295,7 +295,7 @@ impl<T: Config> Pallet<T> {
         // --- 0. The unique ID associated with the root network.
         let root_netuid: u16 = Self::get_root_netuid();
 
-        // --- 3. Check if we should update the emission values based on blocks since emission was last set.
+        // --- 1. Check if we should update the emission values based on blocks since emission was last set.
         let blocks_until_next_epoch: u64 =
             Self::blocks_until_next_epoch(root_netuid, Self::get_tempo(root_netuid), block_number);
         if blocks_until_next_epoch != 0 {
@@ -304,7 +304,7 @@ impl<T: Config> Pallet<T> {
             return Err("");
         }
 
-        // --- 1. Retrieves the number of root validators on subnets.
+        // --- 2. Retrieves the number of root validators on subnets.
         let n: u16 = Self::get_num_root_validators();
         log::debug!("n:\n{:?}\n", n);
         if n == 0 {
@@ -312,7 +312,7 @@ impl<T: Config> Pallet<T> {
             return Err("No validators to validate emission values.");
         }
 
-        // --- 2. Obtains the number of registered subnets.
+        // --- 3. Obtains the number of registered subnets.
         let k: u16 = Self::get_all_subnet_netuids().len() as u16;
         log::debug!("k:\n{:?}\n", k);
         if k == 0 {
@@ -344,7 +344,7 @@ impl<T: Config> Pallet<T> {
         inplace_normalize_64(&mut stake_i64);
         log::debug!("S:\n{:?}\n", &stake_i64);
 
-        // --- 8. Retrieves the network weights in a 2D Vector format. Weights have shape
+        // --- 7. Retrieves the network weights in a 2D Vector format. Weights have shape
         // n x k where is n is the number of registered peers and k is the number of subnets.
         let mut weights: Vec<Vec<I64F64>> = Self::get_root_weights();
         log::debug!("W:\n{:?}\n", &weights);
@@ -353,12 +353,12 @@ impl<T: Config> Pallet<T> {
         inplace_row_normalize_64(&mut weights);
         log::debug!("W(norm):\n{:?}\n", &weights);
 
-        // --- 9. Calculates the rank of networks. Rank is a product of weights and stakes.
+        // --- 8. Calculates the rank of networks. Rank is a product of weights and stakes.
         // Ranks will have shape k, a score for each subnet.
         let ranks: Vec<I64F64> = matmul_64(&weights, &stake_i64);
         log::debug!("R:\n{:?}\n", &ranks);
 
-        // --- 10. Calculates the trust of networks. Trust is a sum of all stake with weights > 0.
+        // --- 9. Calculates the trust of networks. Trust is a sum of all stake with weights > 0.
         // Trust will have shape k, a score for each subnet.
         let total_networks = Self::get_num_subnets();
         let mut trust = vec![I64F64::from_num(0); total_networks as usize];
@@ -385,7 +385,7 @@ impl<T: Config> Pallet<T> {
             }
         }
 
-        // --- 11. Calculates the consensus of networks. Consensus is a sigmoid normalization of the trust scores.
+        // --- 10. Calculates the consensus of networks. Consensus is a sigmoid normalization of the trust scores.
         // Consensus will have shape k, a score for each subnet.
         log::debug!("T:\n{:?}\n", &trust);
         let one = I64F64::from_num(1);

--- a/pallets/subtensor/tests/root.rs
+++ b/pallets/subtensor/tests/root.rs
@@ -594,21 +594,42 @@ fn test_network_pruning() {
                 (i as u16) + 1
             );
         }
+        // Stakes
+        // 0 : 10_000
+        // 1 : 9_000
+        // 2 : 8_000
+        // 3 : 7_000
+        // 4 : 6_000
+        // 5 : 5_000
+        // 6 : 4_000
+        // 7 : 3_000
+        // 8 : 2_000
+        // 9 : 1_000
+
         step_block(1);
         assert_ok!(SubtensorModule::root_epoch(1_000_000_000));
-        assert_eq!(SubtensorModule::get_subnet_emission_value(0), 277_820_113);
-        assert_eq!(SubtensorModule::get_subnet_emission_value(1), 246_922_263);
-        assert_eq!(SubtensorModule::get_subnet_emission_value(2), 215_549_466);
-        assert_eq!(SubtensorModule::get_subnet_emission_value(3), 176_432_500);
-        assert_eq!(SubtensorModule::get_subnet_emission_value(4), 77_181_559);
-        assert_eq!(SubtensorModule::get_subnet_emission_value(5), 5_857_251);
+        // assert_eq!(SubtensorModule::get_subnet_emission_value(0), 277_820_113);
+        assert_eq!(SubtensorModule::get_subnet_emission_value(0), 385_861_815);
+        // assert_eq!(SubtensorModule::get_subnet_emission_value(1), 246_922_263);
+        assert_eq!(SubtensorModule::get_subnet_emission_value(1), 249_435_914);
+        // assert_eq!(SubtensorModule::get_subnet_emission_value(2), 215_549_466);
+        assert_eq!(SubtensorModule::get_subnet_emission_value(2), 180_819_837);
+        // assert_eq!(SubtensorModule::get_subnet_emission_value(3), 176_432_500);
+        assert_eq!(SubtensorModule::get_subnet_emission_value(3), 129_362_980);
+        // assert_eq!(SubtensorModule::get_subnet_emission_value(4), 77_181_559);
+        assert_eq!(SubtensorModule::get_subnet_emission_value(4), 50_857_187);
+        // assert_eq!(SubtensorModule::get_subnet_emission_value(5), 5_857_251);
+        assert_eq!(SubtensorModule::get_subnet_emission_value(5), 3_530_356);
         step_block(1);
         assert_eq!(SubtensorModule::get_pending_emission(0), 0); // root network gets no pending emission.
-        assert_eq!(SubtensorModule::get_pending_emission(1), 246_922_263);
+        // assert_eq!(SubtensorModule::get_pending_emission(1), 246_922_263);
+        assert_eq!(SubtensorModule::get_pending_emission(1), 249_435_914);
         assert_eq!(SubtensorModule::get_pending_emission(2), 0); // This has been drained.
-        assert_eq!(SubtensorModule::get_pending_emission(3), 176_432_500);
+        // assert_eq!(SubtensorModule::get_pending_emission(3), 176_432_500);
+        assert_eq!(SubtensorModule::get_pending_emission(3), 129_362_980);
         assert_eq!(SubtensorModule::get_pending_emission(4), 0); // This network has been drained.
-        assert_eq!(SubtensorModule::get_pending_emission(5), 5_857_251);
+        // assert_eq!(SubtensorModule::get_pending_emission(5), 5_857_251);
+        assert_eq!(SubtensorModule::get_pending_emission(5), 3_530_356);
         step_block(1);
     });
 }
@@ -766,7 +787,7 @@ fn test_weights_after_network_pruning() {
 /// Run this test using the following command:
 /// `cargo test --package pallet-subtensor --test root test_issance_bounds`
 #[test]
-fn test_issance_bounds() {
+fn test_issuance_bounds() {
     new_test_ext(1).execute_with(|| {
         // Simulate 100 halvings convergence to 21M. Note that the total issuance never reaches 21M because of rounding errors.
         // We converge to 20_999_999_989_500_000 (< 1 TAO away).

--- a/pallets/subtensor/tests/root.rs
+++ b/pallets/subtensor/tests/root.rs
@@ -608,27 +608,18 @@ fn test_network_pruning() {
 
         step_block(1);
         assert_ok!(SubtensorModule::root_epoch(1_000_000_000));
-        // assert_eq!(SubtensorModule::get_subnet_emission_value(0), 277_820_113);
         assert_eq!(SubtensorModule::get_subnet_emission_value(0), 385_861_815);
-        // assert_eq!(SubtensorModule::get_subnet_emission_value(1), 246_922_263);
         assert_eq!(SubtensorModule::get_subnet_emission_value(1), 249_435_914);
-        // assert_eq!(SubtensorModule::get_subnet_emission_value(2), 215_549_466);
         assert_eq!(SubtensorModule::get_subnet_emission_value(2), 180_819_837);
-        // assert_eq!(SubtensorModule::get_subnet_emission_value(3), 176_432_500);
         assert_eq!(SubtensorModule::get_subnet_emission_value(3), 129_362_980);
-        // assert_eq!(SubtensorModule::get_subnet_emission_value(4), 77_181_559);
         assert_eq!(SubtensorModule::get_subnet_emission_value(4), 50_857_187);
-        // assert_eq!(SubtensorModule::get_subnet_emission_value(5), 5_857_251);
         assert_eq!(SubtensorModule::get_subnet_emission_value(5), 3_530_356);
         step_block(1);
         assert_eq!(SubtensorModule::get_pending_emission(0), 0); // root network gets no pending emission.
-                                                                 // assert_eq!(SubtensorModule::get_pending_emission(1), 246_922_263);
         assert_eq!(SubtensorModule::get_pending_emission(1), 249_435_914);
         assert_eq!(SubtensorModule::get_pending_emission(2), 0); // This has been drained.
-                                                                 // assert_eq!(SubtensorModule::get_pending_emission(3), 176_432_500);
         assert_eq!(SubtensorModule::get_pending_emission(3), 129_362_980);
         assert_eq!(SubtensorModule::get_pending_emission(4), 0); // This network has been drained.
-                                                                 // assert_eq!(SubtensorModule::get_pending_emission(5), 5_857_251);
         assert_eq!(SubtensorModule::get_pending_emission(5), 3_530_356);
         step_block(1);
     });

--- a/pallets/subtensor/tests/root.rs
+++ b/pallets/subtensor/tests/root.rs
@@ -622,13 +622,13 @@ fn test_network_pruning() {
         assert_eq!(SubtensorModule::get_subnet_emission_value(5), 3_530_356);
         step_block(1);
         assert_eq!(SubtensorModule::get_pending_emission(0), 0); // root network gets no pending emission.
-        // assert_eq!(SubtensorModule::get_pending_emission(1), 246_922_263);
+                                                                 // assert_eq!(SubtensorModule::get_pending_emission(1), 246_922_263);
         assert_eq!(SubtensorModule::get_pending_emission(1), 249_435_914);
         assert_eq!(SubtensorModule::get_pending_emission(2), 0); // This has been drained.
-        // assert_eq!(SubtensorModule::get_pending_emission(3), 176_432_500);
+                                                                 // assert_eq!(SubtensorModule::get_pending_emission(3), 176_432_500);
         assert_eq!(SubtensorModule::get_pending_emission(3), 129_362_980);
         assert_eq!(SubtensorModule::get_pending_emission(4), 0); // This network has been drained.
-        // assert_eq!(SubtensorModule::get_pending_emission(5), 5_857_251);
+                                                                 // assert_eq!(SubtensorModule::get_pending_emission(5), 5_857_251);
         assert_eq!(SubtensorModule::get_pending_emission(5), 3_530_356);
         step_block(1);
     });


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->

This PR was original created by [Igor](https://github.com/igoralferov), but taking it over, as its easier to manage. 

Summary:

Weights are upscaled to u16 for storage.
Therefore, weight normalization is required after weights extraction from storage.

Detailed explanation of the fix: 

Without re-normalization original validator weights are being distorted by upscaling process before being applied for subnet emissions consensus.
As one of the consequences, it allows validators which set weights uniformly across subnetworks to have bigger emissions impact on subnets vs those validators who have higher variance in the weights they set.

The following example illustrates that.
Let's say:
validator 1 sets equal weights for 4 subnets: 0.25, 0.25, 0.25, 0.25 to sn1, sn2, sn3, sn4
validator 2 sets equal weights for 10 subnets: 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1 to sn 1 .. 10
validator 3 sets variable weights for 3 subnets: 0.75, 0.2, 0.05, to sn1, sn2, sn3

Max upscale to u16 makes these weight vectors to look like this in storage:
validator 1 = 65535, 65535, 65535, 65535, 0, 0, 0, 0, 0, 0, 0, …
validator 2 = 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535, 0, …
validator 3 = 65535, 17476, 4369, 0, 0, 0, 0, 0, 0, 0, …

Sum of the weights:
Validator 1 has the sum = 262140
Validator 2 has the sum = 655350
Validator 3 has the sum = 87380

As a result, validator weights are distorted for emissions accounting.

E.g. for subnet 2 original weights are:
from validator 1 = 0.25
from validator 2 = 0.1
from validator 3 = 0.2

But for consensus emissions calculation they are accounted as:
from validator 1 = 65535
from validator 2 = 65535
from validator 3 = 17476

It doesn't correlate with original weights.
If we assume equal stakes of these 3 validators, validator 2 with weight 0.1 was able to have 4x bigger impact on subnet 2 rank than validator 3 with weight 0.2.


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.