### PR TITLE
Swap hot and cold keys in SubStake map

### DIFF
--- a/pallets/subtensor/src/delegate_info.rs
+++ b/pallets/subtensor/src/delegate_info.rs
@@ -96,21 +96,18 @@ impl<T: Config> Pallet<T> {
         if coldkey_bytes.len() != 32 {
             return Vec::new();
         }
-        let coldkey: AccountIdOf<T> =
+        let coldkey_account_id: AccountIdOf<T> =
             T::AccountId::decode(&mut coldkey_bytes.as_slice()).expect("Coldkey decoding failed");
-        let mut response: Vec<SubStakeElement<T>> = Vec::new();
-        for ((_hotkey, _coldkey, _netuid), _stake) in SubStake::<T>::iter() {
-            if _coldkey == coldkey && _stake != 0 {
-                let value = SubStakeElement {
-                    hotkey: _hotkey.clone(),
-                    coldkey: _coldkey.clone(),
-                    netuid: _netuid.into(),
-                    stake: _stake.into(),
-                };
-                response.push(value);
+        SubStake::<T>::iter().filter(|((coldkey, _, _), stake)| {
+            *coldkey == coldkey_account_id && *stake != 0
+        }).map(|((coldkey, hotkey, nid), stake)|{
+            SubStakeElement {
+                hotkey: hotkey,
+                coldkey: coldkey,
+                netuid: Compact(nid),
+                stake: Compact(stake),
             }
-        }
-        response
+        }).collect()
     }
 
     /// Returns all `SubStakeElement` instances associated with a given netuid.
@@ -128,19 +125,16 @@ impl<T: Config> Pallet<T> {
     /// A vector of `SubStakeElement<T>` instances representing all the stakes associated with the given netuid.
     ///
     pub fn get_substake_for_netuid(netuid: u16) -> Vec<SubStakeElement<T>> {
-        let mut response: Vec<SubStakeElement<T>> = Vec::new();
-        for ((_hotkey, _coldkey, _netuid), _stake) in SubStake::<T>::iter() {
-            if _netuid == netuid && _stake != 0 {
-                let value = SubStakeElement {
-                    hotkey: _hotkey.clone(),
-                    coldkey: _coldkey.clone(),
-                    netuid: _netuid.into(),
-                    stake: _stake.into(),
-                };
-                response.push(value);
+        SubStake::<T>::iter().filter(|((_, _, nid), stake)| {
+            *nid == netuid && *stake != 0
+        }).map(|((coldkey, hotkey, nid), stake)|{
+            SubStakeElement {
+                hotkey: hotkey,
+                coldkey: coldkey,
+                netuid: Compact(nid),
+                stake: Compact(stake),
             }
-        }
-        response
+        }).collect()
     }
 
     fn get_delegate_by_existing_account(delegate: AccountIdOf<T>) -> DelegateInfo<T> {

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -323,12 +323,12 @@ pub mod pallet {
         ValueQuery,
         DefaultZeroU64<T>,
     >;
-    #[pallet::storage] // --- NMAP ( hot, cold, netuid ) --> stake | Returns the stake under a subnet prefixed by hotkey, coldkey, netuid triplet.
+    #[pallet::storage] // --- NMAP ( cold, hot, netuid ) --> stake | Returns the stake under a subnet prefixed by coldkey, hotkey, netuid triplet.
     pub type SubStake<T: Config> = StorageNMap<
         _,
         (
-            NMapKey<Blake2_128Concat, T::AccountId>, // hot
             NMapKey<Blake2_128Concat, T::AccountId>, // cold
+            NMapKey<Blake2_128Concat, T::AccountId>, // hot
             NMapKey<Identity, u16>,                  // subnet
         ),
         u64,

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1298,7 +1298,10 @@ pub mod pallet {
                 .saturating_add(migration::migrate_stake_to_substake::<T>())
                 .saturating_add(migration::migrate_remove_deprecated_stake_variables::<T>());
 
-            log::info!("Runtime upgrade migration in subtensor pallet, total weight = ({})", weight);
+            log::info!(
+                "Runtime upgrade migration in subtensor pallet, total weight = ({})",
+                weight
+            );
 
             return frame_support::weights::Weight::from_parts(0, 0);
         }

--- a/pallets/subtensor/src/migration.rs
+++ b/pallets/subtensor/src/migration.rs
@@ -444,7 +444,7 @@ pub fn migrate_stake_to_substake<T: Config>() -> Weight {
             if stake > 0 {
                 // Ensure we're only migrating non-zero stakes
                 // Insert into SubStake with netuid set to 0 for all entries
-                SubStake::<T>::insert((&hotkey, &coldkey, &0u16), stake);
+                SubStake::<T>::insert((&coldkey, &hotkey, &0u16), stake);
                 // Accrue read and write weights
                 weight.saturating_accrue(T::DbWeight::get().reads_writes(1, 1));
                 counter += 1;
@@ -454,7 +454,7 @@ pub fn migrate_stake_to_substake<T: Config>() -> Weight {
 
         // Assuming TotalHotkeySubStake needs to be updated similarly
         let mut total_stakes: BTreeMap<T::AccountId, u64> = BTreeMap::new();
-        SubStake::<T>::iter().for_each(|((hotkey, _, _), stake)| {
+        SubStake::<T>::iter().for_each(|((_, hotkey, _), stake)| {
             *total_stakes.entry(hotkey.clone()).or_insert(0) += stake;
         });
 

--- a/pallets/subtensor/src/stake_info.rs
+++ b/pallets/subtensor/src/stake_info.rs
@@ -32,7 +32,7 @@ impl<T: Config> Pallet<T> {
         for coldkey_ in coldkeys {
             let mut stake_info_for_coldkey: Vec<StakeInfo<T>> = Vec::new();
 
-            for ((hotkey, coldkey, _netuid), stake) in <SubStake<T>>::iter() {
+            for ((coldkey, hotkey, _netuid), stake) in <SubStake<T>>::iter() {
                 if coldkey == coldkey_ {
                     stake_info_for_coldkey.push(StakeInfo {
                         hotkey,
@@ -115,7 +115,7 @@ impl<T: Config> Pallet<T> {
 
         // Filter `SubStake` storage map for entries matching the coldkey and netuid.
         let mut subnet_stake_info: Vec<SubnetStakeInfo<T>> = Vec::new();
-        for ((hotkey, coldkey_iter, subnet), stake) in SubStake::<T>::iter() {
+        for ((coldkey_iter, hotkey, subnet), stake) in SubStake::<T>::iter() {
             if coldkey == coldkey_iter && netuid == subnet {
                 subnet_stake_info.push(SubnetStakeInfo {
                     hotkey,
@@ -156,7 +156,7 @@ impl<T: Config> Pallet<T> {
 
             // Filter `SubStake` storage map for entries matching the coldkey and netuid.
             let mut subnet_stake_info: Vec<SubnetStakeInfo<T>> = Vec::new();
-            for ((hotkey, coldkey_iter, subnet), stake) in SubStake::<T>::iter() {
+            for ((coldkey_iter, hotkey, subnet), stake) in SubStake::<T>::iter() {
                 if coldkey == coldkey_iter && netuid == subnet {
                     subnet_stake_info.push(SubnetStakeInfo {
                         hotkey,
@@ -222,7 +222,7 @@ impl<T: Config> Pallet<T> {
 
         // Iterate over `SubStake` storage map for entries matching the coldkey and collect their information.
         // If stake != 0
-        for ((hotkey, coldkey_iter, netuid), stake) in SubStake::<T>::iter() {
+        for ((coldkey_iter, hotkey, netuid), stake) in SubStake::<T>::iter() {
             // if coldkey == coldkey_iter {
             //     all_stake_info.push((hotkey, netuid, Compact(stake)));
             // }
@@ -252,7 +252,7 @@ impl<T: Config> Pallet<T> {
 
         // Filter `SubStake` storage map for entries matching the coldkey across all subnets.
         let mut all_subnet_stake_info: Vec<SubnetStakeInfo<T>> = Vec::new();
-        for ((hotkey, coldkey_iter, netuid), stake) in SubStake::<T>::iter() {
+        for ((coldkey_iter, hotkey, netuid), stake) in SubStake::<T>::iter() {
             if coldkey == coldkey_iter {
                 all_subnet_stake_info.push(SubnetStakeInfo {
                     hotkey,

--- a/pallets/subtensor/src/staking.rs
+++ b/pallets/subtensor/src/staking.rs
@@ -973,7 +973,7 @@ impl<T: Config> Pallet<T> {
         hotkey: &T::AccountId,
         netuid: u16,
     ) -> u64 {
-        SubStake::<T>::try_get((hotkey, coldkey, netuid)).unwrap_or(0)
+        SubStake::<T>::try_get((coldkey, hotkey, netuid)).unwrap_or(0)
     }
 
     // Returns the stake under the cold - hot pairing in the staking table.
@@ -1076,8 +1076,8 @@ impl<T: Config> Pallet<T> {
             *stake = stake.saturating_add(increment);
         });
         SubStake::<T>::insert(
-            (hotkey, coldkey, netuid),
-            SubStake::<T>::try_get((hotkey, coldkey, netuid))
+            (coldkey, hotkey, netuid),
+            SubStake::<T>::try_get((coldkey, hotkey, netuid))
                 .unwrap_or(0)
                 .saturating_add(increment),
         );
@@ -1108,12 +1108,12 @@ impl<T: Config> Pallet<T> {
         }
 
         // Delete substake map entry if all stake is removed
-        let existing_substake = SubStake::<T>::get((hotkey, coldkey, netuid));
+        let existing_substake = SubStake::<T>::get((coldkey, hotkey, netuid));
         if existing_substake == decrement {
-            SubStake::<T>::remove((hotkey, coldkey, netuid));
+            SubStake::<T>::remove((coldkey, hotkey, netuid));
         } else {
             SubStake::<T>::insert(
-                (hotkey, coldkey, netuid),
+                (coldkey, hotkey, netuid),
                 existing_substake.saturating_sub(decrement),
             );
         }

--- a/pallets/subtensor/src/uids.rs
+++ b/pallets/subtensor/src/uids.rs
@@ -117,7 +117,7 @@ impl<T: Config> Pallet<T> {
     //
     pub fn get_stake_for_uid_and_subnetwork(netuid: u16, neuron_uid: u16) -> u64 {
         match Self::get_hotkey_for_net_and_uid(netuid, neuron_uid) {
-            Ok(hotkey) => SubStake::<T>::get((&hotkey, Owner::<T>::get(&hotkey), netuid)),
+            Ok(hotkey) => SubStake::<T>::get((Owner::<T>::get(&hotkey), &hotkey, netuid)),
             Err(_) => 0,
         }
     }

--- a/pallets/subtensor/tests/migration.rs
+++ b/pallets/subtensor/tests/migration.rs
@@ -246,11 +246,11 @@ fn test_migration_stake_to_substake() {
         );
 
         assert_eq!(
-            pallet_subtensor::SubStake::<Test>::get((&hotkey1, &coldkey1, &0u16)),
+            pallet_subtensor::SubStake::<Test>::get((&coldkey1, &hotkey1, &0u16)),
             0
         );
         assert_eq!(
-            pallet_subtensor::SubStake::<Test>::get((&hotkey2, &coldkey2, &0u16)),
+            pallet_subtensor::SubStake::<Test>::get((&coldkey2, &hotkey2, &0u16)),
             0
         );
         // Run the migration
@@ -258,11 +258,11 @@ fn test_migration_stake_to_substake() {
 
         // Verify that Stake entries have been migrated to SubStake
         assert_eq!(
-            pallet_subtensor::SubStake::<Test>::get((&hotkey1, &coldkey1, &0u16)),
+            pallet_subtensor::SubStake::<Test>::get((&coldkey1, &hotkey1, &0u16)),
             stake_amount1
         );
         assert_eq!(
-            pallet_subtensor::SubStake::<Test>::get((&hotkey2, &coldkey2, &0u16)),
+            pallet_subtensor::SubStake::<Test>::get((&coldkey2, &hotkey2, &0u16)),
             stake_amount2
         );
 

--- a/pallets/subtensor/tests/mock.rs
+++ b/pallets/subtensor/tests/mock.rs
@@ -553,7 +553,7 @@ pub fn set_emission_values(netuid: u16, amount: u64) {
 #[allow(dead_code)]
 pub fn get_total_stake_for_coldkey(coldkey: &U256) -> u64 {
     pallet_subtensor::SubStake::<Test>::iter()
-        .filter(|((_, cold, _), _)| *cold == *coldkey)
+        .filter(|((cold, _, _), _)| *cold == *coldkey)
         .map(|((_, _, _), stake)| stake)
         .sum()
 }


### PR DESCRIPTION
## Description
Searching for owning coldkey by hotkey is O(1), so we don't need hotkey to be the first key in SubStake map. This PR allows us to calculate TotalColdkeyStake with O(1) complexity.

## Related Issue(s)

n/a

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please describe): Reimplementing TotalColdkeyStake for dtao

## Breaking Change

n/a

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

n/a

## Additional Notes

n/a