### PR TITLE
Refactor epoch function

### DIFF
--- a/pallets/subtensor/src/epoch.rs
+++ b/pallets/subtensor/src/epoch.rs
@@ -1,210 +1,204 @@
 use super::*;
 use crate::math::*;
-use frame_support::IterableStorageDoubleMap;
 use sp_std::vec;
 use substrate_fixed::types::{I32F32, I64F64, I96F32};
 
-impl<T: Config> Pallet<T> {
-    /// Calculates reward consensus and returns the emissions for uids/hotkeys in a given `netuid`.
-    /// (Dense version used only for testing purposes.)
-    #[allow(clippy::indexing_slicing)]
-    pub fn epoch_dense(netuid: u16, rao_emission: u64) -> Vec<(T::AccountId, u64, u64)> {
-        // Get subnetwork size.
-        let n: u16 = Self::get_subnetwork_n(netuid);
-        log::trace!("n:\n{:?}\n", n);
+#[derive(Default)]
+pub struct EpochInstance<T: Config> {
+    pub netuid: u16,
+    pub neuron_count: u16,
+    pub current_block: u64,
+    pub last_update: Vec<u64>,
+    pub active_mask: Vec<bool>,
+    pub inactive_mask: Vec<bool>,
+    // Outdated matrix, to be removed with DTAO
+    pub outdated: Vec<Vec<bool>>,
+    pub activity_cutoff: u64,
+    // Block at registration vector (block when each neuron was most recently registered).
+    pub block_at_registration: Vec<u64>,
+    // (neuron_id, hotkey) vector, stored in Keys state, initially added in append_neuron
+    pub hotkeys: Vec<(u16, T::AccountId)>,
+    pub stake: Vec<I32F32>,
+    pub active_stake: Vec<I32F32>,
+    pub validator_permits: Vec<bool>,
+    pub validator_forbids: Vec<bool>,
+    pub max_allowed_validators: u16,
+    pub weights: Vec<Vec<I32F32>>,
+    pub preranks: Vec<I32F32>,
+    // consensus majority ratio, e.g. 51%.
+    pub kappa: I32F32,
+    pub consensus: Vec<I32F32>,
+    pub ranks: Vec<I32F32>,
+    // Server trust: ratio of rank after vs. rank before.
+    pub trust: Vec<I32F32>,
+    pub incentive: Vec<I32F32>,
+    pub bonds: Vec<Vec<I32F32>>,
+    pub bonds_moving_average: I64F64,
+    pub ema_bonds: Vec<Vec<I32F32>>,
+    pub dividends: Vec<I32F32>,
+    pub combined_emission: Vec<u64>,
+    pub server_emission: Vec<u64>,
+    pub validator_emission: Vec<u64>,
+    pub pruning_scores: Vec<I32F32>,
+    pub validator_trust: Vec<u16>,
+    pub new_validator_permits: Vec<bool>,
+}
 
-        // ======================
-        // == Active & updated ==
-        // ======================
+pub trait InitializeEpoch {
+    fn set_stake(&mut self, stake: Vec<I32F32>);
+}
 
-        // Get current block.
-        let current_block: u64 = Self::get_current_block_as_u64();
-        log::trace!("current_block:\n{:?}\n", current_block);
+pub trait CalculateEpoch {
+    // Calculate active and inactive masks.
+    fn calc_active_inactive(&mut self);
+    // Calculate validator forbids
+    fn calc_validator_forbids(&mut self);
+    fn calc_active_stake(&mut self);
+    fn adjust_weights(&mut self);
+    fn calc_consensus(&mut self);
+    fn calc_ranks(&mut self);
+    fn calc_trust(&mut self);
+    fn calc_incentive(&mut self);
+    fn calc_bonds_and_dividends(&mut self);
+    fn calc_emission_and_pruning_scores(&mut self, rao_emission: u64);
+    fn calc_validator_trust(&mut self);
+    fn calc_new_validator_permits(&mut self);
+    fn adjust_ema_bonds(&mut self);
+    fn log_epoch(&self);
+    fn run(&mut self, rao_emission: u64);
+}
 
-        // Get activity cutoff.
-        let activity_cutoff: u64 = Self::get_activity_cutoff(netuid) as u64;
-        log::trace!("activity_cutoff:\n{:?}\n", activity_cutoff);
+impl<T: Config> InitializeEpoch for EpochInstance<T> {
+    fn set_stake(&mut self, stake: Vec<I32F32>) {
+        self.stake = stake;
+    }
+}
 
-        // Last update vector.
-        let last_update: Vec<u64> = Self::get_last_update(netuid);
-        log::trace!("Last update:\n{:?}\n", &last_update);
-
-        // Inactive mask.
-        let inactive: Vec<bool> = last_update
+impl<T: Config> CalculateEpoch for EpochInstance<T> {
+    fn calc_active_inactive(&mut self) {
+        self.inactive_mask = self
+            .last_update
             .iter()
-            .map(|updated| *updated + activity_cutoff < current_block)
+            .map(|updated| *updated + self.activity_cutoff < self.current_block)
             .collect();
-        log::trace!("Inactive:\n{:?}\n", inactive.clone());
 
-        // Logical negation of inactive.
-        let active: Vec<bool> = inactive.iter().map(|&b| !b).collect();
-
-        // Block at registration vector (block when each neuron was most recently registered).
-        let block_at_registration: Vec<u64> = Self::get_block_at_registration(netuid);
-        log::trace!("Block at registration:\n{:?}\n", &block_at_registration);
+        // Active is a logical negation of inactive.
+        self.active_mask = self.inactive_mask.iter().map(|&b| !b).collect();
 
         // Outdated matrix, updated_ij=True if i has last updated (weights) after j has last registered.
-        let outdated: Vec<Vec<bool>> = last_update
+        self.outdated = self.last_update
             .iter()
             .map(|updated| {
-                block_at_registration
+                self.block_at_registration
                     .iter()
                     .map(|registered| updated <= registered)
                     .collect()
             })
             .collect();
-        log::trace!("Outdated:\n{:?}\n", &outdated);
-
-        // ===========
-        // == Stake ==
-        // ===========
-
-        let hotkeys: Vec<(u16, T::AccountId)> =
-            <Keys<T> as IterableStorageDoubleMap<u16, u16, T::AccountId>>::iter_prefix(netuid)
-                .collect();
-        log::trace!("hotkeys: {:?}", &hotkeys);
-
-        // Access network stake as normalized vector.
-        let mut stake_64: Vec<I64F64> = vec![I64F64::from_num(0.0); n as usize];
-        for (uid_i, hotkey) in &hotkeys {
-            stake_64[*uid_i as usize] = I64F64::from_num(Self::get_total_stake_for_hotkey(hotkey));
-        }
-        inplace_normalize_64(&mut stake_64);
-        let stake: Vec<I32F32> = vec_fixed64_to_fixed32(stake_64);
-        log::trace!("S:\n{:?}\n", &stake);
-
-        // =======================
-        // == Validator permits ==
-        // =======================
-
-        // Get validator permits.
-        let validator_permits: Vec<bool> = Self::get_validator_permit(netuid);
-        log::trace!("validator_permits: {:?}", validator_permits);
-
+    }
+    fn calc_validator_forbids(&mut self) {
         // Logical negation of validator_permits.
-        let validator_forbids: Vec<bool> = validator_permits.iter().map(|&b| !b).collect();
-
-        // Get max allowed validators.
-        let max_allowed_validators: u16 = Self::get_max_allowed_validators(netuid);
-        log::trace!("max_allowed_validators: {:?}", max_allowed_validators);
-
-        // Get new validator permits.
-        let new_validator_permits: Vec<bool> = is_topk(&stake, max_allowed_validators as usize);
-        log::trace!("new_validator_permits: {:?}", new_validator_permits);
-
-        // ==================
-        // == Active Stake ==
-        // ==================
-
-        let mut active_stake: Vec<I32F32> = stake.clone();
+        self.validator_forbids = self.validator_permits.iter().map(|&b| !b).collect();
+    }
+    fn calc_active_stake(&mut self) {
+        self.active_stake = self.stake.clone();
 
         // Remove inactive stake.
-        inplace_mask_vector(&inactive, &mut active_stake);
+        inplace_mask_vector(&self.inactive_mask, &mut self.active_stake);
 
         // Remove non-validator stake.
-        inplace_mask_vector(&validator_forbids, &mut active_stake);
+        inplace_mask_vector(&self.validator_forbids, &mut self.active_stake);
 
         // Normalize active stake.
-        inplace_normalize(&mut active_stake);
-        log::trace!("S:\n{:?}\n", &active_stake);
-
-        // =============
-        // == Weights ==
-        // =============
-
-        // Access network weights row unnormalized.
-        let mut weights: Vec<Vec<I32F32>> = Self::get_weights(netuid);
-        log::trace!("W:\n{:?}\n", &weights);
-
+        inplace_normalize(&mut self.active_stake);
+    }
+    fn adjust_weights(&mut self) {
+        // log::trace!("W: {:?}", &inst.weights );
         // Mask weights that are not from permitted validators.
-        inplace_mask_rows(&validator_forbids, &mut weights);
+        inplace_mask_rows(&self.validator_forbids, &mut self.weights);
         // log::trace!( "W (permit): {:?}", &weights );
 
         // Remove self-weight by masking diagonal.
-        inplace_mask_diag(&mut weights);
-        // log::trace!( "W (permit+diag):\n{:?}\n", &weights );
+        inplace_mask_diag(&mut self.weights);
+        // log::trace!( "W (permit+diag): {:?}", &weights );
 
         // Mask outdated weights: remove weights referring to deregistered neurons.
-        inplace_mask_matrix(&outdated, &mut weights);
-        // log::trace!( "W (permit+diag+outdate):\n{:?}\n", &weights );
+        inplace_mask_matrix(&self.outdated, &mut self.weights);
 
         // Normalize remaining weights.
-        inplace_row_normalize(&mut weights);
-        // log::trace!( "W (mask+norm):\n{:?}\n", &weights );
+        inplace_row_normalize(&mut self.weights);
+        // log::trace!( "W (mask+norm): {:?}", &weights );
+    }
 
-        // ================================
-        // == Consensus, Validator Trust ==
-        // ================================
-
+    fn calc_consensus(&mut self) {
         // Compute preranks: r_j = SUM(i) w_ij * s_i
-        let preranks: Vec<I32F32> = matmul(&weights, &active_stake);
+        self.preranks = matmul(&self.weights, &self.active_stake);
 
-        // Clip weights at majority consensus
-        let kappa: I32F32 = Self::get_float_kappa(netuid); // consensus majority ratio, e.g. 51%.
-        let consensus: Vec<I32F32> = weighted_median_col(&active_stake, &weights, kappa);
-        inplace_col_clip(&mut weights, &consensus);
-        let validator_trust: Vec<I32F32> = row_sum(&weights);
+        self.consensus = weighted_median_col(
+            &self.active_stake,
+            &self.weights,
+            self.kappa,
+        );
 
-        // ====================================
-        // == Ranks, Server Trust, Incentive ==
-        // ====================================
+        // update weights
+        inplace_col_clip(&mut self.weights, &self.consensus);
+        // log::trace!( "W: {:?}", &weights );
+    }
 
-        // Compute ranks: r_j = SUM(i) w_ij * s_i
-        let mut ranks: Vec<I32F32> = matmul(&weights, &active_stake);
+    fn calc_ranks(&mut self) {
+        self.ranks = matmul(&self.weights, &self.active_stake);
+    }
 
+    fn calc_trust(&mut self) {
         // Compute server trust: ratio of rank after vs. rank before.
-        let trust: Vec<I32F32> = vecdiv(&ranks, &preranks);
+        self.trust = vecdiv(&self.ranks, &self.preranks);
+        // Sets trust in range: I32F32(0, 1)
+        inplace_normalize(&mut self.ranks);
+    }
 
-        inplace_normalize(&mut ranks);
-        let incentive: Vec<I32F32> = ranks.clone();
-        log::trace!("I:\n{:?}\n", &incentive);
+    fn calc_incentive(&mut self) {
+        self.incentive = self.ranks.clone();
+    }
 
-        // =========================
-        // == Bonds and Dividends ==
-        // =========================
+    fn calc_bonds_and_dividends(&mut self) {
+        // mask outdated bonds
+        inplace_mask_matrix(&self.outdated, &mut self.bonds);
 
-        // Access network bonds.
-        let mut bonds: Vec<Vec<I32F32>> = Self::get_bonds(netuid);
-        inplace_mask_matrix(&outdated, &mut bonds); // mask outdated bonds
-        inplace_col_normalize(&mut bonds); // sum_i b_ij = 1
-                                           // log::trace!( "B:\n{:?}\n", &bonds );
+        // Normalize bonds delta. (sum_i b_ij = 1)
+        inplace_col_normalize(&mut self.bonds);
 
-        // Compute bonds delta column normalized.
-        let mut bonds_delta: Vec<Vec<I32F32>> = row_hadamard(&weights, &active_stake); // ΔB = W◦S
-        inplace_col_normalize(&mut bonds_delta); // sum_i b_ij = 1
-                                                 // log::trace!( "ΔB:\n{:?}\n", &bonds_delta );
+        // Compute bonds delta column normalized (ΔB = W◦S)
+        let mut bonds_delta: Vec<Vec<I32F32>> = row_hadamard(&self.weights, &self.active_stake);
+
+        // sum_i b_ij = 1
+        inplace_col_normalize(&mut bonds_delta);
 
         // Compute bonds moving average.
-        let bonds_moving_average: I64F64 =
-            I64F64::from_num(Self::get_bonds_moving_average(netuid)) / I64F64::from_num(1_000_000);
-        let alpha: I32F32 = I32F32::from_num(1) - I32F32::from_num(bonds_moving_average);
-        let mut ema_bonds: Vec<Vec<I32F32>> = mat_ema(&bonds_delta, &bonds, alpha);
-        inplace_col_normalize(&mut ema_bonds); // sum_i b_ij = 1
-                                               // log::trace!( "emaB:\n{:?}\n", &ema_bonds );
+        let alpha: I32F32 = I32F32::from_num(1) - I32F32::from_num(self.bonds_moving_average);
+        self.ema_bonds = mat_ema(&bonds_delta, &self.bonds, alpha);
+
+        // sum_i b_ij = 1
+        inplace_col_normalize(&mut self.ema_bonds);
 
         // Compute dividends: d_i = SUM(j) b_ij * inc_j
-        let mut dividends: Vec<I32F32> = matmul_transpose(&ema_bonds, &incentive);
-        inplace_normalize(&mut dividends);
-        log::trace!("D:\n{:?}\n", &dividends);
+        self.dividends = matmul_transpose(&self.ema_bonds, &self.incentive);
+        inplace_normalize(&mut self.dividends);
+    }
 
-        // =================================
-        // == Emission and Pruning scores ==
-        // =================================
-
-        // Compute emission scores.
-
+    fn calc_emission_and_pruning_scores(&mut self, rao_emission: u64) {
         // Compute normalized emission scores. range: I32F32(0, 1)
-        // Compute normalized emission scores. range: I32F32(0, 1)
-        let combined_emission: Vec<I32F32> = incentive
+        let combined_emission_i32f32: Vec<I32F32> = self
+            .incentive
             .iter()
-            .zip(dividends.clone())
+            .zip(self.dividends.clone())
             .map(|(ii, di)| ii + di)
             .collect();
-        let emission_sum: I32F32 = combined_emission.iter().sum();
+        let emission_sum: I32F32 = combined_emission_i32f32.iter().sum();
 
-        let mut normalized_server_emission: Vec<I32F32> = incentive.clone(); // Servers get incentive.
-        let mut normalized_validator_emission: Vec<I32F32> = dividends.clone(); // Validators get dividends.
-        let mut normalized_combined_emission: Vec<I32F32> = combined_emission.clone();
+        let mut normalized_server_emission: Vec<I32F32> = self.incentive.clone(); // Servers get incentive.
+        let mut normalized_validator_emission: Vec<I32F32> = self.dividends.clone(); // Validators get dividends.
+        let mut normalized_combined_emission: Vec<I32F32> = combined_emission_i32f32.clone();
+
         // Normalize on the sum of incentive + dividends.
         inplace_normalize_using_sum(&mut normalized_server_emission, emission_sum);
         inplace_normalize_using_sum(&mut normalized_validator_emission, emission_sum);
@@ -213,133 +207,115 @@ impl<T: Config> Pallet<T> {
         // If emission is zero, replace emission with normalized stake.
         if emission_sum == I32F32::from(0) {
             // no weights set | outdated weights | self_weights
-            if is_zero(&active_stake) {
+            if is_zero(&self.active_stake) {
                 // no active stake
-                normalized_validator_emission.clone_from(&stake); // do not mask inactive, assumes stake is normalized
-                normalized_combined_emission.clone_from(&stake);
+                normalized_validator_emission = self.stake.clone(); // do not mask inactive, assumes stake is normalized
+                normalized_combined_emission = self.stake.clone();
             } else {
-                normalized_validator_emission.clone_from(&active_stake); // emission proportional to inactive-masked normalized stake
-                normalized_combined_emission.clone_from(&active_stake);
+                normalized_validator_emission = self.active_stake.clone(); // emission proportional to inactive-masked normalized stake
+                normalized_combined_emission = self.active_stake.clone();
             }
         }
 
         // Compute rao based emission scores. range: I96F32(0, rao_emission)
         let float_rao_emission: I96F32 = I96F32::from_num(rao_emission);
 
-        let server_emission: Vec<I96F32> = normalized_server_emission
+        self.server_emission = normalized_server_emission
             .iter()
-            .map(|se: &I32F32| I96F32::from_num(*se) * float_rao_emission)
+            .map(|se: &I32F32| (I96F32::from_num(*se) * float_rao_emission).to_num::<u64>())
             .collect();
-        let server_emission: Vec<u64> = server_emission
+        self.validator_emission = normalized_validator_emission
             .iter()
-            .map(|e: &I96F32| e.to_num::<u64>())
-            .collect();
-
-        let validator_emission: Vec<I96F32> = normalized_validator_emission
-            .iter()
-            .map(|ve: &I32F32| I96F32::from_num(*ve) * float_rao_emission)
-            .collect();
-        let validator_emission: Vec<u64> = validator_emission
-            .iter()
-            .map(|e: &I96F32| e.to_num::<u64>())
+            .map(|ve: &I32F32| (I96F32::from_num(*ve) * float_rao_emission).to_num::<u64>())
             .collect();
 
-        // Used only to track combined emission in the storage.
-        let combined_emission: Vec<I96F32> = normalized_combined_emission
+        // Only used to track emission in storage.
+        self.combined_emission = normalized_combined_emission
             .iter()
-            .map(|ce: &I32F32| I96F32::from_num(*ce) * float_rao_emission)
+            .map(|ce: &I32F32| (I96F32::from_num(*ce) * float_rao_emission).to_num::<u64>())
             .collect();
-        let combined_emission: Vec<u64> = combined_emission
-            .iter()
-            .map(|e: &I96F32| e.to_num::<u64>())
-            .collect();
-
-        log::trace!("nSE: {:?}", &normalized_server_emission);
-        log::trace!("SE: {:?}", &server_emission);
-        log::trace!("nVE: {:?}", &normalized_validator_emission);
-        log::trace!("VE: {:?}", &validator_emission);
-        log::trace!("nCE: {:?}", &normalized_combined_emission);
-        log::trace!("CE: {:?}", &combined_emission);
 
         // Set pruning scores using combined emission scores.
-        let pruning_scores: Vec<I32F32> = normalized_combined_emission.clone();
-        log::trace!("P: {:?}", &pruning_scores);
+        self.pruning_scores = normalized_combined_emission.clone();
 
-        // ===================
-        // == Value storage ==
-        // ===================
-        let cloned_emission: Vec<u64> = combined_emission.clone();
-        let cloned_ranks: Vec<u16> = ranks
-            .iter()
-            .map(|xi| fixed_proportion_to_u16(*xi))
-            .collect::<Vec<u16>>();
-        let cloned_trust: Vec<u16> = trust
-            .iter()
-            .map(|xi| fixed_proportion_to_u16(*xi))
-            .collect::<Vec<u16>>();
-        let cloned_consensus: Vec<u16> = consensus
-            .iter()
-            .map(|xi| fixed_proportion_to_u16(*xi))
-            .collect::<Vec<u16>>();
-        let cloned_incentive: Vec<u16> = incentive
-            .iter()
-            .map(|xi| fixed_proportion_to_u16(*xi))
-            .collect::<Vec<u16>>();
-        let cloned_dividends: Vec<u16> = dividends
-            .iter()
-            .map(|xi| fixed_proportion_to_u16(*xi))
-            .collect::<Vec<u16>>();
-        let cloned_pruning_scores: Vec<u16> = vec_max_upscale_to_u16(&pruning_scores);
-        let cloned_validator_trust: Vec<u16> = validator_trust
-            .iter()
-            .map(|xi| fixed_proportion_to_u16(*xi))
-            .collect::<Vec<u16>>();
-        Active::<T>::insert(netuid, active.clone());
-        Emission::<T>::insert(netuid, cloned_emission);
-        Rank::<T>::insert(netuid, cloned_ranks);
-        Trust::<T>::insert(netuid, cloned_trust);
-        Consensus::<T>::insert(netuid, cloned_consensus);
-        Incentive::<T>::insert(netuid, cloned_incentive);
-        Dividends::<T>::insert(netuid, cloned_dividends);
-        PruningScores::<T>::insert(netuid, cloned_pruning_scores);
-        ValidatorTrust::<T>::insert(netuid, cloned_validator_trust);
-        ValidatorPermit::<T>::insert(netuid, new_validator_permits.clone());
-
-        // Column max-upscale EMA bonds for storage: max_i w_ij = 1.
-        inplace_col_max_upscale(&mut ema_bonds);
-        new_validator_permits
-            .iter()
-            .zip(validator_permits)
-            .zip(ema_bonds)
-            .enumerate()
-            .for_each(|(i, ((new_permit, validator_permit), ema_bond))| {
-                // Set bonds only if uid retains validator permit, otherwise clear bonds.
-                if *new_permit {
-                    let new_bonds_row: Vec<(u16, u16)> = (0..n)
-                        .zip(vec_fixed_proportions_to_u16(ema_bond.clone()))
-                        .collect();
-                    Bonds::<T>::insert(netuid, i as u16, new_bonds_row);
-                } else if validator_permit {
-                    // Only overwrite the intersection.
-                    let new_empty_bonds_row: Vec<(u16, u16)> = vec![];
-                    Bonds::<T>::insert(netuid, i as u16, new_empty_bonds_row);
-                }
-            });
-
-        hotkeys
-            .into_iter()
-            .map(|(uid_i, hotkey)| {
-                (
-                    hotkey,
-                    server_emission[uid_i as usize],
-                    validator_emission[uid_i as usize],
-                )
-            })
-            .collect()
+        log::trace!("nSE: {:?}", &normalized_server_emission);
+        log::trace!("nVE: {:?}", &normalized_validator_emission);
+        log::trace!("nCE: {:?}", &normalized_combined_emission);
     }
 
+    fn calc_validator_trust(&mut self) {
+        // Calculate updated validator trust
+        self.validator_trust = row_sum(&self.weights)
+            .iter()
+            .map(|xi| fixed_proportion_to_u16(*xi))
+            .collect();
+    }
+
+    fn calc_new_validator_permits(&mut self) {
+        // Column max-upscale EMA bonds for storage: max_i w_ij = 1.
+        // Get new validator permits.
+        self.new_validator_permits = is_topk(&self.stake, self.max_allowed_validators as usize);
+    }
+
+    fn adjust_ema_bonds(&mut self) {
+        inplace_col_max_upscale(&mut self.ema_bonds);
+    }
+
+    fn log_epoch(&self) {
+        log::trace!("n: {:?}", self.neuron_count);
+        log::trace!("current_block: {:?}", self.current_block);
+        log::trace!("Last update: {:?}", &self.last_update);
+        log::trace!("activity_cutoff: {:?}", self.activity_cutoff);
+        log::trace!("Block at registration: {:?}", &self.block_at_registration);
+        log::trace!("Inactive: {:?}", &self.inactive_mask);
+        log::trace!("hotkeys: {:?}", &self.hotkeys);
+        log::trace!("S:\n{:?}\n", &self.stake);
+        log::trace!("validator_permits: {:?}", self.validator_permits);
+        log::trace!("max_allowed_validators: {:?}", self.max_allowed_validators);
+        log::trace!("S:\n{:?}\n", &self.active_stake);
+        // log::trace!( "R (before): {:?}", &preranks );
+        log::trace!("C: {:?}", &self.consensus);
+        // log::trace!( "R (after): {:?}", &ranks );
+        log::trace!("T: {:?}", &self.trust);
+        log::trace!("I (=R): {:?}", &self.incentive);
+        // log::trace!( "B (outdatedmask): {:?}", &bonds );
+        // log::trace!( "B (mask+norm): {:?}", &bonds );
+        // log::trace!( "ΔB: {:?}", &bonds_delta );
+        // log::trace!( "ΔB (norm): {:?}", &bonds_delta );
+        // log::trace!( "emaB: {:?}", &ema_bonds );
+        log::trace!("D: {:?}", &self.dividends);
+        log::trace!("SE: {:?}", &self.server_emission);
+        log::trace!("VE: {:?}", &self.validator_emission);
+        log::trace!("CE: {:?}", &self.combined_emission);
+        log::trace!("P: {:?}", &self.pruning_scores);
+        log::trace!("Tv: {:?}", &self.validator_trust);
+        log::trace!("Tv: {:?}", &self.validator_trust);
+        log::trace!("new_validator_permits: {:?}", self.new_validator_permits);
+    }
+
+    fn run(&mut self, rao_emission: u64) {
+        // Perform all epoch calculations
+        self.calc_active_inactive();
+        self.calc_validator_forbids();
+        self.calc_active_stake();
+        self.adjust_weights();
+        self.calc_consensus();
+        self.calc_ranks();
+        self.calc_trust();
+        self.calc_incentive();
+        self.calc_bonds_and_dividends();
+        self.calc_emission_and_pruning_scores(rao_emission);
+        self.calc_validator_trust();
+        self.calc_new_validator_permits();
+        self.adjust_ema_bonds();
+        self.log_epoch();
+    }
+}
+
+impl<T: Config> Pallet<T> {
     /// Calculates reward consensus values, then updates rank, trust, consensus, incentive, dividend, pruning_score, emission and bonds, and
     /// returns the emissions for uids/hotkeys in a given `netuid`.
+    /// (Dense version used only for testing purposes.)
     ///
     /// # Args:
     ///  * 'netuid': ( u16 ):
@@ -352,332 +328,77 @@ impl<T: Config> Pallet<T> {
     ///     - Print debugging outputs.
     ///
     #[allow(clippy::indexing_slicing)]
-    pub fn epoch(netuid: u16, rao_emission: u64) -> Vec<(T::AccountId, u64, u64)> {
-        // Get subnetwork size.
-        let n: u16 = Self::get_subnetwork_n(netuid);
-        log::trace!("n: {:?}", n);
+    pub fn epoch_dense(netuid: u16, rao_emission: u64) -> Vec<(T::AccountId, u64, u64)> {
+        let mut inst = Self::init_epoch_instance(netuid);
 
-        // ======================
-        // == Active & updated ==
-        // ======================
+        // Perform all epoch calculations
+        inst.run(rao_emission); 
 
-        // Get current block.
-        let current_block: u64 = Self::get_current_block_as_u64();
-        log::trace!("current_block: {:?}", current_block);
+        // Persist and return emissions
+        Self::persist_epoch_updates(netuid, inst)
+    }
 
-        // Get activity cutoff.
-        let activity_cutoff: u64 = Self::get_activity_cutoff(netuid) as u64;
-        log::trace!("activity_cutoff: {:?}", activity_cutoff);
+    pub fn init_epoch_instance(netuid: u16) -> EpochInstance<T> {
+        // =================================================
+        // == Initialize epoch instance with state values ==
+        // =================================================
 
-        // Last update vector.
-        let last_update: Vec<u64> = Self::get_last_update(netuid);
-        log::trace!("Last update: {:?}", &last_update);
+        let neuron_count = Self::get_subnetwork_n(netuid);
+        let mut inst: EpochInstance<T> = EpochInstance {
+            netuid: netuid,
+            neuron_count: neuron_count,
+            current_block: Self::get_current_block_as_u64(),
+            last_update: Self::get_last_update(netuid),
+            activity_cutoff: Self::get_activity_cutoff(netuid) as u64,
+            block_at_registration: Self::get_block_at_registration(netuid),
+            hotkeys: Keys::<T>::iter_prefix(netuid).collect(),
+            validator_permits: Self::get_validator_permit(netuid),
+            max_allowed_validators: Self::get_max_allowed_validators(netuid),
+            weights: Self::get_weights(netuid),
+            kappa: Self::get_float_kappa(netuid),
+            bonds: Self::get_bonds(netuid),
+            bonds_moving_average: I64F64::from_num(Self::get_bonds_moving_average(netuid)) 
+                / I64F64::from_num(1_000_000),
 
-        // Inactive mask.
-        let inactive: Vec<bool> = last_update
+            active_mask: Vec::new(),
+            inactive_mask: Vec::new(),
+            outdated: Vec::new(),
+            stake: Vec::new(),
+            active_stake: Vec::new(),
+            validator_forbids: Vec::new(),
+            preranks: Vec::new(),
+            consensus: Vec::new(),
+            ranks: Vec::new(),
+            trust: Vec::new(),
+            incentive: Vec::new(),
+            ema_bonds: Vec::new(),
+            dividends: Vec::new(),
+            combined_emission: Vec::new(),
+            server_emission: Vec::new(),
+            validator_emission: Vec::new(),
+            pruning_scores: Vec::new(),
+            validator_trust: Vec::new(),
+            new_validator_permits: Vec::new(),
+        };
+        inst.set_stake(Self::get_stakes(netuid, &inst.hotkeys, neuron_count));
+        inst
+    }
+
+    pub fn persist_epoch_updates(netuid: u16, inst: EpochInstance<T>) -> Vec<(T::AccountId, u64, u64)> {
+        // ============================
+        // == Persist in chain state ==
+        // ============================
+
+        inst.new_validator_permits
             .iter()
-            .map(|updated| *updated + activity_cutoff < current_block)
-            .collect();
-        log::trace!("Inactive: {:?}", inactive.clone());
-
-        // Logical negation of inactive.
-        let active: Vec<bool> = inactive.iter().map(|&b| !b).collect();
-
-        // Block at registration vector (block when each neuron was most recently registered).
-        let block_at_registration: Vec<u64> = Self::get_block_at_registration(netuid);
-        log::trace!("Block at registration: {:?}", &block_at_registration);
-
-        // ===========
-        // == Stake ==
-        // ===========
-
-        let hotkeys: Vec<(u16, T::AccountId)> =
-            <Keys<T> as IterableStorageDoubleMap<u16, u16, T::AccountId>>::iter_prefix(netuid)
-                .collect();
-        log::trace!("hotkeys: {:?}", &hotkeys);
-
-        // Access network stake as normalized vector.
-        let mut stake_64: Vec<I64F64> = vec![I64F64::from_num(0.0); n as usize];
-        for (uid_i, hotkey) in &hotkeys {
-            stake_64[*uid_i as usize] = I64F64::from_num(Self::get_total_stake_for_hotkey(hotkey));
-        }
-        inplace_normalize_64(&mut stake_64);
-        let stake: Vec<I32F32> = vec_fixed64_to_fixed32(stake_64);
-        // range: I32F32(0, 1)
-        log::trace!("S: {:?}", &stake);
-
-        // =======================
-        // == Validator permits ==
-        // =======================
-
-        // Get current validator permits.
-        let validator_permits: Vec<bool> = Self::get_validator_permit(netuid);
-        log::trace!("validator_permits: {:?}", validator_permits);
-
-        // Logical negation of validator_permits.
-        let validator_forbids: Vec<bool> = validator_permits.iter().map(|&b| !b).collect();
-
-        // Get max allowed validators.
-        let max_allowed_validators: u16 = Self::get_max_allowed_validators(netuid);
-        log::trace!("max_allowed_validators: {:?}", max_allowed_validators);
-
-        // Get new validator permits.
-        let new_validator_permits: Vec<bool> = is_topk(&stake, max_allowed_validators as usize);
-        log::trace!("new_validator_permits: {:?}", new_validator_permits);
-
-        // ==================
-        // == Active Stake ==
-        // ==================
-
-        let mut active_stake: Vec<I32F32> = stake.clone();
-
-        // Remove inactive stake.
-        inplace_mask_vector(&inactive, &mut active_stake);
-
-        // Remove non-validator stake.
-        inplace_mask_vector(&validator_forbids, &mut active_stake);
-
-        // Normalize active stake.
-        inplace_normalize(&mut active_stake);
-        log::trace!("S:\n{:?}\n", &active_stake);
-
-        // =============
-        // == Weights ==
-        // =============
-
-        // Access network weights row unnormalized.
-        let mut weights: Vec<Vec<(u16, I32F32)>> = Self::get_weights_sparse(netuid);
-        // log::trace!( "W: {:?}", &weights );
-
-        // Mask weights that are not from permitted validators.
-        weights = mask_rows_sparse(&validator_forbids, &weights);
-        // log::trace!( "W (permit): {:?}", &weights );
-
-        // Remove self-weight by masking diagonal.
-        weights = mask_diag_sparse(&weights);
-        // log::trace!( "W (permit+diag): {:?}", &weights );
-
-        // Remove weights referring to deregistered neurons.
-        weights = vec_mask_sparse_matrix(
-            &weights,
-            &last_update,
-            &block_at_registration,
-            &|updated, registered| updated <= registered,
-        );
-        // log::trace!( "W (permit+diag+outdate): {:?}", &weights );
-
-        // Normalize remaining weights.
-        inplace_row_normalize_sparse(&mut weights);
-        // log::trace!( "W (mask+norm): {:?}", &weights );
-
-        // ================================
-        // == Consensus, Validator Trust ==
-        // ================================
-
-        // Compute preranks: r_j = SUM(i) w_ij * s_i
-        let preranks: Vec<I32F32> = matmul_sparse(&weights, &active_stake, n);
-        // log::trace!( "R (before): {:?}", &preranks );
-
-        // Clip weights at majority consensus
-        let kappa: I32F32 = Self::get_float_kappa(netuid); // consensus majority ratio, e.g. 51%.
-        let consensus: Vec<I32F32> = weighted_median_col_sparse(&active_stake, &weights, n, kappa);
-        log::trace!("C: {:?}", &consensus);
-
-        weights = col_clip_sparse(&weights, &consensus);
-        // log::trace!( "W: {:?}", &weights );
-
-        let validator_trust: Vec<I32F32> = row_sum_sparse(&weights);
-        log::trace!("Tv: {:?}", &validator_trust);
-
-        // =============================
-        // == Ranks, Trust, Incentive ==
-        // =============================
-
-        // Compute ranks: r_j = SUM(i) w_ij * s_i.
-        let mut ranks: Vec<I32F32> = matmul_sparse(&weights, &active_stake, n);
-        // log::trace!( "R (after): {:?}", &ranks );
-
-        // Compute server trust: ratio of rank after vs. rank before.
-        let trust: Vec<I32F32> = vecdiv(&ranks, &preranks); // range: I32F32(0, 1)
-        log::trace!("T: {:?}", &trust);
-
-        inplace_normalize(&mut ranks); // range: I32F32(0, 1)
-        let incentive: Vec<I32F32> = ranks.clone();
-        log::trace!("I (=R): {:?}", &incentive);
-
-        // =========================
-        // == Bonds and Dividends ==
-        // =========================
-
-        // Access network bonds.
-        let mut bonds: Vec<Vec<(u16, I32F32)>> = Self::get_bonds_sparse(netuid);
-        // log::trace!( "B: {:?}", &bonds );
-
-        // Remove bonds referring to deregistered neurons.
-        bonds = vec_mask_sparse_matrix(
-            &bonds,
-            &last_update,
-            &block_at_registration,
-            &|updated, registered| updated <= registered,
-        );
-        // log::trace!( "B (outdatedmask): {:?}", &bonds );
-
-        // Normalize remaining bonds: sum_i b_ij = 1.
-        inplace_col_normalize_sparse(&mut bonds, n);
-        // log::trace!( "B (mask+norm): {:?}", &bonds );
-
-        // Compute bonds delta column normalized.
-        let mut bonds_delta: Vec<Vec<(u16, I32F32)>> = row_hadamard_sparse(&weights, &active_stake); // ΔB = W◦S (outdated W masked)
-                                                                                                     // log::trace!( "ΔB: {:?}", &bonds_delta );
-
-        // Normalize bonds delta.
-        inplace_col_normalize_sparse(&mut bonds_delta, n); // sum_i b_ij = 1
-                                                           // log::trace!( "ΔB (norm): {:?}", &bonds_delta );
-
-        // Compute bonds moving average.
-        let bonds_moving_average: I64F64 =
-            I64F64::from_num(Self::get_bonds_moving_average(netuid)) / I64F64::from_num(1_000_000);
-        let alpha: I32F32 = I32F32::from_num(1) - I32F32::from_num(bonds_moving_average);
-        let mut ema_bonds: Vec<Vec<(u16, I32F32)>> = mat_ema_sparse(&bonds_delta, &bonds, alpha);
-
-        // Normalize EMA bonds.
-        inplace_col_normalize_sparse(&mut ema_bonds, n); // sum_i b_ij = 1
-                                                         // log::trace!( "emaB: {:?}", &ema_bonds );
-
-        // Compute dividends: d_i = SUM(j) b_ij * inc_j.
-        // range: I32F32(0, 1)
-        let mut dividends: Vec<I32F32> = matmul_transpose_sparse(&ema_bonds, &incentive);
-        inplace_normalize(&mut dividends);
-        log::trace!("D: {:?}", &dividends);
-
-        // =================================
-        // == Emission and Pruning scores ==
-        // =================================
-
-        // Compute normalized emission scores. range: I32F32(0, 1)
-        let combined_emission: Vec<I32F32> = incentive
-            .iter()
-            .zip(dividends.clone())
-            .map(|(ii, di)| ii + di)
-            .collect();
-        let emission_sum: I32F32 = combined_emission.iter().sum();
-
-        let mut normalized_server_emission: Vec<I32F32> = incentive.clone(); // Servers get incentive.
-        let mut normalized_validator_emission: Vec<I32F32> = dividends.clone(); // Validators get dividends.
-        let mut normalized_combined_emission: Vec<I32F32> = combined_emission.clone();
-        // Normalize on the sum of incentive + dividends.
-        inplace_normalize_using_sum(&mut normalized_server_emission, emission_sum);
-        inplace_normalize_using_sum(&mut normalized_validator_emission, emission_sum);
-        inplace_normalize(&mut normalized_combined_emission);
-
-        // If emission is zero, replace emission with normalized stake.
-        if emission_sum == I32F32::from(0) {
-            // no weights set | outdated weights | self_weights
-            if is_zero(&active_stake) {
-                // no active stake
-                normalized_validator_emission.clone_from(&stake); // do not mask inactive, assumes stake is normalized
-                normalized_combined_emission.clone_from(&stake);
-            } else {
-                normalized_validator_emission.clone_from(&active_stake); // emission proportional to inactive-masked normalized stake
-                normalized_combined_emission.clone_from(&active_stake);
-            }
-        }
-
-        // Compute rao based emission scores. range: I96F32(0, rao_emission)
-        let float_rao_emission: I96F32 = I96F32::from_num(rao_emission);
-
-        let server_emission: Vec<I96F32> = normalized_server_emission
-            .iter()
-            .map(|se: &I32F32| I96F32::from_num(*se) * float_rao_emission)
-            .collect();
-        let server_emission: Vec<u64> = server_emission
-            .iter()
-            .map(|e: &I96F32| e.to_num::<u64>())
-            .collect();
-
-        let validator_emission: Vec<I96F32> = normalized_validator_emission
-            .iter()
-            .map(|ve: &I32F32| I96F32::from_num(*ve) * float_rao_emission)
-            .collect();
-        let validator_emission: Vec<u64> = validator_emission
-            .iter()
-            .map(|e: &I96F32| e.to_num::<u64>())
-            .collect();
-
-        // Only used to track emission in storage.
-        let combined_emission: Vec<I96F32> = normalized_combined_emission
-            .iter()
-            .map(|ce: &I32F32| I96F32::from_num(*ce) * float_rao_emission)
-            .collect();
-        let combined_emission: Vec<u64> = combined_emission
-            .iter()
-            .map(|e: &I96F32| e.to_num::<u64>())
-            .collect();
-
-        log::trace!("nSE: {:?}", &normalized_server_emission);
-        log::trace!("SE: {:?}", &server_emission);
-        log::trace!("nVE: {:?}", &normalized_validator_emission);
-        log::trace!("VE: {:?}", &validator_emission);
-        log::trace!("nCE: {:?}", &normalized_combined_emission);
-        log::trace!("CE: {:?}", &combined_emission);
-
-        // Set pruning scores using combined emission scores.
-        let pruning_scores: Vec<I32F32> = normalized_combined_emission.clone();
-        log::trace!("P: {:?}", &pruning_scores);
-
-        // ===================
-        // == Value storage ==
-        // ===================
-        let cloned_emission: Vec<u64> = combined_emission.clone();
-        let cloned_ranks: Vec<u16> = ranks
-            .iter()
-            .map(|xi| fixed_proportion_to_u16(*xi))
-            .collect::<Vec<u16>>();
-        let cloned_trust: Vec<u16> = trust
-            .iter()
-            .map(|xi| fixed_proportion_to_u16(*xi))
-            .collect::<Vec<u16>>();
-        let cloned_consensus: Vec<u16> = consensus
-            .iter()
-            .map(|xi| fixed_proportion_to_u16(*xi))
-            .collect::<Vec<u16>>();
-        let cloned_incentive: Vec<u16> = incentive
-            .iter()
-            .map(|xi| fixed_proportion_to_u16(*xi))
-            .collect::<Vec<u16>>();
-        let cloned_dividends: Vec<u16> = dividends
-            .iter()
-            .map(|xi| fixed_proportion_to_u16(*xi))
-            .collect::<Vec<u16>>();
-        let cloned_pruning_scores: Vec<u16> = vec_max_upscale_to_u16(&pruning_scores);
-        let cloned_validator_trust: Vec<u16> = validator_trust
-            .iter()
-            .map(|xi| fixed_proportion_to_u16(*xi))
-            .collect::<Vec<u16>>();
-        Active::<T>::insert(netuid, active.clone());
-        Emission::<T>::insert(netuid, cloned_emission);
-        Rank::<T>::insert(netuid, cloned_ranks);
-        Trust::<T>::insert(netuid, cloned_trust);
-        Consensus::<T>::insert(netuid, cloned_consensus);
-        Incentive::<T>::insert(netuid, cloned_incentive);
-        Dividends::<T>::insert(netuid, cloned_dividends);
-        PruningScores::<T>::insert(netuid, cloned_pruning_scores);
-        ValidatorTrust::<T>::insert(netuid, cloned_validator_trust);
-        ValidatorPermit::<T>::insert(netuid, new_validator_permits.clone());
-
-        // Column max-upscale EMA bonds for storage: max_i w_ij = 1.
-        inplace_col_max_upscale_sparse(&mut ema_bonds, n);
-        new_validator_permits
-            .iter()
-            .zip(validator_permits)
-            .zip(ema_bonds)
+            .zip(inst.validator_permits)
+            .zip(inst.ema_bonds)
             .enumerate()
             .for_each(|(i, ((new_permit, validator_permit), ema_bond))| {
                 // Set bonds only if uid retains validator permit, otherwise clear bonds.
                 if *new_permit {
-                    let new_bonds_row: Vec<(u16, u16)> = ema_bond
-                        .iter()
-                        .map(|(j, value)| (*j, fixed_proportion_to_u16(*value)))
+                    let new_bonds_row: Vec<(u16, u16)> = (0..inst.neuron_count)
+                        .zip(vec_fixed_proportions_to_u16(ema_bond.clone()))
                         .collect();
                     Bonds::<T>::insert(netuid, i as u16, new_bonds_row);
                 } else if validator_permit {
@@ -687,17 +408,68 @@ impl<T: Config> Pallet<T> {
                 }
             });
 
-        // Emission tuples ( hotkeys, server_emission, validator_emission )
-        hotkeys
-            .into_iter()
-            .map(|(uid_i, hotkey)| {
+        Active::<T>::insert(netuid, inst.active_mask);
+        Emission::<T>::insert(netuid, inst.combined_emission);
+        Rank::<T>::insert(
+            netuid,
+            inst.ranks
+                .iter()
+                .map(|xi| fixed_proportion_to_u16(*xi))
+                .collect::<Vec<u16>>(),
+        );
+        Trust::<T>::insert(
+            netuid,
+            inst.trust
+                .iter()
+                .map(|xi| fixed_proportion_to_u16(*xi))
+                .collect::<Vec<u16>>(),
+        );
+        Consensus::<T>::insert(
+            netuid,
+            inst.consensus
+                .iter()
+                .map(|xi| fixed_proportion_to_u16(*xi))
+                .collect::<Vec<u16>>(),
+        );
+        Incentive::<T>::insert(
+            netuid,
+            inst.incentive
+                .iter()
+                .map(|xi| fixed_proportion_to_u16(*xi))
+                .collect::<Vec<u16>>(),
+        );
+        Dividends::<T>::insert(
+            netuid,
+            inst.dividends
+                .iter()
+                .map(|xi| fixed_proportion_to_u16(*xi))
+                .collect::<Vec<u16>>(),
+        );
+        PruningScores::<T>::insert(netuid, vec_max_upscale_to_u16(&inst.pruning_scores));
+        ValidatorPermit::<T>::insert(netuid, inst.new_validator_permits);
+        ValidatorTrust::<T>::insert(netuid, inst.validator_trust);
+
+        // Return emission tuples ( hotkeys, server_emission, validator_emission )
+        inst.hotkeys
+            .iter()
+            .map(|(uid, hotkey): &(u16, T::AccountId)| {
                 (
-                    hotkey,
-                    server_emission[uid_i as usize],
-                    validator_emission[uid_i as usize],
+                    hotkey.clone(),
+                    inst.server_emission[*uid as usize],
+                    inst.validator_emission[*uid as usize],
                 )
             })
             .collect()
+    }
+
+    pub fn get_stakes(_netuid: u16, hotkeys: &Vec<(u16, T::AccountId)>, neuron_count: u16) -> Vec<I32F32> {
+        // Access network stake as normalized vector.
+        let mut stake_64: Vec<I64F64> = vec![I64F64::from_num(0.0); neuron_count as usize];
+        hotkeys.iter().for_each(|(uid_i, hotkey)| {
+            stake_64[*uid_i as usize] = I64F64::from_num(Self::get_total_stake_for_hotkey(hotkey));
+        });
+        inplace_normalize_64(&mut stake_64);
+        vec_fixed64_to_fixed32(stake_64)
     }
 
     pub fn get_float_rho(netuid: u16) -> I32F32 {
@@ -733,64 +505,58 @@ impl<T: Config> Pallet<T> {
         block_at_registration
     }
 
-    /// Output unnormalized sparse weights, input weights are assumed to be row max-upscaled in u16.
-    #[allow(clippy::indexing_slicing)]
-    pub fn get_weights_sparse(netuid: u16) -> Vec<Vec<(u16, I32F32)>> {
-        let n: usize = Self::get_subnetwork_n(netuid) as usize;
-        let mut weights: Vec<Vec<(u16, I32F32)>> = vec![vec![]; n];
-        for (uid_i, weights_i) in
-            <Weights<T> as IterableStorageDoubleMap<u16, u16, Vec<(u16, u16)>>>::iter_prefix(netuid)
-                .filter(|(uid_i, _)| *uid_i < n as u16)
-        {
-            for (uid_j, weight_ij) in weights_i.iter().filter(|(uid_j, _)| *uid_j < n as u16) {
-                weights[uid_i as usize].push((*uid_j, I32F32::from_num(*weight_ij)));
-            }
-        }
-        weights
-    }
+    // // Output unnormalized sparse weights, input weights are assumed to be row max-upscaled in u16.
+    // #[allow(clippy::indexing_slicing)]
+    // pub fn get_weights_sparse(netuid: u16, neuron_count: u16) -> Vec<Vec<(u16, I32F32)>> {
+    //     let mut weights: Vec<Vec<(u16, I32F32)>> = vec![vec![]; neuron_count as usize];
+    //     Weights::<T>::iter_prefix(netuid)
+    //         .filter(|(uid_i, _)| *uid_i < neuron_count as u16)
+    //         .for_each(|(uid_i, weights_i)| {
+    //             weights[uid_i as usize] = weights_i
+    //                 .iter()
+    //                 .filter(|(uid_j, _)| *uid_j < neuron_count)
+    //                 .map(|(uid_j, weight_ij)| (*uid_j, I32F32::from_num(*weight_ij)))
+    //                 .collect();
+    //         });
+    //     weights
+    // }
 
     /// Output unnormalized weights in [n, n] matrix, input weights are assumed to be row max-upscaled in u16.
     #[allow(clippy::indexing_slicing)]
     pub fn get_weights(netuid: u16) -> Vec<Vec<I32F32>> {
         let n: usize = Self::get_subnetwork_n(netuid) as usize;
         let mut weights: Vec<Vec<I32F32>> = vec![vec![I32F32::from_num(0.0); n]; n];
-        for (uid_i, weights_i) in
-            <Weights<T> as IterableStorageDoubleMap<u16, u16, Vec<(u16, u16)>>>::iter_prefix(netuid)
-        {
-            for (uid_j, weight_ij) in weights_i {
-                weights[uid_i as usize][uid_j as usize] = I32F32::from_num(weight_ij);
-            }
-        }
+        Weights::<T>::iter_prefix(netuid).for_each(|(uid_i, weights_i)| {
+            weights_i.iter().for_each(|(uid_j, weight_ij)| {
+                weights[uid_i as usize][*uid_j as usize] = I32F32::from_num(*weight_ij);
+            });
+        });
         weights
     }
 
-    /// Output unnormalized sparse bonds, input bonds are assumed to be column max-upscaled in u16.
-    #[allow(clippy::indexing_slicing)]
-    pub fn get_bonds_sparse(netuid: u16) -> Vec<Vec<(u16, I32F32)>> {
-        let n: usize = Self::get_subnetwork_n(netuid) as usize;
-        let mut bonds: Vec<Vec<(u16, I32F32)>> = vec![vec![]; n];
-        for (uid_i, bonds_i) in
-            <Bonds<T> as IterableStorageDoubleMap<u16, u16, Vec<(u16, u16)>>>::iter_prefix(netuid)
-        {
-            for (uid_j, bonds_ij) in bonds_i {
-                bonds[uid_i as usize].push((uid_j, I32F32::from_num(bonds_ij)));
-            }
-        }
-        bonds
-    }
+    // /// Output unnormalized sparse bonds, input bonds are assumed to be column max-upscaled in u16.
+    // #[allow(clippy::indexing_slicing)]
+    // pub fn get_bonds_sparse(netuid: u16, neuron_count: u16) -> Vec<Vec<(u16, I32F32)>> {
+    //     let mut bonds: Vec<Vec<(u16, I32F32)>> = vec![vec![]; neuron_count as usize];
+    //     Bonds::<T>::iter_prefix(netuid).for_each(|(uid_i, bonds_i)| {
+    //         bonds[uid_i as usize] = bonds_i
+    //             .iter()
+    //             .map(|(uid_j, bonds_ij)| (*uid_j, I32F32::from_num(*bonds_ij)))
+    //             .collect();
+    //     });
+    //     bonds
+    // }
 
     /// Output unnormalized bonds in [n, n] matrix, input bonds are assumed to be column max-upscaled in u16.
     #[allow(clippy::indexing_slicing)]
     pub fn get_bonds(netuid: u16) -> Vec<Vec<I32F32>> {
         let n: usize = Self::get_subnetwork_n(netuid) as usize;
         let mut bonds: Vec<Vec<I32F32>> = vec![vec![I32F32::from_num(0.0); n]; n];
-        for (uid_i, bonds_i) in
-            <Bonds<T> as IterableStorageDoubleMap<u16, u16, Vec<(u16, u16)>>>::iter_prefix(netuid)
-        {
-            for (uid_j, bonds_ij) in bonds_i {
-                bonds[uid_i as usize][uid_j as usize] = I32F32::from_num(bonds_ij);
-            }
-        }
+        Bonds::<T>::iter_prefix(netuid).for_each(|(uid_i, bonds_i)| {
+            bonds_i.iter().for_each(|(uid_j, bonds_ij)| {
+                bonds[uid_i as usize][*uid_j as usize] = I32F32::from_num(*bonds_ij);
+            });
+        });
         bonds
     }
 }

--- a/pallets/subtensor/src/epoch_sparse.rs
+++ b/pallets/subtensor/src/epoch_sparse.rs
@@ -333,13 +333,12 @@ impl<T: Config> Pallet<T> {
     // Output unnormalized sparse weights, input weights are assumed to be row max-upscaled in u16.
     #[allow(clippy::indexing_slicing)]
     pub fn get_weights_sparse(netuid: u16, neuron_count: u16) -> Vec<Vec<(u16, I32F32)>> {
-        let n: usize = Self::get_subnetwork_n(netuid) as usize;
-        let mut weights: Vec<Vec<(u16, I32F32)>> = vec![vec![]; n];
+        let mut weights: Vec<Vec<(u16, I32F32)>> = vec![vec![]; neuron_count as usize];
         for (uid_i, weights_i) in
-            <Weights<T> as IterableStorageDoubleMap<u16, u16, Vec<(u16, u16)>>>::iter_prefix(netuid)
-                .filter(|(uid_i, _)| *uid_i < n as u16)
+            Weights::<T>::iter_prefix(netuid)
+                .filter(|(uid_i, _)| *uid_i < neuron_count)
         {
-            for (uid_j, weight_ij) in weights_i.iter().filter(|(uid_j, _)| *uid_j < n as u16) {
+            for (uid_j, weight_ij) in weights_i.iter().filter(|(uid_j, _)| *uid_j < neuron_count) {
                 weights
                     .get_mut(uid_i as usize)
                     .expect("uid_i is filtered to be less than n; qed")
@@ -350,12 +349,11 @@ impl<T: Config> Pallet<T> {
     }
 
     /// Output unnormalized sparse bonds, input bonds are assumed to be column max-upscaled in u16.
-    pub fn get_bonds_sparse(netuid: u16) -> Vec<Vec<(u16, I32F32)>> {
-        let n: usize = Self::get_subnetwork_n(netuid) as usize;
-        let mut bonds: Vec<Vec<(u16, I32F32)>> = vec![vec![]; n];
+    pub fn get_bonds_sparse(netuid: u16, neuron_count: u16) -> Vec<Vec<(u16, I32F32)>> {
+        let mut bonds: Vec<Vec<(u16, I32F32)>> = vec![vec![]; neuron_count as usize];
         for (uid_i, bonds_vec) in
-            <Bonds<T> as IterableStorageDoubleMap<u16, u16, Vec<(u16, u16)>>>::iter_prefix(netuid)
-                .filter(|(uid_i, _)| *uid_i < n as u16)
+            Bonds::<T>::iter_prefix(netuid)
+                .filter(|(uid_i, _)| *uid_i < neuron_count)
         {
             for (uid_j, bonds_ij) in bonds_vec {
                 bonds

--- a/pallets/subtensor/src/epoch_sparse.rs
+++ b/pallets/subtensor/src/epoch_sparse.rs
@@ -1,0 +1,361 @@
+use super::*;
+use crate::{epoch::*, math::*};
+use sp_std::vec;
+use substrate_fixed::types::{I32F32, I64F64};
+
+pub struct EpochInstanceSparse<T: Config> {
+    pub inner: EpochInstance<T>,
+    pub weights: Vec<Vec<(u16, I32F32)>>,
+    pub bonds: Vec<Vec<(u16, I32F32)>>,
+    pub ema_bonds: Vec<Vec<(u16, I32F32)>>,
+}
+
+impl<T: Config> InitializeEpoch for EpochInstanceSparse<T> {
+    fn set_stake(&mut self, stake: Vec<I32F32>) {
+        self.inner.set_stake(stake);
+    }
+}
+
+impl<T: Config> CalculateEpoch for EpochInstanceSparse<T> {
+    fn calc_active_inactive(&mut self) {
+        self.inner.inactive_mask = self.inner.last_update
+            .iter()
+            .map(|updated| *updated + self.inner.activity_cutoff < self.inner.current_block)
+            .collect();
+
+        // Active is a logical negation of inactive.
+        self.inner.active_mask = self.inner.inactive_mask.iter().map(|&b| !b).collect();
+    }
+    fn calc_validator_forbids(&mut self) {
+        self.inner.calc_validator_forbids();
+    }
+    fn calc_active_stake(&mut self) {
+        self.inner.calc_active_stake();
+    }
+    fn adjust_weights(&mut self) {
+        // Mask weights that are not from permitted validators.
+        self.weights = mask_rows_sparse(&self.inner.validator_forbids, &self.weights);
+
+        // Remove self-weight by masking diagonal.
+        self.weights = mask_diag_sparse(&self.weights);
+
+        // Remove weights referring to deregistered neurons.
+        self.weights = vec_mask_sparse_matrix(
+            &self.weights,
+            &self.inner.last_update,
+            &self.inner.block_at_registration,
+            &|updated, registered| updated <= registered,
+        );
+
+        // Normalize remaining weights.
+        inplace_row_normalize_sparse(&mut self.weights);
+    }
+    fn calc_consensus(&mut self) {
+        // Compute preranks: r_j = SUM(i) w_ij * s_i
+        self.inner.preranks = matmul_sparse(&self.weights, &self.inner.active_stake, self.inner.neuron_count);
+
+        // Clip weights at majority consensus
+        // consensus majority ratio, e.g. 51%.
+        self.inner.consensus = weighted_median_col_sparse(&self.inner.active_stake, &self.weights, self.inner.neuron_count, self.inner.kappa);
+
+        self.weights = col_clip_sparse(&self.weights, &self.inner.consensus);
+    }
+
+    fn calc_ranks(&mut self) {
+        self.inner.ranks = matmul_sparse(&self.weights, &self.inner.active_stake, self.inner.neuron_count);
+    }
+
+    fn calc_trust(&mut self) {
+        self.inner.calc_trust();
+    }
+
+    fn calc_incentive(&mut self) {
+        self.inner.calc_incentive();
+    }
+
+    fn calc_bonds_and_dividends(&mut self) {
+        // Remove bonds referring to deregistered neurons.
+        self.bonds = vec_mask_sparse_matrix(
+            &self.bonds,
+            &self.inner.last_update,
+            &self.inner.block_at_registration,
+            &|updated, registered| updated <= registered,
+        );
+
+        // Normalize remaining bonds: sum_i b_ij = 1.
+        inplace_col_normalize_sparse(&mut self.bonds, self.inner.neuron_count);
+
+        // Compute bonds delta column normalized (ΔB = W◦S (outdated W masked)).
+        let mut bonds_delta = row_hadamard_sparse(&self.weights, &self.inner.active_stake);
+
+        // Normalize bonds delta (sum_i b_ij = 1).
+        inplace_col_normalize_sparse(&mut bonds_delta, self.inner.neuron_count);
+
+        // Compute bonds moving average.
+        let alpha: I32F32 = I32F32::from_num(1) - I32F32::from_num(self.inner.bonds_moving_average);
+        self.ema_bonds = mat_ema_sparse(&bonds_delta, &self.bonds, alpha);
+
+        // Normalize EMA bonds (sum_i b_ij = 1)
+        inplace_col_normalize_sparse(&mut self.ema_bonds, self.inner.neuron_count);
+
+        // Compute dividends: d_i = SUM(j) b_ij * inc_j.
+        // range: I32F32(0, 1)
+        self.inner.dividends = matmul_transpose_sparse(&self.ema_bonds, &self.inner.incentive);
+        inplace_normalize(&mut self.inner.dividends);
+    }
+
+    fn calc_emission_and_pruning_scores(&mut self, rao_emission: u64) {
+        self.inner.calc_emission_and_pruning_scores(rao_emission);
+    }
+
+    fn calc_validator_trust(&mut self) {
+        // Calculate updated validator trust
+        self.inner.validator_trust = row_sum_sparse(&self.weights)
+            .iter()
+            .map(|xi| fixed_proportion_to_u16(*xi))
+            .collect();
+    }
+
+    fn calc_new_validator_permits(&mut self) {
+        self.inner.calc_new_validator_permits();
+    }
+
+    fn adjust_ema_bonds(&mut self) {
+        inplace_col_max_upscale_sparse(&mut self.ema_bonds, self.inner.neuron_count);
+    }
+
+    fn log_epoch(&self) {
+        log::trace!("n: {:?}", self.inner.neuron_count);
+        log::trace!("current_block: {:?}", self.inner.current_block);
+        log::trace!("Last update: {:?}", &self.inner.last_update);
+        log::trace!("activity_cutoff: {:?}", self.inner.activity_cutoff);
+        log::trace!("Block at registration: {:?}", &self.inner.block_at_registration);
+        log::trace!("Inactive: {:?}", &self.inner.inactive_mask);
+        log::trace!("hotkeys: {:?}", &self.inner.hotkeys);
+        log::trace!("S:\n{:?}\n", &self.inner.stake);
+        log::trace!("validator_permits: {:?}", self.inner.validator_permits);
+        log::trace!("max_allowed_validators: {:?}", self.inner.max_allowed_validators);
+        log::trace!("S:\n{:?}\n", &self.inner.active_stake);
+        // log::trace!( "R (before): {:?}", &preranks );
+        log::trace!("C: {:?}", &self.inner.consensus);
+        // log::trace!( "R (after): {:?}", &ranks );
+        log::trace!("T: {:?}", &self.inner.trust);
+        log::trace!("I (=R): {:?}", &self.inner.incentive);
+        // log::trace!( "B (outdatedmask): {:?}", &bonds );
+        // log::trace!( "B (mask+norm): {:?}", &bonds );
+        // log::trace!( "ΔB: {:?}", &bonds_delta );
+        // log::trace!( "ΔB (norm): {:?}", &bonds_delta );
+        // log::trace!( "emaB: {:?}", &ema_bonds );
+        log::trace!("D: {:?}", &self.inner.dividends);
+        log::trace!("SE: {:?}", &self.inner.server_emission);
+        log::trace!("VE: {:?}", &self.inner.validator_emission);
+        log::trace!("CE: {:?}", &self.inner.combined_emission);
+        log::trace!("P: {:?}", &self.inner.pruning_scores);
+        log::trace!("Tv: {:?}", &self.inner.validator_trust);
+        log::trace!("Tv: {:?}", &self.inner.validator_trust);
+        log::trace!("new_validator_permits: {:?}", self.inner.new_validator_permits);
+    }
+
+    fn run(&mut self, rao_emission: u64) {
+        // Perform all epoch calculations
+        self.calc_active_inactive();
+        self.calc_validator_forbids();
+        self.calc_active_stake();
+        self.adjust_weights();
+        self.calc_consensus();
+        self.calc_ranks();
+        self.calc_trust();
+        self.calc_incentive();
+        self.calc_bonds_and_dividends();
+        self.calc_emission_and_pruning_scores(rao_emission);
+        self.calc_validator_trust();
+        self.calc_new_validator_permits();
+        self.adjust_ema_bonds();
+        self.log_epoch();
+    }
+}
+
+impl<T: Config> Pallet<T> {
+    /// Calculates reward consensus values, then updates rank, trust, consensus, incentive, dividend, pruning_score, emission and bonds, and
+    /// returns the emissions for uids/hotkeys in a given `netuid`.
+    ///
+    /// # Args:
+    ///  * 'netuid': ( u16 ):
+    ///     - The network to distribute the emission onto.
+    ///
+    ///  * 'rao_emission': ( u64 ):
+    ///     - The total emission for the epoch.
+    ///
+    ///  * 'debug' ( bool ):
+    ///     - Print debugging outputs.
+    ///
+    #[allow(clippy::indexing_slicing)]
+    pub fn epoch(netuid: u16, rao_emission: u64) -> Vec<(T::AccountId, u64, u64)> {
+        let mut inst = Self::init_epoch_instance_sparse(netuid);
+
+        // Perform all epoch calculations
+        inst.run(rao_emission);
+
+        // Persist and return emissions
+        Self::persist_epoch_updates_sparse(netuid, inst)
+    }
+
+    pub fn init_epoch_instance_sparse(netuid: u16) -> EpochInstanceSparse<T> {
+        // =================================================
+        // == Initialize epoch instance with state values ==
+        // =================================================
+
+        let neuron_count = Self::get_subnetwork_n(netuid);
+        let mut inst: EpochInstanceSparse<T> = EpochInstanceSparse {
+            inner: EpochInstance {
+                netuid: netuid,
+                neuron_count: neuron_count,
+                current_block: Self::get_current_block_as_u64(),
+                last_update: Self::get_last_update(netuid),
+                activity_cutoff: Self::get_activity_cutoff(netuid) as u64,
+                block_at_registration: Self::get_block_at_registration(netuid),
+                hotkeys: Keys::<T>::iter_prefix(netuid).collect(),
+                validator_permits: Self::get_validator_permit(netuid),
+                max_allowed_validators: Self::get_max_allowed_validators(netuid),
+                kappa: Self::get_float_kappa(netuid),
+                bonds_moving_average: I64F64::from_num(Self::get_bonds_moving_average(netuid)) 
+                    / I64F64::from_num(1_000_000),
+    
+                active_mask: Vec::new(),
+                inactive_mask: Vec::new(),
+                outdated: Vec::new(),
+                stake: Vec::new(),
+                active_stake: Vec::new(),
+                validator_forbids: Vec::new(),
+                preranks: Vec::new(),
+                consensus: Vec::new(),
+                ranks: Vec::new(),
+                trust: Vec::new(),
+                incentive: Vec::new(),
+                ema_bonds: Vec::new(),
+                dividends: Vec::new(),
+                combined_emission: Vec::new(),
+                server_emission: Vec::new(),
+                validator_emission: Vec::new(),
+                pruning_scores: Vec::new(),
+                validator_trust: Vec::new(),
+                new_validator_permits: Vec::new(),
+                weights: Vec::new(),
+                bonds: Vec::new(),
+            },
+            weights: Self::get_weights_sparse(netuid, neuron_count),
+            bonds: Self::get_bonds_sparse(netuid, neuron_count),
+            ema_bonds: Vec::new(),
+        };
+        inst.set_stake(Self::get_stakes(netuid, &inst.inner.hotkeys, neuron_count));
+        inst
+    }
+
+    pub fn persist_epoch_updates_sparse(netuid: u16, inst: EpochInstanceSparse<T>) -> Vec<(T::AccountId, u64, u64)> {
+        // ============================
+        // == Persist in chain state ==
+        // ============================
+
+        inst.inner.new_validator_permits
+            .iter()
+            .zip(inst.inner.validator_permits)
+            .zip(inst.ema_bonds)
+            .enumerate()
+            .for_each(|(i, ((new_permit, validator_permit), ema_bond))| {
+                // Set bonds only if uid retains validator permit, otherwise clear bonds.
+                if *new_permit {
+                    let new_bonds_row: Vec<(u16, u16)> = ema_bond
+                        .iter()
+                        .map(|(j, value)| (*j, fixed_proportion_to_u16(*value)))
+                        .collect();
+                    Bonds::<T>::insert(netuid, i as u16, new_bonds_row);
+                } else if validator_permit {
+                    // Only overwrite the intersection.
+                    let new_empty_bonds_row: Vec<(u16, u16)> = vec![];
+                    Bonds::<T>::insert(netuid, i as u16, new_empty_bonds_row);
+                }
+            });
+
+        Active::<T>::insert(netuid, inst.inner.active_mask);
+        Emission::<T>::insert(netuid, inst.inner.combined_emission);
+        Rank::<T>::insert(
+            netuid,
+            inst.inner.ranks
+                .iter()
+                .map(|xi| fixed_proportion_to_u16(*xi))
+                .collect::<Vec<u16>>(),
+        );
+        Trust::<T>::insert(
+            netuid,
+            inst.inner.trust
+                .iter()
+                .map(|xi| fixed_proportion_to_u16(*xi))
+                .collect::<Vec<u16>>(),
+        );
+        Consensus::<T>::insert(
+            netuid,
+            inst.inner.consensus
+                .iter()
+                .map(|xi| fixed_proportion_to_u16(*xi))
+                .collect::<Vec<u16>>(),
+        );
+        Incentive::<T>::insert(
+            netuid,
+            inst.inner.incentive
+                .iter()
+                .map(|xi| fixed_proportion_to_u16(*xi))
+                .collect::<Vec<u16>>(),
+        );
+        Dividends::<T>::insert(
+            netuid,
+            inst.inner.dividends
+                .iter()
+                .map(|xi| fixed_proportion_to_u16(*xi))
+                .collect::<Vec<u16>>(),
+        );
+        PruningScores::<T>::insert(netuid, vec_max_upscale_to_u16(&inst.inner.pruning_scores));
+        ValidatorPermit::<T>::insert(netuid, inst.inner.new_validator_permits);
+        ValidatorTrust::<T>::insert(netuid, inst.inner.validator_trust);
+
+        // Return emission tuples ( hotkeys, server_emission, validator_emission )
+        inst.inner.hotkeys
+            .iter()
+            .map(|(uid, hotkey): &(u16, T::AccountId)| {
+                (
+                    hotkey.clone(),
+                    inst.inner.server_emission[*uid as usize],
+                    inst.inner.validator_emission[*uid as usize],
+                )
+            })
+            .collect()
+    }
+
+    // Output unnormalized sparse weights, input weights are assumed to be row max-upscaled in u16.
+    #[allow(clippy::indexing_slicing)]
+    pub fn get_weights_sparse(netuid: u16, neuron_count: u16) -> Vec<Vec<(u16, I32F32)>> {
+        let mut weights: Vec<Vec<(u16, I32F32)>> = vec![vec![]; neuron_count as usize];
+        Weights::<T>::iter_prefix(netuid)
+            .filter(|(uid_i, _)| *uid_i < neuron_count as u16)
+            .for_each(|(uid_i, weights_i)| {
+                weights[uid_i as usize] = weights_i
+                    .iter()
+                    .filter(|(uid_j, _)| *uid_j < neuron_count)
+                    .map(|(uid_j, weight_ij)| (*uid_j, I32F32::from_num(*weight_ij)))
+                    .collect();
+            });
+        weights
+    }
+
+    /// Output unnormalized sparse bonds, input bonds are assumed to be column max-upscaled in u16.
+    #[allow(clippy::indexing_slicing)]
+    pub fn get_bonds_sparse(netuid: u16, neuron_count: u16) -> Vec<Vec<(u16, I32F32)>> {
+        let mut bonds: Vec<Vec<(u16, I32F32)>> = vec![vec![]; neuron_count as usize];
+        Bonds::<T>::iter_prefix(netuid).for_each(|(uid_i, bonds_i)| {
+            bonds[uid_i as usize] = bonds_i
+                .iter()
+                .map(|(uid_j, bonds_ij)| (*uid_j, I32F32::from_num(*bonds_ij)))
+                .collect();
+        });
+        bonds
+    }
+}

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -37,6 +37,7 @@ mod benchmarks;
 // =========================
 mod block_step;
 mod epoch;
+mod epoch_sparse;
 mod errors;
 mod events;
 mod math;


### PR DESCRIPTION
## Description

We need this refactoring to prepare for a safe DTAO upgrade:
Separate `epoch` and `epoch_sparse` functions into different parts:

1. Initialization
2. Running
3. Saving to storage

Also, split running into following functions to make it more testable and extendable:
1.     fn calc_active_inactive(&mut self);
2.     fn calc_validator_forbids(&mut self);
3.     fn calc_active_stake(&mut self);
4.     fn adjust_weights(&mut self);
5.     fn calc_consensus(&mut self);
6.     fn calc_ranks(&mut self);
7.     fn calc_trust(&mut self);
8.     fn calc_incentive(&mut self);
9.     fn calc_bonds_and_dividends(&mut self);
10.     fn calc_emission_and_pruning_scores(&mut self, rao_emission: u64);
11.     fn calc_validator_trust(&mut self);
12.     fn calc_new_validator_permits(&mut self);
13.     fn adjust_ema_bonds(&mut self);
14.     fn log_epoch(&self);

## Related Issue(s)

n/a

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please describe): Refactoring

## Breaking Change

none (hopefully :))

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

n/a

## Additional Notes

n/a