### PR TITLE
[Fix] fix reg interval too short

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1988,7 +1988,7 @@ where
                     Pallet::<T>::get_registrations_this_interval(*netuid);
                 let max_registrations_per_interval =
                     Pallet::<T>::get_target_registrations_per_interval(*netuid);
-                if registrations_this_interval >= max_registrations_per_interval {
+                if registrations_this_interval >= (max_registrations_per_interval * 3) {
                     // If the registration limit for the interval is exceeded, reject the transaction
                     return InvalidTransaction::ExhaustsResources.into();
                 }

--- a/pallets/subtensor/tests/mock.rs
+++ b/pallets/subtensor/tests/mock.rs
@@ -141,7 +141,7 @@ parameter_types! {
     pub const InitialAdjustmentInterval: u16 = 100;
     pub const InitialAdjustmentAlpha: u64 = 0; // no weight to previous value.
     pub const InitialMaxRegistrationsPerBlock: u16 = 3;
-    pub const InitialTargetRegistrationsPerInterval: u16 = 2;
+    pub const InitialTargetRegistrationsPerInterval: u16 = 3;
     pub const InitialPruningScore : u16 = u16::MAX;
     pub const InitialRegistrationRequirement: u16 = u16::MAX; // Top 100%
     pub const InitialMinDifficulty: u64 = 1;

--- a/pallets/subtensor/tests/registration.rs
+++ b/pallets/subtensor/tests/registration.rs
@@ -290,18 +290,18 @@ fn test_burned_registration_under_limit() {
         let netuid: u16 = 1;
         let hotkey_account_id: U256 = U256::from(1);
         let coldkey_account_id = U256::from(667);
-        let who: <Test as frame_system::Config>::AccountId = hotkey_account_id;
-        let block_number: u64 = 0;
+        let who: <Test as frame_system::Config>::AccountId = coldkey_account_id;
+        let burn_cost = 1000;
+        // Set the burn cost
+        SubtensorModule::set_burn(netuid, burn_cost);
 
-        let (nonce, work) = SubtensorModule::create_work_for_block_number(
-            netuid,
-            block_number,
-            129123813,
-            &hotkey_account_id,
-        );
+        add_network(netuid, 13, 0); // Add the network
+                                    // Give it some TAO to the coldkey balance; more than the burn cost
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, burn_cost + 10_000);
 
-        let max_registrants = 2;
-        SubtensorModule::set_target_registrations_per_interval(netuid, max_registrants);
+        let target_registrants = 2;
+        let max_registrants = target_registrants * 3; // Maximum is 3 times the target
+        SubtensorModule::set_target_registrations_per_interval(netuid, target_registrants);
 
         let call_burned_register: pallet_subtensor::Call<Test> =
             pallet_subtensor::Call::burned_register {
@@ -317,21 +317,15 @@ fn test_burned_registration_under_limit() {
             extension.validate(&who, &call_burned_register.into(), &info, 10);
         assert_ok!(burned_register_result);
 
-        add_network(netuid, 13, 0);
         //actually call register
-        assert_ok!(SubtensorModule::register(
-            <<Test as Config>::RuntimeOrigin>::signed(hotkey_account_id),
+        assert_ok!(SubtensorModule::burned_register(
+            <<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id),
             netuid,
-            block_number,
-            nonce,
-            work,
             hotkey_account_id,
-            coldkey_account_id
         ));
 
         let current_registrants = SubtensorModule::get_registrations_this_interval(netuid);
-        let target_registrants = SubtensorModule::get_target_registrations_per_interval(netuid);
-        assert!(current_registrants <= target_registrants);
+        assert!(current_registrants <= max_registrants);
     });
 }
 
@@ -340,11 +334,15 @@ fn test_burned_registration_rate_limit_exceeded() {
     new_test_ext(1).execute_with(|| {
         let netuid: u16 = 1;
         let hotkey_account_id: U256 = U256::from(1);
-        let who: <Test as frame_system::Config>::AccountId = hotkey_account_id;
-        let max_registrants = 1;
+        let coldkey_account_id = U256::from(667);
+        let who: <Test as frame_system::Config>::AccountId = coldkey_account_id;
 
-        SubtensorModule::set_target_registrations_per_interval(netuid, max_registrants);
-        SubtensorModule::set_registrations_this_interval(netuid, 1);
+        let target_registrants = 1;
+        let max_registrants = target_registrants * 3; // Maximum is 3 times the target
+
+        SubtensorModule::set_target_registrations_per_interval(netuid, target_registrants);
+        // Set the current registrations to the maximum; should not be able to register more
+        SubtensorModule::set_registrations_this_interval(netuid, max_registrants);
 
         let call_burned_register: pallet_subtensor::Call<Test> =
             pallet_subtensor::Call::burned_register {
@@ -366,6 +364,55 @@ fn test_burned_registration_rate_limit_exceeded() {
 
         let current_registrants = SubtensorModule::get_registrations_this_interval(netuid);
         assert!(current_registrants <= max_registrants);
+    });
+}
+
+#[test]
+fn test_burned_registration_rate_allows_burn_adjustment() {
+    // We need to be able to register more than the *target* registrations per interval
+    new_test_ext().execute_with(|| {
+        let netuid: u16 = 1;
+        let hotkey_account_id: U256 = U256::from(1);
+        let coldkey_account_id = U256::from(667);
+        let who: <Test as frame_system::Config>::AccountId = coldkey_account_id;
+
+        let burn_cost = 1000;
+        // Set the burn cost
+        SubtensorModule::set_burn(netuid, burn_cost);
+
+        add_network(netuid, 13, 0); // Add the network
+                                    // Give it some TAO to the coldkey balance; more than the burn cost
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, burn_cost + 10_000);
+
+        let target_registrants = 1; // Target is 1, but we can register more than that, up to some maximum.
+        SubtensorModule::set_target_registrations_per_interval(netuid, target_registrants);
+        // Set the current registrations to above the target; we should be able to register at least 1 more
+        SubtensorModule::set_registrations_this_interval(netuid, target_registrants);
+
+        // Register one more, so the current registrations are above the target
+        let call_burned_register: pallet_subtensor::Call<Test> =
+            pallet_subtensor::Call::burned_register {
+                netuid,
+                hotkey: hotkey_account_id,
+            };
+
+        let info: DispatchInfo =
+            DispatchInfoOf::<<Test as frame_system::Config>::RuntimeCall>::default();
+        let extension = SubtensorSignedExtension::<Test>::new();
+        //does not actually call register
+        let burned_register_result =
+            extension.validate(&who, &call_burned_register.into(), &info, 10);
+        assert_ok!(burned_register_result);
+
+        //actually call register
+        assert_ok!(SubtensorModule::burned_register(
+            <<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id),
+            netuid,
+            hotkey_account_id
+        ));
+
+        let current_registrants = SubtensorModule::get_registrations_this_interval(netuid);
+        assert!(current_registrants > target_registrants); // Should be able to register more than the target
     });
 }
 

--- a/pallets/subtensor/tests/registration.rs
+++ b/pallets/subtensor/tests/registration.rs
@@ -249,9 +249,10 @@ fn test_registration_rate_limit_exceeded() {
         let coldkey_account_id = U256::from(667);
         let who: <Test as frame_system::Config>::AccountId = hotkey_account_id;
 
-        let max_registrants = 1;
-        SubtensorModule::set_target_registrations_per_interval(netuid, max_registrants);
-        SubtensorModule::set_registrations_this_interval(netuid, 1);
+        let target_registrants = 1;
+        let max_registrants = target_registrants * 3;
+        SubtensorModule::set_target_registrations_per_interval(netuid, target_registrants);
+        SubtensorModule::set_registrations_this_interval(netuid, max_registrants);
 
         let (nonce, work) = SubtensorModule::create_work_for_block_number(
             netuid,
@@ -370,7 +371,7 @@ fn test_burned_registration_rate_limit_exceeded() {
 #[test]
 fn test_burned_registration_rate_allows_burn_adjustment() {
     // We need to be able to register more than the *target* registrations per interval
-    new_test_ext().execute_with(|| {
+    new_test_ext(1).execute_with(|| {
         let netuid: u16 = 1;
         let hotkey_account_id: U256 = U256::from(1);
         let coldkey_account_id = U256::from(667);


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->

(re-)fixes the bug with the registration filtering which caused registrations to be rejected without passing the maximum theshold of `3*target_registrations`. This was fixed initially via hotfix in #379 and inadvertently rolled-back during #366.

## Related Issue(s)

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

NA

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

NA

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.