### PR TITLE
Enable exponential backoff for AuRa

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4645,6 +4645,7 @@ dependencies = [
  "sc-consensus-aura",
  "sc-consensus-grandpa",
  "sc-consensus-grandpa-rpc",
+ "sc-consensus-slots",
  "sc-executor",
  "sc-keystore",
  "sc-network",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ sc-consensus = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "
 sc-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-v1.10.0" }
 sc-consensus-grandpa = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-v1.10.0" }
 sc-consensus-grandpa-rpc = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-v1.10.0" }
+sc-consensus-slots = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-v1.10.0" }
 sc-executor = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-v1.10.0" }
 sc-keystore = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-v1.10.0" }
 sc-network = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-v1.10.0" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -45,6 +45,7 @@ sc-consensus = { workspace = true }
 sc-consensus-grandpa = { workspace = true }
 sc-consensus-grandpa-rpc = { workspace = true }
 sp-consensus-grandpa = { workspace = true }
+sc-consensus-slots = { workspace = true }
 sc-client-api = { workspace = true }
 sp-runtime = { workspace = true }
 sp-io = { workspace = true }

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -241,7 +241,10 @@ pub fn new_full(config: Configuration) -> Result<TaskManager, ServiceError> {
 
     let role = config.role.clone();
     let force_authoring = config.force_authoring;
-    let backoff_authoring_blocks = Some(BackoffAuthoringOnFinalizedHeadLagging::default());
+    let backoff_authoring_blocks = Some(BackoffAuthoringOnFinalizedHeadLagging {
+        unfinalized_slack: 15,
+        ..Default::default()
+    });
     let name = config.network.node_name.clone();
     let enable_grandpa = !config.disable_grandpa;
     let prometheus_registry = config.prometheus_registry().cloned();

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -242,7 +242,7 @@ pub fn new_full(config: Configuration) -> Result<TaskManager, ServiceError> {
     let role = config.role.clone();
     let force_authoring = config.force_authoring;
     let backoff_authoring_blocks = Some(BackoffAuthoringOnFinalizedHeadLagging {
-        unfinalized_slack: 15,
+        unfinalized_slack: 6,
         ..Default::default()
     });
     let name = config.network.node_name.clone();

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -241,8 +241,7 @@ pub fn new_full(config: Configuration) -> Result<TaskManager, ServiceError> {
 
     let role = config.role.clone();
     let force_authoring = config.force_authoring;
-    let backoff_authoring_blocks =
-        Some(BackoffAuthoringOnFinalizedHeadLagging::default());
+    let backoff_authoring_blocks = Some(BackoffAuthoringOnFinalizedHeadLagging::default());
     let name = config.network.node_name.clone();
     let enable_grandpa = !config.disable_grandpa;
     let prometheus_registry = config.prometheus_registry().cloned();

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -5,6 +5,7 @@ use node_subtensor_runtime::{opaque::Block, RuntimeApi};
 use sc_client_api::{Backend, BlockBackend};
 use sc_consensus_aura::{ImportQueueParams, SlotProportion, StartAuraParams};
 use sc_consensus_grandpa::SharedVoterState;
+use sc_consensus_slots::BackoffAuthoringOnFinalizedHeadLagging;
 use sc_executor::sp_wasm_interface::{Function, HostFunctionRegistry, HostFunctions};
 pub use sc_executor::NativeElseWasmExecutor;
 use sc_service::{error::Error as ServiceError, Configuration, TaskManager, WarpSyncParams};
@@ -240,7 +241,8 @@ pub fn new_full(config: Configuration) -> Result<TaskManager, ServiceError> {
 
     let role = config.role.clone();
     let force_authoring = config.force_authoring;
-    let backoff_authoring_blocks: Option<()> = None;
+    let backoff_authoring_blocks =
+        Some(BackoffAuthoringOnFinalizedHeadLagging::default());
     let name = config.network.node_name.clone();
     let enable_grandpa = !config.disable_grandpa;
     let prometheus_registry = config.prometheus_registry().cloned();


### PR DESCRIPTION
This PR enables exponential backoff for the block authoring gadget AuRa. It uses the default backoff settings, i.e. it never waits more than 100 blocks before authoring, it starts considering backing off after 50 or more unfinalized blocks, and it is biased to consider the unfinalized head suffix length to grow half as fast as in actuality.