### PR TITLE
feat: localnet fast blocks

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -94,6 +94,7 @@ substrate-wasm-builder = { workspace = true, optional = true }
 [features]
 default = ["std"]
 pow-faucet = ["pallet-subtensor/pow-faucet"]
+fast-blocks = []
 std = [
 	"frame-try-runtime?/std",
 	"frame-system-benchmarking?/std",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -148,7 +148,12 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 /// up by `pallet_aura` to implement `fn slot_duration()`.
 ///
 /// Change this to adjust the block time.
+#[cfg(not(feature = "fast-blocks"))]
 pub const MILLISECS_PER_BLOCK: u64 = 12000;
+
+/// Fast blocks for development
+#[cfg(feature = "fast-blocks")]
+pub const MILLISECS_PER_BLOCK: u64 = 250;
 
 // NOTE: Currently it is not possible to change the slot duration after the chain has started.
 //       Attempting to do so will brick block production.

--- a/scripts/localnet.sh
+++ b/scripts/localnet.sh
@@ -8,10 +8,14 @@ BASE_DIR="$SCRIPT_DIR/.."
 
 : "${CHAIN:=local}"
 : "${BUILD_BINARY:=1}"
-: "${FEATURES:="pow-faucet runtime-benchmarks fast-blocks"}"
+: "${FEATURES:="pow-faucet fast-blocks"}"
 
 SPEC_PATH="${SCRIPT_DIR}/specs/"
 FULL_PATH="$SPEC_PATH$CHAIN.json"
+
+# Kill any existing nodes which may have not exited correctly after a previous
+# run.
+pkill -9 'node-subtensor'
 
 if [ ! -d "$SPEC_PATH" ]; then
   echo "*** Creating directory ${SPEC_PATH}..."
@@ -63,7 +67,6 @@ trap 'pkill -P $$' EXIT SIGINT SIGTERM
 
 (
   ("${alice_start[@]}" 2>&1) &
-  sleep 0.5 # sleep 500ms between starting each node to help them peer
   ("${bob_start[@]}" 2>&1)
   wait
 )

--- a/scripts/localnet.sh
+++ b/scripts/localnet.sh
@@ -8,7 +8,7 @@ BASE_DIR="$SCRIPT_DIR/.."
 
 : "${CHAIN:=local}"
 : "${BUILD_BINARY:=1}"
-: "${FEATURES:=pow-faucet}"
+: "${FEATURES:="pow-faucet runtime-benchmarks fast-blocks"}"
 
 SPEC_PATH="${SCRIPT_DIR}/specs/"
 FULL_PATH="$SPEC_PATH$CHAIN.json"
@@ -59,8 +59,11 @@ bob_start=(
   --discover-local
 )
 
+trap 'pkill -P $$' EXIT SIGINT SIGTERM
+
 (
-  trap 'kill 0' SIGINT
   ("${alice_start[@]}" 2>&1) &
+  sleep 0.5 # sleep 500ms between starting each node to help them peer
   ("${bob_start[@]}" 2>&1)
+  wait
 )


### PR DESCRIPTION
- Adds `fast-blocks` feature that enables 500ms blocks
- Catches more exit signals, to help reduce the occurrence of hanging node processes more often
- Kills any hung node processes before starting, to prevent alice or bob failing to start due to used ports