### PR TITLE
[fix] Revert axon info field ordering

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -672,9 +672,9 @@ pub mod pallet {
         ///  Axon version
         pub version: u32,
         ///  Axon u128 encoded ip address of type v6 or v4.
-        pub port: u16,
-        ///  Axon u16 encoded port.
         pub ip: u128,
+        ///  Axon u16 encoded port.
+        pub port: u16,
         ///  Axon ip type, 4 for ipv4 and 6 for ipv6.
         pub ip_type: u8,
         ///  Axon protocol. TCP, UDP, other.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -135,7 +135,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 185,
+    spec_version: 186,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->

The ordering of the `AxonInfo` struct fields `ip` and `port` was swapped erroneously, causing a metadata mismatch with the client-code.

Note: this change only affects testnet. Devent appears not to have the errant change included

## Related Issue(s)

- Supersedes opentensor/bittensor/pull/1962
- Supersedes opentensor/bittensor/pull/1978

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

NA

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.