### PR TITLE
reset neuron data on registration

### DIFF
--- a/pallets/subtensor/src/uids.rs
+++ b/pallets/subtensor/src/uids.rs
@@ -9,6 +9,22 @@ impl<T: Config> Pallet<T> {
         SubnetworkN::<T>::get(netuid)
     }
 
+    pub fn set_emission_for_uid(netuid: u16, neuron_uid: u16, emission: u64) {
+        Emission::<T>::mutate(netuid, |v| v[neuron_uid as usize] = emission);
+    }
+    pub fn set_trust_for_uid(netuid: u16, neuron_uid: u16, trust: u16) {
+        Trust::<T>::mutate(netuid, |v| v[neuron_uid as usize] = trust);
+    }
+    pub fn set_consensus_for_uid(netuid: u16, neuron_uid: u16, consensus: u16) {
+        Consensus::<T>::mutate(netuid, |v| v[neuron_uid as usize] = consensus);
+    }
+    pub fn set_incentive_for_uid(netuid: u16, neuron_uid: u16, incentive: u16) {
+        Incentive::<T>::mutate(netuid, |v| v[neuron_uid as usize] = incentive);
+    }
+    pub fn set_dividends_for_uid(netuid: u16, neuron_uid: u16, dividends: u16) {
+        Dividends::<T>::mutate(netuid, |v| v[neuron_uid as usize] = dividends);
+    }
+
     /// Replace the neuron under this uid.
     pub fn replace_neuron(
         netuid: u16,
@@ -45,6 +61,16 @@ impl<T: Config> Pallet<T> {
         Uids::<T>::insert(netuid, new_hotkey.clone(), uid_to_replace); // Make uid - hotkey association.
         BlockAtRegistration::<T>::insert(netuid, uid_to_replace, block_number); // Fill block at registration.
         IsNetworkMember::<T>::insert(new_hotkey.clone(), netuid, true); // Fill network is member.
+
+        // 4. Reset trust, emission, consensus, incentive, dividends and axon_info for the new uid.
+        Self::set_trust_for_uid(netuid, uid_to_replace, 0);
+        Self::set_emission_for_uid(netuid, uid_to_replace, 0);
+        Self::set_consensus_for_uid(netuid, uid_to_replace, 0);
+        Self::set_incentive_for_uid(netuid, uid_to_replace, 0);
+        Self::set_dividends_for_uid(netuid, uid_to_replace, 0);
+
+        // 4a. reset axon info for the new uid.
+        Axons::<T>::remove(netuid, old_hotkey);
     }
 
     /// Appends the uid to the network.

--- a/pallets/subtensor/tests/uids.rs
+++ b/pallets/subtensor/tests/uids.rs
@@ -48,14 +48,37 @@ fn test_replace_neuron() {
         // Get UID
         let neuron_uid = SubtensorModule::get_uid_for_net_and_hotkey(netuid, &hotkey_account_id);
         assert_ok!(neuron_uid);
+        let neuron_uid = neuron_uid.unwrap();
+
+        // set non-default values
+        SubtensorModule::set_trust_for_uid(netuid, neuron_uid, 5u16);
+        SubtensorModule::set_emission_for_uid(netuid, neuron_uid, 5u64);
+        SubtensorModule::set_consensus_for_uid(netuid, neuron_uid, 5u16);
+        SubtensorModule::set_incentive_for_uid(netuid, neuron_uid, 5u16);
+        SubtensorModule::set_dividends_for_uid(netuid, neuron_uid, 5u16);
+
+        // serve axon mock address
+        let ip: u128 = 1676056785;
+        let port: u16 = 9999;
+        let ip_type: u8 = 4;
+        let hotkey = SubtensorModule::get_hotkey_for_net_and_uid(netuid, neuron_uid).unwrap();
+        assert!(SubtensorModule::serve_axon(
+            <<Test as Config>::RuntimeOrigin>::signed(hotkey_account_id),
+            netuid,
+            0,
+            ip,
+            port,
+            ip_type,
+            0,
+            0,
+            0
+        )
+        .is_ok());
 
         // Replace the neuron.
-        SubtensorModule::replace_neuron(
-            netuid,
-            neuron_uid.unwrap(),
-            &new_hotkey_account_id,
-            block_number,
-        );
+        SubtensorModule::replace_neuron(netuid, neuron_uid, &new_hotkey_account_id, block_number);
+
+        assert_eq!(SubtensorModule::has_axon_info(netuid, &hotkey), false);
 
         // Check old hotkey is not registered on any network.
         assert!(SubtensorModule::get_uid_for_net_and_hotkey(netuid, &hotkey_account_id).is_err());
@@ -63,7 +86,7 @@ fn test_replace_neuron() {
             &hotkey_account_id
         ));
 
-        let curr_hotkey = SubtensorModule::get_hotkey_for_net_and_uid(netuid, neuron_uid.unwrap());
+        let curr_hotkey = SubtensorModule::get_hotkey_for_net_and_uid(netuid, neuron_uid);
         assert_ok!(curr_hotkey);
         assert_ne!(curr_hotkey.unwrap(), hotkey_account_id);
 
@@ -75,6 +98,33 @@ fn test_replace_neuron() {
             &new_hotkey_account_id
         ));
         assert_eq!(curr_hotkey.unwrap(), new_hotkey_account_id);
+
+        // Check trust, emission, consensus, incentive, dividends have been reset to 0.
+        assert_eq!(SubtensorModule::get_trust_for_uid(netuid, neuron_uid), 0);
+        assert_eq!(SubtensorModule::get_emission_for_uid(netuid, neuron_uid), 0);
+        assert_eq!(
+            SubtensorModule::get_consensus_for_uid(netuid, neuron_uid),
+            0
+        );
+        assert_eq!(
+            SubtensorModule::get_incentive_for_uid(netuid, neuron_uid),
+            0
+        );
+        assert_eq!(
+            SubtensorModule::get_dividends_for_uid(netuid, neuron_uid),
+            0
+        );
+
+        assert_eq!(
+            SubtensorModule::has_axon_info(netuid, &new_hotkey_account_id),
+            false
+        );
+
+        // Check axon info is reset.
+        let axon_info = SubtensorModule::get_axon_info(netuid, &curr_hotkey.unwrap());
+        assert_eq!(axon_info.ip, 0);
+        assert_eq!(axon_info.port, 0);
+        assert_eq!(axon_info.ip_type, 0);
     });
 }
 


### PR DESCRIPTION
## Description

On neuron registration the trust, emission, consensus, incentive, dividends values as well as axon info associated with the assigned neuron_uid are inherited from the previous neuron. Thus for the first few blocks after registration these values will be wrong, then reset to zero and then get populated with the correct values for the newly registered neuron. This change resets these values on neuron registration.

## Related Issue(s)
N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change
no

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

N/A

## Additional Notes

N/A