### PR TITLE
reset neuron data on registration

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1001,19 +1001,18 @@ pub mod pallet {
     pub(super) type Rank<T: Config> =
         StorageMap<_, Identity, u16, Vec<u16>, ValueQuery, EmptyU16Vec<T>>;
     #[pallet::storage] // --- DMAP ( netuid ) --> trust
-    pub(super) type Trust<T: Config> =
-        StorageMap<_, Identity, u16, Vec<u16>, ValueQuery, EmptyU16Vec<T>>;
+    pub type Trust<T: Config> = StorageMap<_, Identity, u16, Vec<u16>, ValueQuery, EmptyU16Vec<T>>;
     #[pallet::storage] // --- DMAP ( netuid ) --> consensus
-    pub(super) type Consensus<T: Config> =
+    pub type Consensus<T: Config> =
         StorageMap<_, Identity, u16, Vec<u16>, ValueQuery, EmptyU16Vec<T>>;
     #[pallet::storage] // --- DMAP ( netuid ) --> incentive
-    pub(super) type Incentive<T: Config> =
+    pub type Incentive<T: Config> =
         StorageMap<_, Identity, u16, Vec<u16>, ValueQuery, EmptyU16Vec<T>>;
     #[pallet::storage] // --- DMAP ( netuid ) --> dividends
-    pub(super) type Dividends<T: Config> =
+    pub type Dividends<T: Config> =
         StorageMap<_, Identity, u16, Vec<u16>, ValueQuery, EmptyU16Vec<T>>;
     #[pallet::storage] // --- DMAP ( netuid ) --> emission
-    pub(super) type Emission<T: Config> =
+    pub type Emission<T: Config> =
         StorageMap<_, Identity, u16, Vec<u64>, ValueQuery, EmptyU64Vec<T>>;
     #[pallet::storage] // --- DMAP ( netuid ) --> last_update
     pub(super) type LastUpdate<T: Config> =

--- a/pallets/subtensor/src/uids.rs
+++ b/pallets/subtensor/src/uids.rs
@@ -9,22 +9,6 @@ impl<T: Config> Pallet<T> {
         SubnetworkN::<T>::get(netuid)
     }
 
-    pub fn set_emission_for_uid(netuid: u16, neuron_uid: u16, emission: u64) {
-        Emission::<T>::mutate(netuid, |v| v[neuron_uid as usize] = emission);
-    }
-    pub fn set_trust_for_uid(netuid: u16, neuron_uid: u16, trust: u16) {
-        Trust::<T>::mutate(netuid, |v| v[neuron_uid as usize] = trust);
-    }
-    pub fn set_consensus_for_uid(netuid: u16, neuron_uid: u16, consensus: u16) {
-        Consensus::<T>::mutate(netuid, |v| v[neuron_uid as usize] = consensus);
-    }
-    pub fn set_incentive_for_uid(netuid: u16, neuron_uid: u16, incentive: u16) {
-        Incentive::<T>::mutate(netuid, |v| v[neuron_uid as usize] = incentive);
-    }
-    pub fn set_dividends_for_uid(netuid: u16, neuron_uid: u16, dividends: u16) {
-        Dividends::<T>::mutate(netuid, |v| v[neuron_uid as usize] = dividends);
-    }
-
     /// Replace the neuron under this uid.
     pub fn replace_neuron(
         netuid: u16,
@@ -63,11 +47,11 @@ impl<T: Config> Pallet<T> {
         IsNetworkMember::<T>::insert(new_hotkey.clone(), netuid, true); // Fill network is member.
 
         // 4. Reset trust, emission, consensus, incentive, dividends and axon_info for the new uid.
-        Self::set_trust_for_uid(netuid, uid_to_replace, 0);
-        Self::set_emission_for_uid(netuid, uid_to_replace, 0);
-        Self::set_consensus_for_uid(netuid, uid_to_replace, 0);
-        Self::set_incentive_for_uid(netuid, uid_to_replace, 0);
-        Self::set_dividends_for_uid(netuid, uid_to_replace, 0);
+        Emission::<T>::mutate(netuid, |v| v[uid_to_replace as usize] = 0);
+        Trust::<T>::mutate(netuid, |v| v[uid_to_replace as usize] = 0);
+        Consensus::<T>::mutate(netuid, |v| v[uid_to_replace as usize] = 0);
+        Incentive::<T>::mutate(netuid, |v| v[uid_to_replace as usize] = 0);
+        Dividends::<T>::mutate(netuid, |v| v[uid_to_replace as usize] = 0);
 
         // 4a. reset axon info for the new uid.
         Axons::<T>::remove(netuid, old_hotkey);

--- a/pallets/subtensor/src/uids.rs
+++ b/pallets/subtensor/src/uids.rs
@@ -9,6 +9,15 @@ impl<T: Config> Pallet<T> {
         SubnetworkN::<T>::get(netuid)
     }
 
+    /// Resets the trust, emission, consensus, incentive, dividends of the neuron to default
+    pub fn clear_neuron(netuid: u16, neuron_uid: u16) {
+        Emission::<T>::mutate(netuid, |v| v[neuron_uid as usize] = 0);
+        Trust::<T>::mutate(netuid, |v| v[neuron_uid as usize] = 0);
+        Consensus::<T>::mutate(netuid, |v| v[neuron_uid as usize] = 0);
+        Incentive::<T>::mutate(netuid, |v| v[neuron_uid as usize] = 0);
+        Dividends::<T>::mutate(netuid, |v| v[neuron_uid as usize] = 0);
+    }
+
     /// Replace the neuron under this uid.
     pub fn replace_neuron(
         netuid: u16,
@@ -46,12 +55,8 @@ impl<T: Config> Pallet<T> {
         BlockAtRegistration::<T>::insert(netuid, uid_to_replace, block_number); // Fill block at registration.
         IsNetworkMember::<T>::insert(new_hotkey.clone(), netuid, true); // Fill network is member.
 
-        // 4. Reset trust, emission, consensus, incentive, dividends and axon_info for the new uid.
-        Emission::<T>::mutate(netuid, |v| v[uid_to_replace as usize] = 0);
-        Trust::<T>::mutate(netuid, |v| v[uid_to_replace as usize] = 0);
-        Consensus::<T>::mutate(netuid, |v| v[uid_to_replace as usize] = 0);
-        Incentive::<T>::mutate(netuid, |v| v[uid_to_replace as usize] = 0);
-        Dividends::<T>::mutate(netuid, |v| v[uid_to_replace as usize] = 0);
+        // 4. Reset new neuron's values.
+        Self::clear_neuron(netuid, uid_to_replace);
 
         // 4a. reset axon info for the new uid.
         Axons::<T>::remove(netuid, old_hotkey);

--- a/pallets/subtensor/src/uids.rs
+++ b/pallets/subtensor/src/uids.rs
@@ -9,13 +9,24 @@ impl<T: Config> Pallet<T> {
         SubnetworkN::<T>::get(netuid)
     }
 
+    fn clear_element_at<N>(position: u16) -> impl Fn(&mut Vec<N>)
+    where
+        N: From<u8>,
+    {
+        move |vec: &mut Vec<N>| {
+            if vec.len() > position as usize {
+                vec[position as usize] = N::from(0);
+            };
+        }
+    }
+
     /// Resets the trust, emission, consensus, incentive, dividends of the neuron to default
     pub fn clear_neuron(netuid: u16, neuron_uid: u16) {
-        Emission::<T>::mutate(netuid, |v| v[neuron_uid as usize] = 0);
-        Trust::<T>::mutate(netuid, |v| v[neuron_uid as usize] = 0);
-        Consensus::<T>::mutate(netuid, |v| v[neuron_uid as usize] = 0);
-        Incentive::<T>::mutate(netuid, |v| v[neuron_uid as usize] = 0);
-        Dividends::<T>::mutate(netuid, |v| v[neuron_uid as usize] = 0);
+        Emission::<T>::mutate(netuid, Self::clear_element_at(neuron_uid));
+        Trust::<T>::mutate(netuid, Self::clear_element_at(neuron_uid));
+        Consensus::<T>::mutate(netuid, Self::clear_element_at(neuron_uid));
+        Incentive::<T>::mutate(netuid, Self::clear_element_at(neuron_uid));
+        Dividends::<T>::mutate(netuid, Self::clear_element_at(neuron_uid));
     }
 
     /// Replace the neuron under this uid.

--- a/pallets/subtensor/src/uids.rs
+++ b/pallets/subtensor/src/uids.rs
@@ -9,6 +9,8 @@ impl<T: Config> Pallet<T> {
         SubnetworkN::<T>::get(netuid)
     }
 
+    /// Returns a callback that sets the element at the given position to zero, doing nothing if the
+    /// position is out of bounds
     fn clear_element_at<N>(position: u16) -> impl Fn(&mut Vec<N>)
     where
         N: From<u8>,

--- a/pallets/subtensor/src/uids.rs
+++ b/pallets/subtensor/src/uids.rs
@@ -9,6 +9,22 @@ impl<T: Config> Pallet<T> {
         SubnetworkN::<T>::get(netuid)
     }
 
+    pub fn set_emission_for_uid(netuid: u16, neuron_uid: u16, emission: u64) {
+        Emission::<T>::mutate(netuid, |v| v[neuron_uid as usize] = emission);
+    }
+    pub fn set_trust_for_uid(netuid: u16, neuron_uid: u16, trust: u16) {
+        Trust::<T>::mutate(netuid, |v| v[neuron_uid as usize] = trust);
+    }
+    pub fn set_consensus_for_uid(netuid: u16, neuron_uid: u16, consensus: u16) {
+        Consensus::<T>::mutate(netuid, |v| v[neuron_uid as usize] = consensus);
+    }
+    pub fn set_incentive_for_uid(netuid: u16, neuron_uid: u16, incentive: u16) {
+        Incentive::<T>::mutate(netuid, |v| v[neuron_uid as usize] = incentive);
+    }
+    pub fn set_dividends_for_uid(netuid: u16, neuron_uid: u16, dividends: u16) {
+        Dividends::<T>::mutate(netuid, |v| v[neuron_uid as usize] = dividends);
+    }
+
     /// Replace the neuron under this uid.
     pub fn replace_neuron(
         netuid: u16,
@@ -45,6 +61,16 @@ impl<T: Config> Pallet<T> {
         Uids::<T>::insert(netuid, new_hotkey.clone(), uid_to_replace); // Make uid - hotkey association.
         BlockAtRegistration::<T>::insert(netuid, uid_to_replace, block_number); // Fill block at registration.
         IsNetworkMember::<T>::insert(new_hotkey.clone(), netuid, true); // Fill network is member.
+
+        // 4. Reset trust, emission, consensus, incentive, dividends and axon_info for the new uid.
+        Self::set_trust_for_uid(netuid, uid_to_replace, 0);
+        Self::set_emission_for_uid(netuid, uid_to_replace, 0);
+        Self::set_consensus_for_uid(netuid, uid_to_replace, 0);
+        Self::set_incentive_for_uid(netuid, uid_to_replace, 0);
+        Self::set_dividends_for_uid(netuid, uid_to_replace, 0);
+
+        // 4a. reset axon info for the new uid.
+        Axons::<T>::remove(netuid, old_hotkey);
     }
 
     /// Appends the uid to the network.

--- a/pallets/subtensor/tests/uids.rs
+++ b/pallets/subtensor/tests/uids.rs
@@ -48,14 +48,37 @@ fn test_replace_neuron() {
         // Get UID
         let neuron_uid = SubtensorModule::get_uid_for_net_and_hotkey(netuid, &hotkey_account_id);
         assert_ok!(neuron_uid);
+        let neuron_uid = neuron_uid.unwrap();
+
+        // set non-default values
+        SubtensorModule::set_trust_for_uid(netuid, neuron_uid, 5u16);
+        SubtensorModule::set_emission_for_uid(netuid, neuron_uid, 5u64);
+        SubtensorModule::set_consensus_for_uid(netuid, neuron_uid, 5u16);
+        SubtensorModule::set_incentive_for_uid(netuid, neuron_uid, 5u16);
+        SubtensorModule::set_dividends_for_uid(netuid, neuron_uid, 5u16);
+
+        // serve axon mock address
+        let ip: u128 = 1676056785;
+        let port: u16 = 9999;
+        let ip_type: u8 = 4;
+        let hotkey = SubtensorModule::get_hotkey_for_net_and_uid(netuid, neuron_uid).unwrap();
+        assert!(SubtensorModule::serve_axon(
+            <<Test as Config>::RuntimeOrigin>::signed(hotkey_account_id),
+            netuid,
+            0,
+            ip,
+            port,
+            ip_type,
+            0,
+            0,
+            0
+        )
+        .is_ok());
 
         // Replace the neuron.
-        SubtensorModule::replace_neuron(
-            netuid,
-            neuron_uid.unwrap(),
-            &new_hotkey_account_id,
-            block_number,
-        );
+        SubtensorModule::replace_neuron(netuid, neuron_uid, &new_hotkey_account_id, block_number);
+
+        assert!(!SubtensorModule::has_axon_info(netuid, &hotkey));
 
         // Check old hotkey is not registered on any network.
         assert!(SubtensorModule::get_uid_for_net_and_hotkey(netuid, &hotkey_account_id).is_err());
@@ -63,7 +86,7 @@ fn test_replace_neuron() {
             &hotkey_account_id
         ));
 
-        let curr_hotkey = SubtensorModule::get_hotkey_for_net_and_uid(netuid, neuron_uid.unwrap());
+        let curr_hotkey = SubtensorModule::get_hotkey_for_net_and_uid(netuid, neuron_uid);
         assert_ok!(curr_hotkey);
         assert_ne!(curr_hotkey.unwrap(), hotkey_account_id);
 
@@ -75,6 +98,33 @@ fn test_replace_neuron() {
             &new_hotkey_account_id
         ));
         assert_eq!(curr_hotkey.unwrap(), new_hotkey_account_id);
+
+        // Check trust, emission, consensus, incentive, dividends have been reset to 0.
+        assert_eq!(SubtensorModule::get_trust_for_uid(netuid, neuron_uid), 0);
+        assert_eq!(SubtensorModule::get_emission_for_uid(netuid, neuron_uid), 0);
+        assert_eq!(
+            SubtensorModule::get_consensus_for_uid(netuid, neuron_uid),
+            0
+        );
+        assert_eq!(
+            SubtensorModule::get_incentive_for_uid(netuid, neuron_uid),
+            0
+        );
+        assert_eq!(
+            SubtensorModule::get_dividends_for_uid(netuid, neuron_uid),
+            0
+        );
+
+        assert!(!SubtensorModule::has_axon_info(
+            netuid,
+            &new_hotkey_account_id
+        ));
+
+        // Check axon info is reset.
+        let axon_info = SubtensorModule::get_axon_info(netuid, &curr_hotkey.unwrap());
+        assert_eq!(axon_info.ip, 0);
+        assert_eq!(axon_info.port, 0);
+        assert_eq!(axon_info.ip_type, 0);
     });
 }
 

--- a/pallets/subtensor/tests/uids.rs
+++ b/pallets/subtensor/tests/uids.rs
@@ -1,6 +1,7 @@
 use crate::mock::*;
 use frame_support::assert_ok;
 use frame_system::Config;
+use pallet_subtensor::*;
 use sp_core::U256;
 
 mod mock;
@@ -51,11 +52,11 @@ fn test_replace_neuron() {
         let neuron_uid = neuron_uid.unwrap();
 
         // set non-default values
-        SubtensorModule::set_trust_for_uid(netuid, neuron_uid, 5u16);
-        SubtensorModule::set_emission_for_uid(netuid, neuron_uid, 5u64);
-        SubtensorModule::set_consensus_for_uid(netuid, neuron_uid, 5u16);
-        SubtensorModule::set_incentive_for_uid(netuid, neuron_uid, 5u16);
-        SubtensorModule::set_dividends_for_uid(netuid, neuron_uid, 5u16);
+        Trust::<Test>::mutate(netuid, |v| v[neuron_uid as usize] = 5u16);
+        Emission::<Test>::mutate(netuid, |v| v[neuron_uid as usize] = 5u64);
+        Consensus::<Test>::mutate(netuid, |v| v[neuron_uid as usize] = 5u16);
+        Incentive::<Test>::mutate(netuid, |v| v[neuron_uid as usize] = 5u16);
+        Dividends::<Test>::mutate(netuid, |v| v[neuron_uid as usize] = 5u16);
 
         // serve axon mock address
         let ip: u128 = 1676056785;


### PR DESCRIPTION
## Description

On neuron registration the trust, emission, consensus, incentive, dividends values as well as axon info associated with the assigned neuron_uid are inherited from the previous neuron. Thus for the first few blocks after registration these values will be wrong, then reset to zero and then get populated with the correct values for the newly registered neuron. This change resets these values on neuron registration.

## Related Issue(s)
N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change
no

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

N/A

## Additional Notes

N/A