### PR TITLE
[Fix] Run epoch no emission

### DIFF
--- a/pallets/subtensor/src/block_step.rs
+++ b/pallets/subtensor/src/block_step.rs
@@ -110,13 +110,17 @@ impl<T: Config> Pallet<T> {
         // --- 1. Iterate across each network and add pending emission into stash.
         for (netuid, tempo) in <Tempo<T> as IterableStorageMap<u16, u16>>::iter() {
             // Skip the root network or subnets with registrations turned off
-            if netuid == Self::get_root_netuid() || !Self::is_registration_allowed(netuid) {
+            if netuid == Self::get_root_netuid() {
                 // Root emission or subnet emission is burned
                 continue;
             }
 
             // --- 2. Queue the emission due to this network.
-            let new_queued_emission: u64 = Self::get_subnet_emission_value(netuid);
+            let mut new_queued_emission: u64 = Self::get_subnet_emission_value(netuid);
+			if !Self::is_registration_allowed(netuid) {
+				new_queued_emission = 0; // No emission for this network if registration is off.
+			}
+
             log::debug!(
                 "generate_emission for netuid: {:?} with tempo: {:?} and emission: {:?}",
                 netuid,

--- a/pallets/subtensor/tests/block_step.rs
+++ b/pallets/subtensor/tests/block_step.rs
@@ -894,3 +894,42 @@ fn test_emission_based_on_registration_status() {
         );
     });
 }
+
+#[test]
+fn test_epoch_runs_when_registration_disabled() {
+    new_test_ext(1).execute_with(|| {
+        let n: u16 = 100;
+        let netuid_off: u16 = 1;
+        let tempo: u16 = 1;
+        let netuids: Vec<u16> = vec![netuid_off];
+        let emissions: Vec<u64> = vec![1000000000];
+
+        // Add subnets with registration turned off and on
+        add_network(netuid_off, tempo, 0);
+        SubtensorModule::set_max_allowed_uids(netuid_off, n);
+        SubtensorModule::set_emission_values(&netuids, emissions).unwrap();
+        SubtensorModule::set_network_registration_allowed(netuid_off, false);
+
+        // Populate the subnets with neurons
+        for i in 0..n {
+            SubtensorModule::append_neuron(netuid_off, &U256::from(i), 0);
+        }
+
+        // Generate emission at block 1
+        let block: u64 = 1;
+        SubtensorModule::generate_emission(block);
+
+		step_block(1); // Now block 2
+
+		// Verify blocks since last step was set
+		assert_eq!(SubtensorModule::get_blocks_since_last_step(netuid_off), 1);
+
+        // Step to the next epoch block
+        let epoch_block: u16 = tempo;
+        step_block(epoch_block);
+
+		// Verify blocks since last step was set, this indicates we ran the epoch
+		assert_eq!(SubtensorModule::get_blocks_since_last_step(netuid_off), 0 as u64);
+		assert!(SubtensorModule::get_loaded_emission_tuples(netuid_off).is_some());
+    });
+}


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
When a subnet has a disabled registration during the epoch, we skip giving it emission. This was implemented in #474 but accidentally also skipped the epoch, making the incentive not update as we would expect. This fix emits 0 emission instead of exiting the epoch early.

## Related Issue(s)

- Fixes bug from #474 

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):


## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
