### PR TITLE
Add unit test for stake-unstake total issuance

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -672,9 +672,9 @@ pub mod pallet {
         ///  Axon version
         pub version: u32,
         ///  Axon u128 encoded ip address of type v6 or v4.
-        pub port: u16,
-        ///  Axon u16 encoded port.
         pub ip: u128,
+        ///  Axon u16 encoded port.
+        pub port: u16,
         ///  Axon ip type, 4 for ipv4 and 6 for ipv6.
         pub ip_type: u8,
         ///  Axon protocol. TCP, UDP, other.

--- a/pallets/subtensor/tests/staking.rs
+++ b/pallets/subtensor/tests/staking.rs
@@ -3151,9 +3151,12 @@ fn test_stake_unstake_total_issuance_ok() {
             SubtensorModule::get_min_take()
         ));
 
-        // Total issuance in balances pallet should be equal to stake + lock amount 
+        // Total issuance in balances pallet should be equal to stake + lock amount
         // because we don't reserve lock amount in tests
-        assert_eq!(pallet_balances::TotalIssuance::<Test>::get(), lock_amount + stake);
+        assert_eq!(
+            pallet_balances::TotalIssuance::<Test>::get(),
+            lock_amount + stake
+        );
 
         assert_ok!(SubtensorModule::add_stake(
             <<Test as Config>::RuntimeOrigin>::signed(coldkey2),
@@ -3162,7 +3165,10 @@ fn test_stake_unstake_total_issuance_ok() {
         ));
 
         // Total issuance goes down to lock_amount + ED because we staked everything
-        assert_eq!(pallet_balances::TotalIssuance::<Test>::get(), lock_amount + ed);
+        assert_eq!(
+            pallet_balances::TotalIssuance::<Test>::get(),
+            lock_amount + ed
+        );
 
         // Unstake everything
         assert_ok!(SubtensorModule::remove_stake(
@@ -3172,6 +3178,9 @@ fn test_stake_unstake_total_issuance_ok() {
         ));
 
         // Total issuance goes up to lock_amount + stake because we unstaked everything and got the balance back
-        assert_eq!(pallet_balances::TotalIssuance::<Test>::get(), lock_amount + stake);
+        assert_eq!(
+            pallet_balances::TotalIssuance::<Test>::get(),
+            lock_amount + stake
+        );
     });
 }


### PR DESCRIPTION
## Description
The added tests proves that we have accurate accounting for total issuance when staking and unstaking.

## Related Issue(s)

n/a

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please describe): More tests

## Breaking Change

n/a

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

n/a

## Additional Notes

n/a
