### PR TITLE
hotfix/set-root-weights

### DIFF
--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -65,101 +65,101 @@ jobs:
       - name: cargo fmt
         run: cargo fmt --check --all
 
-  # cargo-clippy-default-features:
-  #   name: cargo clippy
-  #   runs-on: SubtensorCI
-  #   strategy:
-  #     matrix:
-  #       rust-branch:
-  #         - stable
-  #       rust-target:
-  #         - x86_64-unknown-linux-gnu
-  #         # - x86_64-apple-darwin
-  #       os:
-  #         - ubuntu-latest
-  #         # - macos-latest
-  #       include:
-  #         - os: ubuntu-latest
-  #         # - os: macos-latest
-  #   env:
-  #     RELEASE_NAME: development
-  #     # RUSTFLAGS: -A warnings
-  #     RUSTV: ${{ matrix.rust-branch }}
-  #     RUST_BACKTRACE: full
-  #     RUST_BIN_DIR: target/${{ matrix.rust-target }}
-  #     SKIP_WASM_BUILD: 1
-  #     TARGET: ${{ matrix.rust-target }}
-  #   steps:
-  #     - name: Check-out repository under $GITHUB_WORKSPACE
-  #       uses: actions/checkout@v4
+  cargo-clippy-default-features:
+    name: cargo clippy
+    runs-on: SubtensorCI
+    strategy:
+      matrix:
+        rust-branch:
+          - stable
+        rust-target:
+          - x86_64-unknown-linux-gnu
+          # - x86_64-apple-darwin
+        os:
+          - ubuntu-latest
+          # - macos-latest
+        include:
+          - os: ubuntu-latest
+          # - os: macos-latest
+    env:
+      RELEASE_NAME: development
+      # RUSTFLAGS: -A warnings
+      RUSTV: ${{ matrix.rust-branch }}
+      RUST_BACKTRACE: full
+      RUST_BIN_DIR: target/${{ matrix.rust-target }}
+      SKIP_WASM_BUILD: 1
+      TARGET: ${{ matrix.rust-target }}
+    steps:
+      - name: Check-out repository under $GITHUB_WORKSPACE
+        uses: actions/checkout@v4
 
-  #     - name: Install dependencies
-  #       run: |
-  #         sudo apt-get update &&
-  #         sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
+      - name: Install dependencies
+        run: |
+          sudo apt-get update &&
+          sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
 
-  #     - name: Install Rust ${{ matrix.rust-branch }}
-  #       uses: actions-rs/toolchain@v1.0.6
-  #       with:
-  #         toolchain: ${{ matrix.rust-branch }}
-  #         components: rustfmt, clippy
-  #         profile: minimal
+      - name: Install Rust ${{ matrix.rust-branch }}
+        uses: actions-rs/toolchain@v1.0.6
+        with:
+          toolchain: ${{ matrix.rust-branch }}
+          components: rustfmt, clippy
+          profile: minimal
 
-  #     - name: Utilize Shared Rust Cache
-  #       uses: Swatinem/rust-cache@v2.2.1
-  #       with:
-  #         key: ${{ matrix.os }}-${{ env.RUST_BIN_DIR }}
+      - name: Utilize Shared Rust Cache
+        uses: Swatinem/rust-cache@v2.2.1
+        with:
+          key: ${{ matrix.os }}-${{ env.RUST_BIN_DIR }}
 
-  #     - name: cargo clippy --workspace --all-targets -- -D warnings
-  #       run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
-  # cargo-clippy-all-features:
-  #   name: cargo clippy --all-features
-  #   runs-on: SubtensorCI
-  #   strategy:
-  #     matrix:
-  #       rust-branch:
-  #         - stable
-  #       rust-target:
-  #         - x86_64-unknown-linux-gnu
-  #         # - x86_64-apple-darwin
-  #       os:
-  #         - ubuntu-latest
-  #         # - macos-latest
-  #       include:
-  #         - os: ubuntu-latest
-  #         # - os: macos-latest
-  #   env:
-  #     RELEASE_NAME: development
-  #     # RUSTFLAGS: -A warnings
-  #     RUSTV: ${{ matrix.rust-branch }}
-  #     RUST_BACKTRACE: full
-  #     RUST_BIN_DIR: target/${{ matrix.rust-target }}
-  #     SKIP_WASM_BUILD: 1
-  #     TARGET: ${{ matrix.rust-target }}
-  #   steps:
-  #     - name: Check-out repository under $GITHUB_WORKSPACE
-  #       uses: actions/checkout@v2
+  cargo-clippy-all-features:
+    name: cargo clippy --all-features
+    runs-on: SubtensorCI
+    strategy:
+      matrix:
+        rust-branch:
+          - stable
+        rust-target:
+          - x86_64-unknown-linux-gnu
+          # - x86_64-apple-darwin
+        os:
+          - ubuntu-latest
+          # - macos-latest
+        include:
+          - os: ubuntu-latest
+          # - os: macos-latest
+    env:
+      RELEASE_NAME: development
+      # RUSTFLAGS: -A warnings
+      RUSTV: ${{ matrix.rust-branch }}
+      RUST_BACKTRACE: full
+      RUST_BIN_DIR: target/${{ matrix.rust-target }}
+      SKIP_WASM_BUILD: 1
+      TARGET: ${{ matrix.rust-target }}
+    steps:
+      - name: Check-out repository under $GITHUB_WORKSPACE
+        uses: actions/checkout@v2
 
-  #     - name: Install dependencies
-  #       run: |
-  #         sudo apt-get update &&
-  #         sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
+      - name: Install dependencies
+        run: |
+          sudo apt-get update &&
+          sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
 
-  #     - name: Install Rust ${{ matrix.rust-branch }}
-  #       uses: actions-rs/toolchain@v1.0.6
-  #       with:
-  #         toolchain: ${{ matrix.rust-branch }}
-  #         components: rustfmt, clippy
-  #         profile: minimal
+      - name: Install Rust ${{ matrix.rust-branch }}
+        uses: actions-rs/toolchain@v1.0.6
+        with:
+          toolchain: ${{ matrix.rust-branch }}
+          components: rustfmt, clippy
+          profile: minimal
 
-  #     - name: Utilize Shared Rust Cache
-  #       uses: Swatinem/rust-cache@v2.2.1
-  #       with:
-  #         key: ${{ matrix.os }}-${{ env.RUST_BIN_DIR }}
+      - name: Utilize Shared Rust Cache
+        uses: Swatinem/rust-cache@v2.2.1
+        with:
+          key: ${{ matrix.os }}-${{ env.RUST_BIN_DIR }}
 
-  #     - name: cargo clippy --workspace --all-targets --all-features -- -D warnings
-  #       run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - name: cargo clippy --workspace --all-targets --all-features -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
   # runs cargo test --workspace
   cargo-test:
     name: cargo test

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -65,101 +65,101 @@ jobs:
       - name: cargo fmt
         run: cargo fmt --check --all
 
-  cargo-clippy-default-features:
-    name: cargo clippy
-    runs-on: SubtensorCI
-    strategy:
-      matrix:
-        rust-branch:
-          - stable
-        rust-target:
-          - x86_64-unknown-linux-gnu
-          # - x86_64-apple-darwin
-        os:
-          - ubuntu-latest
-          # - macos-latest
-        include:
-          - os: ubuntu-latest
-          # - os: macos-latest
-    env:
-      RELEASE_NAME: development
-      # RUSTFLAGS: -A warnings
-      RUSTV: ${{ matrix.rust-branch }}
-      RUST_BACKTRACE: full
-      RUST_BIN_DIR: target/${{ matrix.rust-target }}
-      SKIP_WASM_BUILD: 1
-      TARGET: ${{ matrix.rust-target }}
-    steps:
-      - name: Check-out repository under $GITHUB_WORKSPACE
-        uses: actions/checkout@v4
+  # cargo-clippy-default-features:
+  #   name: cargo clippy
+  #   runs-on: SubtensorCI
+  #   strategy:
+  #     matrix:
+  #       rust-branch:
+  #         - stable
+  #       rust-target:
+  #         - x86_64-unknown-linux-gnu
+  #         # - x86_64-apple-darwin
+  #       os:
+  #         - ubuntu-latest
+  #         # - macos-latest
+  #       include:
+  #         - os: ubuntu-latest
+  #         # - os: macos-latest
+  #   env:
+  #     RELEASE_NAME: development
+  #     # RUSTFLAGS: -A warnings
+  #     RUSTV: ${{ matrix.rust-branch }}
+  #     RUST_BACKTRACE: full
+  #     RUST_BIN_DIR: target/${{ matrix.rust-target }}
+  #     SKIP_WASM_BUILD: 1
+  #     TARGET: ${{ matrix.rust-target }}
+  #   steps:
+  #     - name: Check-out repository under $GITHUB_WORKSPACE
+  #       uses: actions/checkout@v4
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update &&
-          sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
+  #     - name: Install dependencies
+  #       run: |
+  #         sudo apt-get update &&
+  #         sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
 
-      - name: Install Rust ${{ matrix.rust-branch }}
-        uses: actions-rs/toolchain@v1.0.6
-        with:
-          toolchain: ${{ matrix.rust-branch }}
-          components: rustfmt, clippy
-          profile: minimal
+  #     - name: Install Rust ${{ matrix.rust-branch }}
+  #       uses: actions-rs/toolchain@v1.0.6
+  #       with:
+  #         toolchain: ${{ matrix.rust-branch }}
+  #         components: rustfmt, clippy
+  #         profile: minimal
 
-      - name: Utilize Shared Rust Cache
-        uses: Swatinem/rust-cache@v2.2.1
-        with:
-          key: ${{ matrix.os }}-${{ env.RUST_BIN_DIR }}
+  #     - name: Utilize Shared Rust Cache
+  #       uses: Swatinem/rust-cache@v2.2.1
+  #       with:
+  #         key: ${{ matrix.os }}-${{ env.RUST_BIN_DIR }}
 
-      - name: cargo clippy --workspace --all-targets -- -D warnings
-        run: cargo clippy --workspace --all-targets -- -D warnings
+  #     - name: cargo clippy --workspace --all-targets -- -D warnings
+  #       run: cargo clippy --workspace --all-targets -- -D warnings
 
-  cargo-clippy-all-features:
-    name: cargo clippy --all-features
-    runs-on: SubtensorCI
-    strategy:
-      matrix:
-        rust-branch:
-          - stable
-        rust-target:
-          - x86_64-unknown-linux-gnu
-          # - x86_64-apple-darwin
-        os:
-          - ubuntu-latest
-          # - macos-latest
-        include:
-          - os: ubuntu-latest
-          # - os: macos-latest
-    env:
-      RELEASE_NAME: development
-      # RUSTFLAGS: -A warnings
-      RUSTV: ${{ matrix.rust-branch }}
-      RUST_BACKTRACE: full
-      RUST_BIN_DIR: target/${{ matrix.rust-target }}
-      SKIP_WASM_BUILD: 1
-      TARGET: ${{ matrix.rust-target }}
-    steps:
-      - name: Check-out repository under $GITHUB_WORKSPACE
-        uses: actions/checkout@v2
+  # cargo-clippy-all-features:
+  #   name: cargo clippy --all-features
+  #   runs-on: SubtensorCI
+  #   strategy:
+  #     matrix:
+  #       rust-branch:
+  #         - stable
+  #       rust-target:
+  #         - x86_64-unknown-linux-gnu
+  #         # - x86_64-apple-darwin
+  #       os:
+  #         - ubuntu-latest
+  #         # - macos-latest
+  #       include:
+  #         - os: ubuntu-latest
+  #         # - os: macos-latest
+  #   env:
+  #     RELEASE_NAME: development
+  #     # RUSTFLAGS: -A warnings
+  #     RUSTV: ${{ matrix.rust-branch }}
+  #     RUST_BACKTRACE: full
+  #     RUST_BIN_DIR: target/${{ matrix.rust-target }}
+  #     SKIP_WASM_BUILD: 1
+  #     TARGET: ${{ matrix.rust-target }}
+  #   steps:
+  #     - name: Check-out repository under $GITHUB_WORKSPACE
+  #       uses: actions/checkout@v2
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update &&
-          sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
+  #     - name: Install dependencies
+  #       run: |
+  #         sudo apt-get update &&
+  #         sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
 
-      - name: Install Rust ${{ matrix.rust-branch }}
-        uses: actions-rs/toolchain@v1.0.6
-        with:
-          toolchain: ${{ matrix.rust-branch }}
-          components: rustfmt, clippy
-          profile: minimal
+  #     - name: Install Rust ${{ matrix.rust-branch }}
+  #       uses: actions-rs/toolchain@v1.0.6
+  #       with:
+  #         toolchain: ${{ matrix.rust-branch }}
+  #         components: rustfmt, clippy
+  #         profile: minimal
 
-      - name: Utilize Shared Rust Cache
-        uses: Swatinem/rust-cache@v2.2.1
-        with:
-          key: ${{ matrix.os }}-${{ env.RUST_BIN_DIR }}
+  #     - name: Utilize Shared Rust Cache
+  #       uses: Swatinem/rust-cache@v2.2.1
+  #       with:
+  #         key: ${{ matrix.os }}-${{ env.RUST_BIN_DIR }}
 
-      - name: cargo clippy --workspace --all-targets --all-features -- -D warnings
-        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+  #     - name: cargo clippy --workspace --all-targets --all-features -- -D warnings
+  #       run: cargo clippy --workspace --all-targets --all-features -- -D warnings
   # runs cargo test --workspace
   cargo-test:
     name: cargo test

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -160,55 +160,6 @@ jobs:
 
       - name: cargo clippy --workspace --all-targets --all-features -- -D warnings
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
-
-  cargo-clippy-all-features:
-    name: cargo clippy --all-features
-    runs-on: SubtensorCI
-    strategy:
-      matrix:
-        rust-branch:
-          - nightly-2024-03-05
-        rust-target:
-          - x86_64-unknown-linux-gnu
-          # - x86_64-apple-darwin
-        os:
-          - ubuntu-latest
-          # - macos-latest
-        include:
-          - os: ubuntu-latest
-          # - os: macos-latest
-    env:
-      RELEASE_NAME: development
-      # RUSTFLAGS: -A warnings
-      RUSTV: ${{ matrix.rust-branch }}
-      RUST_BACKTRACE: full
-      RUST_BIN_DIR: target/${{ matrix.rust-target }}
-      SKIP_WASM_BUILD: 1
-      TARGET: ${{ matrix.rust-target }}
-    steps:
-      - name: Check-out repository under $GITHUB_WORKSPACE
-        uses: actions/checkout@v2
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update &&
-          sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
-
-      - name: Install Rust ${{ matrix.rust-branch }}
-        uses: actions-rs/toolchain@v1.0.6
-        with:
-          toolchain: ${{ matrix.rust-branch }}
-          components: rustfmt, clippy
-          profile: minimal
-
-      - name: Utilize Shared Rust Cache
-        uses: Swatinem/rust-cache@v2.2.1
-        with:
-          key: ${{ matrix.os }}-${{ env.RUST_BIN_DIR }}
-
-      - name: cargo clippy --workspace --all-targets --all-features -- -D warnings
-        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
-
   # runs cargo test --workspace
   cargo-test:
     name: cargo test

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -6,7 +6,7 @@ concurrency:
 
 on:
   push:
-    # branches: [main, devnet-ready, devnet, testnet, finney]
+    branches: [main, devnet-ready, devnet, testnet, finney]
 
   pull_request:
 

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -6,7 +6,7 @@ concurrency:
 
 on:
   push:
-    branches: [main, devnet-ready, devnet, testnet, finney]
+    # branches: [main, devnet-ready, devnet, testnet, finney]
 
   pull_request:
 

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -71,7 +71,7 @@ jobs:
     strategy:
       matrix:
         rust-branch:
-          - nightly-2024-03-05
+          - stable
         rust-target:
           - x86_64-unknown-linux-gnu
           # - x86_64-apple-darwin
@@ -119,7 +119,7 @@ jobs:
     strategy:
       matrix:
         rust-branch:
-          - nightly-2024-03-05
+          - stable
         rust-target:
           - x86_64-unknown-linux-gnu
           # - x86_64-apple-darwin
@@ -167,7 +167,7 @@ jobs:
     strategy:
       matrix:
         rust-branch:
-          - nightly-2024-03-05
+          - stable
         rust-target:
           - x86_64-unknown-linux-gnu
           # - x86_64-apple-darwin
@@ -216,7 +216,7 @@ jobs:
     strategy:
       matrix:
         rust-branch:
-          - nightly-2024-03-05
+          - stable
         rust-target:
           - x86_64-unknown-linux-gnu
           # - x86_64-apple-darwin
@@ -265,7 +265,7 @@ jobs:
     strategy:
       matrix:
         rust-branch:
-          - nightly-2024-03-05
+          - stable
         rust-target:
           - x86_64-unknown-linux-gnu
           # - x86_64-apple-darwin

--- a/.github/workflows/e2e-bittensor-tests.yml
+++ b/.github/workflows/e2e-bittensor-tests.yml
@@ -82,4 +82,4 @@ jobs:
         run: |
           pwd
           ls
-          LOCALNET_SH_PATH="${{ github.workspace }}/scripts/localnet.sh" pytest tests/e2e_tests/ -s
+          LOCALNET_SH_PATH="${{ github.workspace }}/scripts/localnet.sh False" pytest tests/e2e_tests/ -s

--- a/.github/workflows/e2e-bittensor-tests.yml
+++ b/.github/workflows/e2e-bittensor-tests.yml
@@ -82,4 +82,4 @@ jobs:
         run: |
           pwd
           ls
-          LOCALNET_SH_PATH="${{ github.workspace }}/scripts/localnet.sh False" pytest tests/e2e_tests/ -s
+          LOCALNET_SH_PATH="${{ github.workspace }}/scripts/localnet.sh" pytest tests/e2e_tests/ -s

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -42,7 +42,7 @@ pub struct FullDeps<C, P, B> {
     /// Grandpa block import setup.
     pub grandpa: GrandpaDeps<B>,
     /// Backend used by the node.
-    pub backend: Arc<B>,
+    pub _backend: Arc<B>,
 }
 
 /// Instantiate all full RPC extensions.

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -74,7 +74,7 @@ where
         pool,
         deny_unsafe,
         grandpa,
-        backend: _,
+        _backend: _,
     } = deps;
 
     // Custom RPC methods for Paratensor

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -266,7 +266,7 @@ pub fn new_full(config: Configuration) -> Result<TaskManager, ServiceError> {
                         subscription_executor: subscription_executor.clone(),
                         finality_provider: finality_proof_provider.clone(),
                     },
-                    backend: rpc_backend.clone(),
+                    _backend: rpc_backend.clone(),
                 };
                 crate::rpc::create_full(deps).map_err(Into::into)
             },

--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -7,7 +7,6 @@ pub use weights::WeightInfo;
 use sp_runtime::DispatchError;
 use sp_runtime::{traits::Member, RuntimeAppPublic};
 
-#[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
 
 #[deny(missing_docs)]

--- a/pallets/commitments/src/lib.rs
+++ b/pallets/commitments/src/lib.rs
@@ -234,7 +234,7 @@ where
     pub fn get_priority_vanilla() -> u64 {
         // Return high priority so that every extrinsic except set_weights function will
         // have a higher priority than the set_weights call
-        u64::max_value()
+        u64::MAX()
     }
 }
 

--- a/pallets/commitments/src/lib.rs
+++ b/pallets/commitments/src/lib.rs
@@ -234,7 +234,7 @@ where
     pub fn get_priority_vanilla() -> u64 {
         // Return high priority so that every extrinsic except set_weights function will
         // have a higher priority than the set_weights call
-        u64::MAX()
+        u64::MAX
     }
 }
 

--- a/pallets/commitments/src/lib.rs
+++ b/pallets/commitments/src/lib.rs
@@ -1,10 +1,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+mod benchmarking;
 #[cfg(test)]
 mod tests;
-
-#[cfg(feature = "runtime-benchmarks")]
-mod benchmarking;
 
 pub mod types;
 pub mod weights;

--- a/pallets/registry/src/lib.rs
+++ b/pallets/registry/src/lib.rs
@@ -3,7 +3,6 @@
 #[cfg(test)]
 mod tests;
 
-#[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
 pub mod types;
 pub mod weights;

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -2063,7 +2063,7 @@ pub mod pallet {
                 let current_block_number: u64 = Self::get_current_block_as_u64();
                 let default_priority: u64 =
                     current_block_number - Self::get_last_update_for_uid(netuid, uid);
-                return default_priority + u32::max_value() as u64;
+                return default_priority + u32::MAX as u64;
             }
             0
         }
@@ -2141,7 +2141,7 @@ where
     pub fn get_priority_vanilla() -> u64 {
         // Return high priority so that every extrinsic except set_weights function will
         // have a higher priority than the set_weights call
-        u64::max_value()
+        u64::MAX
     }
 
     pub fn get_priority_set_weights(who: &T::AccountId, netuid: u16) -> u64 {

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -2221,7 +2221,7 @@ where
             }
             Some(Call::set_root_weights { netuid, hotkey,  .. }) => {
                 if Self::check_weights_min_stake(hotkey) {
-                    let priority: u64 = Self::get_priority_set_weights(who, *netuid);
+                    let priority: u64 = Self::get_priority_set_weights(hotkey, *netuid);
                     Ok(ValidTransaction {
                         priority,
                         longevity: 1,

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -2219,7 +2219,7 @@ where
                     Err(InvalidTransaction::Call.into())
                 }
             }
-            Some(Call::set_root_weights { netuid, hotkey,  .. }) => {
+            Some(Call::set_root_weights { netuid, hotkey, .. }) => {
                 if Self::check_weights_min_stake(hotkey) {
                     let priority: u64 = Self::get_priority_set_weights(hotkey, *netuid);
                     Ok(ValidTransaction {

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -2219,8 +2219,8 @@ where
                     Err(InvalidTransaction::Call.into())
                 }
             }
-            Some(Call::set_root_weights { netuid, .. }) => {
-                if Self::check_weights_min_stake(who) {
+            Some(Call::set_root_weights { netuid, hotkey,  .. }) => {
+                if Self::check_weights_min_stake(hotkey) {
                     let priority: u64 = Self::get_priority_set_weights(who, *netuid);
                     Ok(ValidTransaction {
                         priority,

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -29,7 +29,6 @@ use sp_std::marker::PhantomData;
 // ============================
 //	==== Benchmark Imports =====
 // ============================
-#[cfg(feature = "runtime-benchmarks")]
 mod benchmarks;
 
 // =========================

--- a/pallets/subtensor/src/root.rs
+++ b/pallets/subtensor/src/root.rs
@@ -1009,12 +1009,12 @@ impl<T: Config> Pallet<T> {
         NetworkRegisteredAt::<T>::remove(netuid);
 
         // --- 8. Remove incentive mechanism memory.
-        let _ = Uids::<T>::clear_prefix(netuid, u32::MAX(), None);
-        let _ = Keys::<T>::clear_prefix(netuid, u32::MAX(), None);
-        let _ = Bonds::<T>::clear_prefix(netuid, u32::MAX(), None);
+        let _ = Uids::<T>::clear_prefix(netuid, u32::MAX, None);
+        let _ = Keys::<T>::clear_prefix(netuid, u32::MAX, None);
+        let _ = Bonds::<T>::clear_prefix(netuid, u32::MAX, None);
 
         // --- 8. Removes the weights for this subnet (do not remove).
-        let _ = Weights::<T>::clear_prefix(netuid, u32::MAX(), None);
+        let _ = Weights::<T>::clear_prefix(netuid, u32::MAX, None);
 
         // --- 9. Iterate over stored weights and fill the matrix.
         for (uid_i, weights_i) in

--- a/pallets/subtensor/src/root.rs
+++ b/pallets/subtensor/src/root.rs
@@ -1009,12 +1009,12 @@ impl<T: Config> Pallet<T> {
         NetworkRegisteredAt::<T>::remove(netuid);
 
         // --- 8. Remove incentive mechanism memory.
-        let _ = Uids::<T>::clear_prefix(netuid, u32::max_value(), None);
-        let _ = Keys::<T>::clear_prefix(netuid, u32::max_value(), None);
-        let _ = Bonds::<T>::clear_prefix(netuid, u32::max_value(), None);
+        let _ = Uids::<T>::clear_prefix(netuid, u32::MAX(), None);
+        let _ = Keys::<T>::clear_prefix(netuid, u32::MAX(), None);
+        let _ = Bonds::<T>::clear_prefix(netuid, u32::MAX(), None);
 
         // --- 8. Removes the weights for this subnet (do not remove).
-        let _ = Weights::<T>::clear_prefix(netuid, u32::max_value(), None);
+        let _ = Weights::<T>::clear_prefix(netuid, u32::MAX(), None);
 
         // --- 9. Iterate over stored weights and fill the matrix.
         for (uid_i, weights_i) in

--- a/pallets/subtensor/src/weights.rs
+++ b/pallets/subtensor/src/weights.rs
@@ -405,7 +405,7 @@ impl<T: Config> Pallet<T> {
             return weights;
         }
         weights.iter_mut().for_each(|x| {
-            *x = (*x as u64 * u16::max_value() as u64 / sum) as u16;
+            *x = (*x as u64 * u16::MAX as u64 / sum) as u16;
         });
         weights
     }

--- a/pallets/subtensor/tests/block_step.rs
+++ b/pallets/subtensor/tests/block_step.rs
@@ -1,4 +1,3 @@
-
 mod mock;
 use frame_support::assert_ok;
 use frame_system::Config;
@@ -873,7 +872,7 @@ fn test_emission_based_on_registration_status() {
         let block: u64 = 0;
         // drain the emission tuples for the subnet with registration on
         #[allow(clippy::fn_to_numeric_cast)]
-        SubtensorModule::drain_emission( next_block as u64 );
+        SubtensorModule::drain_emission(next_block as u64);
         // Turn on registration for the subnet with registration off
         SubtensorModule::set_network_registration_allowed(netuid_off, true);
         SubtensorModule::set_network_registration_allowed(netuid_on, false);

--- a/pallets/subtensor/tests/block_step.rs
+++ b/pallets/subtensor/tests/block_step.rs
@@ -872,7 +872,7 @@ fn test_emission_based_on_registration_status() {
         let block: u64 = 0;
         // drain the emission tuples for the subnet with registration on
         #[allow(clippy::fn_to_numeric_cast)]
-        SubtensorModule::drain_emission(next_block as u64);
+        SubtensorModule::drain_emission(block as u64);
         // Turn on registration for the subnet with registration off
         SubtensorModule::set_network_registration_allowed(netuid_off, true);
         SubtensorModule::set_network_registration_allowed(netuid_on, false);

--- a/pallets/subtensor/tests/block_step.rs
+++ b/pallets/subtensor/tests/block_step.rs
@@ -871,7 +871,7 @@ fn test_emission_based_on_registration_status() {
 
         let block: u64 = 0;
         // drain the emission tuples for the subnet with registration on
-        SubtensorModule::drain_emission(block as u64);
+        SubtensorModule::drain_emission(block);
         // Turn on registration for the subnet with registration off
         SubtensorModule::set_network_registration_allowed(netuid_off, true);
         SubtensorModule::set_network_registration_allowed(netuid_on, false);

--- a/pallets/subtensor/tests/block_step.rs
+++ b/pallets/subtensor/tests/block_step.rs
@@ -1,3 +1,4 @@
+
 mod mock;
 use frame_support::assert_ok;
 use frame_system::Config;
@@ -869,8 +870,10 @@ fn test_emission_based_on_registration_status() {
             n as usize
         );
 
+        let block: u64 = 0;
         // drain the emission tuples for the subnet with registration on
-        SubtensorModule::drain_emission(next_block as u64);
+        #[allow(clippy::fn_to_numeric_cast)]
+        SubtensorModule::drain_emission( next_block as u64 );
         // Turn on registration for the subnet with registration off
         SubtensorModule::set_network_registration_allowed(netuid_off, true);
         SubtensorModule::set_network_registration_allowed(netuid_on, false);

--- a/pallets/subtensor/tests/block_step.rs
+++ b/pallets/subtensor/tests/block_step.rs
@@ -871,7 +871,6 @@ fn test_emission_based_on_registration_status() {
 
         let block: u64 = 0;
         // drain the emission tuples for the subnet with registration on
-        #[allow(clippy::fn_to_numeric_cast)]
         SubtensorModule::drain_emission(block as u64);
         // Turn on registration for the subnet with registration off
         SubtensorModule::set_network_registration_allowed(netuid_off, true);

--- a/pallets/subtensor/tests/epoch.rs
+++ b/pallets/subtensor/tests/epoch.rs
@@ -38,7 +38,7 @@ fn normalize_weights(mut weights: Vec<u16>) -> Vec<u16> {
         return weights;
     }
     weights.iter_mut().for_each(|x| {
-        *x = (*x as u64 * u16::max_value() as u64 / sum) as u16;
+        *x = (*x as u64 * u16::MAX as u64 / sum) as u16;
     });
     weights
 }

--- a/pallets/subtensor/tests/weights.rs
+++ b/pallets/subtensor/tests/weights.rs
@@ -102,7 +102,7 @@ fn test_set_rootweights_validate() {
 
         let extension = pallet_subtensor::SubtensorSignedExtension::<Test>::new();
         // Submit to the signed extension validate function
-        let result_no_stake = extension.validate(&who, &call.clone().into(), &info, 10);
+        let result_no_stake = extension.validate(&who, &call.clone(), &info, 10);
         // Should fail
         assert_err!(
             // Should get an invalid transaction error
@@ -120,7 +120,7 @@ fn test_set_rootweights_validate() {
         );
 
         // Submit to the signed extension validate function
-        let result_min_stake = extension.validate(&who, &call.clone().into(), &info, 10);
+        let result_min_stake = extension.validate(&who, &call.clone(), &info, 10);
         // Now the call should pass
         assert_ok!(result_min_stake);
 
@@ -130,7 +130,7 @@ fn test_set_rootweights_validate() {
         // Verify stake is more than minimum
         assert!(SubtensorModule::get_total_stake_for_hotkey(&hotkey) > min_stake);
 
-        let result_more_stake = extension.validate(&who, &call.clone().into(), &info, 10);
+        let result_more_stake = extension.validate(&who, &call.clone(), &info, 10);
         // The call should still pass
         assert_ok!(result_more_stake);
     });
@@ -202,7 +202,7 @@ fn test_commit_weights_validate() {
 
         let extension = pallet_subtensor::SubtensorSignedExtension::<Test>::new();
         // Submit to the signed extension validate function
-        let result_no_stake = extension.validate(&who, &call.clone().into(), &info, 10);
+        let result_no_stake = extension.validate(&who, &call.clone(), &info, 10);
         // Should fail
         assert_err!(
             // Should get an invalid transaction error
@@ -220,7 +220,7 @@ fn test_commit_weights_validate() {
         );
 
         // Submit to the signed extension validate function
-        let result_min_stake = extension.validate(&who, &call.clone().into(), &info, 10);
+        let result_min_stake = extension.validate(&who, &call.clone(), &info, 10);
         // Now the call should pass
         assert_ok!(result_min_stake);
 
@@ -230,7 +230,7 @@ fn test_commit_weights_validate() {
         // Verify stake is more than minimum
         assert!(SubtensorModule::get_total_stake_for_hotkey(&hotkey) > min_stake);
 
-        let result_more_stake = extension.validate(&who, &call.clone().into(), &info, 10);
+        let result_more_stake = extension.validate(&who, &call.clone(), &info, 10);
         // The call should still pass
         assert_ok!(result_more_stake);
     });
@@ -301,7 +301,7 @@ fn test_reveal_weights_validate() {
 
         let extension = pallet_subtensor::SubtensorSignedExtension::<Test>::new();
         // Submit to the signed extension validate function
-        let result_no_stake = extension.validate(&who, &call.clone().into(), &info, 10);
+        let result_no_stake = extension.validate(&who, &call.clone(), &info, 10);
         // Should fail
         assert_err!(
             // Should get an invalid transaction error
@@ -319,7 +319,7 @@ fn test_reveal_weights_validate() {
         );
 
         // Submit to the signed extension validate function
-        let result_min_stake = extension.validate(&who, &call.clone().into(), &info, 10);
+        let result_min_stake = extension.validate(&who, &call.clone(), &info, 10);
         // Now the call should pass
         assert_ok!(result_min_stake);
 
@@ -329,7 +329,7 @@ fn test_reveal_weights_validate() {
         // Verify stake is more than minimum
         assert!(SubtensorModule::get_total_stake_for_hotkey(&hotkey) > min_stake);
 
-        let result_more_stake = extension.validate(&who, &call.clone().into(), &info, 10);
+        let result_more_stake = extension.validate(&who, &call.clone(), &info, 10);
         // The call should still pass
         assert_ok!(result_more_stake);
     });

--- a/pallets/subtensor/tests/weights.rs
+++ b/pallets/subtensor/tests/weights.rs
@@ -37,7 +37,28 @@ fn test_set_weights_dispatch_info_ok() {
         assert_eq!(dispatch_info.pays_fee, Pays::No);
     });
 }
+#[test]
+#[cfg(not(tarpaulin))]
+fn test_set_rootweights_dispatch_info_ok() {
+    new_test_ext(0).execute_with(|| {
+        let dests = vec![1, 1];
+        let weights = vec![1, 1];
+        let netuid: u16 = 1;
+        let version_key: u64 = 0;
+        let hotkey: U256 = U256::from(1); // Add the hotkey field
+        let call = RuntimeCall::SubtensorModule(SubtensorCall::set_root_weights {
+            netuid,
+            dests,
+            weights,
+            version_key,
+            hotkey, // Include the hotkey field
+        });
+        let dispatch_info = call.get_dispatch_info();
 
+        assert_eq!(dispatch_info.class, DispatchClass::Normal);
+        assert_eq!(dispatch_info.pays_fee, Pays::No);
+    });
+}
 #[test]
 fn test_commit_weights_dispatch_info_ok() {
     new_test_ext(0).execute_with(|| {

--- a/pallets/subtensor/tests/weights.rs
+++ b/pallets/subtensor/tests/weights.rs
@@ -161,6 +161,82 @@ fn test_commit_weights_dispatch_info_ok() {
 }
 
 #[test]
+fn test_commit_weights_validate() {
+    // Testing the signed extension validate function
+    // correctly filters this transaction.
+
+    new_test_ext(0).execute_with(|| {
+        let dests = vec![1, 1];
+        let weights = vec![1, 1];
+        let netuid: u16 = 1;
+        let salt: Vec<u16> = vec![1, 2, 3, 4, 5, 6, 7, 8];
+        let version_key: u64 = 0;
+        let coldkey = U256::from(0);
+        let hotkey: U256 = U256::from(1); // Add the hotkey field
+        assert_ne!(hotkey, coldkey); // Ensure hotkey is NOT the same as coldkey !!!
+
+        let who = hotkey; // The hotkey signs this transaction
+
+        let commit_hash: H256 =
+            BlakeTwo256::hash_of(&(hotkey, netuid, dests, weights, salt, version_key));
+
+        let call = RuntimeCall::SubtensorModule(SubtensorCall::commit_weights {
+            netuid,
+            commit_hash,
+        });
+
+        // Create netuid
+        add_network(netuid, 0, 0);
+        // Register the hotkey
+        SubtensorModule::append_neuron(netuid, &hotkey, 0);
+        Owner::<Test>::insert(hotkey, coldkey);
+
+        let min_stake = 500_000_000_000;
+        // Set the minimum stake
+        SubtensorModule::set_weights_min_stake(min_stake);
+
+        // Verify stake is less than minimum
+        assert!(SubtensorModule::get_total_stake_for_hotkey(&hotkey) < min_stake);
+        let info: DispatchInfo =
+            DispatchInfoOf::<<Test as frame_system::Config>::RuntimeCall>::default();
+
+        let extension = pallet_subtensor::SubtensorSignedExtension::<Test>::new();
+        // Submit to the signed extension validate function
+        let result_no_stake = extension.validate(&who, &call.clone().into(), &info, 10);
+        // Should fail
+        assert_err!(
+            // Should get an invalid transaction error
+            result_no_stake,
+            TransactionValidityError::Invalid(InvalidTransaction::Call,)
+        );
+
+        // Increase the stake to be equal to the minimum
+        SubtensorModule::increase_stake_on_hotkey_account(&hotkey, min_stake);
+
+        // Verify stake is equal to minimum
+        assert_eq!(
+            SubtensorModule::get_total_stake_for_hotkey(&hotkey),
+            min_stake
+        );
+
+        // Submit to the signed extension validate function
+        let result_min_stake = extension.validate(&who, &call.clone().into(), &info, 10);
+        // Now the call should pass
+        assert_ok!(result_min_stake);
+
+        // Try with more stake than minimum
+        SubtensorModule::increase_stake_on_hotkey_account(&hotkey, 1);
+
+        // Verify stake is more than minimum
+        assert!(SubtensorModule::get_total_stake_for_hotkey(&hotkey) > min_stake);
+
+        let result_more_stake = extension.validate(&who, &call.clone().into(), &info, 10);
+        // The call should still pass
+        assert_ok!(result_more_stake);
+    });
+}
+
+#[test]
 fn test_reveal_weights_dispatch_info_ok() {
     new_test_ext(0).execute_with(|| {
         let dests = vec![1, 1];
@@ -180,6 +256,82 @@ fn test_reveal_weights_dispatch_info_ok() {
 
         assert_eq!(dispatch_info.class, DispatchClass::Normal);
         assert_eq!(dispatch_info.pays_fee, Pays::No);
+    });
+}
+
+#[test]
+fn test_reveal_weights_validate() {
+    // Testing the signed extension validate function
+    // correctly filters this transaction.
+
+    new_test_ext(0).execute_with(|| {
+        let dests = vec![1, 1];
+        let weights = vec![1, 1];
+        let netuid: u16 = 1;
+        let salt: Vec<u16> = vec![1, 2, 3, 4, 5, 6, 7, 8];
+        let version_key: u64 = 0;
+        let coldkey = U256::from(0);
+        let hotkey: U256 = U256::from(1); // Add the hotkey field
+        assert_ne!(hotkey, coldkey); // Ensure hotkey is NOT the same as coldkey !!!
+
+        let who = hotkey; // The hotkey signs this transaction
+
+        let call = RuntimeCall::SubtensorModule(SubtensorCall::reveal_weights {
+            netuid,
+            uids: dests,
+            values: weights,
+            salt,
+            version_key,
+        });
+
+        // Create netuid
+        add_network(netuid, 0, 0);
+        // Register the hotkey
+        SubtensorModule::append_neuron(netuid, &hotkey, 0);
+        Owner::<Test>::insert(hotkey, coldkey);
+
+        let min_stake = 500_000_000_000;
+        // Set the minimum stake
+        SubtensorModule::set_weights_min_stake(min_stake);
+
+        // Verify stake is less than minimum
+        assert!(SubtensorModule::get_total_stake_for_hotkey(&hotkey) < min_stake);
+        let info: DispatchInfo =
+            DispatchInfoOf::<<Test as frame_system::Config>::RuntimeCall>::default();
+
+        let extension = pallet_subtensor::SubtensorSignedExtension::<Test>::new();
+        // Submit to the signed extension validate function
+        let result_no_stake = extension.validate(&who, &call.clone().into(), &info, 10);
+        // Should fail
+        assert_err!(
+            // Should get an invalid transaction error
+            result_no_stake,
+            TransactionValidityError::Invalid(InvalidTransaction::Call,)
+        );
+
+        // Increase the stake to be equal to the minimum
+        SubtensorModule::increase_stake_on_hotkey_account(&hotkey, min_stake);
+
+        // Verify stake is equal to minimum
+        assert_eq!(
+            SubtensorModule::get_total_stake_for_hotkey(&hotkey),
+            min_stake
+        );
+
+        // Submit to the signed extension validate function
+        let result_min_stake = extension.validate(&who, &call.clone().into(), &info, 10);
+        // Now the call should pass
+        assert_ok!(result_min_stake);
+
+        // Try with more stake than minimum
+        SubtensorModule::increase_stake_on_hotkey_account(&hotkey, 1);
+
+        // Verify stake is more than minimum
+        assert!(SubtensorModule::get_total_stake_for_hotkey(&hotkey) > min_stake);
+
+        let result_more_stake = extension.validate(&who, &call.clone().into(), &info, 10);
+        // The call should still pass
+        assert_ok!(result_more_stake);
     });
 }
 

--- a/runtime/src/check_nonce.rs
+++ b/runtime/src/check_nonce.rs
@@ -120,7 +120,7 @@ where
             priority: 0,
             requires,
             provides,
-            longevity: TransactionLongevity::max_value(),
+            longevity: TransactionLongevity::MAX,
             propagate: true,
         })
     }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -135,7 +135,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 151,
+    spec_version: 152,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/scripts/localnet.sh
+++ b/scripts/localnet.sh
@@ -6,9 +6,24 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 # The base directory of the subtensor project
 BASE_DIR="$SCRIPT_DIR/.."
 
-: "${CHAIN:=local}"
-: "${BUILD_BINARY:=1}"
-: "${FEATURES:="pow-faucet runtime-benchmarks fast-blocks"}"
+# get parameters
+# Get the value of fast_blocks from the first argument
+fast_blocks=${1:-"True"}
+
+# Check the value of fast_blocks
+if [ "$fast_blocks" == "False" ]; then
+  # Block of code to execute if fast_blocks is False
+  echo "fast_blocks is Off"
+  : "${CHAIN:=local}"
+  : "${BUILD_BINARY:=1}"
+  : "${FEATURES:="pow-faucet runtime-benchmarks"}"
+else
+  # Block of code to execute if fast_blocks is not False
+  echo "fast_blocks is On"
+  : "${CHAIN:=local}"
+  : "${BUILD_BINARY:=1}"
+  : "${FEATURES:="pow-faucet runtime-benchmarks fast-blocks"}"
+fi
 
 SPEC_PATH="${SCRIPT_DIR}/specs/"
 FULL_PATH="$SPEC_PATH$CHAIN.json"


### PR DESCRIPTION
## Description
This PR hotfixes a bug that occurred when setting root weights. When checking if the caller had the minimum stake the coldkey was used rather than the hotkey. 

```{'code': 1010, 'message': 'Invalid Transaction', 'data': 'Transaction call is not expected'}```

## TODO
BUMP SPEC VERSION