### PR TITLE
Remove unneeded argument on drain_emission

### DIFF
--- a/pallets/subtensor/src/block_step.rs
+++ b/pallets/subtensor/src/block_step.rs
@@ -20,7 +20,7 @@ impl<T: Config> Pallet<T> {
             }
         }
         // --- 3. Drains emission tuples ( hotkey, amount ).
-        Self::drain_emission(block_number);
+        Self::drain_emission();
         // --- 4. Generates emission tuples from epoch functions.
         Self::generate_emission(block_number);
         // Return ok.
@@ -81,7 +81,7 @@ impl<T: Config> Pallet<T> {
     /// Reads from the loaded emission storage which contains lists of pending emission tuples ( hotkey, amount )
     /// and distributes small chunks of them at a time.
     ///
-    pub fn drain_emission(_: u64) {
+    pub fn drain_emission() {
         // --- 1. We iterate across each network.
         for (netuid, _) in <Tempo<T> as IterableStorageMap<u16, u16>>::iter() {
             let Some(tuples_to_drain) = Self::get_loaded_emission_tuples(netuid) else {

--- a/pallets/subtensor/tests/block_step.rs
+++ b/pallets/subtensor/tests/block_step.rs
@@ -49,7 +49,7 @@ fn test_loaded_emission() {
         // Try draining the emission tuples
         // None remaining because we are at epoch.
         let block: u64 = 8;
-        SubtensorModule::drain_emission(block);
+        SubtensorModule::drain_emission();
         assert!(SubtensorModule::get_loaded_emission_tuples(netuid).is_none());
 
         // Generate more emission.
@@ -69,7 +69,7 @@ fn test_loaded_emission() {
                 n_to_drain =
                     SubtensorModule::tuples_to_drain_this_block(netuid, tempo, block, tuples.len());
             }
-            SubtensorModule::drain_emission(block); // drain it with 9 more blocks to go
+            SubtensorModule::drain_emission(); // drain it with 9 more blocks to go
             if let Some(tuples) = SubtensorModule::get_loaded_emission_tuples(netuid) {
                 assert_eq!(tuples.len(), n_remaining - n_to_drain);
             }
@@ -870,7 +870,7 @@ fn test_emission_based_on_registration_status() {
         );
 
         // drain the emission tuples for the subnet with registration on
-        SubtensorModule::drain_emission(next_block as u64);
+        SubtensorModule::drain_emission();
         // Turn on registration for the subnet with registration off
         SubtensorModule::set_network_registration_allowed(netuid_off, true);
         SubtensorModule::set_network_registration_allowed(netuid_on, false);

--- a/pallets/subtensor/tests/block_step.rs
+++ b/pallets/subtensor/tests/block_step.rs
@@ -48,7 +48,6 @@ fn test_loaded_emission() {
 
         // Try draining the emission tuples
         // None remaining because we are at epoch.
-        let block: u64 = 8;
         SubtensorModule::drain_emission();
         assert!(SubtensorModule::get_loaded_emission_tuples(netuid).is_none());
 


### PR DESCRIPTION
Found while running clippy, warning about a function pointer typecasted into a `u64`.