### PR TITLE
add CI check for companion labels, update deployment docs

### DIFF
--- a/.github/workflows/devnet-ready-labels.yml
+++ b/.github/workflows/devnet-ready-labels.yml
@@ -1,0 +1,17 @@
+name: Companion Labels (devnet)
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+    branches: [devnet-ready]
+jobs:
+  check-labels:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: mheap/github-action-required-labels@v5
+        with:
+          mode: minimum
+          count: 1
+          labels: devnet-companion

--- a/.github/workflows/testnet-ready-labels.yml
+++ b/.github/workflows/testnet-ready-labels.yml
@@ -1,8 +1,8 @@
-name: devnet-companion Label Check
+name: testnet-companion Label Check
 on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
-    branches: [devnet-ready]
+    branches: [testnet-ready]
 jobs:
   check-labels:
     runs-on: ubuntu-latest
@@ -14,4 +14,4 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: devnet-companion
+          labels: testnet-companion

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,9 +15,9 @@
    add appropriate labels to your PR as shown below. Three positive reviews are required.
 4. Once the required passing reviews have been obtained, you are ready to request that your PR
    be included in the next `devnet` deploy. To do this, you should open a companion PR merging
-   your branch into the `devnet-ready` branch. You must include a link to the parent PR in the
-   description and preface your PR title with "(Devnet Ready)" or the PR will be
-   closed/ignored.
+   a copy of your branch into the `devnet-ready` branch. You must include a link to the parent
+   PR in the description and preface your PR title with "(Devnet Ready)" or the PR will be
+   closed/ignored. Your companion PR should have the `devnet-companion` label.
 5. A core team administrator will review your "(Devnet Ready)" PR, verifying that it logically
    matches the changes introduced in the parent PR (there will sometimes be minor differences
    due to merge conflicts) and will either request changes or approve the PR and merge it. Once

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,11 +86,13 @@
 | `runtime` | PR contains substantive changes to runtime / pallet code | none |
 | `breaking-change` | PR requires synchronized changes with bittensor | Triggers an automatic bot message so the relevant teams are made aware of the change well in advance |
 | `migration` | PR contains one or more migrations | none |
+| `devnet-companion` | Designates a devnet companion PR | Presence of `devnet-companion` label is checked |
 | `devnet-ready` | PR's branch has been merged into the `devnet-ready` branch and will be included in the next `devnet` deploy | none |
 | `on-devnet` | PR has been deployed to `devnet` | Removes `devnet-ready` |
 | `devnet-pass` | PR has passed manual testing on `devnet` | `devnet-pass` or `devnet-skip` required |
 | `devnet-skip` | Allows a critical hotfix PR to skip required testing on `devnet` | `devnet-pass` or `devnet-skip` required |
 | `devnet-fail` | PR has failed manual testing on `devnet` and requires modification | none |
+| `testnet-companion` | Designates a testnet companion PR | Presence of `testnet-companion` label is checked |
 | `on-testnet` | PR has been deployed to `testnet` | none |
 | `testnet-pass` | PR has passed manual testing on `testnet` | `testnet-pass` or `testnet-skip` required |
 | `testnet-skip` | Allows a critical hotfix PR to skip required manual testing and SOP on `testnet` | `testnet-pass` or `testnet-skip` required |


### PR DESCRIPTION
* `devnet-companion` label now required on PRs into `devnet-ready`
* `testnet-companion` label now reuqired on PRs into `testnet-ready`
* updated docs accordingly