### PR TITLE
Children to use u16s for proprotions

### DIFF
--- a/pallets/subtensor/rpc/src/lib.rs
+++ b/pallets/subtensor/rpc/src/lib.rs
@@ -58,7 +58,7 @@ pub trait SubtensorCustomApi<BlockHash> {
         &self,
         netuid: u16,
         child: Vec<u8>,
-        proportion: u64,
+        proportion: u16,
         at: Option<BlockHash>,
     ) -> RpcResult<Vec<u8>>;
 }

--- a/pallets/subtensor/rpc/src/lib.rs
+++ b/pallets/subtensor/rpc/src/lib.rs
@@ -252,7 +252,7 @@ where
         &self,
         netuid: u16,
         child: Vec<u8>,
-        proportion: u64,
+        proportion: u16,
         at: Option<<Block as BlockT>::Hash>,
     ) -> RpcResult<Vec<u8>> {
         let api = self.client.runtime_api();

--- a/pallets/subtensor/runtime-api/src/lib.rs
+++ b/pallets/subtensor/runtime-api/src/lib.rs
@@ -35,6 +35,6 @@ sp_api::decl_runtime_apis! {
 
     pub trait ChildrenInfoRuntimeApi {
         fn get_children_info(netuid: u16) -> Vec<u8>;
-        fn get_child_info(netuid: u16, child: Vec<u8>, proportion: u64) -> Vec<u8>;
+        fn get_child_info(netuid: u16, child: Vec<u8>, proportion: u16) -> Vec<u8>;
     }
 }

--- a/pallets/subtensor/src/benchmarks.rs
+++ b/pallets/subtensor/src/benchmarks.rs
@@ -452,7 +452,7 @@ reveal_weights {
     assert_ok!(Subtensor::<T>::do_burned_registration(RawOrigin::Signed(coldkey.clone()).into(), netuid, hotkey.clone()));
 
     // Set proportion
-    let proportion: u64 = 500;
+    let proportion: u16 = 500;
 
 }: set_child_singular(RawOrigin::Signed(coldkey.clone()), hotkey.clone(), child.clone(), netuid, proportion)
 
@@ -485,7 +485,7 @@ reveal_weights {
       assert_ok!(Subtensor::<T>::do_burned_registration(RawOrigin::Signed(coldkey.clone()).into(), netuid, hotkey.clone()));
 
       // Set child
-      let proportion: u64 = 500;
+      let proportion: u16 = 500;
       assert_ok!(Subtensor::<T>::do_set_child_singular(RawOrigin::Signed(coldkey.clone()).into(), hotkey.clone(), child.clone(), netuid, proportion));
 
   }: revoke_child_singular(RawOrigin::Signed(coldkey.clone()), hotkey.clone(), child.clone(), netuid)

--- a/pallets/subtensor/src/children.rs
+++ b/pallets/subtensor/src/children.rs
@@ -281,9 +281,343 @@ impl<T: Config> Pallet<T> {
             new_children,
             netuid,
         ));
+        // --- 12. Return success
+        Ok(())
+    }
+    /// ---- The implementation for the extrinsic do_revoke_child_singular: Revokes a single child.
+    ///
+    /// This function allows a coldkey to revoke a single child for a given hotkey on a specified network.
+    ///
+    /// # Arguments:
+    /// * `origin` (<T as frame_system::Config>::RuntimeOrigin):
+    ///     - The signature of the calling coldkey. Revoking a hotkey child can only be done by the coldkey.
+    ///
+    /// * `hotkey` (T::AccountId):
+    ///     - The hotkey from which the child will be revoked.
+    ///
+    /// * `child` (T::AccountId):
+    ///     - The child which will be revoked from the hotkey.
+    ///
+    /// * `netuid` (u16):
+    ///     - The u16 network identifier where the childkey exists.
+    ///
+    /// # Events:
+    /// * `ChildRevokedSingular`:
+    ///     - On successfully revoking a child from a hotkey.
+    ///
+    /// # Errors:
+    /// * `SubNetworkDoesNotExist`:
+    ///     - Attempting to revoke from a non-existent network.
+    /// * `NonAssociatedColdKey`:
+    ///     - The coldkey does not own the hotkey or the child is not associated with the hotkey.
+    /// * `HotKeyAccountNotExists`:
+    ///     - The hotkey account does not exist.
+    ///
+    pub fn do_revoke_child_singular(
+        origin: T::RuntimeOrigin,
+        hotkey: T::AccountId,
+        child: T::AccountId,
+        netuid: u16,
+    ) -> DispatchResult {
+        // --- 1. Check that the caller has signed the transaction. (the coldkey of the pairing)
+        let coldkey = ensure_signed(origin)?;
+        log::info!(
+            "do_revoke_child_singular( coldkey:{:?} netuid:{:?} hotkey:{:?} child:{:?} )",
+            coldkey,
+            netuid,
+            hotkey,
+            child
+        );
+
+        // --- 2. Check that the network we are trying to revoke the child from exists.
+        ensure!(
+            Self::if_subnet_exist(netuid),
+            Error::<T>::SubNetworkDoesNotExist
+        );
+
+        // --- 3. Check that the coldkey owns the hotkey.
+        ensure!(
+            Self::coldkey_owns_hotkey(&coldkey, &hotkey),
+            Error::<T>::NonAssociatedColdKey
+        );
+
+        // --- 4. Get the current children of the hotkey.
+        let mut children: Vec<(u64, T::AccountId)> = ChildKeys::<T>::get(hotkey.clone(), netuid);
+
+        // --- 5. Ensure that the child is actually a child of the hotkey.
+        ensure!(
+            children.iter().any(|(_, c)| c == &child),
+            Error::<T>::NonAssociatedColdKey
+        );
+
+        // --- 6. Remove the child from the hotkey's children list.
+        children.retain(|(_, c)| c != &child);
+
+        // --- 7. Update the children list in storage.
+        ChildKeys::<T>::insert(hotkey.clone(), netuid, children.clone());
+
+        // --- 8. Remove the hotkey from the child's parent list.
+        let mut parents: Vec<(u64, T::AccountId)> = ParentKeys::<T>::get(child.clone(), netuid);
+        parents.retain(|(_, p)| p != &hotkey);
+        ParentKeys::<T>::insert(child.clone(), netuid, parents);
+
+        // --- 9. Log and return.
+        log::info!(
+            "RevokeChildSingular( hotkey:{:?}, child:{:?}, netuid:{:?} )",
+            hotkey,
+            child,
+            netuid
+        );
+        Self::deposit_event(Event::RevokeChildSingular(hotkey.clone(), child, netuid));
+        // Ok and return.
+        Ok(())
+    }
+    /// Revokes multiple children for a given hotkey on a specified network.
+    ///
+    /// This function allows a coldkey to revoke multiple children for a given hotkey on a specified network.
+    ///
+    /// # Arguments:
+    /// * `origin` (<T as frame_system::Config>::RuntimeOrigin):
+    ///     - The signature of the calling coldkey. Revoking hotkey children can only be done by the coldkey.
+    ///
+    /// * `hotkey` (T::AccountId):
+    ///     - The hotkey from which the children will be revoked.
+    ///
+    /// * `children` (Vec<T::AccountId>):
+    ///     - A vector of AccountIds representing the children to be revoked.
+    ///
+    /// * `netuid` (u16):
+    ///     - The u16 network identifier where the childkeys exist.
+    ///
+    /// # Events:
+    /// * `ChildrenRevokedMultiple`:
+    ///     - On successfully revoking multiple children from a hotkey.
+    ///
+    /// # Errors:
+    /// * `SubNetworkDoesNotExist`:
+    ///     - Attempting to revoke from a non-existent network.
+    /// * `NonAssociatedColdKey`:
+    ///     - The coldkey does not own the hotkey.
+    /// * `HotKeyAccountNotExists`:
+    ///     - The hotkey account does not exist.
+    pub fn do_revoke_children_multiple(
+        origin: T::RuntimeOrigin,
+        hotkey: T::AccountId,
+        children: Vec<T::AccountId>,
+        netuid: u16,
+    ) -> DispatchResult {
+        // --- 1. Check that the caller has signed the transaction. (the coldkey of the pairing)
+        let coldkey = ensure_signed(origin)?;
+        log::info!(
+            "do_revoke_children_multiple( coldkey:{:?} netuid:{:?} hotkey:{:?} children:{:?} )",
+            coldkey,
+            netuid,
+            hotkey,
+            children
+        );
+
+        // --- 2. Check that the network we are trying to revoke the children from exists.
+        ensure!(
+            Self::if_subnet_exist(netuid),
+            Error::<T>::SubNetworkDoesNotExist
+        );
+
+        // --- 3. Check that the coldkey owns the hotkey.
+        ensure!(
+            Self::coldkey_owns_hotkey(&coldkey, &hotkey),
+            Error::<T>::NonAssociatedColdKey
+        );
+
+        // --- 4. Get the current children of the hotkey.
+        let mut current_children: Vec<(u64, T::AccountId)> =
+            ChildKeys::<T>::get(hotkey.clone(), netuid);
+
+        // --- 5. Remove the specified children from the hotkey's children list.
+        current_children.retain(|(_, child)| !children.contains(child));
+
+        // --- 6. Update the children list in storage.
+        ChildKeys::<T>::insert(hotkey.clone(), netuid, current_children);
+
+        // --- 7. Remove the hotkey from each child's parent list.
+        for child in children.iter() {
+            let mut parents: Vec<(u64, T::AccountId)> = ParentKeys::<T>::get(child.clone(), netuid);
+            parents.retain(|(_, p)| p != &hotkey);
+            ParentKeys::<T>::insert(child.clone(), netuid, parents);
+        }
+
+        // --- 8. Log and return.
+        log::info!(
+            "RevokeChildrenMultiple( hotkey:{:?}, children:{:?}, netuid:{:?} )",
+            hotkey,
+            children,
+            netuid
+        );
+        Self::deposit_event(Event::RevokeChildrenMultiple(
+            hotkey.clone(),
+            children,
+            netuid,
+        ));
 
         // Ok and return.
         Ok(())
     }
 
+    /// Calculates the total stake held by a hotkey on the network, considering child/parent relationships.
+    ///
+    /// This function performs the following steps:
+    /// 1. Checks for self-loops in the delegation graph.
+    /// 2. Retrieves the initial stake of the hotkey.
+    /// 3. Calculates the stake allocated to children.
+    /// 4. Calculates the stake received from parents.
+    /// 5. Computes the final stake by adjusting the initial stake with child and parent contributions.
+    ///
+    /// # Arguments
+    /// * `hotkey` - AccountId of the hotkey whose total network stake is to be calculated.
+    /// * `netuid` - Network unique identifier specifying the network context.
+    ///
+    /// # Returns
+    /// * `u64` - The total stake for the hotkey on the network after considering the stakes
+    ///           from children and parents.
+    ///
+    /// # Note
+    /// This function now includes a check for self-loops in the delegation graph using the
+    /// `dfs_check_self_loops` method. However, it currently only logs warnings for detected loops
+    /// and does not alter the stake calculation based on these findings.
+    ///
+    /// # Panics
+    /// This function does not explicitly panic, but underlying arithmetic operations
+    /// use saturating arithmetic to prevent overflows.
+    ///
+    /// TODO: check for self loops.
+    /// TODO: (@distributedstatemachine): check if we should return error , otherwise self loop
+    /// detection is impossible to test.
+    pub fn get_stake_with_children_and_parents(hotkey: &T::AccountId, netuid: u16) -> u64 {
+        let mut visited = BTreeSet::new();
+        Self::dfs_check_self_loops(hotkey, netuid, &mut visited);
+
+        // Retrieve the initial total stake for the hotkey without any child/parent adjustments.
+        let initial_stake: u64 = Self::get_total_stake_for_hotkey(hotkey);
+        let mut stake_to_children: u64 = 0;
+        let mut stake_from_parents: u64 = 0;
+
+        // Retrieve lists of parents and children from storage, based on the hotkey and network ID.
+        let parents: Vec<(u64, T::AccountId)> = Self::get_parents(hotkey, netuid);
+        let children: Vec<(u64, T::AccountId)> = Self::get_children(hotkey, netuid);
+
+        // Iterate over children to calculate the total stake allocated to them.
+        for (proportion, _) in children {
+            // Calculate the stake proportion allocated to the child based on the initial stake.
+            let stake_proportion_to_child: I96F32 = I96F32::from_num(initial_stake)
+                .saturating_mul(I96F32::from_num(proportion))
+                .saturating_div(I96F32::from_num(u64::MAX));
+            // Accumulate the total stake given to children.
+            stake_to_children =
+                stake_to_children.saturating_add(stake_proportion_to_child.to_num::<u64>());
+        }
+
+        // Iterate over parents to calculate the total stake received from them.
+        for (proportion, parent) in parents {
+            // Retrieve the parent's total stake.
+            let parent_stake: u64 = Self::get_total_stake_for_hotkey(&parent);
+            // Calculate the stake proportion received from the parent.
+            let stake_proportion_from_parent: I96F32 = I96F32::from_num(parent_stake)
+                .saturating_mul(I96F32::from_num(proportion))
+                .saturating_div(I96F32::from_num(u64::MAX));
+
+            // Accumulate the total stake received from parents.
+            stake_from_parents =
+                stake_from_parents.saturating_add(stake_proportion_from_parent.to_num::<u64>());
+        }
+
+        // Calculate the final stake for the hotkey by adjusting the initial stake with the stakes
+        // to/from children and parents.
+        let mut finalized_stake: u64 = initial_stake
+            .saturating_sub(stake_to_children)
+            .saturating_add(stake_from_parents);
+
+        // get the max stake for the network
+        let max_stake = Self::get_network_max_stake(netuid);
+
+        // Return the finalized stake value for the hotkey, but capped at the max stake.
+        finalized_stake = finalized_stake.min(max_stake);
+
+        // Return the finalized stake value for the hotkey.
+        finalized_stake
+    }
+
+    /* Retrieves the list of children for a given hotkey and network.
+    ///
+    /// # Arguments
+    /// * `hotkey` - The hotkey whose children are to be retrieved.
+    /// * `netuid` - The network identifier.
+    ///
+    /// # Returns
+    /// * `Vec<(u16, T::AccountId)>` - A vector of tuples containing the proportion and child account ID.
+    ///
+    /// # Example
+    /// ```
+    /// let children = SubtensorModule::get_children(&hotkey, netuid);
+     */
+    pub fn get_children(hotkey: &T::AccountId, netuid: u16) -> Vec<(u16, T::AccountId)> {
+        ChildKeys::<T>::get(hotkey, netuid)
+    }
+
+    /* Retrieves the list of parents for a given child and network.
+    ///
+    /// # Arguments
+    /// * `child` - The child whose parents are to be retrieved.
+    /// * `netuid` - The network identifier.
+    ///
+    /// # Returns
+    /// * `Vec<(u16, T::AccountId)>` - A vector of tuples containing the proportion and parent account ID.
+    ///
+    /// # Example
+    /// ```
+    /// let parents = SubtensorModule::get_parents(&child, netuid);
+     */
+    pub fn get_parents(child: &T::AccountId, netuid: u16) -> Vec<(u16, T::AccountId)> {
+        ParentKeys::<T>::get(child, netuid)
+    }
+
+    /// Performs a depth-first search to detect self-loops in the delegation graph.
+    ///
+    /// This function traverses the delegation graph starting from a given account,
+    /// checking for circular dependencies (self-loops) in the process.
+    ///
+    /// # Arguments
+    ///
+    /// * `current` - A reference to the `AccountId` of the current node being examined.
+    /// * `netuid` - The network ID in which to perform the check.
+    /// * `visited` - A mutable reference to a `BTreeSet` keeping track of visited accounts.
+    ///
+    /// # Behavior
+    ///
+    /// - If a node is encountered that has already been visited, a warning is logged
+    ///   indicating a self-loop has been detected.
+    /// - The function recursively checks all children of the current node.
+    /// - After checking all children, the current node is removed from the visited set
+    ///   to allow for correct backtracking in the DFS algorithm.
+    ///
+    /// # Note
+    ///
+    /// This function does not return a Result or stop execution when a loop is detected.
+    /// It only logs a warning. Depending on your requirements, you might want to modify
+    /// this behavior to return an error or take other actions when a loop is found.
+    fn dfs_check_self_loops(
+        current: &T::AccountId,
+        netuid: u16,
+        visited: &mut BTreeSet<T::AccountId>,
+    ) {
+        if !visited.insert(current.clone()) {
+            // We've encountered this node before, which means there's a loop
+            log::warn!("Self-loop detected for account: {:?}", current);
+        }
+
+        let children = Self::get_children(current, netuid);
+        for (_, child) in children {
+            Self::dfs_check_self_loops(&child, netuid, visited);
+        }
+
+        visited.remove(current);
+    }
 }

--- a/pallets/subtensor/src/children.rs
+++ b/pallets/subtensor/src/children.rs
@@ -22,7 +22,7 @@ impl<T: Config> Pallet<T> {
     /// * `netuid` (u16):
     ///     - The u16 network identifier where the childkey will exist.
     ///
-    /// * `proportion` (u64):
+    /// * `proportion` (u16):
     ///     - Proportion of the hotkey's stake to be given to the child, the value must be u64 normalized.
     ///
     /// # Events:

--- a/pallets/subtensor/src/children_info.rs
+++ b/pallets/subtensor/src/children_info.rs
@@ -9,7 +9,7 @@ pub struct ChildInfo<T: Config> {
     /// The AccountId of the child neuron
     pub child_ss58: T::AccountId,
     /// The proportion of stake allocated to this child
-    pub proportion: Compact<u64>,
+    pub proportion: Compact<u16>,
     /// The total stake of the child (including its own children and parents)
     pub total_stake: Compact<u64>,
     /// The emissions per day for this child
@@ -71,7 +71,7 @@ impl<T: Config> Pallet<T> {
     /// # Returns
     ///
     /// * `ChildInfo<T>` - A struct containing detailed information about the child neuron
-    pub fn get_child_info(netuid: u16, child_bytes: Vec<u8>, proportion: u64) -> ChildInfo<T> {
+    pub fn get_child_info(netuid: u16, child_bytes: Vec<u8>, proportion: u16) -> ChildInfo<T> {
         // Convert Vec<u8> to T::AccountId
         let child = T::AccountId::decode(&mut &child_bytes[..])
             .expect("Failed to decode child_bytes into AccountId");

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -342,7 +342,7 @@ pub mod pallet {
     }
     /// Default account linkage
     #[pallet::type_value]
-    pub fn DefaultProportion<T: Config>() -> u64 {
+    pub fn DefaultProportion<T: Config>() -> u16 {
         0
     }
     /// Default accumulated emission for a hotkey
@@ -469,7 +469,7 @@ pub mod pallet {
         T::AccountId,
         Identity,
         u16,
-        Vec<(u64, T::AccountId)>,
+        Vec<(u16, T::AccountId)>,
         ValueQuery,
         DefaultAccountLinkage<T>,
     >;
@@ -481,7 +481,7 @@ pub mod pallet {
         T::AccountId,
         Identity,
         u16,
-        Vec<(u64, T::AccountId)>,
+        Vec<(u16, T::AccountId)>,
         ValueQuery,
         DefaultAccountLinkage<T>,
     >;
@@ -2297,7 +2297,7 @@ pub mod pallet {
         /// * `netuid` (u16):
         ///     - The u16 network identifier where the childkey will exist.
         ///
-        /// * `proportion` (u64):
+        /// * `proportion` (u16):
         ///     - Proportion of the hotkey's stake to be given to the child, the value must be u64 normalized.
         ///
         /// # Events:
@@ -2333,7 +2333,7 @@ pub mod pallet {
             hotkey: T::AccountId,
             child: T::AccountId,
             netuid: u16,
-            proportion: u64,
+            proportion: u16,
         ) -> DispatchResultWithPostInfo {
             Self::do_set_child_singular(origin, hotkey, child, netuid, proportion)?;
             Ok(().into())
@@ -2394,9 +2394,9 @@ pub mod pallet {
         /// * `hotkey` (T::AccountId):
         ///     - The hotkey which will be assigned the children.
         ///
-        /// * `children_with_proportions` (Vec<(T::AccountId, u64)>):
+        /// * `children_with_proportions` (Vec<(T::AccountId, u16)>):
         ///     - A vector of tuples, each containing a child AccountId and its corresponding proportion.
-        ///       The proportion must be a u64 normalized value.
+        ///       The proportion must be a u16 normalized value.
         ///
         /// * `netuid` (u16):
         ///     - The u16 network identifier where the childkeys will exist.
@@ -2431,7 +2431,7 @@ pub mod pallet {
         pub fn set_children_multiple(
             origin: OriginFor<T>,
             hotkey: T::AccountId,
-            children_with_proportions: Vec<(T::AccountId, u64)>,
+            children_with_proportions: Vec<(T::AccountId, u16)>,
             netuid: u16,
         ) -> DispatchResultWithPostInfo {
             Self::do_set_children_multiple(origin, hotkey, children_with_proportions, netuid)?;

--- a/pallets/subtensor/tests/children.rs
+++ b/pallets/subtensor/tests/children.rs
@@ -11,7 +11,7 @@ fn test_do_set_child_singular_success() {
         let hotkey = U256::from(2);
         let child = U256::from(3);
         let netuid: u16 = 1;
-        let proportion: u64 = 1000;
+        let proportion: u16 = 1000;
 
         // Add network and register hotkey
         add_network(netuid, 13, 0);
@@ -39,7 +39,7 @@ fn test_do_set_child_singular_network_does_not_exist() {
         let hotkey = U256::from(2);
         let child = U256::from(3);
         let netuid: u16 = 999; // Non-existent network
-        let proportion: u64 = 1000;
+        let proportion: u16 = 1000;
 
         // Attempt to set child
         assert_err!(
@@ -61,7 +61,7 @@ fn test_do_set_child_singular_invalid_child() {
         let coldkey = U256::from(1);
         let hotkey = U256::from(2);
         let netuid: u16 = 1;
-        let proportion: u64 = 1000;
+        let proportion: u16 = 1000;
 
         // Add network and register hotkey
         add_network(netuid, 13, 0);
@@ -88,7 +88,7 @@ fn test_do_set_child_singular_non_associated_coldkey() {
         let hotkey = U256::from(2);
         let child = U256::from(3);
         let netuid: u16 = 1;
-        let proportion: u64 = 1000;
+        let proportion: u16 = 1000;
 
         // Add network and register hotkey with a different coldkey
         add_network(netuid, 13, 0);
@@ -115,7 +115,7 @@ fn test_do_set_child_singular_root_network() {
         let hotkey = U256::from(2);
         let child = U256::from(3);
         let netuid: u16 = SubtensorModule::get_root_netuid(); // Root network
-        let proportion: u64 = 1000;
+        let proportion: u16 = 1000;
 
         // Add network and register hotkey
         add_network(netuid, 13, 0);
@@ -142,7 +142,7 @@ fn test_do_set_child_singular_old_children_cleanup() {
         let old_child = U256::from(3);
         let new_child = U256::from(4);
         let netuid: u16 = 1;
-        let proportion: u64 = 1000;
+        let proportion: u16 = 1000;
 
         // Add network and register hotkey
         add_network(netuid, 13, 0);
@@ -183,7 +183,7 @@ fn test_do_set_child_singular_new_children_assignment() {
         let hotkey = U256::from(2);
         let child = U256::from(3);
         let netuid: u16 = 1;
-        let proportion: u64 = 1000;
+        let proportion: u16 = 1000;
 
         // Add network and register hotkey
         add_network(netuid, 13, 0);
@@ -221,7 +221,7 @@ fn test_do_set_child_singular_proportion_edge_cases() {
         register_ok_neuron(netuid, hotkey, coldkey, 0);
 
         // Set child with minimum proportion
-        let min_proportion: u64 = 0;
+        let min_proportion: u16 = 0;
         assert_ok!(SubtensorModule::do_set_child_singular(
             RuntimeOrigin::signed(coldkey),
             hotkey,
@@ -235,7 +235,7 @@ fn test_do_set_child_singular_proportion_edge_cases() {
         assert_eq!(children, vec![(min_proportion, child)]);
 
         // Set child with maximum proportion
-        let max_proportion: u64 = u64::MAX;
+        let max_proportion: u16 = u16::MAX;
         assert_ok!(SubtensorModule::do_set_child_singular(
             RuntimeOrigin::signed(coldkey),
             hotkey,
@@ -258,8 +258,8 @@ fn test_do_set_child_singular_multiple_children() {
         let child1 = U256::from(3);
         let child2 = U256::from(4);
         let netuid: u16 = 1;
-        let proportion1: u64 = 500;
-        let proportion2: u64 = 500;
+        let proportion1: u16 = 500;
+        let proportion2: u16 = 500;
 
         // Add network and register hotkey
         add_network(netuid, 13, 0);
@@ -436,7 +436,7 @@ fn test_do_revoke_child_singular_success() {
         let hotkey = U256::from(2);
         let child = U256::from(3);
         let netuid: u16 = 1;
-        let proportion: u64 = 1000;
+        let proportion: u16 = 1000;
 
         // Add network and register hotkey
         add_network(netuid, 13, 0);
@@ -551,7 +551,7 @@ fn test_do_set_children_multiple_network_does_not_exist() {
         let hotkey = U256::from(2);
         let child1 = U256::from(3);
         let netuid: u16 = 999; // Non-existent network
-        let proportion: u64 = 1000;
+        let proportion: u16 = 1000;
 
         // Attempt to set children
         assert_err!(
@@ -572,7 +572,7 @@ fn test_do_set_children_multiple_invalid_child() {
         let coldkey = U256::from(1);
         let hotkey = U256::from(2);
         let netuid: u16 = 1;
-        let proportion: u64 = 1000;
+        let proportion: u16 = 1000;
 
         // Add network and register hotkey
         add_network(netuid, 13, 0);
@@ -598,7 +598,7 @@ fn test_do_set_children_multiple_non_associated_coldkey() {
         let hotkey = U256::from(2);
         let child = U256::from(3);
         let netuid: u16 = 1;
-        let proportion: u64 = 1000;
+        let proportion: u16 = 1000;
 
         // Add network and register hotkey with a different coldkey
         add_network(netuid, 13, 0);
@@ -624,7 +624,7 @@ fn test_do_set_children_multiple_root_network() {
         let hotkey = U256::from(2);
         let child = U256::from(3);
         let netuid: u16 = SubtensorModule::get_root_netuid(); // Root network
-        let proportion: u64 = 1000;
+        let proportion: u16 = 1000;
 
         // Add network and register hotkey
         add_network(netuid, 13, 0);
@@ -656,8 +656,8 @@ fn test_do_set_children_multiple_proportion_edge_cases() {
         register_ok_neuron(netuid, hotkey, coldkey, 0);
 
         // Set children with minimum and maximum proportions
-        let min_proportion: u64 = 0;
-        let max_proportion: u64 = u64::MAX;
+        let min_proportion: u16 = 0;
+        let max_proportion: u16 = u16::MAX;
         assert_ok!(SubtensorModule::do_set_children_multiple(
             RuntimeOrigin::signed(coldkey),
             hotkey,
@@ -681,7 +681,7 @@ fn test_do_set_children_multiple_duplicate_child() {
         let hotkey = U256::from(2);
         let child1 = U256::from(3);
         let netuid: u16 = 1;
-        let proportion: u64 = 1000;
+        let proportion: u16 = 1000;
 
         add_network(netuid, 13, 0);
         register_ok_neuron(netuid, hotkey, coldkey, 0);
@@ -779,9 +779,9 @@ fn test_do_revoke_children_multiple_complex_scenario() {
         let child2 = U256::from(4);
         let child3 = U256::from(5);
         let netuid: u16 = 1;
-        let proportion1: u64 = u64::MAX / 3;
-        let proportion2: u64 = u64::MAX / 3;
-        let proportion3: u64 = u64::MAX - proportion1 - proportion2; // Ensure sum is u64::MAX
+        let proportion1: u16 = u16::MAX / 3;
+        let proportion2: u16 = u16::MAX / 3;
+        let proportion3: u16 = u16::MAX - proportion1 - proportion2; // Ensure sum is u16::MAX
 
         // Add network and register hotkey
         add_network(netuid, 13, 0);
@@ -883,9 +883,9 @@ fn test_do_revoke_children_multiple_partial_revocation() {
         let child2 = U256::from(4);
         let child3 = U256::from(5);
         let netuid: u16 = 1;
-        let proportion1: u64 = u64::MAX / 3;
-        let proportion2: u64 = u64::MAX / 3;
-        let proportion3: u64 = u64::MAX - proportion1 - proportion2; // Ensure sum is u64::MAX
+        let proportion1: u16 = u16::MAX / 3;
+        let proportion2: u16 = u16::MAX / 3;
+        let proportion3: u16 = u16::MAX - proportion1 - proportion2; // Ensure sum is u16::MAX
 
         // Add network and register hotkey
         add_network(netuid, 13, 0);
@@ -935,8 +935,8 @@ fn test_do_revoke_children_multiple_success() {
         let child1 = U256::from(3);
         let child2 = U256::from(4);
         let netuid: u16 = 1;
-        let proportion1: u64 = u64::MAX / 2;
-        let proportion2: u64 = u64::MAX - proportion1; // Ensure sum is u64::MAX
+        let proportion1: u16 = u16::MAX / 2;
+        let proportion2: u16 = u16::MAX - proportion1; // Ensure sum is u16::MAX
 
         // Add network and register hotkey
         add_network(netuid, 13, 0);
@@ -1049,9 +1049,9 @@ fn test_do_set_children_multiple_overwrite_existing() {
         let child1 = U256::from(3);
         let child2 = U256::from(4);
         let netuid: u16 = 1;
-        let initial_proportion: u64 = u64::MAX;
-        let new_proportion1: u64 = u64::MAX / 2;
-        let new_proportion2: u64 = u64::MAX - new_proportion1; // Ensure sum is u64::MAX
+        let initial_proportion: u16 = u16::MAX;
+        let new_proportion1: u16 = u16::MAX / 2;
+        let new_proportion2: u16 = u16::MAX - new_proportion1; // Ensure sum is u16::MAX
 
         // Add network and register hotkey
         add_network(netuid, 13, 0);
@@ -1097,9 +1097,9 @@ fn test_do_set_children_multiple_success() {
         let child2 = U256::from(4);
         let child3 = U256::from(5);
         let netuid: u16 = 1;
-        let proportion1: u64 = u64::MAX / 3;
-        let proportion2: u64 = u64::MAX / 3;
-        let proportion3: u64 = u64::MAX - proportion1 - proportion2; // Ensure sum is u64::MAX
+        let proportion1: u16 = u16::MAX / 3;
+        let proportion2: u16 = u16::MAX / 3;
+        let proportion3: u16 = u16::MAX - proportion1 - proportion2; // Ensure sum is u16::MAX
 
         // Add network and register hotkey
         add_network(netuid, 13, 0);
@@ -1244,10 +1244,10 @@ fn test_do_set_children_multiple_proportions_sum_to_one() {
         let child3 = U256::from(5);
         let netuid: u16 = 1;
 
-        // Proportions that sum to u64::MAX (representing 1)
-        let proportion1: u64 = u64::MAX / 3;
-        let proportion2: u64 = u64::MAX / 3;
-        let proportion3: u64 = u64::MAX - proportion1 - proportion2;
+        // Proportions that sum to u16::MAX (representing 1)
+        let proportion1: u16 = u16::MAX / 3;
+        let proportion2: u16 = u16::MAX / 3;
+        let proportion3: u16 = u16::MAX - proportion1 - proportion2;
 
         // Add network and register hotkey
         add_network(netuid, 13, 0);
@@ -1276,9 +1276,9 @@ fn test_do_set_children_multiple_proportions_sum_to_one() {
             ]
         );
 
-        // Verify the sum of proportions is exactly u64::MAX
-        let sum: u64 = children.iter().map(|(prop, _)| prop).sum();
-        assert_eq!(sum, u64::MAX);
+        // Verify the sum of proportions is exactly u16::MAX
+        let sum: u16 = children.iter().map(|(prop, _)| prop).sum();
+        assert_eq!(sum, u16::MAX);
     });
 }
 
@@ -1291,9 +1291,9 @@ fn test_do_set_children_multiple_proportions_sum_less_than_one() {
         let child2 = U256::from(4);
         let netuid: u16 = 1;
 
-        // Proportions that sum to less than u64::MAX
-        let proportion1: u64 = u64::MAX / 3;
-        let proportion2: u64 = u64::MAX / 3;
+        // Proportions that sum to less than u16::MAX
+        let proportion1: u16 = u16::MAX / 3;
+        let proportion2: u16 = u16::MAX / 3;
 
         // Add network and register hotkey
         add_network(netuid, 13, 0);
@@ -1321,9 +1321,9 @@ fn test_do_set_children_multiple_proportions_sum_greater_than_one() {
         let child2 = U256::from(4);
         let netuid: u16 = 1;
 
-        // Proportions that sum to more than u64::MAX
-        let proportion1: u64 = u64::MAX / 2 + 1;
-        let proportion2: u64 = u64::MAX / 2 + 1;
+        // Proportions that sum to more than u16::MAX
+        let proportion1: u16 = u16::MAX / 2 + 1;
+        let proportion2: u16 = u16::MAX / 2 + 1;
 
         // Add network and register hotkey
         add_network(netuid, 13, 0);
@@ -1358,12 +1358,12 @@ fn test_do_set_children_multiple_single_child_full_proportion() {
         assert_ok!(SubtensorModule::do_set_children_multiple(
             RuntimeOrigin::signed(coldkey),
             hotkey,
-            vec![(child, u64::MAX)],
+            vec![(child, u16::MAX)],
             netuid
         ));
 
         // Verify child is set correctly
         let children = SubtensorModule::get_children(&hotkey, netuid);
-        assert_eq!(children, vec![(u64::MAX, child)]);
+        assert_eq!(children, vec![(u16::MAX, child)]);
     });
 }

--- a/pallets/subtensor/tests/children_info.rs
+++ b/pallets/subtensor/tests/children_info.rs
@@ -12,7 +12,7 @@ fn test_get_child_info() {
         let coldkey = U256::from(1);
         let hotkey = U256::from(2);
         let child = U256::from(3);
-        let proportion: u64 = 500_000_000;
+        let proportion: u16 = 50_000;
 
         // Add network and register hotkey and child
         add_network(netuid, 1, 0);
@@ -54,8 +54,8 @@ fn test_get_children_info() {
         let hotkey = U256::from(2);
         let child1 = U256::from(3);
         let child2 = U256::from(4);
-        let proportion1: u64 = 300_000_000;
-        let proportion2: u64 = u64::MAX - proportion1;
+        let proportion1: u16 = 30_000;
+        let proportion2: u16 = u16::MAX - proportion1;
 
         // Add network and register hotkey and children
         add_network(netuid, 13, 0);
@@ -106,8 +106,8 @@ fn test_get_children_info_multiple_parents() {
         let hotkey1 = U256::from(2);
         let hotkey2 = U256::from(3);
         let child = U256::from(4);
-        let proportion1: u64 = 300_000_000; // 30% of u64::MAX
-        let proportion2: u64 = 200_000_000; // 20% of u64::MAX
+        let proportion1: u16 = 19_660; // 30% of u16::MAX
+        let proportion2: u16 = 13_107; // 20% of u16::MAX
 
         // Add network and register hotkeys and child
         add_network(netuid, 13, 0);
@@ -195,7 +195,7 @@ fn test_get_children_info_after_revoke() {
         let coldkey = U256::from(1);
         let hotkey = U256::from(2);
         let child = U256::from(3);
-        let proportion: u64 = 500_000_000; // 50% of u64::MAX
+        let proportion: u16 = 32_767; // 50% of u16::MAX
 
         // Add network and register hotkey and child
         add_network(netuid, 13, 0);


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please describe): 

Children use u16s for proportions. 

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.