### PR TITLE
Cleanup swap and unstake all code around StakingHotkeys

### DIFF
--- a/pallets/subtensor/src/staking.rs
+++ b/pallets/subtensor/src/staking.rs
@@ -890,34 +890,6 @@ impl<T: Config> Pallet<T> {
         // Ensure the new coldkey is different from the current one
         ensure!(current_coldkey != new_coldkey, Error::<T>::SameColdkey);
 
-        // Get all the hotkeys associated with this coldkey
-        let hotkeys: Vec<T::AccountId> = OwnedHotkeys::<T>::get(&current_coldkey);
-
-        // iterate over all hotkeys.
-        for next_hotkey in hotkeys {
-            ensure!(
-                Self::hotkey_account_exists(&next_hotkey),
-                Error::<T>::HotKeyAccountNotExists
-            );
-            ensure!(
-                Self::coldkey_owns_hotkey(&current_coldkey, &next_hotkey),
-                Error::<T>::NonAssociatedColdKey
-            );
-
-            // Get the current stake
-            let current_stake: u64 =
-                Self::get_stake_for_coldkey_and_hotkey(&current_coldkey, &next_hotkey);
-
-            // Unstake all balance if there's any stake
-            if current_stake > 0 {
-                Self::do_remove_stake(
-                    RawOrigin::Signed(current_coldkey.clone()).into(),
-                    next_hotkey.clone(),
-                    current_stake,
-                )?;
-            }
-        }
-
         // Unstake all delegate stake make by this coldkey to non-owned hotkeys
         let staking_hotkeys = StakingHotkeys::<T>::get(&current_coldkey);
 

--- a/pallets/subtensor/tests/swap.rs
+++ b/pallets/subtensor/tests/swap.rs
@@ -1213,7 +1213,7 @@ fn test_swap_stake_for_coldkey() {
         assert_eq!(TotalIssuance::<Test>::get(), stake_amount1 + stake_amount2);
 
         // Verify weight update
-        let expected_weight = <Test as frame_system::Config>::DbWeight::get().reads_writes(5, 6);
+        let expected_weight = <Test as frame_system::Config>::DbWeight::get().reads_writes(3, 4);
         assert_eq!(weight, expected_weight);
     });
 }


### PR DESCRIPTION
## Description
Separate method for swapping StakingHotkeys
Remove unneeded code in unstake all and transfer

