### PR TITLE
Fix coldkey swap balance transfer

### DIFF
--- a/pallets/subtensor/src/swap.rs
+++ b/pallets/subtensor/src/swap.rs
@@ -402,7 +402,7 @@ impl<T: Config> Pallet<T> {
         );
         Self::swap_subnet_owner_for_coldkey(old_coldkey, new_coldkey, &mut weight);
 
-        // Swap the coldkey.
+        // Transfer any remaining balance from old_coldkey to new_coldkey
         let total_balance: u64 = Self::get_coldkey_balance(old_coldkey);
         weight.saturating_accrue(T::DbWeight::get().reads_writes(1, 0));
         if total_balance > 0 {

--- a/pallets/subtensor/src/swap.rs
+++ b/pallets/subtensor/src/swap.rs
@@ -404,6 +404,7 @@ impl<T: Config> Pallet<T> {
 
         // Swap the coldkey.
         let total_balance: u64 = Self::get_coldkey_balance(old_coldkey);
+        weight.saturating_accrue(T::DbWeight::get().reads_writes(1, 0));
         if total_balance > 0 {
             // Attempt to transfer the entire total balance to coldkeyB.
             if let Err(e) = T::Currency::transfer(
@@ -414,6 +415,7 @@ impl<T: Config> Pallet<T> {
             ) {
                 return Err(e.into());
             }
+            weight.saturating_accrue(T::DbWeight::get().reads_writes(2, 2));
         }
 
         Ok(weight)

--- a/pallets/subtensor/src/swap.rs
+++ b/pallets/subtensor/src/swap.rs
@@ -402,15 +402,6 @@ impl<T: Config> Pallet<T> {
         );
         Self::swap_subnet_owner_for_coldkey(old_coldkey, new_coldkey, &mut weight);
 
-        // Transfer any remaining balance from old_coldkey to new_coldkey
-        let remaining_balance = Self::get_coldkey_balance(old_coldkey);
-        if remaining_balance > 0 {
-            if let Err(e) = Self::kill_coldkey_account(old_coldkey, remaining_balance) {
-                return Err(e.into());
-            }
-            Self::add_balance_to_coldkey_account(new_coldkey, remaining_balance);
-        }
-
         // Swap the coldkey.
         let total_balance: u64 = Self::get_coldkey_balance(old_coldkey);
         if total_balance > 0 {


### PR DESCRIPTION
## Description

1. Remove redundant balance transfer from old key to new key in `perform_swap_coldkey`
2. Add weights to balance transfer

