### PR TITLE
Add test: subnet owner lock returned to new coldkey after coldkey swap

### DIFF
--- a/pallets/subtensor/tests/swap.rs
+++ b/pallets/subtensor/tests/swap.rs
@@ -1684,10 +1684,7 @@ fn test_dissolve_subnet_after_swap() {
         pallet_subtensor::SubnetLocked::<Test>::insert(netuid, lock_cost);
 
         // Perform the swap from coldkey1 to coldkey2
-        assert_ok!(SubtensorModule::perform_swap_coldkey(
-            &coldkey1,
-            &coldkey2
-        ));
+        assert_ok!(SubtensorModule::perform_swap_coldkey(&coldkey1, &coldkey2));
 
         // Check that Subnet still has its lock
         assert_eq!(
@@ -1704,10 +1701,7 @@ fn test_dissolve_subnet_after_swap() {
         assert!(SubtensorModule::if_subnet_exist(netuid));
 
         // Check new subnet owner balance before dissolving
-        assert_eq!(
-            SubtensorModule::get_coldkey_balance(&coldkey2),
-            balance
-        );
+        assert_eq!(SubtensorModule::get_coldkey_balance(&coldkey2), balance);
 
         // Dissolve subnet using coldkey2
         assert_ok!(SubtensorModule::dissolve_network(


### PR DESCRIPTION
## Description
Add test that verifies that if subnet is dissolved after coldkey swap, the new coldkey receives subnet lock.

## Related Issue(s)

n/a

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please describe): Added unit test

## Breaking Change

No

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

n/a

## Additional Notes

n/a