### PR TITLE
Enforce rate limits in decrease take

### DIFF
--- a/pallets/subtensor/src/staking.rs
+++ b/pallets/subtensor/src/staking.rs
@@ -165,11 +165,11 @@ impl<T: Config> Pallet<T> {
             Error::<T>::DelegateTxRateLimitExceeded
         );
 
-        // Set last block for rate limiting
-        Self::set_last_tx_block_delegate_take(&coldkey, block);
-
         // --- 4. Set the new take value.
         Delegates::<T>::insert(hotkey.clone(), take);
+
+        // Set last block for rate limiting
+        Self::set_last_tx_block_delegate_take(&coldkey, block);
 
         // --- 5. Emit the take value.
         log::info!(
@@ -254,11 +254,11 @@ impl<T: Config> Pallet<T> {
             Error::<T>::DelegateTxRateLimitExceeded
         );
 
-        // Set last block for rate limiting
-        Self::set_last_tx_block_delegate_take(&coldkey, block);
-
         // --- 6. Set the new take value.
         Delegates::<T>::insert(hotkey.clone(), take);
+
+        // Set last block for rate limiting
+        Self::set_last_tx_block_delegate_take(&coldkey, block);
 
         // --- 7. Emit the take value.
         log::info!(

--- a/pallets/subtensor/src/staking.rs
+++ b/pallets/subtensor/src/staking.rs
@@ -155,6 +155,10 @@ impl<T: Config> Pallet<T> {
         let min_take = MinTake::<T>::get();
         ensure!(take >= min_take, Error::<T>::DelegateTakeTooLow);
 
+        // Set last block for rate limiting
+        let block: u64 = Self::get_current_block_as_u64();
+        Self::set_last_tx_block_delegate_take(&coldkey, block);
+
         // --- 4. Set the new take value.
         Delegates::<T>::insert(hotkey.clone(), take);
 

--- a/pallets/subtensor/src/staking.rs
+++ b/pallets/subtensor/src/staking.rs
@@ -155,7 +155,7 @@ impl<T: Config> Pallet<T> {
         let min_take = MinTake::<T>::get();
         ensure!(take >= min_take, Error::<T>::DelegateTakeTooLow);
 
-        // --- 5. Enforce the rate limit (independently on do_add_stake rate limits)
+        // Enforce the rate limit (independently on do_add_stake rate limits)
         let block: u64 = Self::get_current_block_as_u64();
         ensure!(
             !Self::exceeds_tx_delegate_take_rate_limit(

--- a/pallets/subtensor/src/staking.rs
+++ b/pallets/subtensor/src/staking.rs
@@ -155,8 +155,17 @@ impl<T: Config> Pallet<T> {
         let min_take = MinTake::<T>::get();
         ensure!(take >= min_take, Error::<T>::DelegateTakeTooLow);
 
-        // Set last block for rate limiting
+        // --- 5. Enforce the rate limit (independently on do_add_stake rate limits)
         let block: u64 = Self::get_current_block_as_u64();
+        ensure!(
+            !Self::exceeds_tx_delegate_take_rate_limit(
+                Self::get_last_tx_block_delegate_take(&coldkey),
+                block
+            ),
+            Error::<T>::DelegateTxRateLimitExceeded
+        );
+
+        // Set last block for rate limiting
         Self::set_last_tx_block_delegate_take(&coldkey, block);
 
         // --- 4. Set the new take value.

--- a/pallets/subtensor/tests/staking.rs
+++ b/pallets/subtensor/tests/staking.rs
@@ -3136,6 +3136,66 @@ fn test_rate_limits_enforced_on_increase_take() {
     });
 }
 
+// Test rate-limiting on increase_take
+#[test]
+fn test_rate_limits_enforced_on_increase_take_after_decrease() {
+    new_test_ext(1).execute_with(|| {
+        // Make account
+        let hotkey0 = U256::from(1);
+        let coldkey0 = U256::from(3);
+
+        // Add balance
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey0, 100000);
+
+        // Register the neuron to a new network
+        let netuid = 1;
+        add_network(netuid, 0, 0);
+        register_ok_neuron(netuid, hotkey0, coldkey0, 124124);
+
+        // Coldkey / hotkey 0 become delegates with max take
+        assert_ok!(SubtensorModule::do_become_delegate(
+            <<Test as Config>::RuntimeOrigin>::signed(coldkey0),
+            hotkey0,
+            pallet_subtensor::MaxTake::<Test>::get()
+        ));
+
+        // Coldkey / hotkey 0 decreases take
+        assert_ok!(SubtensorModule::do_decrease_take(
+            <<Test as Config>::RuntimeOrigin>::signed(coldkey0),
+            hotkey0,
+            SubtensorModule::get_min_take()
+        ));
+
+        // Attempt to immediately increase fails due to rate limit
+        assert_eq!(
+            SubtensorModule::do_increase_take(
+                <<Test as Config>::RuntimeOrigin>::signed(coldkey0),
+                hotkey0,
+                pallet_subtensor::MaxTake::<Test>::get()
+            ),
+            Err(Error::<Test>::DelegateTxRateLimitExceeded.into())
+        );
+        assert_eq!(
+            SubtensorModule::get_hotkey_take(&hotkey0),
+            SubtensorModule::get_min_take()
+        );
+
+        // After number of blocks, take can be increased
+        step_block(1 + InitialTxDelegateTakeRateLimit::get() as u16);
+
+        // Can increase after waiting
+        assert_ok!(SubtensorModule::do_increase_take(
+            <<Test as Config>::RuntimeOrigin>::signed(coldkey0),
+            hotkey0,
+            pallet_subtensor::MaxTake::<Test>::get()
+        ));
+        assert_eq!(
+            SubtensorModule::get_hotkey_take(&hotkey0),
+            pallet_subtensor::MaxTake::<Test>::get()
+        );
+    });
+}
+
 // Helper function to set up a test environment
 fn setup_test_environment() -> (AccountId, AccountId, AccountId) {
     let current_coldkey = U256::from(1);


### PR DESCRIPTION
## Description
- Take cannot be increased right away after decreasing
- Rate limits are enforced in decrease_take extrinsic

## Related Issue(s)

n/a

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

n/a

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

n/a

## Additional Notes

n/a