### PR TITLE
Add a test for validator vs miner emissions

### DIFF
--- a/pallets/subtensor/tests/staking.rs
+++ b/pallets/subtensor/tests/staking.rs
@@ -2275,7 +2275,7 @@ fn test_full_block_emission_occurs() {
     });
 }
 
-// This test sets up one validator and one miner for a subnet, and 
+// This test sets up one validator and one miner for a subnet, and
 // then runs an epoch and checks that validator gets validator emission only
 // and miner gets miner emission only.
 //

--- a/pallets/subtensor/tests/staking.rs
+++ b/pallets/subtensor/tests/staking.rs
@@ -2295,9 +2295,18 @@ fn test_only_validators_provide_rewards_to_nominators() {
         SubtensorModule::set_target_stakes_per_interval(10);
 
         // Add balances.
-        SubtensorModule::add_balance_to_coldkey_account(&coldkey, 11 * stake + ExistentialDeposit::get());
-        SubtensorModule::add_balance_to_coldkey_account(&nominator1, stake + ExistentialDeposit::get());
-        SubtensorModule::add_balance_to_coldkey_account(&nominator2, stake + ExistentialDeposit::get());
+        SubtensorModule::add_balance_to_coldkey_account(
+            &coldkey,
+            11 * stake + ExistentialDeposit::get(),
+        );
+        SubtensorModule::add_balance_to_coldkey_account(
+            &nominator1,
+            stake + ExistentialDeposit::get(),
+        );
+        SubtensorModule::add_balance_to_coldkey_account(
+            &nominator2,
+            stake + ExistentialDeposit::get(),
+        );
 
         // Register the 2 neurons to a new network.
         add_network(netuid, 0, 0);
@@ -2306,7 +2315,7 @@ fn test_only_validators_provide_rewards_to_nominators() {
         assert!(SubtensorModule::coldkey_owns_hotkey(&coldkey, &validator));
         assert!(SubtensorModule::coldkey_owns_hotkey(&coldkey, &miner));
 
-        // Setup validator and miner roles: 
+        // Setup validator and miner roles:
         //   Validator is in top k by stake because it has 10x stake of a regular user
         //   Validator has validator permit (and epoch function will not change it because it is still the top staker)
         //   Max validators is 1


### PR DESCRIPTION
## Description
This PR adds one unit test for epoch function that checks that validator and miner emissions.

While there's not much testing value added, it has some comments that explain very well how emissions are distributed between validators and miners, etc. This is one more proof that Yuma works as intended.

## Related Issue(s)

n/a

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please describe): unit test only

## Breaking Change

n/a

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

n/a

## Additional Notes

n/a