### PR TITLE
Fix issues with Subtensor storage versions

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -84,7 +84,7 @@ pub mod pallet {
 
     /// Tracks version for migrations. Should be monotonic with respect to the
     /// order of migrations. (i.e. always increasing)
-    const STORAGE_VERSION: StorageVersion = StorageVersion::new(6);
+    const STORAGE_VERSION: StorageVersion = StorageVersion::new(7);
 
     /// Minimum balance required to perform a coldkey swap
     pub const MIN_BALANCE_TO_PERFORM_COLDKEY_SWAP: u64 = 100_000_000; // 0.1 TAO in RAO
@@ -1140,6 +1140,9 @@ pub mod pallet {
         DefaultBonds<T>,
     >;
 
+    #[pallet::storage] // --- Storage for migration run status
+    pub type HasMigrationRun<T: Config> = StorageMap<_, Identity, Vec<u8>, bool, ValueQuery>;
+
     /// ==================
     /// ==== Genesis =====
     /// ==================
@@ -1420,7 +1423,7 @@ pub mod pallet {
                 .saturating_add(migration::migrate_populate_owned::<T>())
                 // Populate StakingHotkeys map for coldkey swap. Doesn't update storage vesion.
                 .saturating_add(migration::migrate_populate_staking_hotkeys::<T>())
-                // Fix total coldkey stake.
+                //Fix total coldkey stake.
                 .saturating_add(migration::migrate_fix_total_coldkey_stake::<T>());
 
             weight

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1423,7 +1423,7 @@ pub mod pallet {
                 .saturating_add(migration::migrate_populate_owned::<T>())
                 // Populate StakingHotkeys map for coldkey swap. Doesn't update storage vesion.
                 .saturating_add(migration::migrate_populate_staking_hotkeys::<T>())
-                //Fix total coldkey stake.
+                // Fix total coldkey stake.
                 .saturating_add(migration::migrate_fix_total_coldkey_stake::<T>());
 
             weight

--- a/pallets/subtensor/src/migration.rs
+++ b/pallets/subtensor/src/migration.rs
@@ -1,4 +1,5 @@
 use super::*;
+use alloc::string::String;
 use frame_support::traits::DefensiveResult;
 use frame_support::{
     pallet_prelude::{Identity, OptionQuery},
@@ -79,7 +80,10 @@ pub fn migrate_fix_total_coldkey_stake<T: Config>() -> Weight {
         return Weight::zero();
     }
 
-    log::info!("Running migration '{:?}'", migration_name);
+    log::info!(
+        "Running migration '{}'",
+        String::from_utf8_lossy(&migration_name)
+    );
 
     // Run the migration
     weight = weight.saturating_add(do_migrate_fix_total_coldkey_stake::<T>());
@@ -94,7 +98,7 @@ pub fn migrate_fix_total_coldkey_stake<T: Config>() -> Weight {
 
     log::info!(
         "Migration '{:?}' completed. Storage version set to 7.",
-        migration_name
+        String::from_utf8_lossy(&migration_name)
     );
 
     // Return the migration weight.

--- a/pallets/subtensor/src/migration.rs
+++ b/pallets/subtensor/src/migration.rs
@@ -57,10 +57,6 @@ pub fn do_migrate_fix_total_coldkey_stake<T: Config>() -> Weight {
     weight
 }
 
-// #[pallet::storage]
-// #[pallet::getter(fn has_migration_run)]
-// pub type HasMigrationRun<T: Config> = StorageMap<_, Identity, &'static str, bool, ValueQuery>;
-
 /// Migrates and fixes the total coldkey stake.
 ///
 /// This function checks if the migration has already run, and if not, it performs the migration

--- a/pallets/subtensor/src/migration.rs
+++ b/pallets/subtensor/src/migration.rs
@@ -56,30 +56,54 @@ pub fn do_migrate_fix_total_coldkey_stake<T: Config>() -> Weight {
     }
     weight
 }
-// Public migrate function to be called by Lib.rs on upgrade.
+
+// #[pallet::storage]
+// #[pallet::getter(fn has_migration_run)]
+// pub type HasMigrationRun<T: Config> = StorageMap<_, Identity, &'static str, bool, ValueQuery>;
+
+/// Migrates and fixes the total coldkey stake.
+///
+/// This function checks if the migration has already run, and if not, it performs the migration
+/// to fix the total coldkey stake. It also marks the migration as completed after running.
+///
+/// # Returns
+/// The weight of the migration process.
 pub fn migrate_fix_total_coldkey_stake<T: Config>() -> Weight {
-    let current_storage_version: u16 = 7;
-    let next_storage_version: u16 = 8;
+    let migration_name = b"fix_total_coldkey_stake_v7".to_vec();
 
     // Initialize the weight with one read operation.
     let mut weight = T::DbWeight::get().reads(1);
 
-    // Grab the current on-chain storage version.
-    // Cant fail on retrieval.
-    let onchain_version = Pallet::<T>::on_chain_storage_version();
-
-    // Only run this migration on storage version 6.
-    if onchain_version == current_storage_version {
-        weight = weight.saturating_add(do_migrate_fix_total_coldkey_stake::<T>());
-        // Cant fail on insert.
-        StorageVersion::new(next_storage_version).put::<Pallet<T>>();
-        weight.saturating_accrue(T::DbWeight::get().writes(1));
+    // Check if the migration has already run
+    if HasMigrationRun::<T>::get(&migration_name) {
+        log::info!(
+            "Migration '{:?}' has already run. Skipping.",
+            migration_name
+        );
+        return Weight::zero();
     }
+
+    log::info!("Running migration '{:?}'", migration_name);
+
+    // Run the migration
+    weight = weight.saturating_add(do_migrate_fix_total_coldkey_stake::<T>());
+
+    // Mark the migration as completed
+    HasMigrationRun::<T>::insert(&migration_name, true);
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+    // Set the storage version to 7
+    StorageVersion::new(7).put::<Pallet<T>>();
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+    log::info!(
+        "Migration '{:?}' completed. Storage version set to 7.",
+        migration_name
+    );
 
     // Return the migration weight.
     weight
 }
-
 /// Performs migration to update the total issuance based on the sum of stakes and total balances.
 /// This migration is applicable only if the current storage version is 5, after which it updates the storage version to 6.
 ///

--- a/pallets/subtensor/tests/migration.rs
+++ b/pallets/subtensor/tests/migration.rs
@@ -405,6 +405,3 @@ fn run_migration_and_check(migration_name: &'static str) -> frame_support::weigh
     // Return the weight of the executed migration
     weight
 }
-
-// TODO: Consider adding error handling for cases where the migration fails or is already completed.
-// NOTE: The use of `as_bytes().to_vec()` might be inefficient for larger strings. Consider using a more efficient encoding method if performance becomes an issue.


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->

This PR Subtensor storage version. We had it hardcoded to 6, but the on chain version was 7, which was causing issue with try runtime and running the actual migrations on clone.

## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.