### PR TITLE
Fix/total coldkey stake migration; clear map first

### DIFF
--- a/pallets/subtensor/src/migration.rs
+++ b/pallets/subtensor/src/migration.rs
@@ -37,7 +37,7 @@ pub fn do_migrate_fix_total_coldkey_stake<T: Config>() -> Weight {
     // Initialize the weight with one read operation.
     let mut weight = T::DbWeight::get().reads(1);
 
-    // Clear everything from the map first
+    // Clear everything from the map first, no limit (u32::MAX)
     let removal_results = TotalColdkeyStake::<T>::clear(u32::MAX, None);
     // 1 read/write per removal
     let entries_removed: u64 = removal_results.backend.into();

--- a/pallets/subtensor/src/migration.rs
+++ b/pallets/subtensor/src/migration.rs
@@ -38,7 +38,11 @@ pub fn do_migrate_fix_total_coldkey_stake<T: Config>() -> Weight {
     let mut weight = T::DbWeight::get().reads(1);
 
     // Clear everything from the map first
-    let _ = TotalColdkeyStake::<T>::clear(u32::MAX, None);
+    let removal_results = TotalColdkeyStake::<T>::clear(u32::MAX, None);
+    // 1 read/write per removal
+    let entries_removed: u64 = removal_results.backend.into();
+    weight =
+        weight.saturating_add(T::DbWeight::get().reads_writes(entries_removed, entries_removed));
 
     // Iterate through all staking hotkeys.
     for (coldkey, hotkey_vec) in StakingHotkeys::<T>::iter() {

--- a/pallets/subtensor/src/migration.rs
+++ b/pallets/subtensor/src/migration.rs
@@ -37,6 +37,9 @@ pub fn do_migrate_fix_total_coldkey_stake<T: Config>() -> Weight {
     // Initialize the weight with one read operation.
     let mut weight = T::DbWeight::get().reads(1);
 
+    // Clear everything from the map first
+    let _ = TotalColdkeyStake::<T>::clear(u32::MAX, None);
+
     // Iterate through all staking hotkeys.
     for (coldkey, hotkey_vec) in StakingHotkeys::<T>::iter() {
         // Init the zero value.

--- a/pallets/subtensor/tests/migration.rs
+++ b/pallets/subtensor/tests/migration.rs
@@ -392,9 +392,9 @@ fn test_migrate_fix_total_coldkey_stake_runs_once() {
     })
 }
 
-// SKIP_WASM_BUILD=1 RUST_LOG=info cargo test --test migration -- test_migrate_fix_total_coldkey_stake_starts_with_value_no_more_entries --exact --nocapture
+// SKIP_WASM_BUILD=1 RUST_LOG=info cargo test --test migration -- test_migrate_fix_total_coldkey_stake_starts_with_value_no_stake_map_entries --exact --nocapture
 #[test]
-fn test_migrate_fix_total_coldkey_stake_starts_with_value_no_more_entries() {
+fn test_migrate_fix_total_coldkey_stake_starts_with_value_no_stake_map_entries() {
     new_test_ext(1).execute_with(|| {
         let migration_name = "fix_total_coldkey_stake_v7";
         let coldkey = U256::from(0);

--- a/pallets/subtensor/tests/migration.rs
+++ b/pallets/subtensor/tests/migration.rs
@@ -392,6 +392,23 @@ fn test_migrate_fix_total_coldkey_stake_runs_once() {
     })
 }
 
+// SKIP_WASM_BUILD=1 RUST_LOG=info cargo test --test migration -- test_migrate_fix_total_coldkey_stake_starts_with_value_no_more_entries --exact --nocapture
+#[test]
+fn test_migrate_fix_total_coldkey_stake_starts_with_value_no_more_entries() {
+    new_test_ext(1).execute_with(|| {
+        let migration_name = "fix_total_coldkey_stake_v7";
+        let coldkey = U256::from(0);
+        TotalColdkeyStake::<Test>::insert(coldkey, 123_456_789);
+
+        // Notably, coldkey has no stake map or staking_hotkeys map entries
+
+        let weight = run_migration_and_check(migration_name);
+        assert!(weight != Weight::zero());
+        // Therefore 0
+        assert_eq!(TotalColdkeyStake::<Test>::get(coldkey), 0);
+    })
+}
+
 fn run_migration_and_check(migration_name: &'static str) -> frame_support::weights::Weight {
     // Execute the migration and store its weight
     let weight: frame_support::weights::Weight =


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
Fixes an issue with #636 where the `TotalColdkeyStake` map was not cleared before being set to the new values. So some keys retain an errant value of non-zero when they have no corresponding stake-map entry.


## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
