### PR TITLE
LastAddStakeIncrease, division by zero in drain_hotkey_emission, and tests for childkeys and run_coinbase

### DIFF
--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -267,8 +267,11 @@ impl<T: Config> Pallet<T> {
         // --- 3 Update the block value to the current block number.
         LastHotkeyEmissionDrain::<T>::insert(hotkey, block_number);
 
-        // --- 4 Retrieve the total stake for the hotkey from all nominations.
-        let total_hotkey_stake: u64 = Self::get_total_stake_for_hotkey(hotkey);
+        // --- 4 Retrieve the total stake for the hotkey from all nominations with parents and children from all subnets
+        let total_hotkey_stake: u64 = Self::get_all_subnet_netuids()
+            .iter()
+            .map(|&netuid| Self::get_stake_for_hotkey_on_subnet(hotkey, netuid))
+            .sum();
 
         if total_hotkey_stake == 0 {
             // If there's no stake, we can't distribute any emission

--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -270,6 +270,11 @@ impl<T: Config> Pallet<T> {
         // --- 4 Retrieve the total stake for the hotkey from all nominations.
         let total_hotkey_stake: u64 = Self::get_total_stake_for_hotkey(hotkey);
 
+        if total_hotkey_stake == 0 {
+            // If there's no stake, we can't distribute any emission
+            return 0;
+        }
+
         // --- 5 Calculate the emission take for the hotkey.
         let take_proportion: I64F64 = I64F64::from_num(Delegates::<T>::get(hotkey))
             .saturating_div(I64F64::from_num(u16::MAX));

--- a/pallets/subtensor/src/macros/config.rs
+++ b/pallets/subtensor/src/macros/config.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::crate_in_macro_def)]
 use frame_support::pallet_macros::pallet_section;
 
 /// A [`pallet_section`] that defines the errors for a pallet.

--- a/pallets/subtensor/src/subnets/registration.rs
+++ b/pallets/subtensor/src/subnets/registration.rs
@@ -550,7 +550,11 @@ impl<T: Config> Pallet<T> {
         // Copy the hotkey_bytes into the first half of full_bytes
         full_bytes[..32].copy_from_slice(hotkey_bytes);
         let keccak_256_seal_hash_vec: [u8; 32] = keccak_256(&full_bytes[..]);
-        let hash_u64: u64 = u64::from_le_bytes(keccak_256_seal_hash_vec[0..8].try_into().unwrap_or_default());
+        let hash_u64: u64 = u64::from_le_bytes(
+            keccak_256_seal_hash_vec[0..8]
+                .try_into()
+                .unwrap_or_default(),
+        );
         hash_u64
     }
 

--- a/pallets/subtensor/tests/children.rs
+++ b/pallets/subtensor/tests/children.rs
@@ -1398,8 +1398,11 @@ fn test_drain_hotkey_emission_division_by_zero() {
             step_block(1);
             let block = SubtensorModule::get_current_block_as_u64();
 
-            println!("block = {}, should drain = {}", block, SubtensorModule::should_drain_hotkey(&validator2, block, 10u64));
-
+            println!(
+                "block = {}, should drain = {}",
+                block,
+                SubtensorModule::should_drain_hotkey(&validator2, block, 10u64)
+            );
 
             if SubtensorModule::should_drain_hotkey(&validator2, block, tempo as u64) {
                 break;

--- a/pallets/subtensor/tests/children.rs
+++ b/pallets/subtensor/tests/children.rs
@@ -1260,8 +1260,10 @@ fn test_children_stake_values() {
     });
 }
 
+// This test sets us a childkey-validator that has zero own or delegated stake and has only become
+// a validator because of his parents' stake.
 #[test]
-fn test_drain_hotkey_emission_division_by_zero() {
+fn test_drain_hotkey_emission_no_division_by_zero_with_zero_stake() {
     new_test_ext(1).execute_with(|| {
         let netuid: u16 = 1;
         let tempo = 10;

--- a/pallets/subtensor/tests/coinbase.rs
+++ b/pallets/subtensor/tests/coinbase.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use crate::mock::*;
 mod mock;
 // use frame_support::{assert_err, assert_ok};

--- a/scripts/test_specific.sh
+++ b/scripts/test_specific.sh
@@ -3,4 +3,4 @@ features="${4:-pow-faucet}"
 
 # RUST_LOG="pallet_subtensor=info" cargo test --release --features=$features -p $pallet --test $1 -- $2 --nocapture --exact
 
-RUST_LOG=INFO cargo test --release --features=$features -p $pallet --test $1 -- $2 --nocapture --exact
+RUST_LOG=debug cargo test --release --features=$features -p $pallet --test $1 -- $2 --nocapture --exact


### PR DESCRIPTION
## Description
1. Fix missing LastAddStakeIncrease
2. Fix division by zero in drain_hotkey_emission
3. Add childkey test for zero childkey stake
4. Add test for run_coinbase: test_staking_at_block_7198_does_not_affect_others_rewards, that tests for a nominator playing the system and staking 2 blocks before hotkey draining tempo.
