### PR TITLE
Added `--no-purge` flag to `scripts/localnet.sh` to be able to save state when restarting a script.

### DIFF
--- a/scripts/localnet.sh
+++ b/scripts/localnet.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# Check if `--no-purge` passed as a parameter
+NO_PURGE=0
+for arg in "$@"; do
+    if [ "$arg" = "--no-purge" ]; then
+        NO_PURGE=1
+        break
+    fi
+done
+
 # Determine the directory this script resides in. This allows invoking it from any location.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
@@ -32,10 +41,14 @@ echo "*** Building chainspec..."
 "$BASE_DIR/target/release/node-subtensor" build-spec --disable-default-bootnode --raw --chain $CHAIN >$FULL_PATH
 echo "*** Chainspec built and output to file"
 
-echo "*** Purging previous state..."
-"$BASE_DIR/target/release/node-subtensor" purge-chain -y --base-path /tmp/bob --chain="$FULL_PATH" >/dev/null 2>&1
-"$BASE_DIR/target/release/node-subtensor" purge-chain -y --base-path /tmp/alice --chain="$FULL_PATH" >/dev/null 2>&1
-echo "*** Previous chainstate purged"
+if [ $NO_PURGE -eq 1 ]; then
+  echo "*** Purging previous state skipped..."
+else
+  echo "*** Purging previous state..."
+  "$BASE_DIR/target/release/node-subtensor" purge-chain -y --base-path /tmp/bob --chain="$FULL_PATH" >/dev/null 2>&1
+  "$BASE_DIR/target/release/node-subtensor" purge-chain -y --base-path /tmp/alice --chain="$FULL_PATH" >/dev/null 2>&1
+  echo "*** Previous chainstate purged"
+fi
 
 echo "*** Starting localnet nodes..."
 alice_start=(


### PR DESCRIPTION
When working with localnet, there is often a need to restart the script. To save the state and not waste time on settings, you need to comment out some lines. I suggest introducing a flag that will bypass local state cleanup.