### PR TITLE
[devnet-ready] [clippy] fix clippy warnings

### DIFF
--- a/pallets/subtensor/tests/swap_hotkey.rs
+++ b/pallets/subtensor/tests/swap_hotkey.rs
@@ -19,7 +19,7 @@ fn test_swap_owner() {
         let coldkey = U256::from(3);
         let mut weight = Weight::zero();
 
-        Owner::<Test>::insert(&old_hotkey, &coldkey);
+        Owner::<Test>::insert(old_hotkey, coldkey);
         assert_ok!(SubtensorModule::perform_hotkey_swap(
             &old_hotkey,
             &new_hotkey,
@@ -27,8 +27,8 @@ fn test_swap_owner() {
             &mut weight
         ));
 
-        assert!(!Owner::<Test>::contains_key(&old_hotkey));
-        assert_eq!(Owner::<Test>::get(&new_hotkey), coldkey);
+        assert!(!Owner::<Test>::contains_key(old_hotkey));
+        assert_eq!(Owner::<Test>::get(new_hotkey), coldkey);
     });
 }
 
@@ -41,7 +41,7 @@ fn test_swap_owned_hotkeys() {
         let coldkey = U256::from(3);
         let mut weight = Weight::zero();
 
-        OwnedHotkeys::<Test>::insert(&coldkey, vec![old_hotkey]);
+        OwnedHotkeys::<Test>::insert(coldkey, vec![old_hotkey]);
         assert_ok!(SubtensorModule::perform_hotkey_swap(
             &old_hotkey,
             &new_hotkey,
@@ -49,7 +49,7 @@ fn test_swap_owned_hotkeys() {
             &mut weight
         ));
 
-        let hotkeys = OwnedHotkeys::<Test>::get(&coldkey);
+        let hotkeys = OwnedHotkeys::<Test>::get(coldkey);
         assert!(!hotkeys.contains(&old_hotkey));
         assert!(hotkeys.contains(&new_hotkey));
     });
@@ -64,8 +64,8 @@ fn test_swap_total_hotkey_stake() {
         let coldkey = U256::from(3);
         let mut weight = Weight::zero();
 
-        TotalHotkeyStake::<Test>::insert(&old_hotkey, 100);
-        TotalHotkeyStake::<Test>::insert(&new_hotkey, 50);
+        TotalHotkeyStake::<Test>::insert(old_hotkey, 100);
+        TotalHotkeyStake::<Test>::insert(new_hotkey, 50);
         assert_ok!(SubtensorModule::perform_hotkey_swap(
             &old_hotkey,
             &new_hotkey,
@@ -73,8 +73,8 @@ fn test_swap_total_hotkey_stake() {
             &mut weight
         ));
 
-        assert!(!TotalHotkeyStake::<Test>::contains_key(&old_hotkey));
-        assert_eq!(TotalHotkeyStake::<Test>::get(&new_hotkey), 150);
+        assert!(!TotalHotkeyStake::<Test>::contains_key(old_hotkey));
+        assert_eq!(TotalHotkeyStake::<Test>::get(new_hotkey), 150);
     });
 }
 
@@ -87,7 +87,7 @@ fn test_swap_total_hotkey_coldkey_stakes_this_interval() {
         let coldkey = U256::from(3);
         let mut weight = Weight::zero();
 
-        TotalHotkeyColdkeyStakesThisInterval::<Test>::insert(&old_hotkey, &coldkey, (100, 1000));
+        TotalHotkeyColdkeyStakesThisInterval::<Test>::insert(old_hotkey, coldkey, (100, 1000));
         assert_ok!(SubtensorModule::perform_hotkey_swap(
             &old_hotkey,
             &new_hotkey,
@@ -96,11 +96,11 @@ fn test_swap_total_hotkey_coldkey_stakes_this_interval() {
         ));
 
         assert!(!TotalHotkeyColdkeyStakesThisInterval::<Test>::contains_key(
-            &old_hotkey,
-            &coldkey
+            old_hotkey,
+            coldkey
         ));
         assert_eq!(
-            TotalHotkeyColdkeyStakesThisInterval::<Test>::get(&new_hotkey, &coldkey),
+            TotalHotkeyColdkeyStakesThisInterval::<Test>::get(new_hotkey, coldkey),
             (100, 1000)
         );
     });
@@ -115,7 +115,7 @@ fn test_swap_last_tx_block() {
         let coldkey = U256::from(3);
         let mut weight = Weight::zero();
 
-        LastTxBlock::<Test>::insert(&old_hotkey, 1000);
+        LastTxBlock::<Test>::insert(old_hotkey, 1000);
         assert_ok!(SubtensorModule::perform_hotkey_swap(
             &old_hotkey,
             &new_hotkey,
@@ -123,9 +123,9 @@ fn test_swap_last_tx_block() {
             &mut weight
         ));
 
-        assert!(!LastTxBlock::<Test>::contains_key(&old_hotkey));
+        assert!(!LastTxBlock::<Test>::contains_key(old_hotkey));
         assert_eq!(
-            LastTxBlock::<Test>::get(&new_hotkey),
+            LastTxBlock::<Test>::get(new_hotkey),
             SubtensorModule::get_current_block_as_u64()
         );
     });
@@ -140,7 +140,7 @@ fn test_swap_last_tx_block_delegate_take() {
         let coldkey = U256::from(3);
         let mut weight = Weight::zero();
 
-        pallet_subtensor::LastTxBlockDelegateTake::<Test>::insert(&old_hotkey, 1000);
+        pallet_subtensor::LastTxBlockDelegateTake::<Test>::insert(old_hotkey, 1000);
         assert_ok!(SubtensorModule::perform_hotkey_swap(
             &old_hotkey,
             &new_hotkey,
@@ -148,9 +148,9 @@ fn test_swap_last_tx_block_delegate_take() {
             &mut weight
         ));
 
-        assert!(!LastTxBlockDelegateTake::<Test>::contains_key(&old_hotkey));
+        assert!(!LastTxBlockDelegateTake::<Test>::contains_key(old_hotkey));
         assert_eq!(
-            LastTxBlockDelegateTake::<Test>::get(&new_hotkey),
+            LastTxBlockDelegateTake::<Test>::get(new_hotkey),
             SubtensorModule::get_current_block_as_u64()
         );
     });
@@ -189,7 +189,7 @@ fn test_swap_delegates() {
         let coldkey = U256::from(3);
         let mut weight = Weight::zero();
 
-        Delegates::<Test>::insert(&old_hotkey, 100);
+        Delegates::<Test>::insert(old_hotkey, 100);
         assert_ok!(SubtensorModule::perform_hotkey_swap(
             &old_hotkey,
             &new_hotkey,
@@ -197,8 +197,8 @@ fn test_swap_delegates() {
             &mut weight
         ));
 
-        assert!(!Delegates::<Test>::contains_key(&old_hotkey));
-        assert_eq!(Delegates::<Test>::get(&new_hotkey), 100);
+        assert!(!Delegates::<Test>::contains_key(old_hotkey));
+        assert_eq!(Delegates::<Test>::get(new_hotkey), 100);
     });
 }
 
@@ -213,7 +213,7 @@ fn test_swap_subnet_membership() {
         let mut weight = Weight::zero();
 
         add_network(netuid, 0, 1);
-        IsNetworkMember::<Test>::insert(&old_hotkey, netuid, true);
+        IsNetworkMember::<Test>::insert(old_hotkey, netuid, true);
         assert_ok!(SubtensorModule::perform_hotkey_swap(
             &old_hotkey,
             &new_hotkey,
@@ -221,8 +221,8 @@ fn test_swap_subnet_membership() {
             &mut weight
         ));
 
-        assert!(!IsNetworkMember::<Test>::contains_key(&old_hotkey, netuid));
-        assert!(IsNetworkMember::<Test>::get(&new_hotkey, netuid));
+        assert!(!IsNetworkMember::<Test>::contains_key(old_hotkey, netuid));
+        assert!(IsNetworkMember::<Test>::get(new_hotkey, netuid));
     });
 }
 
@@ -238,8 +238,8 @@ fn test_swap_uids_and_keys() {
         let mut weight = Weight::zero();
 
         add_network(netuid, 0, 1);
-        IsNetworkMember::<Test>::insert(&old_hotkey, netuid, true);
-        Uids::<Test>::insert(netuid, &old_hotkey, uid);
+        IsNetworkMember::<Test>::insert(old_hotkey, netuid, true);
+        Uids::<Test>::insert(netuid, old_hotkey, uid);
         Keys::<Test>::insert(netuid, uid, old_hotkey);
 
         assert_ok!(SubtensorModule::perform_hotkey_swap(
@@ -249,8 +249,8 @@ fn test_swap_uids_and_keys() {
             &mut weight
         ));
 
-        assert_eq!(Uids::<Test>::get(netuid, &old_hotkey), None);
-        assert_eq!(Uids::<Test>::get(netuid, &new_hotkey), Some(uid));
+        assert_eq!(Uids::<Test>::get(netuid, old_hotkey), None);
+        assert_eq!(Uids::<Test>::get(netuid, new_hotkey), Some(uid));
         assert_eq!(Keys::<Test>::get(netuid, uid), new_hotkey);
     });
 }
@@ -267,8 +267,8 @@ fn test_swap_prometheus() {
         let mut weight = Weight::zero();
 
         add_network(netuid, 0, 1);
-        IsNetworkMember::<Test>::insert(&old_hotkey, netuid, true);
-        Prometheus::<Test>::insert(netuid, &old_hotkey, prometheus_info.clone());
+        IsNetworkMember::<Test>::insert(old_hotkey, netuid, true);
+        Prometheus::<Test>::insert(netuid, old_hotkey, prometheus_info.clone());
 
         assert_ok!(SubtensorModule::perform_hotkey_swap(
             &old_hotkey,
@@ -277,9 +277,9 @@ fn test_swap_prometheus() {
             &mut weight
         ));
 
-        assert!(!Prometheus::<Test>::contains_key(netuid, &old_hotkey));
+        assert!(!Prometheus::<Test>::contains_key(netuid, old_hotkey));
         assert_eq!(
-            Prometheus::<Test>::get(netuid, &new_hotkey),
+            Prometheus::<Test>::get(netuid, new_hotkey),
             Some(prometheus_info)
         );
     });
@@ -297,8 +297,8 @@ fn test_swap_axons() {
         let mut weight = Weight::zero();
 
         add_network(netuid, 0, 1);
-        IsNetworkMember::<Test>::insert(&old_hotkey, netuid, true);
-        Axons::<Test>::insert(netuid, &old_hotkey, axon_info.clone());
+        IsNetworkMember::<Test>::insert(old_hotkey, netuid, true);
+        Axons::<Test>::insert(netuid, old_hotkey, axon_info.clone());
 
         assert_ok!(SubtensorModule::perform_hotkey_swap(
             &old_hotkey,
@@ -307,8 +307,8 @@ fn test_swap_axons() {
             &mut weight
         ));
 
-        assert!(!Axons::<Test>::contains_key(netuid, &old_hotkey));
-        assert_eq!(Axons::<Test>::get(netuid, &new_hotkey), Some(axon_info));
+        assert!(!Axons::<Test>::contains_key(netuid, old_hotkey));
+        assert_eq!(Axons::<Test>::get(netuid, new_hotkey), Some(axon_info));
     });
 }
 
@@ -324,8 +324,8 @@ fn test_swap_weight_commits() {
         let mut weight = Weight::zero();
 
         add_network(netuid, 0, 1);
-        IsNetworkMember::<Test>::insert(&old_hotkey, netuid, true);
-        WeightCommits::<Test>::insert(netuid, &old_hotkey, weight_commits.clone());
+        IsNetworkMember::<Test>::insert(old_hotkey, netuid, true);
+        WeightCommits::<Test>::insert(netuid, old_hotkey, weight_commits);
 
         assert_ok!(SubtensorModule::perform_hotkey_swap(
             &old_hotkey,
@@ -334,9 +334,9 @@ fn test_swap_weight_commits() {
             &mut weight
         ));
 
-        assert!(!WeightCommits::<Test>::contains_key(netuid, &old_hotkey));
+        assert!(!WeightCommits::<Test>::contains_key(netuid, old_hotkey));
         assert_eq!(
-            WeightCommits::<Test>::get(netuid, &new_hotkey),
+            WeightCommits::<Test>::get(netuid, new_hotkey),
             Some(weight_commits)
         );
     });
@@ -355,7 +355,7 @@ fn test_swap_loaded_emission() {
         let mut weight = Weight::zero();
 
         add_network(netuid, 0, 1);
-        IsNetworkMember::<Test>::insert(&old_hotkey, netuid, true);
+        IsNetworkMember::<Test>::insert(old_hotkey, netuid, true);
         LoadedEmission::<Test>::insert(
             netuid,
             vec![(old_hotkey, server_emission, validator_emission)],
@@ -386,7 +386,7 @@ fn test_swap_stake() {
         let stake_amount = 100u64;
         let mut weight = Weight::zero();
 
-        Stake::<Test>::insert(&old_hotkey, &coldkey, stake_amount);
+        Stake::<Test>::insert(old_hotkey, coldkey, stake_amount);
 
         assert_ok!(SubtensorModule::perform_hotkey_swap(
             &old_hotkey,
@@ -395,8 +395,8 @@ fn test_swap_stake() {
             &mut weight
         ));
 
-        assert!(!Stake::<Test>::contains_key(&old_hotkey, &coldkey));
-        assert_eq!(Stake::<Test>::get(&new_hotkey, &coldkey), stake_amount);
+        assert!(!Stake::<Test>::contains_key(old_hotkey, coldkey));
+        assert_eq!(Stake::<Test>::get(new_hotkey, coldkey), stake_amount);
     });
 }
 
@@ -409,8 +409,8 @@ fn test_swap_staking_hotkeys() {
         let coldkey = U256::from(3);
         let mut weight = Weight::zero();
 
-        Stake::<Test>::insert(&old_hotkey, &coldkey, 100);
-        StakingHotkeys::<Test>::insert(&coldkey, vec![old_hotkey]);
+        Stake::<Test>::insert(old_hotkey, coldkey, 100);
+        StakingHotkeys::<Test>::insert(coldkey, vec![old_hotkey]);
 
         assert_ok!(SubtensorModule::perform_hotkey_swap(
             &old_hotkey,
@@ -419,7 +419,7 @@ fn test_swap_staking_hotkeys() {
             &mut weight
         ));
 
-        let staking_hotkeys = StakingHotkeys::<Test>::get(&coldkey);
+        let staking_hotkeys = StakingHotkeys::<Test>::get(coldkey);
         assert!(!staking_hotkeys.contains(&old_hotkey));
         assert!(staking_hotkeys.contains(&new_hotkey));
     });
@@ -435,10 +435,10 @@ fn test_swap_hotkey_with_multiple_coldkeys() {
         let coldkey2 = U256::from(4);
         let mut weight = Weight::zero();
 
-        Stake::<Test>::insert(&old_hotkey, &coldkey1, 100);
-        Stake::<Test>::insert(&old_hotkey, &coldkey2, 200);
-        StakingHotkeys::<Test>::insert(&coldkey1, vec![old_hotkey]);
-        StakingHotkeys::<Test>::insert(&coldkey2, vec![old_hotkey]);
+        Stake::<Test>::insert(old_hotkey, coldkey1, 100);
+        Stake::<Test>::insert(old_hotkey, coldkey2, 200);
+        StakingHotkeys::<Test>::insert(coldkey1, vec![old_hotkey]);
+        StakingHotkeys::<Test>::insert(coldkey2, vec![old_hotkey]);
 
         assert_ok!(SubtensorModule::perform_hotkey_swap(
             &old_hotkey,
@@ -447,10 +447,10 @@ fn test_swap_hotkey_with_multiple_coldkeys() {
             &mut weight
         ));
 
-        assert_eq!(Stake::<Test>::get(&new_hotkey, &coldkey1), 100);
-        assert_eq!(Stake::<Test>::get(&new_hotkey, &coldkey2), 200);
-        assert!(StakingHotkeys::<Test>::get(&coldkey1).contains(&new_hotkey));
-        assert!(StakingHotkeys::<Test>::get(&coldkey2).contains(&new_hotkey));
+        assert_eq!(Stake::<Test>::get(new_hotkey, coldkey1), 100);
+        assert_eq!(Stake::<Test>::get(new_hotkey, coldkey2), 200);
+        assert!(StakingHotkeys::<Test>::get(coldkey1).contains(&new_hotkey));
+        assert!(StakingHotkeys::<Test>::get(coldkey2).contains(&new_hotkey));
     });
 }
 
@@ -463,8 +463,8 @@ fn test_swap_hotkey_with_existing_stake() {
         let coldkey = U256::from(3);
         let mut weight = Weight::zero();
 
-        Stake::<Test>::insert(&old_hotkey, &coldkey, 100);
-        Stake::<Test>::insert(&new_hotkey, &coldkey, 50);
+        Stake::<Test>::insert(old_hotkey, coldkey, 100);
+        Stake::<Test>::insert(new_hotkey, coldkey, 50);
 
         assert_ok!(SubtensorModule::perform_hotkey_swap(
             &old_hotkey,
@@ -473,7 +473,7 @@ fn test_swap_hotkey_with_existing_stake() {
             &mut weight
         ));
 
-        assert_eq!(Stake::<Test>::get(&new_hotkey, &coldkey), 150);
+        assert_eq!(Stake::<Test>::get(new_hotkey, coldkey), 150);
     });
 }
 
@@ -490,8 +490,8 @@ fn test_swap_hotkey_with_multiple_subnets() {
 
         add_network(netuid1, 0, 1);
         add_network(netuid2, 0, 1);
-        IsNetworkMember::<Test>::insert(&old_hotkey, netuid1, true);
-        IsNetworkMember::<Test>::insert(&old_hotkey, netuid2, true);
+        IsNetworkMember::<Test>::insert(old_hotkey, netuid1, true);
+        IsNetworkMember::<Test>::insert(old_hotkey, netuid2, true);
 
         assert_ok!(SubtensorModule::perform_hotkey_swap(
             &old_hotkey,
@@ -500,10 +500,10 @@ fn test_swap_hotkey_with_multiple_subnets() {
             &mut weight
         ));
 
-        assert!(IsNetworkMember::<Test>::get(&new_hotkey, netuid1));
-        assert!(IsNetworkMember::<Test>::get(&new_hotkey, netuid2));
-        assert!(!IsNetworkMember::<Test>::get(&old_hotkey, netuid1));
-        assert!(!IsNetworkMember::<Test>::get(&old_hotkey, netuid2));
+        assert!(IsNetworkMember::<Test>::get(new_hotkey, netuid1));
+        assert!(IsNetworkMember::<Test>::get(new_hotkey, netuid2));
+        assert!(!IsNetworkMember::<Test>::get(old_hotkey, netuid1));
+        assert!(!IsNetworkMember::<Test>::get(old_hotkey, netuid2));
     });
 }
 
@@ -518,10 +518,10 @@ fn test_swap_staking_hotkeys_multiple_coldkeys() {
         let mut weight = Weight::zero();
 
         // Set up initial state
-        Stake::<Test>::insert(&old_hotkey, &coldkey1, 100);
-        Stake::<Test>::insert(&old_hotkey, &coldkey2, 200);
-        StakingHotkeys::<Test>::insert(&coldkey1, vec![old_hotkey]);
-        StakingHotkeys::<Test>::insert(&coldkey2, vec![old_hotkey, U256::from(5)]);
+        Stake::<Test>::insert(old_hotkey, coldkey1, 100);
+        Stake::<Test>::insert(old_hotkey, coldkey2, 200);
+        StakingHotkeys::<Test>::insert(coldkey1, vec![old_hotkey]);
+        StakingHotkeys::<Test>::insert(coldkey2, vec![old_hotkey, U256::from(5)]);
 
         assert_ok!(SubtensorModule::perform_hotkey_swap(
             &old_hotkey,
@@ -531,13 +531,13 @@ fn test_swap_staking_hotkeys_multiple_coldkeys() {
         ));
 
         // Check if new_hotkey replaced old_hotkey in StakingHotkeys
-        assert!(StakingHotkeys::<Test>::get(&coldkey1).contains(&new_hotkey));
-        assert!(!StakingHotkeys::<Test>::get(&coldkey1).contains(&old_hotkey));
+        assert!(StakingHotkeys::<Test>::get(coldkey1).contains(&new_hotkey));
+        assert!(!StakingHotkeys::<Test>::get(coldkey1).contains(&old_hotkey));
 
         // Check if new_hotkey replaced old_hotkey for coldkey2 as well
-        assert!(StakingHotkeys::<Test>::get(&coldkey2).contains(&new_hotkey));
-        assert!(!StakingHotkeys::<Test>::get(&coldkey2).contains(&old_hotkey));
-        assert!(StakingHotkeys::<Test>::get(&coldkey2).contains(&U256::from(5)));
+        assert!(StakingHotkeys::<Test>::get(coldkey2).contains(&new_hotkey));
+        assert!(!StakingHotkeys::<Test>::get(coldkey2).contains(&old_hotkey));
+        assert!(StakingHotkeys::<Test>::get(coldkey2).contains(&U256::from(5)));
         // Other hotkeys should remain
     });
 }
@@ -552,7 +552,7 @@ fn test_swap_hotkey_with_no_stake() {
         let mut weight = Weight::zero();
 
         // Set up initial state with no stake
-        Owner::<Test>::insert(&old_hotkey, &coldkey);
+        Owner::<Test>::insert(old_hotkey, coldkey);
 
         assert_ok!(SubtensorModule::perform_hotkey_swap(
             &old_hotkey,
@@ -562,12 +562,12 @@ fn test_swap_hotkey_with_no_stake() {
         ));
 
         // Check if ownership transferred
-        assert!(!Owner::<Test>::contains_key(&old_hotkey));
-        assert_eq!(Owner::<Test>::get(&new_hotkey), coldkey);
+        assert!(!Owner::<Test>::contains_key(old_hotkey));
+        assert_eq!(Owner::<Test>::get(new_hotkey), coldkey);
 
         // Ensure no unexpected changes in Stake
-        assert!(!Stake::<Test>::contains_key(&old_hotkey, &coldkey));
-        assert!(!Stake::<Test>::contains_key(&new_hotkey, &coldkey));
+        assert!(!Stake::<Test>::contains_key(old_hotkey, coldkey));
+        assert!(!Stake::<Test>::contains_key(new_hotkey, coldkey));
     });
 }
 
@@ -586,12 +586,12 @@ fn test_swap_hotkey_with_multiple_coldkeys_and_subnets() {
         // Set up initial state
         add_network(netuid1, 0, 1);
         add_network(netuid2, 0, 1);
-        Owner::<Test>::insert(&old_hotkey, &coldkey1);
-        Stake::<Test>::insert(&old_hotkey, &coldkey1, 100);
-        Stake::<Test>::insert(&old_hotkey, &coldkey2, 200);
-        IsNetworkMember::<Test>::insert(&old_hotkey, netuid1, true);
-        IsNetworkMember::<Test>::insert(&old_hotkey, netuid2, true);
-        TotalHotkeyStake::<Test>::insert(&old_hotkey, 300);
+        Owner::<Test>::insert(old_hotkey, coldkey1);
+        Stake::<Test>::insert(old_hotkey, coldkey1, 100);
+        Stake::<Test>::insert(old_hotkey, coldkey2, 200);
+        IsNetworkMember::<Test>::insert(old_hotkey, netuid1, true);
+        IsNetworkMember::<Test>::insert(old_hotkey, netuid2, true);
+        TotalHotkeyStake::<Test>::insert(old_hotkey, 300);
 
         assert_ok!(SubtensorModule::perform_hotkey_swap(
             &old_hotkey,
@@ -601,24 +601,24 @@ fn test_swap_hotkey_with_multiple_coldkeys_and_subnets() {
         ));
 
         // Check ownership transfer
-        assert!(!Owner::<Test>::contains_key(&old_hotkey));
-        assert_eq!(Owner::<Test>::get(&new_hotkey), coldkey1);
+        assert!(!Owner::<Test>::contains_key(old_hotkey));
+        assert_eq!(Owner::<Test>::get(new_hotkey), coldkey1);
 
         // Check stake transfer
-        assert_eq!(Stake::<Test>::get(&new_hotkey, &coldkey1), 100);
-        assert_eq!(Stake::<Test>::get(&new_hotkey, &coldkey2), 200);
-        assert!(!Stake::<Test>::contains_key(&old_hotkey, &coldkey1));
-        assert!(!Stake::<Test>::contains_key(&old_hotkey, &coldkey2));
+        assert_eq!(Stake::<Test>::get(new_hotkey, coldkey1), 100);
+        assert_eq!(Stake::<Test>::get(new_hotkey, coldkey2), 200);
+        assert!(!Stake::<Test>::contains_key(old_hotkey, coldkey1));
+        assert!(!Stake::<Test>::contains_key(old_hotkey, coldkey2));
 
         // Check subnet membership transfer
-        assert!(IsNetworkMember::<Test>::get(&new_hotkey, netuid1));
-        assert!(IsNetworkMember::<Test>::get(&new_hotkey, netuid2));
-        assert!(!IsNetworkMember::<Test>::get(&old_hotkey, netuid1));
-        assert!(!IsNetworkMember::<Test>::get(&old_hotkey, netuid2));
+        assert!(IsNetworkMember::<Test>::get(new_hotkey, netuid1));
+        assert!(IsNetworkMember::<Test>::get(new_hotkey, netuid2));
+        assert!(!IsNetworkMember::<Test>::get(old_hotkey, netuid1));
+        assert!(!IsNetworkMember::<Test>::get(old_hotkey, netuid2));
 
         // Check total stake transfer
-        assert_eq!(TotalHotkeyStake::<Test>::get(&new_hotkey), 300);
-        assert!(!TotalHotkeyStake::<Test>::contains_key(&old_hotkey));
+        assert_eq!(TotalHotkeyStake::<Test>::get(new_hotkey), 300);
+        assert!(!TotalHotkeyStake::<Test>::contains_key(old_hotkey));
     });
 }
 
@@ -899,9 +899,9 @@ fn test_swap_hotkey_error_cases() {
         let wrong_coldkey = U256::from(4);
 
         // Set up initial state
-        Owner::<Test>::insert(&old_hotkey, &coldkey);
+        Owner::<Test>::insert(old_hotkey, coldkey);
         TotalNetworks::<Test>::put(1);
-        LastTxBlock::<Test>::insert(&coldkey, 0);
+        LastTxBlock::<Test>::insert(coldkey, 0);
 
         // Test not enough balance
         let swap_cost = SubtensorModule::get_key_swap_cost();
@@ -928,7 +928,7 @@ fn test_swap_hotkey_error_cases() {
         );
 
         // Test new hotkey already registered
-        IsNetworkMember::<Test>::insert(&new_hotkey, 0, true);
+        IsNetworkMember::<Test>::insert(new_hotkey, 0, true);
         assert_noop!(
             SubtensorModule::do_swap_hotkey(
                 RuntimeOrigin::signed(coldkey),
@@ -937,7 +937,7 @@ fn test_swap_hotkey_error_cases() {
             ),
             Error::<Test>::HotKeyAlreadyRegisteredInSubNet
         );
-        IsNetworkMember::<Test>::remove(&new_hotkey, 0);
+        IsNetworkMember::<Test>::remove(new_hotkey, 0);
 
         // Test non-associated coldkey
         assert_noop!(
@@ -958,7 +958,7 @@ fn test_swap_hotkey_error_cases() {
 
         // Check balance after swap
         assert_eq!(
-            Balances::free_balance(&coldkey),
+            Balances::free_balance(coldkey),
             initial_balance - swap_cost
         );
     });

--- a/pallets/subtensor/tests/swap_hotkey.rs
+++ b/pallets/subtensor/tests/swap_hotkey.rs
@@ -96,8 +96,7 @@ fn test_swap_total_hotkey_coldkey_stakes_this_interval() {
         ));
 
         assert!(!TotalHotkeyColdkeyStakesThisInterval::<Test>::contains_key(
-            old_hotkey,
-            coldkey
+            old_hotkey, coldkey
         ));
         assert_eq!(
             TotalHotkeyColdkeyStakesThisInterval::<Test>::get(new_hotkey, coldkey),
@@ -957,9 +956,6 @@ fn test_swap_hotkey_error_cases() {
         ));
 
         // Check balance after swap
-        assert_eq!(
-            Balances::free_balance(coldkey),
-            initial_balance - swap_cost
-        );
+        assert_eq!(Balances::free_balance(coldkey), initial_balance - swap_cost);
     });
 }


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->

PR fixes some clippy warnings in the hotkey swap test file.
Also runs `just fmt`

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please describe): Clippy fix
- [ ] 
## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.