### PR TITLE
Only run spec version check when the skip label doesn't exist

### DIFF
--- a/.github/workflows/check-finney.yml
+++ b/.github/workflows/check-finney.yml
@@ -11,6 +11,7 @@ jobs:
   check-spec-version:
     name: Check spec_version bump
     runs-on: SubtensorCI
+    if: !contains(github.event.issue.labels.*.name, 'no-spec-version-bump')
     steps:
       - name: Dependencies
         run: |

--- a/.github/workflows/check-finney.yml
+++ b/.github/workflows/check-finney.yml
@@ -11,7 +11,7 @@ jobs:
   check-spec-version:
     name: Check spec_version bump
     runs-on: SubtensorCI
-    if: !contains(github.event.issue.labels.*.name, 'no-spec-version-bump')
+    if: ${{ !contains(github.event.issue.labels.*.name, 'no-spec-version-bump') }}
     steps:
       - name: Dependencies
         run: |

--- a/.github/workflows/check-finney.yml
+++ b/.github/workflows/check-finney.yml
@@ -11,7 +11,7 @@ jobs:
   check-spec-version:
     name: Check spec_version bump
     runs-on: SubtensorCI
-    if: ${{ !contains(github.event.issue.labels.*.name, 'no-spec-version-bump') }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-spec-version-bump') }}
     steps:
       - name: Dependencies
         run: |

--- a/pallets/collective/src/lib.rs
+++ b/pallets/collective/src/lib.rs
@@ -951,6 +951,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
     ///
     /// If not `approved`:
     /// - one event deposited.
+    ///
     /// Two removals, one mutation.
     /// Computation and i/o `O(P)` where:
     /// - `P` is number of active proposals


### PR DESCRIPTION
Fixes #673.