### PR TITLE
Bump `main` spec version

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -139,7 +139,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 165,
+    spec_version: 166,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Closes #655

A node will attempt to use its native runtime in substitute for the on-chain Wasm runtime if all of spec_name, spec_version, and authoring_version are the same between the Wasm and native binaries. This was causing nodes compiled from `main` to use a runtime slightly different compared to what is on-chain, and write invalid stuff to storage. 

In the future, CI should prevent us from ever pushing to `main` a spec version that matches what is on-chain (cc @sam0x17) 

See https://docs.substrate.io/maintain/runtime-upgrades/ for more.