### PR TITLE
Sensible runtime log level

### DIFF
--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -87,7 +87,7 @@ pub mod pallet {
 
             T::Aura::change_authorities(new_authorities.clone());
 
-            log::info!("Aura authorities changed: {:?}", new_authorities);
+            log::debug!("Aura authorities changed: {:?}", new_authorities);
 
             // Return a successful DispatchResultWithPostInfo
             Ok(())
@@ -101,7 +101,7 @@ pub mod pallet {
         pub fn sudo_set_default_take(origin: OriginFor<T>, default_take: u16) -> DispatchResult {
             ensure_root(origin)?;
             T::Subtensor::set_max_delegate_take(default_take);
-            log::info!("DefaultTakeSet( default_take: {:?} ) ", default_take);
+            log::debug!("DefaultTakeSet( default_take: {:?} ) ", default_take);
             Ok(())
         }
 
@@ -113,7 +113,7 @@ pub mod pallet {
         pub fn sudo_set_tx_rate_limit(origin: OriginFor<T>, tx_rate_limit: u64) -> DispatchResult {
             ensure_root(origin)?;
             T::Subtensor::set_tx_rate_limit(tx_rate_limit);
-            log::info!("TxRateLimitSet( tx_rate_limit: {:?} ) ", tx_rate_limit);
+            log::debug!("TxRateLimitSet( tx_rate_limit: {:?} ) ", tx_rate_limit);
             Ok(())
         }
 
@@ -130,7 +130,7 @@ pub mod pallet {
             T::Subtensor::ensure_subnet_owner_or_root(origin, netuid)?;
 
             T::Subtensor::set_serving_rate_limit(netuid, serving_rate_limit);
-            log::info!(
+            log::debug!(
                 "ServingRateLimitSet( serving_rate_limit: {:?} ) ",
                 serving_rate_limit
             );
@@ -154,7 +154,7 @@ pub mod pallet {
                 Error::<T>::SubnetDoesNotExist
             );
             T::Subtensor::set_min_difficulty(netuid, min_difficulty);
-            log::info!(
+            log::debug!(
                 "MinDifficultySet( netuid: {:?} min_difficulty: {:?} ) ",
                 netuid,
                 min_difficulty
@@ -179,7 +179,7 @@ pub mod pallet {
                 Error::<T>::SubnetDoesNotExist
             );
             T::Subtensor::set_max_difficulty(netuid, max_difficulty);
-            log::info!(
+            log::debug!(
                 "MaxDifficultySet( netuid: {:?} max_difficulty: {:?} ) ",
                 netuid,
                 max_difficulty
@@ -204,7 +204,7 @@ pub mod pallet {
                 Error::<T>::SubnetDoesNotExist
             );
             T::Subtensor::set_weights_version_key(netuid, weights_version_key);
-            log::info!(
+            log::debug!(
                 "WeightsVersionKeySet( netuid: {:?} weights_version_key: {:?} ) ",
                 netuid,
                 weights_version_key
@@ -229,7 +229,7 @@ pub mod pallet {
                 Error::<T>::SubnetDoesNotExist
             );
             T::Subtensor::set_weights_set_rate_limit(netuid, weights_set_rate_limit);
-            log::info!(
+            log::debug!(
                 "WeightsSetRateLimitSet( netuid: {:?} weights_set_rate_limit: {:?} ) ",
                 netuid,
                 weights_set_rate_limit
@@ -254,7 +254,7 @@ pub mod pallet {
                 Error::<T>::SubnetDoesNotExist
             );
             T::Subtensor::set_adjustment_interval(netuid, adjustment_interval);
-            log::info!(
+            log::debug!(
                 "AdjustmentIntervalSet( netuid: {:?} adjustment_interval: {:?} ) ",
                 netuid,
                 adjustment_interval
@@ -285,7 +285,7 @@ pub mod pallet {
                 Error::<T>::SubnetDoesNotExist
             );
             T::Subtensor::set_adjustment_alpha(netuid, adjustment_alpha);
-            log::info!(
+            log::debug!(
                 "AdjustmentAlphaSet( adjustment_alpha: {:?} ) ",
                 adjustment_alpha
             );
@@ -309,7 +309,7 @@ pub mod pallet {
                 Error::<T>::SubnetDoesNotExist
             );
             T::Subtensor::set_max_weight_limit(netuid, max_weight_limit);
-            log::info!(
+            log::debug!(
                 "MaxWeightLimitSet( netuid: {:?} max_weight_limit: {:?} ) ",
                 netuid,
                 max_weight_limit
@@ -334,7 +334,7 @@ pub mod pallet {
             );
 
             T::Subtensor::set_immunity_period(netuid, immunity_period);
-            log::info!(
+            log::debug!(
                 "ImmunityPeriodSet( netuid: {:?} immunity_period: {:?} ) ",
                 netuid,
                 immunity_period
@@ -359,7 +359,7 @@ pub mod pallet {
                 Error::<T>::SubnetDoesNotExist
             );
             T::Subtensor::set_min_allowed_weights(netuid, min_allowed_weights);
-            log::info!(
+            log::debug!(
                 "MinAllowedWeightSet( netuid: {:?} min_allowed_weights: {:?} ) ",
                 netuid,
                 min_allowed_weights
@@ -387,7 +387,7 @@ pub mod pallet {
                 Error::<T>::MaxAllowedUIdsLessThanCurrentUIds
             );
             T::Subtensor::set_max_allowed_uids(netuid, max_allowed_uids);
-            log::info!(
+            log::debug!(
                 "MaxAllowedUidsSet( netuid: {:?} max_allowed_uids: {:?} ) ",
                 netuid,
                 max_allowed_uids
@@ -408,7 +408,7 @@ pub mod pallet {
                 Error::<T>::SubnetDoesNotExist
             );
             T::Subtensor::set_kappa(netuid, kappa);
-            log::info!("KappaSet( netuid: {:?} kappa: {:?} ) ", netuid, kappa);
+            log::debug!("KappaSet( netuid: {:?} kappa: {:?} ) ", netuid, kappa);
             Ok(())
         }
 
@@ -425,7 +425,7 @@ pub mod pallet {
                 Error::<T>::SubnetDoesNotExist
             );
             T::Subtensor::set_rho(netuid, rho);
-            log::info!("RhoSet( netuid: {:?} rho: {:?} ) ", netuid, rho);
+            log::debug!("RhoSet( netuid: {:?} rho: {:?} ) ", netuid, rho);
             Ok(())
         }
 
@@ -446,7 +446,7 @@ pub mod pallet {
                 Error::<T>::SubnetDoesNotExist
             );
             T::Subtensor::set_activity_cutoff(netuid, activity_cutoff);
-            log::info!(
+            log::debug!(
                 "ActivityCutoffSet( netuid: {:?} activity_cutoff: {:?} ) ",
                 netuid,
                 activity_cutoff
@@ -473,7 +473,7 @@ pub mod pallet {
             T::Subtensor::ensure_subnet_owner_or_root(origin, netuid)?;
 
             T::Subtensor::set_network_registration_allowed(netuid, registration_allowed);
-            log::info!(
+            log::debug!(
                 "NetworkRegistrationAllowed( registration_allowed: {:?} ) ",
                 registration_allowed
             );
@@ -498,7 +498,7 @@ pub mod pallet {
             T::Subtensor::ensure_subnet_owner_or_root(origin, netuid)?;
 
             T::Subtensor::set_network_pow_registration_allowed(netuid, registration_allowed);
-            log::info!(
+            log::debug!(
                 "NetworkPowRegistrationAllowed( registration_allowed: {:?} ) ",
                 registration_allowed
             );
@@ -525,7 +525,7 @@ pub mod pallet {
                 netuid,
                 target_registrations_per_interval,
             );
-            log::info!(
+            log::debug!(
             "RegistrationPerIntervalSet( netuid: {:?} target_registrations_per_interval: {:?} ) ",
             netuid,
             target_registrations_per_interval
@@ -550,7 +550,7 @@ pub mod pallet {
                 Error::<T>::SubnetDoesNotExist
             );
             T::Subtensor::set_min_burn(netuid, min_burn);
-            log::info!(
+            log::debug!(
                 "MinBurnSet( netuid: {:?} min_burn: {:?} ) ",
                 netuid,
                 min_burn
@@ -575,7 +575,7 @@ pub mod pallet {
                 Error::<T>::SubnetDoesNotExist
             );
             T::Subtensor::set_max_burn(netuid, max_burn);
-            log::info!(
+            log::debug!(
                 "MaxBurnSet( netuid: {:?} max_burn: {:?} ) ",
                 netuid,
                 max_burn
@@ -599,7 +599,7 @@ pub mod pallet {
                 Error::<T>::SubnetDoesNotExist
             );
             T::Subtensor::set_difficulty(netuid, difficulty);
-            log::info!(
+            log::debug!(
                 "DifficultySet( netuid: {:?} difficulty: {:?} ) ",
                 netuid,
                 difficulty
@@ -628,7 +628,7 @@ pub mod pallet {
             );
 
             T::Subtensor::set_max_allowed_validators(netuid, max_allowed_validators);
-            log::info!(
+            log::debug!(
                 "MaxAllowedValidatorsSet( netuid: {:?} max_allowed_validators: {:?} ) ",
                 netuid,
                 max_allowed_validators
@@ -653,7 +653,7 @@ pub mod pallet {
                 Error::<T>::SubnetDoesNotExist
             );
             T::Subtensor::set_bonds_moving_average(netuid, bonds_moving_average);
-            log::info!(
+            log::debug!(
                 "BondsMovingAverageSet( netuid: {:?} bonds_moving_average: {:?} ) ",
                 netuid,
                 bonds_moving_average
@@ -678,7 +678,7 @@ pub mod pallet {
                 Error::<T>::SubnetDoesNotExist
             );
             T::Subtensor::set_max_registrations_per_block(netuid, max_registrations_per_block);
-            log::info!(
+            log::debug!(
                 "MaxRegistrationsPerBlock( netuid: {:?} max_registrations_per_block: {:?} ) ",
                 netuid,
                 max_registrations_per_block
@@ -702,7 +702,7 @@ pub mod pallet {
         ) -> DispatchResult {
             ensure_root(origin)?;
             T::Subtensor::set_subnet_owner_cut(subnet_owner_cut);
-            log::info!(
+            log::debug!(
                 "SubnetOwnerCut( subnet_owner_cut: {:?} ) ",
                 subnet_owner_cut
             );
@@ -725,7 +725,7 @@ pub mod pallet {
         ) -> DispatchResult {
             ensure_root(origin)?;
             T::Subtensor::set_network_rate_limit(rate_limit);
-            log::info!("NetworkRateLimit( rate_limit: {:?} ) ", rate_limit);
+            log::debug!("NetworkRateLimit( rate_limit: {:?} ) ", rate_limit);
             Ok(())
         }
 
@@ -741,7 +741,7 @@ pub mod pallet {
                 Error::<T>::SubnetDoesNotExist
             );
             T::Subtensor::set_tempo(netuid, tempo);
-            log::info!("TempoSet( netuid: {:?} tempo: {:?} ) ", netuid, tempo);
+            log::debug!("TempoSet( netuid: {:?} tempo: {:?} ) ", netuid, tempo);
             Ok(())
         }
 
@@ -779,7 +779,7 @@ pub mod pallet {
 
             T::Subtensor::set_network_immunity_period(immunity_period);
 
-            log::info!("NetworkImmunityPeriod( period: {:?} ) ", immunity_period);
+            log::debug!("NetworkImmunityPeriod( period: {:?} ) ", immunity_period);
 
             Ok(())
         }
@@ -802,7 +802,7 @@ pub mod pallet {
 
             T::Subtensor::set_network_min_lock(lock_cost);
 
-            log::info!("NetworkMinLockCost( lock_cost: {:?} ) ", lock_cost);
+            log::debug!("NetworkMinLockCost( lock_cost: {:?} ) ", lock_cost);
 
             Ok(())
         }
@@ -821,7 +821,7 @@ pub mod pallet {
             ensure_root(origin)?;
             T::Subtensor::set_subnet_limit(max_subnets);
 
-            log::info!("SubnetLimit( max_subnets: {:?} ) ", max_subnets);
+            log::debug!("SubnetLimit( max_subnets: {:?} ) ", max_subnets);
 
             Ok(())
         }
@@ -844,7 +844,7 @@ pub mod pallet {
 
             T::Subtensor::set_lock_reduction_interval(interval);
 
-            log::info!("NetworkLockReductionInterval( interval: {:?} ) ", interval);
+            log::debug!("NetworkLockReductionInterval( interval: {:?} ) ", interval);
 
             Ok(())
         }
@@ -912,7 +912,7 @@ pub mod pallet {
         ) -> DispatchResult {
             ensure_root(origin)?;
             T::Subtensor::set_tx_delegate_take_rate_limit(tx_rate_limit);
-            log::info!(
+            log::debug!(
                 "TxRateLimitDelegateTakeSet( tx_delegate_take_rate_limit: {:?} ) ",
                 tx_rate_limit
             );
@@ -927,7 +927,7 @@ pub mod pallet {
         pub fn sudo_set_min_delegate_take(origin: OriginFor<T>, take: u16) -> DispatchResult {
             ensure_root(origin)?;
             T::Subtensor::set_min_delegate_take(take);
-            log::info!("TxMinDelegateTakeSet( tx_min_delegate_take: {:?} ) ", take);
+            log::debug!("TxMinDelegateTakeSet( tx_min_delegate_take: {:?} ) ", take);
             Ok(())
         }
 
@@ -942,7 +942,7 @@ pub mod pallet {
         ) -> DispatchResult {
             ensure_root(origin)?;
             T::Subtensor::set_target_stakes_per_interval(target_stakes_per_interval);
-            log::info!(
+            log::debug!(
                 "TxTargetStakesPerIntervalSet( set_target_stakes_per_interval: {:?} ) ",
                 target_stakes_per_interval
             );
@@ -967,7 +967,7 @@ pub mod pallet {
             );
 
             T::Subtensor::set_commit_reveal_weights_interval(netuid, interval);
-            log::info!(
+            log::debug!(
                 "SetWeightCommitInterval( netuid: {:?}, interval: {:?} ) ",
                 netuid,
                 interval
@@ -993,7 +993,7 @@ pub mod pallet {
             );
 
             T::Subtensor::set_commit_reveal_weights_enabled(netuid, enabled);
-            log::info!("ToggleSetWeightsCommitReveal( netuid: {:?} ) ", netuid);
+            log::debug!("ToggleSetWeightsCommitReveal( netuid: {:?} ) ", netuid);
             Ok(())
         }
 
@@ -1015,7 +1015,7 @@ pub mod pallet {
         ) -> DispatchResult {
             T::Subtensor::ensure_subnet_owner_or_root(origin, netuid)?;
             T::Subtensor::set_liquid_alpha_enabled(netuid, enabled);
-            log::info!(
+            log::debug!(
                 "LiquidAlphaEnableToggled( netuid: {:?}, Enabled: {:?} ) ",
                 netuid,
                 enabled
@@ -1059,7 +1059,7 @@ pub mod pallet {
         ) -> DispatchResult {
             ensure_root(origin)?;
             T::Subtensor::set_hotkey_emission_tempo(emission_tempo);
-            log::info!(
+            log::debug!(
                 "HotkeyEmissionTempoSet( emission_tempo: {:?} )",
                 emission_tempo
             );

--- a/pallets/subtensor/src/coinbase/root.rs
+++ b/pallets/subtensor/src/coinbase/root.rs
@@ -486,7 +486,7 @@ impl<T: Config> Pallet<T> {
 
         // --- 1. Ensure that the call originates from a signed source and retrieve the caller's account ID (coldkey).
         let coldkey = ensure_signed(origin)?;
-        log::info!(
+        log::debug!(
             "do_root_register( coldkey: {:?}, hotkey: {:?} )",
             coldkey,
             hotkey
@@ -529,7 +529,7 @@ impl<T: Config> Pallet<T> {
 
             // --- 12.1.2 Add the new account and make them a member of the Senate.
             Self::append_neuron(root_netuid, &hotkey, current_block_number);
-            log::info!("add new neuron: {:?} on uid {:?}", hotkey, subnetwork_uid);
+            log::debug!("add new neuron: {:?} on uid {:?}", hotkey, subnetwork_uid);
         } else {
             // --- 13.1.1 The network is full. Perform replacement.
             // Find the neuron with the lowest stake value to replace.
@@ -562,7 +562,7 @@ impl<T: Config> Pallet<T> {
             // Replace the neuron account with new information.
             Self::replace_neuron(root_netuid, lowest_uid, &hotkey, current_block_number);
 
-            log::info!(
+            log::debug!(
                 "replace neuron: {:?} with {:?} on uid {:?}",
                 replaced_hotkey,
                 hotkey,
@@ -588,7 +588,7 @@ impl<T: Config> Pallet<T> {
         RegistrationsThisBlock::<T>::mutate(root_netuid, |val| *val += 1);
 
         // --- 16. Log and announce the successful registration.
-        log::info!(
+        log::debug!(
             "RootRegistered(netuid:{:?} uid:{:?} hotkey:{:?})",
             root_netuid,
             subnetwork_uid,
@@ -622,7 +622,7 @@ impl<T: Config> Pallet<T> {
 
         // --- 1. Ensure that the call originates from a signed source and retrieve the caller's account ID (coldkey).
         let coldkey = ensure_signed(origin)?;
-        log::info!(
+        log::debug!(
             "do_root_register( coldkey: {:?}, hotkey: {:?} )",
             coldkey,
             hotkey
@@ -652,7 +652,7 @@ impl<T: Config> Pallet<T> {
         }
 
         // --- 5. Log and announce the successful Senate adjustment.
-        log::info!(
+        log::debug!(
             "SenateAdjusted(old_hotkey:{:?} hotkey:{:?})",
             replaced,
             hotkey
@@ -733,7 +733,7 @@ impl<T: Config> Pallet<T> {
     ) -> dispatch::DispatchResult {
         // Check the caller's signature. This is the coldkey of a registered account.
         let coldkey = ensure_signed(origin)?;
-        log::info!(
+        log::debug!(
             "do_set_root_weights( origin:{:?} netuid:{:?}, uids:{:?}, values:{:?})",
             coldkey,
             netuid,
@@ -834,7 +834,7 @@ impl<T: Config> Pallet<T> {
         Self::set_last_update_for_uid(netuid, neuron_uid, current_block);
 
         // Emit the tracking event.
-        log::info!(
+        log::debug!(
             "RootWeightsSet( netuid:{:?}, neuron_uid:{:?} )",
             netuid,
             neuron_uid
@@ -968,7 +968,7 @@ impl<T: Config> Pallet<T> {
         SubnetOwner::<T>::insert(netuid_to_register, coldkey);
 
         // --- 8. Emit the NetworkAdded event.
-        log::info!(
+        log::debug!(
             "NetworkAdded( netuid:{:?}, modality:{:?} )",
             netuid_to_register,
             0
@@ -1012,7 +1012,7 @@ impl<T: Config> Pallet<T> {
         Self::remove_network(netuid);
 
         // --- 5. Emit the NetworkRemoved event.
-        log::info!("NetworkRemoved( netuid:{:?} )", netuid);
+        log::debug!("NetworkRemoved( netuid:{:?} )", netuid);
         Self::deposit_event(Event::NetworkRemoved(netuid));
 
         // --- 6. Return success.
@@ -1274,7 +1274,7 @@ impl<T: Config> Pallet<T> {
             }
         });
 
-        log::info!("Netuids Order: {:?}", netuids);
+        log::debug!("Netuids Order: {:?}", netuids);
 
         match netuids.last() {
             Some(netuid) => *netuid,

--- a/pallets/subtensor/src/epoch/run_epoch.rs
+++ b/pallets/subtensor/src/epoch/run_epoch.rs
@@ -1310,7 +1310,7 @@ impl<T: Config> Pallet<T> {
 
         AlphaValues::<T>::insert(netuid, (alpha_low, alpha_high));
 
-        log::info!(
+        log::debug!(
             "AlphaValuesSet( netuid: {:?}, AlphaLow: {:?}, AlphaHigh: {:?} ) ",
             netuid,
             alpha_low,

--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -19,7 +19,7 @@ mod hooks {
             match block_step_result {
                 Ok(_) => {
                     // --- If the block step was successful, return the weight.
-                    log::info!("Successfully ran block step.");
+                    log::debug!("Successfully ran block step.");
                     Weight::from_parts(110_634_229_000_u64, 0)
                         .saturating_add(T::DbWeight::get().reads(8304_u64))
                         .saturating_add(T::DbWeight::get().writes(110_u64))

--- a/pallets/subtensor/src/rpc_info/delegate_info.rs
+++ b/pallets/subtensor/src/rpc_info/delegate_info.rs
@@ -148,7 +148,7 @@ impl<T: Config> Pallet<T> {
             }
         }
 
-        log::info!(
+        log::debug!(
             "Total delegated stake for coldkey {:?}: {}",
             coldkey,
             total_delegated

--- a/pallets/subtensor/src/staking/add_stake.rs
+++ b/pallets/subtensor/src/staking/add_stake.rs
@@ -37,7 +37,7 @@ impl<T: Config> Pallet<T> {
     ) -> dispatch::DispatchResult {
         // We check that the transaction is signed by the caller and retrieve the T::AccountId coldkey information.
         let coldkey = ensure_signed(origin)?;
-        log::info!(
+        log::debug!(
             "do_add_stake( origin:{:?} hotkey:{:?}, stake_to_be_added:{:?} )",
             coldkey,
             hotkey,
@@ -102,7 +102,7 @@ impl<T: Config> Pallet<T> {
             stakes_this_interval.saturating_add(1),
             block,
         );
-        log::info!(
+        log::debug!(
             "StakeAdded( hotkey:{:?}, stake_to_be_added:{:?} )",
             hotkey,
             actual_amount_to_stake

--- a/pallets/subtensor/src/staking/become_delegate.rs
+++ b/pallets/subtensor/src/staking/become_delegate.rs
@@ -34,7 +34,7 @@ impl<T: Config> Pallet<T> {
     ) -> dispatch::DispatchResult {
         // --- 1. We check the coldkey signuture.
         let coldkey = ensure_signed(origin)?;
-        log::info!(
+        log::debug!(
             "do_become_delegate( origin:{:?} hotkey:{:?}, take:{:?} )",
             coldkey,
             hotkey,
@@ -72,7 +72,7 @@ impl<T: Config> Pallet<T> {
         Self::set_last_tx_block_delegate_take(&coldkey, block);
 
         // --- 7. Emit the staking event.
-        log::info!(
+        log::debug!(
             "DelegateAdded( coldkey:{:?}, hotkey:{:?}, take:{:?} )",
             coldkey,
             hotkey,

--- a/pallets/subtensor/src/staking/decrease_take.rs
+++ b/pallets/subtensor/src/staking/decrease_take.rs
@@ -34,7 +34,7 @@ impl<T: Config> Pallet<T> {
     ) -> dispatch::DispatchResult {
         // --- 1. We check the coldkey signature.
         let coldkey = ensure_signed(origin)?;
-        log::info!(
+        log::debug!(
             "do_decrease_take( origin:{:?} hotkey:{:?}, take:{:?} )",
             coldkey,
             hotkey,
@@ -58,7 +58,7 @@ impl<T: Config> Pallet<T> {
         Delegates::<T>::insert(hotkey.clone(), take);
 
         // --- 5. Emit the take value.
-        log::info!(
+        log::debug!(
             "TakeDecreased( coldkey:{:?}, hotkey:{:?}, take:{:?} )",
             coldkey,
             hotkey,

--- a/pallets/subtensor/src/staking/increase_take.rs
+++ b/pallets/subtensor/src/staking/increase_take.rs
@@ -37,7 +37,7 @@ impl<T: Config> Pallet<T> {
     ) -> dispatch::DispatchResult {
         // --- 1. We check the coldkey signature.
         let coldkey = ensure_signed(origin)?;
-        log::info!(
+        log::debug!(
             "do_increase_take( origin:{:?} hotkey:{:?}, take:{:?} )",
             coldkey,
             hotkey,
@@ -74,7 +74,7 @@ impl<T: Config> Pallet<T> {
         Delegates::<T>::insert(hotkey.clone(), take);
 
         // --- 7. Emit the take value.
-        log::info!(
+        log::debug!(
             "TakeIncreased( coldkey:{:?}, hotkey:{:?}, take:{:?} )",
             coldkey,
             hotkey,

--- a/pallets/subtensor/src/staking/remove_stake.rs
+++ b/pallets/subtensor/src/staking/remove_stake.rs
@@ -37,7 +37,7 @@ impl<T: Config> Pallet<T> {
     ) -> dispatch::DispatchResult {
         // We check the transaction is signed by the caller and retrieve the T::AccountId coldkey information.
         let coldkey = ensure_signed(origin)?;
-        log::info!(
+        log::debug!(
             "do_remove_stake( origin:{:?} hotkey:{:?}, stake_to_be_removed:{:?} )",
             coldkey,
             hotkey,
@@ -96,7 +96,7 @@ impl<T: Config> Pallet<T> {
             unstakes_this_interval.saturating_add(1),
             block,
         );
-        log::info!(
+        log::debug!(
             "StakeRemoved( hotkey:{:?}, stake_to_be_removed:{:?} )",
             hotkey,
             stake_to_be_removed

--- a/pallets/subtensor/src/subnets/registration.rs
+++ b/pallets/subtensor/src/subnets/registration.rs
@@ -41,7 +41,7 @@ impl<T: Config> Pallet<T> {
     ) -> DispatchResult {
         // --- 1. Check that the caller has signed the transaction. (the coldkey of the pairing)
         let coldkey = ensure_signed(origin)?;
-        log::info!(
+        log::debug!(
             "do_registration( coldkey:{:?} netuid:{:?} hotkey:{:?} )",
             coldkey,
             netuid,
@@ -131,7 +131,7 @@ impl<T: Config> Pallet<T> {
 
             // --- 12.1.2 Expand subnetwork with new account.
             Self::append_neuron(netuid, &hotkey, current_block_number);
-            log::info!("add new neuron account");
+            log::debug!("add new neuron account");
         } else {
             // --- 13.1.1 Replacement required.
             // We take the neuron with the lowest pruning score here.
@@ -139,7 +139,7 @@ impl<T: Config> Pallet<T> {
 
             // --- 13.1.1 Replace the neuron account with the new info.
             Self::replace_neuron(netuid, subnetwork_uid, &hotkey, current_block_number);
-            log::info!("prune neuron");
+            log::debug!("prune neuron");
         }
 
         // --- 14. Record the registration and increment block and interval counters.
@@ -149,7 +149,7 @@ impl<T: Config> Pallet<T> {
         Self::increase_rao_recycled(netuid, Self::get_burn_as_u64(netuid));
 
         // --- 15. Deposit successful event.
-        log::info!(
+        log::debug!(
             "NeuronRegistered( netuid:{:?} uid:{:?} hotkey:{:?}  ) ",
             netuid,
             subnetwork_uid,
@@ -220,7 +220,7 @@ impl<T: Config> Pallet<T> {
         // --- 1. Check that the caller has signed the transaction.
         // TODO( const ): This not be the hotkey signature or else an exterior actor can register the hotkey and potentially control it?
         let signing_origin = ensure_signed(origin)?;
-        log::info!(
+        log::debug!(
             "do_registration( origin:{:?} netuid:{:?} hotkey:{:?}, coldkey:{:?} )",
             signing_origin,
             netuid,
@@ -326,7 +326,7 @@ impl<T: Config> Pallet<T> {
 
             // --- 11.1.2 Expand subnetwork with new account.
             Self::append_neuron(netuid, &hotkey, current_block_number);
-            log::info!("add new neuron account");
+            log::debug!("add new neuron account");
         } else {
             // --- 11.1.1 Replacement required.
             // We take the neuron with the lowest pruning score here.
@@ -334,7 +334,7 @@ impl<T: Config> Pallet<T> {
 
             // --- 11.1.1 Replace the neuron account with the new info.
             Self::replace_neuron(netuid, subnetwork_uid, &hotkey, current_block_number);
-            log::info!("prune neuron");
+            log::debug!("prune neuron");
         }
 
         // --- 12. Record the registration and increment block and interval counters.
@@ -343,7 +343,7 @@ impl<T: Config> Pallet<T> {
         RegistrationsThisBlock::<T>::mutate(netuid, |val| val.saturating_inc());
 
         // --- 13. Deposit successful event.
-        log::info!(
+        log::debug!(
             "NeuronRegistered( netuid:{:?} uid:{:?} hotkey:{:?}  ) ",
             netuid,
             subnetwork_uid,
@@ -366,7 +366,7 @@ impl<T: Config> Pallet<T> {
 
         // --- 1. Check that the caller has signed the transaction.
         let coldkey = ensure_signed(origin)?;
-        log::info!("do_faucet( coldkey:{:?} )", coldkey);
+        log::debug!("do_faucet( coldkey:{:?} )", coldkey);
 
         // --- 2. Ensure the passed block number is valid, not in the future or too old.
         // Work must have been done within 3 blocks (stops long range attacks).
@@ -400,7 +400,7 @@ impl<T: Config> Pallet<T> {
         Self::add_balance_to_coldkey_account(&coldkey, balance_to_add);
 
         // --- 6. Deposit successful event.
-        log::info!(
+        log::debug!(
             "Faucet( coldkey:{:?} amount:{:?} ) ",
             coldkey,
             balance_to_add

--- a/pallets/subtensor/src/subnets/serving.rs
+++ b/pallets/subtensor/src/subnets/serving.rs
@@ -106,7 +106,7 @@ impl<T: Config> Pallet<T> {
         Axons::<T>::insert(netuid, hotkey_id.clone(), prev_axon);
 
         // We deposit axon served event.
-        log::info!("AxonServed( hotkey:{:?} ) ", hotkey_id.clone());
+        log::debug!("AxonServed( hotkey:{:?} ) ", hotkey_id.clone());
         Self::deposit_event(Event::AxonServed(netuid, hotkey_id));
 
         // Return is successful dispatch.
@@ -204,7 +204,7 @@ impl<T: Config> Pallet<T> {
         Prometheus::<T>::insert(netuid, hotkey_id.clone(), prev_prometheus);
 
         // We deposit prometheus served event.
-        log::info!("PrometheusServed( hotkey:{:?} ) ", hotkey_id.clone());
+        log::debug!("PrometheusServed( hotkey:{:?} ) ", hotkey_id.clone());
         Self::deposit_event(Event::PrometheusServed(netuid, hotkey_id));
 
         // Return is successful dispatch.

--- a/pallets/subtensor/src/subnets/weights.rs
+++ b/pallets/subtensor/src/subnets/weights.rs
@@ -28,7 +28,7 @@ impl<T: Config> Pallet<T> {
     ) -> DispatchResult {
         let who = ensure_signed(origin)?;
 
-        log::info!("do_commit_weights( hotkey:{:?} netuid:{:?})", who, netuid);
+        log::debug!("do_commit_weights( hotkey:{:?} netuid:{:?})", who, netuid);
 
         ensure!(
             Self::get_commit_reveal_weights_enabled(netuid),
@@ -89,7 +89,7 @@ impl<T: Config> Pallet<T> {
     ) -> DispatchResult {
         let who = ensure_signed(origin.clone())?;
 
-        log::info!("do_reveal_weights( hotkey:{:?} netuid:{:?})", who, netuid);
+        log::debug!("do_reveal_weights( hotkey:{:?} netuid:{:?})", who, netuid);
 
         ensure!(
             Self::get_commit_reveal_weights_enabled(netuid),
@@ -188,7 +188,7 @@ impl<T: Config> Pallet<T> {
     ) -> dispatch::DispatchResult {
         // --- 1. Check the caller's signature. This is the hotkey of a registered account.
         let hotkey = ensure_signed(origin)?;
-        log::info!(
+        log::debug!(
             "do_set_weights( origin:{:?} netuid:{:?}, uids:{:?}, values:{:?})",
             hotkey,
             netuid,
@@ -289,7 +289,7 @@ impl<T: Config> Pallet<T> {
         Self::set_last_update_for_uid(netuid, neuron_uid, current_block);
 
         // --- 19. Emit the tracking event.
-        log::info!(
+        log::debug!(
             "WeightsSet( netuid:{:?}, neuron_uid:{:?} )",
             netuid,
             neuron_uid
@@ -308,7 +308,7 @@ impl<T: Config> Pallet<T> {
     ///
     pub fn check_version_key(netuid: u16, version_key: u64) -> bool {
         let network_version_key: u64 = WeightsVersionKey::<T>::get(netuid);
-        log::info!(
+        log::debug!(
             "check_version_key( network_version_key:{:?}, version_key:{:?} )",
             network_version_key,
             version_key

--- a/pallets/subtensor/src/utils/identity.rs
+++ b/pallets/subtensor/src/utils/identity.rs
@@ -66,7 +66,7 @@ impl<T: Config> Pallet<T> {
         Identities::<T>::insert(coldkey.clone(), identity.clone());
 
         // Log the identity set event
-        log::info!("ChainIdentitySet( coldkey:{:?} ) ", coldkey.clone());
+        log::debug!("ChainIdentitySet( coldkey:{:?} ) ", coldkey.clone());
 
         // Emit an event to notify that an identity has been set
         Self::deposit_event(Event::ChainIdentitySet(coldkey.clone()));

--- a/pallets/subtensor/src/utils/misc.rs
+++ b/pallets/subtensor/src/utils/misc.rs
@@ -150,12 +150,12 @@ impl<T: Config> Pallet<T> {
         Active::<T>::insert(netuid, updated_active_vec);
     }
     pub fn set_pruning_score_for_uid(netuid: u16, uid: u16, pruning_score: u16) {
-        log::info!("netuid = {:?}", netuid);
-        log::info!(
+        log::debug!("netuid = {:?}", netuid);
+        log::debug!(
             "SubnetworkN::<T>::get( netuid ) = {:?}",
             SubnetworkN::<T>::get(netuid)
         );
-        log::info!("uid = {:?}", uid);
+        log::debug!("uid = {:?}", uid);
         assert!(uid < SubnetworkN::<T>::get(netuid));
         PruningScores::<T>::mutate(netuid, |v| {
             if let Some(s) = v.get_mut(uid as usize) {


### PR DESCRIPTION
Closes #731 

Extreme verbose logging was concerning Medulla. Follows best practices by changing "happy path" runtime logging to `debug`. To run a node with debug logs, simply set `RUST_LOG=debug` in your env. 