### PR TITLE
Fix rate limit for setting children

### DIFF
--- a/pallets/subtensor/src/staking/set_children.rs
+++ b/pallets/subtensor/src/staking/set_children.rs
@@ -60,10 +60,10 @@ impl<T: Config> Pallet<T> {
 
         // Ensure the hotkey passes the rate limit.
         ensure!(
-            Self::passes_rate_limit_globally(
+            Self::passes_rate_limit_on_subnet(
+                &TransactionType::SetChildren, // Set children.
                 &hotkey,                       // Specific to a hotkey.
                 netuid,                        // Specific to a subnet.
-                &TransactionType::SetChildren, // Set children.
             ),
             Error::<T>::TxRateLimitExceeded
         );

--- a/pallets/subtensor/src/staking/set_children.rs
+++ b/pallets/subtensor/src/staking/set_children.rs
@@ -61,10 +61,20 @@ impl<T: Config> Pallet<T> {
         // Ensure the hotkey passes the rate limit.
         ensure!(
             Self::passes_rate_limit_globally(
-                &TransactionType::SetChildren, // Set children.
                 &hotkey,                       // Specific to a hotkey.
+                netuid,                        // Specific to a subnet.
+                &TransactionType::SetChildren, // Set children.
             ),
             Error::<T>::TxRateLimitExceeded
+        );
+
+        // Set last transaction block
+        let current_block = Self::get_current_block_as_u64();
+        Self::set_last_transaction_block(
+            &hotkey,
+            netuid,
+            &TransactionType::SetChildren,
+            current_block
         );
 
         // --- 2. Check that this delegation is not on the root network. Child hotkeys are not valid on root.

--- a/pallets/subtensor/src/utils/rate_limiting.rs
+++ b/pallets/subtensor/src/utils/rate_limiting.rs
@@ -58,11 +58,8 @@ impl<T: Config> Pallet<T> {
     }
 
     /// Check if a transaction should be rate limited globally
-    pub fn passes_rate_limit_globally(
-        hotkey: &T::AccountId,
-        netuid: u16,
-        tx_type: &TransactionType,
-    ) -> bool {
+    pub fn passes_rate_limit_globally(tx_type: &TransactionType, hotkey: &T::AccountId) -> bool {
+        let netuid: u16 = u16::MAX;
         let block: u64 = Self::get_current_block_as_u64();
         let limit: u64 = Self::get_rate_limit(tx_type);
         let last_block: u64 = Self::get_last_transaction_block(hotkey, netuid, tx_type);

--- a/pallets/subtensor/src/utils/rate_limiting.rs
+++ b/pallets/subtensor/src/utils/rate_limiting.rs
@@ -58,8 +58,11 @@ impl<T: Config> Pallet<T> {
     }
 
     /// Check if a transaction should be rate limited globally
-    pub fn passes_rate_limit_globally(tx_type: &TransactionType, hotkey: &T::AccountId) -> bool {
-        let netuid: u16 = u16::MAX;
+    pub fn passes_rate_limit_globally(
+        hotkey: &T::AccountId,
+        netuid: u16,
+        tx_type: &TransactionType,
+    ) -> bool {
         let block: u64 = Self::get_current_block_as_u64();
         let limit: u64 = Self::get_rate_limit(tx_type);
         let last_block: u64 = Self::get_last_transaction_block(hotkey, netuid, tx_type);


### PR DESCRIPTION
## Description
Add rate limiting to set_childkeys extrinsic that uses `passes_rate_limit_globally`. Make it specific to subnet.

Matching e2e JS tests:
https://github.com/gztensor/subtensor-js-tests/blob/main/src/childkey.test.js

## Related Issue(s)

n/a

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

n/a

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

n/a

## Additional Notes

n/a