### PR TITLE
fix broken workspace root package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9193,13 +9193,10 @@ version = "0.1.0"
 dependencies = [
  "node-subtensor",
  "node-subtensor-runtime",
- "pallet-commitments",
- "pallet-subtensor",
  "proc-macro2",
  "quote",
  "rayon",
  "subtensor-linting",
- "subtensor-macros",
  "syn 2.0.71",
  "walkdir",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,7 @@ repository = "https://github.com/opentensor/subtensor"
 
 [dependencies]
 node-subtensor = { path = "node", version = "4.0.0-dev" }
-pallet-commitments = { path = "pallets/commitments", version = "4.0.0-dev" }
-pallet-subtensor = { path = "pallets/subtensor", version = "4.0.0-dev" }
 node-subtensor-runtime = { path = "runtime", version = "4.0.0-dev" }
-subtensor-macros = { path = "support/macros", version = "0.1.0" }
 
 [build-dependencies]
 subtensor-linting = { path = "support/linting", version = "0.1.0" }
@@ -167,3 +164,8 @@ opt-level = 3
 inherits = "release"
 lto = true
 codegen-units = 1
+
+[features]
+default = []
+try-runtime = ["node-subtensor/try-runtime", "node-subtensor-runtime/try-runtime"]
+runtime-benchmarks = ["node-subtensor/runtime-benchmarks", "node-subtensor-runtime/runtime-benchmarks"]


### PR DESCRIPTION
Some recent changes to the workspace root package broke some syntax like `cargo test --features=try-runtime` without `--workspace`. This fixes some issues in the root workspace `Cargo.toml` re-enabling that old behavior (both node and runtime are now default build targets for workspace root package) and fixing some other issues with the workspace setup