### PR TITLE
Feat/subnet info versioning

### DIFF
--- a/pallets/admin-utils/tests/tests.rs
+++ b/pallets/admin-utils/tests/tests.rs
@@ -1243,7 +1243,7 @@ fn test_sudo_get_set_alpha() {
             DispatchError::BadOrigin
         );
 
-        assert_ok!(SubtensorModule::register_network(signer.clone(), None));
+        assert_ok!(SubtensorModule::register_network(signer.clone()));
 
         assert_ok!(AdminUtils::sudo_set_alpha_values(
             signer.clone(),

--- a/pallets/subtensor/rpc/src/lib.rs
+++ b/pallets/subtensor/rpc/src/lib.rs
@@ -46,6 +46,10 @@ pub trait SubtensorCustomApi<BlockHash> {
     fn get_subnet_info(&self, netuid: u16, at: Option<BlockHash>) -> RpcResult<Vec<u8>>;
     #[method(name = "subnetInfo_getSubnetsInfo")]
     fn get_subnets_info(&self, at: Option<BlockHash>) -> RpcResult<Vec<u8>>;
+    #[method(name = "subnetInfo_getSubnetInfo_v2")]
+    fn get_subnet_info_v2(&self, netuid: u16, at: Option<BlockHash>) -> RpcResult<Vec<u8>>;
+    #[method(name = "subnetInfo_getSubnetsInf_v2")]
+    fn get_subnets_info_v2(&self, at: Option<BlockHash>) -> RpcResult<Vec<u8>>;
     #[method(name = "subnetInfo_getSubnetHyperparams")]
     fn get_subnet_hyperparams(&self, netuid: u16, at: Option<BlockHash>) -> RpcResult<Vec<u8>>;
 
@@ -212,6 +216,26 @@ where
         let at = at.unwrap_or_else(|| self.client.info().best_hash);
 
         api.get_subnets_info(at)
+            .map_err(|e| Error::RuntimeError(format!("Unable to get subnets info: {:?}", e)).into())
+    }
+
+    fn get_subnet_info_v2(
+        &self,
+        netuid: u16,
+        at: Option<<Block as BlockT>::Hash>,
+    ) -> RpcResult<Vec<u8>> {
+        let api = self.client.runtime_api();
+        let at = at.unwrap_or_else(|| self.client.info().best_hash);
+
+        api.get_subnet_info_v2(at, netuid)
+            .map_err(|e| Error::RuntimeError(format!("Unable to get subnet info: {:?}", e)).into())
+    }
+
+    fn get_subnets_info_v2(&self, at: Option<<Block as BlockT>::Hash>) -> RpcResult<Vec<u8>> {
+        let api = self.client.runtime_api();
+        let at = at.unwrap_or_else(|| self.client.info().best_hash);
+
+        api.get_subnets_info_v2(at)
             .map_err(|e| Error::RuntimeError(format!("Unable to get subnets info: {:?}", e)).into())
     }
 

--- a/pallets/subtensor/runtime-api/src/lib.rs
+++ b/pallets/subtensor/runtime-api/src/lib.rs
@@ -21,6 +21,8 @@ sp_api::decl_runtime_apis! {
     pub trait SubnetInfoRuntimeApi {
         fn get_subnet_info(netuid: u16) -> Vec<u8>;
         fn get_subnets_info() -> Vec<u8>;
+        fn get_subnet_info_v2(netuid: u16) -> Vec<u8>;
+        fn get_subnets_info_v2() -> Vec<u8>;
         fn get_subnet_hyperparams(netuid: u16) -> Vec<u8>;
     }
 

--- a/pallets/subtensor/src/benchmarks.rs
+++ b/pallets/subtensor/src/benchmarks.rs
@@ -299,7 +299,7 @@ benchmarks! {
     let amount: u64 = 1;
     let amount_to_be_staked = 100_000_000_000_000u64;
     Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), amount_to_be_staked);
-  }: register_network(RawOrigin::Signed(coldkey), None)
+  }: register_network(RawOrigin::Signed(coldkey))
 
   benchmark_dissolve_network {
     let seed : u32 = 1;
@@ -311,8 +311,8 @@ benchmarks! {
     let amount: u64 = 1;
     let amount_to_be_staked = 100_000_000_000_000u64;
     Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), amount_to_be_staked);
-    assert_ok!(Subtensor::<T>::register_network(RawOrigin::Signed(coldkey.clone()).into(), None));
-  }: dissolve_network(RawOrigin::Signed(coldkey), 1)
+    assert_ok!(Subtensor::<T>::register_network(RawOrigin::Signed(coldkey.clone()).into()));
+  }: dissolve_network(RawOrigin::Root, coldkey.clone(), 1)
 
 
   // swap_hotkey {
@@ -519,6 +519,6 @@ reveal_weights {
     Identities::<T>::insert(&old_coldkey, identity);
 
     // Benchmark setup complete, now execute the extrinsic
-}: swap_coldkey(RawOrigin::Signed(old_coldkey.clone()), old_coldkey.clone(), new_coldkey.clone())
+}: swap_coldkey(RawOrigin::Root, old_coldkey.clone(), new_coldkey.clone())
 
 }

--- a/pallets/subtensor/src/coinbase/root.rs
+++ b/pallets/subtensor/src/coinbase/root.rs
@@ -891,100 +891,6 @@ impl<T: Config> Pallet<T> {
             .into())
     }
 
-    /// Facilitates user registration of a new subnetwork.
-    ///
-    /// # Args:
-    /// * `origin` (`T::RuntimeOrigin`): The calling origin. Must be signed.
-    ///
-    /// # Events:
-    /// * `NetworkAdded(netuid, modality)`: Emitted when a new network is successfully added.
-    /// * `NetworkRemoved(netuid)`: Emitted when an existing network is removed to make room for the new one.
-    ///
-    /// # Raises:
-    /// * 'TxRateLimitExceeded': If the rate limit for network registration is exceeded.
-    /// * 'NotEnoughBalanceToStake': If there isn't enough balance to stake for network registration.
-    /// * 'BalanceWithdrawalError': If an error occurs during balance withdrawal for network registration.
-    ///
-    pub fn user_add_network(origin: T::RuntimeOrigin) -> dispatch::DispatchResult {
-        // --- 0. Ensure the caller is a signed user.
-        let coldkey = ensure_signed(origin)?;
-
-        // --- 1. Rate limit for network registrations.
-        let current_block = Self::get_current_block_as_u64();
-        let last_lock_block = Self::get_network_last_lock_block();
-        ensure!(
-            current_block.saturating_sub(last_lock_block) >= NetworkRateLimit::<T>::get(),
-            Error::<T>::NetworkTxRateLimitExceeded
-        );
-
-        // --- 2. Calculate and lock the required tokens.
-        let lock_amount: u64 = Self::get_network_lock_cost();
-        log::debug!("network lock_amount: {:?}", lock_amount);
-        ensure!(
-            Self::can_remove_balance_from_coldkey_account(&coldkey, lock_amount),
-            Error::<T>::NotEnoughBalanceToStake
-        );
-
-        // --- 4. Determine the netuid to register.
-        let netuid_to_register: u16 = {
-            log::debug!(
-                "subnet count: {:?}\nmax subnets: {:?}",
-                Self::get_num_subnets(),
-                Self::get_max_subnets()
-            );
-            if Self::get_num_subnets().saturating_sub(1) < Self::get_max_subnets() {
-                // We subtract one because we don't want root subnet to count towards total
-                let mut next_available_netuid = 0;
-                loop {
-                    next_available_netuid.saturating_inc();
-                    if !Self::if_subnet_exist(next_available_netuid) {
-                        log::debug!("got subnet id: {:?}", next_available_netuid);
-                        break next_available_netuid;
-                    }
-                }
-            } else {
-                let netuid_to_prune = Self::get_subnet_to_prune();
-                ensure!(netuid_to_prune > 0, Error::<T>::AllNetworksInImmunity);
-
-                Self::remove_network(netuid_to_prune);
-                log::debug!("remove_network: {:?}", netuid_to_prune,);
-                Self::deposit_event(Event::NetworkRemoved(netuid_to_prune));
-
-                if SubnetIdentities::<T>::take(netuid_to_prune).is_some() {
-                    Self::deposit_event(Event::SubnetIdentityRemoved(netuid_to_prune));
-                }
-
-                netuid_to_prune
-            }
-        };
-
-        // --- 5. Perform the lock operation.
-        let actual_lock_amount = Self::remove_balance_from_coldkey_account(&coldkey, lock_amount)?;
-        Self::set_subnet_locked_balance(netuid_to_register, actual_lock_amount);
-        Self::set_network_last_lock(actual_lock_amount);
-
-        // --- 6. Set initial and custom parameters for the network.
-        Self::init_new_network(netuid_to_register, 360);
-        log::debug!("init_new_network: {:?}", netuid_to_register,);
-
-        // --- 7. Set netuid storage.
-        let current_block_number: u64 = Self::get_current_block_as_u64();
-        NetworkLastRegistered::<T>::set(current_block_number);
-        NetworkRegisteredAt::<T>::insert(netuid_to_register, current_block_number);
-        SubnetOwner::<T>::insert(netuid_to_register, coldkey);
-
-        // --- 8. Emit the NetworkAdded event.
-        log::debug!(
-            "NetworkAdded( netuid:{:?}, modality:{:?} )",
-            netuid_to_register,
-            0
-        );
-        Self::deposit_event(Event::NetworkAdded(netuid_to_register, 0));
-
-        // --- 9. Return success.
-        Ok(())
-    }
-
     /// Facilitates user registration of a new subnetwork with subnet identity.
     ///
     /// # Args:
@@ -1229,12 +1135,6 @@ impl<T: Config> Pallet<T> {
     /// # Note:
     /// This function does not emit any events, nor does it raise any errors. It silently
     /// returns if any internal checks fail.
-    ///
-    /// # Example:
-    /// ```rust
-    /// let netuid_to_remove: u16 = 5;
-    /// Pallet::<T>::remove_network(netuid_to_remove);
-    /// ```
     pub fn remove_network(netuid: u16) {
         // --- 1. Return balance to subnet owner.
         let owner_coldkey: T::AccountId = SubnetOwner::<T>::get(netuid);

--- a/pallets/subtensor/src/coinbase/root.rs
+++ b/pallets/subtensor/src/coinbase/root.rs
@@ -908,7 +908,7 @@ impl<T: Config> Pallet<T> {
     /// * 'NotEnoughBalanceToStake': If there isn't enough balance to stake for network registration.
     /// * 'BalanceWithdrawalError': If an error occurs during balance withdrawal for network registration.
     ///
-    pub fn user_add_network_with_identity(
+    pub fn user_add_network(
         origin: T::RuntimeOrigin,
         identity: Option<SubnetIdentityOf>,
     ) -> dispatch::DispatchResult {

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -902,7 +902,7 @@ mod dispatches {
 		.saturating_add(T::DbWeight::get().reads(16))
 		.saturating_add(T::DbWeight::get().writes(30)), DispatchClass::Operational, Pays::No))]
         pub fn register_network(origin: OriginFor<T>) -> DispatchResult {
-            Self::user_add_network_with_identity(origin, None)
+            Self::user_add_network(origin, None)
         }
 
         /// Facility extrinsic for user to get taken from faucet
@@ -1208,7 +1208,7 @@ mod dispatches {
             origin: OriginFor<T>,
             identity: Option<SubnetIdentityOf>,
         ) -> DispatchResult {
-            Self::user_add_network_with_identity(origin, identity)
+            Self::user_add_network(origin, identity)
         }
     }
 }

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -902,7 +902,7 @@ mod dispatches {
 		.saturating_add(T::DbWeight::get().reads(16))
 		.saturating_add(T::DbWeight::get().writes(30)), DispatchClass::Operational, Pays::No))]
         pub fn register_network(origin: OriginFor<T>) -> DispatchResult {
-            Self::user_add_network(origin)
+            Self::user_add_network_with_identity(origin, None)
         }
 
         /// Facility extrinsic for user to get taken from faucet

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -901,11 +901,8 @@ mod dispatches {
         #[pallet::weight((Weight::from_parts(157_000_000, 0)
 		.saturating_add(T::DbWeight::get().reads(16))
 		.saturating_add(T::DbWeight::get().writes(30)), DispatchClass::Operational, Pays::No))]
-        pub fn register_network(
-            origin: OriginFor<T>,
-            identity: Option<SubnetIdentityOf>,
-        ) -> DispatchResult {
-            Self::user_add_network(origin, identity)
+        pub fn register_network(origin: OriginFor<T>) -> DispatchResult {
+            Self::user_add_network(origin)
         }
 
         /// Facility extrinsic for user to get taken from faucet
@@ -1200,6 +1197,18 @@ mod dispatches {
             subnet_contact: Vec<u8>,
         ) -> DispatchResult {
             Self::do_set_subnet_identity(origin, netuid, subnet_name, github_repo, subnet_contact)
+        }
+
+        /// User register a new subnetwork
+        #[pallet::call_index(79)]
+        #[pallet::weight((Weight::from_parts(157_000_000, 0)
+                .saturating_add(T::DbWeight::get().reads(16))
+                .saturating_add(T::DbWeight::get().writes(30)), DispatchClass::Operational, Pays::No))]
+        pub fn register_network_with_identity(
+            origin: OriginFor<T>,
+            identity: Option<SubnetIdentityOf>,
+        ) -> DispatchResult {
+            Self::user_add_network_with_identity(origin, identity)
         }
     }
 }

--- a/pallets/subtensor/src/rpc_info/subnet_info.rs
+++ b/pallets/subtensor/src/rpc_info/subnet_info.rs
@@ -4,9 +4,32 @@ use frame_support::storage::IterableStorageMap;
 extern crate alloc;
 use codec::Compact;
 
-#[freeze_struct("ccca539640c3f631")]
+#[freeze_struct("fe79d58173da662a")]
 #[derive(Decode, Encode, PartialEq, Eq, Clone, Debug)]
 pub struct SubnetInfo<T: Config> {
+    netuid: Compact<u16>,
+    rho: Compact<u16>,
+    kappa: Compact<u16>,
+    difficulty: Compact<u64>,
+    immunity_period: Compact<u16>,
+    max_allowed_validators: Compact<u16>,
+    min_allowed_weights: Compact<u16>,
+    max_weights_limit: Compact<u16>,
+    scaling_law_power: Compact<u16>,
+    subnetwork_n: Compact<u16>,
+    max_allowed_uids: Compact<u16>,
+    blocks_since_last_step: Compact<u64>,
+    tempo: Compact<u16>,
+    network_modality: Compact<u16>,
+    network_connect: Vec<[u16; 2]>,
+    emission_values: Compact<u64>,
+    burn: Compact<u64>,
+    owner: T::AccountId,
+}
+
+#[freeze_struct("65f931972fa13222")]
+#[derive(Decode, Encode, PartialEq, Eq, Clone, Debug)]
+pub struct SubnetInfov2<T: Config> {
     netuid: Compact<u16>,
     rho: Compact<u16>,
     kappa: Compact<u16>,
@@ -81,8 +104,6 @@ impl<T: Config> Pallet<T> {
         let network_modality = <NetworkModality<T>>::get(netuid);
         let emission_values = Self::get_emission_value(netuid);
         let burn: Compact<u64> = Self::get_burn_as_u64(netuid).into();
-        let identity: Option<SubnetIdentity> = SubnetIdentities::<T>::get(netuid);
-
         // DEPRECATED
         let network_connect: Vec<[u16; 2]> = Vec::<[u16; 2]>::new();
         // DEPRECATED for ( _netuid_, con_req) in < NetworkConnect<T> as IterableStorageDoubleMap<u16, u16, u16> >::iter_prefix(netuid) {
@@ -108,7 +129,6 @@ impl<T: Config> Pallet<T> {
             emission_values: emission_values.into(),
             burn,
             owner: Self::get_subnet_owner(netuid),
-            identity,
         })
     }
 
@@ -134,6 +154,77 @@ impl<T: Config> Pallet<T> {
         subnets_info
     }
 
+    pub fn get_subnet_info_v2(netuid: u16) -> Option<SubnetInfov2<T>> {
+        if !Self::if_subnet_exist(netuid) {
+            return None;
+        }
+
+        let rho = Self::get_rho(netuid);
+        let kappa = Self::get_kappa(netuid);
+        let difficulty: Compact<u64> = Self::get_difficulty_as_u64(netuid).into();
+        let immunity_period = Self::get_immunity_period(netuid);
+        let max_allowed_validators = Self::get_max_allowed_validators(netuid);
+        let min_allowed_weights = Self::get_min_allowed_weights(netuid);
+        let max_weights_limit = Self::get_max_weight_limit(netuid);
+        let scaling_law_power = Self::get_scaling_law_power(netuid);
+        let subnetwork_n = Self::get_subnetwork_n(netuid);
+        let max_allowed_uids = Self::get_max_allowed_uids(netuid);
+        let blocks_since_last_step = Self::get_blocks_since_last_step(netuid);
+        let tempo = Self::get_tempo(netuid);
+        let network_modality = <NetworkModality<T>>::get(netuid);
+        let emission_values = Self::get_emission_value(netuid);
+        let burn: Compact<u64> = Self::get_burn_as_u64(netuid).into();
+        let identity: Option<SubnetIdentity> = SubnetIdentities::<T>::get(netuid);
+
+        // DEPRECATED
+        let network_connect: Vec<[u16; 2]> = Vec::<[u16; 2]>::new();
+        // DEPRECATED for ( _netuid_, con_req) in < NetworkConnect<T> as IterableStorageDoubleMap<u16, u16, u16> >::iter_prefix(netuid) {
+        //     network_connect.push([_netuid_, con_req]);
+        // }
+
+        Some(SubnetInfov2 {
+            rho: rho.into(),
+            kappa: kappa.into(),
+            difficulty,
+            immunity_period: immunity_period.into(),
+            netuid: netuid.into(),
+            max_allowed_validators: max_allowed_validators.into(),
+            min_allowed_weights: min_allowed_weights.into(),
+            max_weights_limit: max_weights_limit.into(),
+            scaling_law_power: scaling_law_power.into(),
+            subnetwork_n: subnetwork_n.into(),
+            max_allowed_uids: max_allowed_uids.into(),
+            blocks_since_last_step: blocks_since_last_step.into(),
+            tempo: tempo.into(),
+            network_modality: network_modality.into(),
+            network_connect,
+            emission_values: emission_values.into(),
+            burn,
+            owner: Self::get_subnet_owner(netuid),
+            identity,
+        })
+    }
+    pub fn get_subnets_info_v2() -> Vec<Option<SubnetInfo<T>>> {
+        let mut subnet_netuids = Vec::<u16>::new();
+        let mut max_netuid: u16 = 0;
+        for (netuid, added) in <NetworksAdded<T> as IterableStorageMap<u16, bool>>::iter() {
+            if added {
+                subnet_netuids.push(netuid);
+                if netuid > max_netuid {
+                    max_netuid = netuid;
+                }
+            }
+        }
+
+        let mut subnets_info = Vec::<Option<SubnetInfo<T>>>::new();
+        for netuid_ in 0..=max_netuid {
+            if subnet_netuids.contains(&netuid_) {
+                subnets_info.push(Self::get_subnet_info(netuid_));
+            }
+        }
+
+        subnets_info
+    }
     pub fn get_subnet_hyperparams(netuid: u16) -> Option<SubnetHyperparams> {
         if !Self::if_subnet_exist(netuid) {
             return None;

--- a/pallets/subtensor/tests/epoch.rs
+++ b/pallets/subtensor/tests/epoch.rs
@@ -1501,7 +1501,7 @@ fn test_set_alpha_disabled() {
         assert_ok!(SubtensorModule::root_register(signer.clone(), hotkey,));
         assert_ok!(SubtensorModule::add_stake(signer.clone(), hotkey, 1000));
         // Only owner can set alpha values
-        assert_ok!(SubtensorModule::register_network(signer.clone(), None));
+        assert_ok!(SubtensorModule::register_network(signer.clone()));
 
         // Explicitly set to false
         SubtensorModule::set_liquid_alpha_enabled(netuid, false);
@@ -2584,7 +2584,7 @@ fn test_get_set_alpha() {
             DispatchError::BadOrigin
         );
 
-        assert_ok!(SubtensorModule::register_network(signer.clone(), None));
+        assert_ok!(SubtensorModule::register_network(signer.clone()));
 
         assert_ok!(SubtensorModule::do_set_alpha_values(
             signer.clone(),

--- a/pallets/subtensor/tests/migration.rs
+++ b/pallets/subtensor/tests/migration.rs
@@ -171,7 +171,6 @@ fn test_total_issuance_global() {
         assert_eq!(SubtensorModule::get_total_issuance(), 0); // initial is zero.
         assert_ok!(SubtensorModule::register_network(
             <<Test as Config>::RuntimeOrigin>::signed(owner),
-            None
         ));
         SubtensorModule::set_max_allowed_uids(netuid, 1); // Set the maximum allowed unique identifiers for the network to 1.
         assert_eq!(SubtensorModule::get_total_issuance(), 0); // initial is zero.

--- a/pallets/subtensor/tests/root.rs
+++ b/pallets/subtensor/tests/root.rs
@@ -237,7 +237,6 @@ fn test_root_set_weights() {
             log::debug!("Adding network with netuid: {}", netuid);
             assert_ok!(SubtensorModule::register_network(
                 <<Test as Config>::RuntimeOrigin>::signed(U256::from(netuid + 456)),
-                None
             ));
         }
 
@@ -383,7 +382,6 @@ fn test_root_set_weights_out_of_order_netuids() {
             if netuid % 2 == 0 {
                 assert_ok!(SubtensorModule::register_network(
                     <<Test as Config>::RuntimeOrigin>::signed(U256::from(netuid)),
-                    None
                 ));
             } else {
                 add_network(netuid as u16 * 10, 1000, 0)
@@ -475,7 +473,6 @@ fn test_root_subnet_creation_deletion() {
         // last_lock: 100000000000, min_lock: 100000000000, last_lock_block: 0, lock_reduction_interval: 2, current_block: 0, mult: 1 lock_cost: 100000000000
         assert_ok!(SubtensorModule::register_network(
             <<Test as Config>::RuntimeOrigin>::signed(owner),
-            None
         ));
         // last_lock: 100000000000, min_lock: 100000000000, last_lock_block: 0, lock_reduction_interval: 2, current_block: 0, mult: 1 lock_cost: 100000000000
         assert_eq!(SubtensorModule::get_network_lock_cost(), 100_000_000_000);
@@ -483,7 +480,6 @@ fn test_root_subnet_creation_deletion() {
         // last_lock: 100000000000, min_lock: 100000000000, last_lock_block: 0, lock_reduction_interval: 2, current_block: 1, mult: 1 lock_cost: 100000000000
         assert_ok!(SubtensorModule::register_network(
             <<Test as Config>::RuntimeOrigin>::signed(owner),
-            None
         ));
         // last_lock: 100000000000, min_lock: 100000000000, last_lock_block: 1, lock_reduction_interval: 2, current_block: 1, mult: 2 lock_cost: 200000000000
         assert_eq!(SubtensorModule::get_network_lock_cost(), 200_000_000_000); // Doubles from previous subnet creation
@@ -498,7 +494,6 @@ fn test_root_subnet_creation_deletion() {
         assert_eq!(SubtensorModule::get_network_lock_cost(), 100_000_000_000); // Reaches min value
         assert_ok!(SubtensorModule::register_network(
             <<Test as Config>::RuntimeOrigin>::signed(owner),
-            None
         ));
         // last_lock: 100000000000, min_lock: 100000000000, last_lock_block: 4, lock_reduction_interval: 2, current_block: 4, mult: 2 lock_cost: 200000000000
         assert_eq!(SubtensorModule::get_network_lock_cost(), 200_000_000_000); // Doubles from previous subnet creation
@@ -506,7 +501,6 @@ fn test_root_subnet_creation_deletion() {
         // last_lock: 100000000000, min_lock: 100000000000, last_lock_block: 4, lock_reduction_interval: 2, current_block: 5, mult: 2 lock_cost: 150000000000
         assert_ok!(SubtensorModule::register_network(
             <<Test as Config>::RuntimeOrigin>::signed(owner),
-            None
         ));
         // last_lock: 150000000000, min_lock: 100000000000, last_lock_block: 5, lock_reduction_interval: 2, current_block: 5, mult: 2 lock_cost: 300000000000
         assert_eq!(SubtensorModule::get_network_lock_cost(), 300_000_000_000); // Doubles from previous subnet creation
@@ -514,7 +508,6 @@ fn test_root_subnet_creation_deletion() {
         // last_lock: 150000000000, min_lock: 100000000000, last_lock_block: 5, lock_reduction_interval: 2, current_block: 6, mult: 2 lock_cost: 225000000000
         assert_ok!(SubtensorModule::register_network(
             <<Test as Config>::RuntimeOrigin>::signed(owner),
-            None
         ));
         // last_lock: 225000000000, min_lock: 100000000000, last_lock_block: 6, lock_reduction_interval: 2, current_block: 6, mult: 2 lock_cost: 450000000000
         assert_eq!(SubtensorModule::get_network_lock_cost(), 450_000_000_000); // Increasing
@@ -522,19 +515,16 @@ fn test_root_subnet_creation_deletion() {
         // last_lock: 225000000000, min_lock: 100000000000, last_lock_block: 6, lock_reduction_interval: 2, current_block: 7, mult: 2 lock_cost: 337500000000
         assert_ok!(SubtensorModule::register_network(
             <<Test as Config>::RuntimeOrigin>::signed(owner),
-            None
         ));
         // last_lock: 337500000000, min_lock: 100000000000, last_lock_block: 7, lock_reduction_interval: 2, current_block: 7, mult: 2 lock_cost: 675000000000
         assert_eq!(SubtensorModule::get_network_lock_cost(), 675_000_000_000); // Increasing.
         assert_ok!(SubtensorModule::register_network(
             <<Test as Config>::RuntimeOrigin>::signed(owner),
-            None
         ));
         // last_lock: 337500000000, min_lock: 100000000000, last_lock_block: 7, lock_reduction_interval: 2, current_block: 7, mult: 2 lock_cost: 675000000000
         assert_eq!(SubtensorModule::get_network_lock_cost(), 1_350_000_000_000); // Double increasing.
         assert_ok!(SubtensorModule::register_network(
             <<Test as Config>::RuntimeOrigin>::signed(owner),
-            None
         ));
         assert_eq!(SubtensorModule::get_network_lock_cost(), 2_700_000_000_000); // Double increasing again.
 
@@ -584,7 +574,6 @@ fn test_network_pruning() {
             ));
             assert_ok!(SubtensorModule::register_network(
                 <<Test as Config>::RuntimeOrigin>::signed(cold),
-                None
             ));
             log::debug!("Adding network with netuid: {}", (i as u16) + 1);
             assert!(SubtensorModule::if_subnet_exist((i as u16) + 1));
@@ -658,19 +647,16 @@ fn test_network_prune_results() {
 
         assert_ok!(SubtensorModule::register_network(
             <<Test as Config>::RuntimeOrigin>::signed(owner),
-            None
         ));
         step_block(3);
 
         assert_ok!(SubtensorModule::register_network(
             <<Test as Config>::RuntimeOrigin>::signed(owner),
-            None
         ));
         step_block(3);
 
         assert_ok!(SubtensorModule::register_network(
             <<Test as Config>::RuntimeOrigin>::signed(owner),
-            None
         ));
         step_block(3);
 
@@ -715,7 +701,6 @@ fn test_weights_after_network_pruning() {
             // Register a network
             assert_ok!(SubtensorModule::register_network(
                 <<Test as Config>::RuntimeOrigin>::signed(cold),
-                None
             ));
 
             log::debug!("Adding network with netuid: {}", (i as u16) + 1);
@@ -776,7 +761,6 @@ fn test_weights_after_network_pruning() {
 
         assert_ok!(SubtensorModule::register_network(
             <<Test as Config>::RuntimeOrigin>::signed(cold),
-            None
         ));
 
         // Subnet should not exist, as it would replace a previous subnet.
@@ -1028,7 +1012,7 @@ fn test_user_add_network_with_identity_fields_ok() {
 
         SubtensorModule::add_balance_to_coldkey_account(&coldkey_1, balance_1);
 
-        assert_ok!(SubtensorModule::user_add_network(
+        assert_ok!(SubtensorModule::user_add_network_with_identity(
             RuntimeOrigin::signed(coldkey_1),
             Some(identity_value_1.clone())
         ));
@@ -1036,7 +1020,7 @@ fn test_user_add_network_with_identity_fields_ok() {
         let balance_2 = SubtensorModule::get_network_lock_cost() + 10_000;
         SubtensorModule::add_balance_to_coldkey_account(&coldkey_2, balance_2);
 
-        assert_ok!(SubtensorModule::user_add_network(
+        assert_ok!(SubtensorModule::user_add_network_with_identity(
             RuntimeOrigin::signed(coldkey_2),
             Some(identity_value_2.clone())
         ));
@@ -1052,10 +1036,7 @@ fn test_user_add_network_with_identity_fields_ok() {
         assert_eq!(stored_identity_2.subnet_contact, subnet_contact_2);
 
         // Now remove the first network.
-        assert_ok!(SubtensorModule::user_remove_network(
-            RuntimeOrigin::signed(coldkey_1),
-            1
-        ));
+        assert_ok!(SubtensorModule::user_remove_network(coldkey_1, 1));
 
         // Verify that the first network and identity have been removed.
         assert!(SubnetIdentities::<Test>::get(1).is_none());

--- a/pallets/subtensor/tests/root.rs
+++ b/pallets/subtensor/tests/root.rs
@@ -1012,7 +1012,7 @@ fn test_user_add_network_with_identity_fields_ok() {
 
         SubtensorModule::add_balance_to_coldkey_account(&coldkey_1, balance_1);
 
-        assert_ok!(SubtensorModule::user_add_network_with_identity(
+        assert_ok!(SubtensorModule::user_add_network(
             RuntimeOrigin::signed(coldkey_1),
             Some(identity_value_1.clone())
         ));
@@ -1020,7 +1020,7 @@ fn test_user_add_network_with_identity_fields_ok() {
         let balance_2 = SubtensorModule::get_network_lock_cost() + 10_000;
         SubtensorModule::add_balance_to_coldkey_account(&coldkey_2, balance_2);
 
-        assert_ok!(SubtensorModule::user_add_network_with_identity(
+        assert_ok!(SubtensorModule::user_add_network(
             RuntimeOrigin::signed(coldkey_2),
             Some(identity_value_2.clone())
         ));

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1426,6 +1426,21 @@ impl_runtime_apis! {
             result.encode()
         }
 
+        fn get_subnet_info_v2(netuid: u16) -> Vec<u8> {
+            let _result = SubtensorModule::get_subnet_info_v2(netuid);
+            if _result.is_some() {
+                let result = _result.expect("Could not get SubnetInfo");
+                result.encode()
+            } else {
+                vec![]
+            }
+        }
+
+        fn get_subnets_info_v2() -> Vec<u8> {
+            let result = SubtensorModule::get_subnets_info_v2();
+            result.encode()
+        }
+
         fn get_subnet_hyperparams(netuid: u16) -> Vec<u8> {
             let _result = SubtensorModule::get_subnet_hyperparams(netuid);
             if _result.is_some() {


### PR DESCRIPTION
## Description
This PR :

- Adds `SubnetInfov2` struct and related RPC methods.
- add `user_add_network_with_identities` struct to preserve backwards compatibility with cli

## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.