### PR TITLE
reset neuron data on dereg

### DIFF
--- a/pallets/subtensor/src/subnets/uids.rs
+++ b/pallets/subtensor/src/subnets/uids.rs
@@ -8,6 +8,23 @@ impl<T: Config> Pallet<T> {
         SubnetworkN::<T>::get(netuid)
     }
 
+    /// Sets value for the element at the given position if it exists.
+    pub fn set_element_at<N>(vec: &mut [N], position: usize, value: N) {
+        if let Some(element) = vec.get_mut(position) {
+            *element = value;
+        }
+    }
+
+    /// Resets the trust, emission, consensus, incentive, dividends of the neuron to default
+    pub fn clear_neuron(netuid: u16, neuron_uid: u16) {
+        let neuron_index: usize = neuron_uid.into();
+        Emission::<T>::mutate(netuid, |v| Self::set_element_at(v, neuron_index, 0));
+        Trust::<T>::mutate(netuid, |v| Self::set_element_at(v, neuron_index, 0));
+        Consensus::<T>::mutate(netuid, |v| Self::set_element_at(v, neuron_index, 0));
+        Incentive::<T>::mutate(netuid, |v| Self::set_element_at(v, neuron_index, 0));
+        Dividends::<T>::mutate(netuid, |v| Self::set_element_at(v, neuron_index, 0));
+    }
+
     /// Replace the neuron under this uid.
     pub fn replace_neuron(
         netuid: u16,
@@ -40,6 +57,12 @@ impl<T: Config> Pallet<T> {
 
         // 4. Clear neuron certificates
         NeuronCertificates::<T>::remove(netuid, old_hotkey.clone());
+
+        // 5. Reset new neuron's values.
+        Self::clear_neuron(netuid, uid_to_replace);
+
+        // 5a. reset axon info for the new uid.
+        Axons::<T>::remove(netuid, old_hotkey);
     }
 
     /// Appends the uid to the network.


### PR DESCRIPTION
reviving: https://github.com/opentensor/subtensor/pull/522

## Description

On neuron registration the trust, emission, consensus, incentive, dividends values as well as axon info associated with the assigned neuron_uid are inherited from the previous neuron. Thus for the first few blocks after registration these values will be wrong, then reset to zero and then get populated with the correct values for the newly registered neuron. This change resets these values on neuron registration.