### PR TITLE
Add token argument to the publish script

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,28 +1,28 @@
 #!/bin/bash
 set -ex
 cd support/macros
-cargo publish
+cargo publish --token $1
 cd ../..
 cd pallets/commitments
-cargo publish
+cargo publish --token $1
 cd ..
 cd collective
-cargo publish
+cargo publish --token $1
 cd ..
 cd registry
-cargo publish
+cargo publish --token $1
 cd ..
 cd subtensor
-cargo publish
+cargo publish --token $1
 cd runtime-api
-cargo publish
+cargo publish --token $1
 cd ../..
 cd admin-utils
-cargo publish
+cargo publish --token $1
 cd ../..
 cd runtime
-cargo publish
+cargo publish --token $1
 cd ..
 cd node
-cargo publish
+cargo publish --token $1
 echo "published successfully."


### PR DESCRIPTION
This PR adds a token argument to the publish script so that we can pass in the correct crates.io token when publishing our crates.