### PR TITLE
Fix remove network

### DIFF
--- a/pallets/subtensor/src/coinbase/root.rs
+++ b/pallets/subtensor/src/coinbase/root.rs
@@ -1159,7 +1159,7 @@ impl<T: Config> Pallet<T> {
 
         for (staking_key, hotkey, coldkey, stake) in stake_entries {
             Self::add_balance_to_coldkey_account(&staking_key, stake);
-            <Stake<T>>::remove(&hotkey, &coldkey);
+            Self::decrease_stake_on_coldkey_hotkey_account(&coldkey, &hotkey, stake);
         }
 
         // --- 3. Remove network count.

--- a/pallets/subtensor/src/coinbase/root.rs
+++ b/pallets/subtensor/src/coinbase/root.rs
@@ -1140,30 +1140,47 @@ impl<T: Config> Pallet<T> {
         let owner_coldkey: T::AccountId = SubnetOwner::<T>::get(netuid);
         let reserved_amount: u64 = Self::get_subnet_locked_balance(netuid);
 
-        // --- 2. Remove network count.
+        // --- 2. Unstake nominators and delegates
+        let stake_entries: Vec<(T::AccountId, T::AccountId, u64)> =
+            <Stake<T> as IterableStorageDoubleMap<T::AccountId, T::AccountId, u64>>::iter()
+                .filter(|(hotkey, _, _)| Uids::<T>::contains_key(netuid, hotkey))
+                .collect();
+
+        for (hotkey, coldkey, stake) in stake_entries {
+            let staking_key = if Self::hotkey_is_delegate(&hotkey) {
+                Owner::<T>::get(&hotkey)
+            } else {
+                coldkey.clone()
+            };
+
+            Self::add_balance_to_coldkey_account(&staking_key, stake);
+            <Stake<T>>::remove(&hotkey, &coldkey);
+        }
+
+        // --- 3. Remove network count.
         SubnetworkN::<T>::remove(netuid);
 
-        // --- 3. Remove network modality storage.
+        // --- 4. Remove network modality storage.
         NetworkModality::<T>::remove(netuid);
 
-        // --- 4. Remove netuid from added networks.
+        // --- 5. Remove netuid from added networks.
         NetworksAdded::<T>::remove(netuid);
 
-        // --- 5. Decrement the network counter.
+        // --- 6. Decrement the network counter.
         TotalNetworks::<T>::mutate(|n: &mut u16| *n = n.saturating_sub(1));
 
-        // --- 6. Remove various network-related storages.
+        // --- 7. Remove various network-related storages.
         NetworkRegisteredAt::<T>::remove(netuid);
 
-        // --- 7. Remove incentive mechanism memory.
+        // --- 8. Remove incentive mechanism memory.
         let _ = Uids::<T>::clear_prefix(netuid, u32::MAX, None);
         let _ = Keys::<T>::clear_prefix(netuid, u32::MAX, None);
         let _ = Bonds::<T>::clear_prefix(netuid, u32::MAX, None);
 
-        // --- 8. Removes the weights for this subnet (do not remove).
+        // --- 9. Removes the weights for this subnet (do not remove).
         let _ = Weights::<T>::clear_prefix(netuid, u32::MAX, None);
 
-        // --- 9. Iterate over stored weights and fill the matrix.
+        // --- 10. Iterate over stored weights and fill the matrix.
         for (uid_i, weights_i) in
             <Weights<T> as IterableStorageDoubleMap<u16, u16, Vec<(u16, u16)>>>::iter_prefix(
                 Self::get_root_netuid(),
@@ -1181,7 +1198,7 @@ impl<T: Config> Pallet<T> {
             Weights::<T>::insert(Self::get_root_netuid(), uid_i, modified_weights);
         }
 
-        // --- 10. Remove various network-related parameters.
+        // --- 11. Remove various network-related parameters.
         Rank::<T>::remove(netuid);
         Trust::<T>::remove(netuid);
         Active::<T>::remove(netuid);
@@ -1194,7 +1211,7 @@ impl<T: Config> Pallet<T> {
         ValidatorPermit::<T>::remove(netuid);
         ValidatorTrust::<T>::remove(netuid);
 
-        // --- 11. Erase network parameters.
+        // --- 12. Erase network parameters.
         Tempo::<T>::remove(netuid);
         Kappa::<T>::remove(netuid);
         Difficulty::<T>::remove(netuid);
@@ -1208,12 +1225,12 @@ impl<T: Config> Pallet<T> {
         POWRegistrationsThisInterval::<T>::remove(netuid);
         BurnRegistrationsThisInterval::<T>::remove(netuid);
 
-        // --- 12. Add the balance back to the owner.
+        // --- 13. Add the balance back to the owner.
         Self::add_balance_to_coldkey_account(&owner_coldkey, reserved_amount);
         Self::set_subnet_locked_balance(netuid, 0);
         SubnetOwner::<T>::remove(netuid);
 
-        // --- 13. Remove subnet identity if it exists.
+        // --- 14. Remove subnet identity if it exists.
         if SubnetIdentities::<T>::contains_key(netuid) {
             SubnetIdentities::<T>::remove(netuid);
             Self::deposit_event(Event::SubnetIdentityRemoved(netuid));

--- a/pallets/subtensor/tests/root.rs
+++ b/pallets/subtensor/tests/root.rs
@@ -1013,9 +1013,7 @@ fn test_dissolve_network_unstake_nominators_ok() {
 
         // Check that the balance was correctly updated and the stake was removed
         assert_eq!(new_balance, initial_balance + stake);
-        assert!(!<pallet_subtensor::Stake<Test>>::contains_key(
-            hotkey, coldkey
-        ));
+        assert_eq!(<pallet_subtensor::Stake<Test>>::get(hotkey, coldkey), 0);
     });
 }
 
@@ -1061,9 +1059,7 @@ fn test_dissolve_network_unstake_delegate_ok() {
 
         // Check that the delegate's balance was correctly updated and the stake was removed
         assert_eq!(new_delegate_balance, initial_delegate_balance + stake);
-        assert!(!<pallet_subtensor::Stake<Test>>::contains_key(
-            hotkey, coldkey
-        ));
+        assert_eq!(<pallet_subtensor::Stake<Test>>::get(hotkey, coldkey), 0);
     });
 }
 
@@ -1107,12 +1103,11 @@ fn test_dissolve_network_unstake_nominators_and_delegates_partial_match() {
         // Check that only the second network's stake was removed and balance updated
         assert_eq!(new_balance1, initial_balance1);
         assert_eq!(new_balance2, initial_balance2 + stake2); // Only change for hotkey2
-        assert!(<pallet_subtensor::Stake<Test>>::contains_key(
-            hotkey1, coldkey1
-        ));
-        assert!(!<pallet_subtensor::Stake<Test>>::contains_key(
-            hotkey2, coldkey2
-        ));
+        assert_eq!(
+            <pallet_subtensor::Stake<Test>>::get(hotkey1, coldkey1),
+            stake1
+        );
+        assert_eq!(<pallet_subtensor::Stake<Test>>::get(hotkey2, coldkey2), 0);
     });
 }
 
@@ -1150,12 +1145,8 @@ fn test_dissolve_network_unstake_multiple_stakes_same_hotkey() {
         // Check that both stakes were removed and the balances updated
         assert_eq!(new_balance1, initial_balance1 + stake1);
         assert_eq!(new_balance2, initial_balance2 + stake2);
-        assert!(!<pallet_subtensor::Stake<Test>>::contains_key(
-            hotkey, coldkey1
-        ));
-        assert!(!<pallet_subtensor::Stake<Test>>::contains_key(
-            hotkey, coldkey2
-        ));
+        assert_eq!(<pallet_subtensor::Stake<Test>>::get(hotkey, coldkey1), 0);
+        assert_eq!(<pallet_subtensor::Stake<Test>>::get(hotkey, coldkey2), 0);
     });
 }
 
@@ -1291,10 +1282,7 @@ fn test_dissolve_network_complex_state() {
             );
 
             assert_eq!(new_balance, stake + initial_balances[i]);
-
-            assert!(!<pallet_subtensor::Stake<Test>>::contains_key(
-                hotkey, coldkey
-            ));
+            assert_eq!(<pallet_subtensor::Stake<Test>>::get(hotkey, coldkey), 0);
         }
     });
 }

--- a/pallets/subtensor/tests/root.rs
+++ b/pallets/subtensor/tests/root.rs
@@ -984,6 +984,182 @@ fn test_dissolve_network_does_not_exist_err() {
 }
 
 #[test]
+fn test_dissolve_network_unstake_nominators_ok() {
+    new_test_ext(1).execute_with(|| {
+        let netuid: u16 = 30;
+        let hotkey = U256::from(1);
+        let coldkey = U256::from(2);
+        let stake: u64 = 1000;
+
+        // Set up the network and stake
+        add_network(netuid, 0, 0);
+        pallet_subtensor::SubnetOwner::<Test>::insert(netuid, coldkey);
+        register_ok_neuron(netuid, hotkey, coldkey, 3);
+
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey, 10);
+        let initial_balance: u64 = SubtensorModule::get_coldkey_balance(&coldkey);
+
+        <pallet_subtensor::Stake<Test>>::insert(hotkey, coldkey, stake);
+        pallet_subtensor::Uids::<Test>::insert(netuid, hotkey, 0);
+
+        // Call the dissolve_network function, which should trigger unstaking
+        assert_ok!(SubtensorModule::dissolve_network(
+            RuntimeOrigin::root(),
+            coldkey,
+            netuid
+        ));
+
+        let new_balance: u64 = SubtensorModule::get_coldkey_balance(&coldkey);
+
+        // Check that the balance was correctly updated and the stake was removed
+        assert_eq!(new_balance, initial_balance + stake);
+        assert!(!<pallet_subtensor::Stake<Test>>::contains_key(
+            hotkey, coldkey
+        ));
+    });
+}
+
+#[test]
+fn test_dissolve_network_unstake_delegate_ok() {
+    new_test_ext(1).execute_with(|| {
+        let netuid: u16 = 30;
+        let hotkey = U256::from(1);
+        let coldkey = U256::from(2);
+        let delegate_coldkey = U256::from(3);
+        let stake: u64 = 1000;
+
+        // Set up the network and associate the coldkey with the hotkey
+        add_network(netuid, 0, 0);
+        pallet_subtensor::SubnetOwner::<Test>::insert(netuid, coldkey);
+        register_ok_neuron(netuid, hotkey, coldkey, 3);
+        <pallet_subtensor::Stake<Test>>::insert(hotkey, coldkey, stake);
+        pallet_subtensor::Uids::<Test>::insert(netuid, hotkey, 0);
+
+        // Insert delegate ownership for the hotkey
+        pallet_subtensor::Owner::<Test>::insert(hotkey, coldkey);
+
+        // Ensure the hotkey is treated as a delegate
+        assert_ok!(SubtensorModule::do_become_delegate(
+            <<Test as Config>::RuntimeOrigin>::signed(coldkey),
+            hotkey,
+            u16::MAX / 10
+        ));
+
+        // Update the owner to the delegate coldkey
+        pallet_subtensor::Owner::<Test>::insert(hotkey, delegate_coldkey);
+
+        let initial_delegate_balance = SubtensorModule::get_coldkey_balance(&delegate_coldkey);
+
+        // Call the dissolve_network function
+        assert_ok!(SubtensorModule::dissolve_network(
+            RuntimeOrigin::root(),
+            coldkey,
+            netuid
+        ));
+
+        let new_delegate_balance: u64 = SubtensorModule::get_coldkey_balance(&delegate_coldkey);
+
+        // Check that the delegate's balance was correctly updated and the stake was removed
+        assert_eq!(new_delegate_balance, initial_delegate_balance + stake);
+        assert!(!<pallet_subtensor::Stake<Test>>::contains_key(
+            hotkey, coldkey
+        ));
+    });
+}
+
+#[test]
+fn test_dissolve_network_unstake_nominators_and_delegates_partial_match() {
+    new_test_ext(1).execute_with(|| {
+        let netuid1: u16 = 30;
+        let hotkey1 = U256::from(1);
+        let coldkey1 = U256::from(2);
+        let stake1: u64 = 1000;
+
+        let netuid2: u16 = 31;
+        let hotkey2 = U256::from(3);
+        let coldkey2 = U256::from(4);
+        let stake2: u64 = 500;
+
+        // Set up two distinct networks and stakes
+        add_network(netuid1, 0, 0);
+        add_network(netuid2, 0, 0);
+        pallet_subtensor::SubnetOwner::<Test>::insert(netuid1, coldkey1);
+        pallet_subtensor::SubnetOwner::<Test>::insert(netuid2, coldkey2);
+        register_ok_neuron(netuid1, hotkey1, coldkey1, 3);
+        register_ok_neuron(netuid2, hotkey2, coldkey2, 3);
+        <pallet_subtensor::Stake<Test>>::insert(hotkey1, coldkey1, stake1);
+        <pallet_subtensor::Stake<Test>>::insert(hotkey2, coldkey2, stake2);
+        pallet_subtensor::Uids::<Test>::insert(netuid1, hotkey1, 0); // Only hotkey1 is in Uids for the first network
+
+        let initial_balance1: u64 = SubtensorModule::get_coldkey_balance(&coldkey1);
+        let initial_balance2: u64 = SubtensorModule::get_coldkey_balance(&coldkey2);
+
+        // Call the dissolve_network function on the second network, which should only affect hotkey2
+        assert_ok!(SubtensorModule::dissolve_network(
+            RuntimeOrigin::root(),
+            coldkey2,
+            netuid2
+        ));
+
+        let new_balance1: u64 = SubtensorModule::get_coldkey_balance(&coldkey1);
+        let new_balance2: u64 = SubtensorModule::get_coldkey_balance(&coldkey2);
+
+        // Check that only the second network's stake was removed and balance updated
+        assert_eq!(new_balance1, initial_balance1);
+        assert_eq!(new_balance2, initial_balance2 + stake2); // Only change for hotkey2
+        assert!(<pallet_subtensor::Stake<Test>>::contains_key(
+            hotkey1, coldkey1
+        ));
+        assert!(!<pallet_subtensor::Stake<Test>>::contains_key(
+            hotkey2, coldkey2
+        ));
+    });
+}
+
+#[test]
+fn test_dissolve_network_unstake_multiple_stakes_same_hotkey() {
+    new_test_ext(1).execute_with(|| {
+        let netuid: u16 = 30;
+        let hotkey = U256::from(1);
+        let coldkey1 = U256::from(2);
+        let coldkey2 = U256::from(3);
+        let stake1: u64 = 1000;
+        let stake2: u64 = 500;
+
+        // Set up the network and multiple stakes
+        add_network(netuid, 0, 0);
+        pallet_subtensor::SubnetOwner::<Test>::insert(netuid, coldkey1);
+        register_ok_neuron(netuid, hotkey, coldkey1, 3);
+        <pallet_subtensor::Stake<Test>>::insert(hotkey, coldkey1, stake1);
+        <pallet_subtensor::Stake<Test>>::insert(hotkey, coldkey2, stake2);
+        pallet_subtensor::Uids::<Test>::insert(netuid, hotkey, 0);
+
+        let initial_balance1: u64 = SubtensorModule::get_coldkey_balance(&coldkey1);
+        let initial_balance2: u64 = SubtensorModule::get_coldkey_balance(&coldkey2);
+
+        // Call the dissolve_network function
+        assert_ok!(SubtensorModule::dissolve_network(
+            RuntimeOrigin::root(),
+            coldkey1,
+            netuid
+        ));
+
+        let new_balance1: u64 = SubtensorModule::get_coldkey_balance(&coldkey1);
+        let new_balance2: u64 = SubtensorModule::get_coldkey_balance(&coldkey2);
+
+        // Check that both stakes were removed and the balances updated
+        assert_eq!(new_balance1, initial_balance1 + stake1);
+        assert_eq!(new_balance2, initial_balance2 + stake2);
+        assert!(!<pallet_subtensor::Stake<Test>>::contains_key(
+            hotkey, coldkey1
+        ));
+        assert!(!<pallet_subtensor::Stake<Test>>::contains_key(
+            hotkey, coldkey2
+        ));
+    });
+}
+
+#[test]
 fn test_user_add_network_with_identity_fields_ok() {
     new_test_ext(1).execute_with(|| {
         let coldkey_1 = U256::from(1);

--- a/pallets/subtensor/tests/root.rs
+++ b/pallets/subtensor/tests/root.rs
@@ -1198,7 +1198,7 @@ fn test_dissolve_network_complex_state() {
 
                 // Alternate between having stake and no stake
                 if i % 2 == 0 {
-                    let stake = (i + 1) as u64 * 1000;
+                    let stake = (i + 1) * 1000;
                     stakes.push(stake);
 
                     register_ok_neuron(netuid, hotkey, coldkey, 3);
@@ -1260,7 +1260,7 @@ fn test_dissolve_network_complex_state() {
                 let staking_key = if SubtensorModule::hotkey_is_delegate(hotkey) {
                     pallet_subtensor::Owner::<Test>::get(hotkey)
                 } else {
-                    coldkey.clone()
+                    *coldkey
                 };
 
                 let new_balance = SubtensorModule::get_coldkey_balance(&staking_key);
@@ -1278,12 +1278,7 @@ fn test_dissolve_network_complex_state() {
         }
 
         // Ensure that all stakes were removed
-        for (_, ((hotkey, coldkey), _stake)) in hotkeys
-            .iter()
-            .zip(coldkeys.iter())
-            .zip(stakes.iter())
-            .enumerate()
-        {
+        for ((hotkey, coldkey), _stake) in hotkeys.iter().zip(coldkeys.iter()).zip(stakes.iter()) {
             log::debug!(
                 "Checking if stake for hotkey {} and coldkey {} was removed",
                 hotkey,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -142,7 +142,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 196,
+    spec_version: 197,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
Adds logic to unstake any accounts staked to a subnet on deregistration 

## Related Issue(s)

- Closes #564

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):