### PR TITLE
change weight commit logic

### DIFF
--- a/pallets/subtensor/src/subnets/weights.rs
+++ b/pallets/subtensor/src/subnets/weights.rs
@@ -43,14 +43,10 @@ impl<T: Config> Pallet<T> {
 
         // Insert the new commit with the current block number.
         let current_block = Self::get_current_block_as_u64();
-        WeightCommits::<T>::insert(
-            netuid,
-            &who,
-            (commit_hash, current_block),
-        );
+        WeightCommits::<T>::insert(netuid, &who, (commit_hash, current_block));
 
         // Retain only commits where committed_block < current_block - commit_reveal_interval * 2
-        let interval = Self::get_commit_reveal_weights_interval(netuid) * 2;
+        let interval = Self::get_commit_reveal_weights_interval(netuid).saturating_mul(2);
         let threshold_block = current_block.saturating_sub(interval);
 
         // Iterate through the commits and remove old entries

--- a/pallets/subtensor/src/subnets/weights.rs
+++ b/pallets/subtensor/src/subnets/weights.rs
@@ -477,40 +477,6 @@ impl<T: Config> Pallet<T> {
         uids.len() <= subnetwork_n as usize
     }
 
-    // ///
-    // /// This function checks if the `weights_rate_limit` time has passed since the last
-    // /// committed weight. If it has, the validator can commit new weights.
-    // ///
-    // ///
-    // pub fn check_rate_limit_for_commit(netuid: u16, who: &T::AccountId) -> bool {
-    //     if let Some((_hash, last_commit_block)) = WeightCommits::<T>::get(netuid, who) {
-    //         let current_block: u64 = Self::get_current_block_as_u64();
-    //         let rate_limit: u64 = Self::get_weights_set_rate_limit(netuid);
-    //         current_block.saturating_sub(last_commit_block) >= rate_limit
-    //     } else {
-    //         true
-    //     }
-    // }
-
-    /// This function is used to enforce a time delay between when weights are committed and when
-    /// they can be revealed. This delay helps prevent certain types of attacks and ensures the
-    /// integrity of the commit-reveal scheme.
-    ///
-    /// # Arguments
-    ///
-    /// * `commit_block` - The block number when the weights were committed
-    /// * `netuid` - The network UID for which to check the reveal validity
-    ///
-    /// # Returns
-    ///
-    /// * `bool` - True if the reveal is valid (enough time has passed), false otherwise
-    #[allow(clippy::arithmetic_side_effects)]
-    pub fn is_reveal_valid(commit_block: u64, netuid: u16) -> bool {
-        let interval = Self::get_commit_reveal_weights_interval(netuid);
-        let current_block = Self::get_current_block_as_u64();
-        current_block.saturating_sub(commit_block) > interval
-    }
-
     /// Checks if the rate limit has been satisfied based on the current block and a given interval.
     ///
     /// # Arguments

--- a/pallets/subtensor/src/subnets/weights.rs
+++ b/pallets/subtensor/src/subnets/weights.rs
@@ -477,11 +477,18 @@ impl<T: Config> Pallet<T> {
         }
     }
 
-    /// ---- The helper logic for checking if a reveal is valid based on the commit.
+    /// This function is used to enforce a time delay between when weights are committed and when
+    /// they can be revealed. This delay helps prevent certain types of attacks and ensures the
+    /// integrity of the commit-reveal scheme.
     ///
-    /// A reveal is valid if the difference between the current block and the committed block
-    /// exceeds the `commit_reveal_interval`.
+    /// # Arguments
     ///
+    /// * `commit_block` - The block number when the weights were committed
+    /// * `netuid` - The network UID for which to check the reveal validity
+    ///
+    /// # Returns
+    ///
+    /// * `bool` - True if the reveal is valid (enough time has passed), false otherwise
     #[allow(clippy::arithmetic_side_effects)]
     pub fn is_reveal_valid(commit_block: u64, netuid: u16) -> bool {
         let interval = Self::get_commit_reveal_weights_interval(netuid);

--- a/pallets/subtensor/tests/weights.rs
+++ b/pallets/subtensor/tests/weights.rs
@@ -160,6 +160,74 @@ fn test_commit_weights_dispatch_info_ok() {
     });
 }
 
+
+#[test]
+fn test_commit_weights_rate_limit() {
+    new_test_ext(1).execute_with(|| {
+        let netuid: u16 = 1;
+        let uids: Vec<u16> = vec![0, 1];
+        let weight_values: Vec<u16> = vec![10, 10];
+        let salt: Vec<u16> = vec![1, 2, 3, 4, 5, 6, 7, 8];
+        let version_key: u64 = 0;
+        let hotkey: U256 = U256::from(1);
+
+        let commit_hash: H256 = BlakeTwo256::hash_of(&(
+            hotkey,
+            netuid,
+            uids.clone(),
+            weight_values.clone(),
+            salt.clone(),
+            version_key,
+        ));
+
+        // Add network and register neurons
+        add_network(netuid, 0, 0);
+        register_ok_neuron(netuid, U256::from(3), U256::from(4), 300000);
+        register_ok_neuron(netuid, U256::from(1), U256::from(2), 100000);
+        
+        // Set the commit/reveal weights rate limit and enable the feature
+        SubtensorModule::set_weights_set_rate_limit(netuid, 5);
+        SubtensorModule::set_commit_reveal_weights_interval(netuid, 5);
+        SubtensorModule::set_commit_reveal_weights_enabled(netuid, true);
+
+        // First commit should succeed
+        assert_ok!(SubtensorModule::commit_weights(
+            RuntimeOrigin::signed(hotkey),
+            netuid,
+            commit_hash
+        ));
+
+        // Try to commit again within the rate limit (should fail)
+        let second_commit_hash: H256 = BlakeTwo256::hash_of(&(
+            hotkey,
+            netuid,
+            uids.clone(),
+            weight_values.clone(),
+            salt.clone(),
+            version_key + 1,
+        ));
+
+        assert_err!(
+            SubtensorModule::commit_weights(
+                RuntimeOrigin::signed(hotkey),
+                netuid,
+                second_commit_hash
+            ),
+            Error::<Test>::WeightsCommitNotAllowed
+        );
+
+        // Simulate the passage of time to exceed the rate limit interval
+        step_block(6);
+
+        // Try to commit again after rate limit interval (should succeed)
+        assert_ok!(SubtensorModule::commit_weights(
+            RuntimeOrigin::signed(hotkey),
+            netuid,
+            second_commit_hash
+        ));
+    });
+}
+
 #[test]
 fn test_commit_weights_validate() {
     // Testing the signed extension validate function

--- a/pallets/subtensor/tests/weights.rs
+++ b/pallets/subtensor/tests/weights.rs
@@ -160,7 +160,6 @@ fn test_commit_weights_dispatch_info_ok() {
     });
 }
 
-
 #[test]
 fn test_commit_weights_rate_limit() {
     new_test_ext(1).execute_with(|| {
@@ -184,7 +183,7 @@ fn test_commit_weights_rate_limit() {
         add_network(netuid, 0, 0);
         register_ok_neuron(netuid, U256::from(3), U256::from(4), 300000);
         register_ok_neuron(netuid, U256::from(1), U256::from(2), 100000);
-        
+
         // Set the commit/reveal weights rate limit and enable the feature
         SubtensorModule::set_weights_set_rate_limit(netuid, 5);
         SubtensorModule::set_commit_reveal_weights_interval(netuid, 5);


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
- This should only check if the weights_rate_limit time has passed since the last committed weights, without imposing the interval-based restriction.
- The chain should now store multiple weight commits in the WeightCommits storage, so we will modify the storage to retain all commits older than the defined commit_reveal_interval * 2
- Validators can reveal weights if the difference between the current_block and committed_block exceeds the commit_reveal_interval.

## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.