### PR TITLE
Remove stake entries with zero stake

### DIFF
--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -70,7 +70,9 @@ mod hooks {
                 // Storage version v8 -> v9
                 .saturating_add(migrations::migrate_fix_total_coldkey_stake::migrate_fix_total_coldkey_stake::<T>())
                 // Migrate Delegate Ids on chain
-                .saturating_add(migrations::migrate_chain_identity::migrate_set_hotkey_identities::<T>());
+                .saturating_add(migrations::migrate_chain_identity::migrate_set_hotkey_identities::<T>())
+                // Remove stake entries with 0 stake
+                .saturating_add(migrations::migrate_remove_zero_stake::migrate_remove_zero_stakes::<T>());
             weight
         }
 

--- a/pallets/subtensor/src/migrations/migrate_remove_zero_stake.rs
+++ b/pallets/subtensor/src/migrations/migrate_remove_zero_stake.rs
@@ -1,0 +1,48 @@
+use super::*;
+use frame_support::{traits::Get, weights::Weight};
+use log;
+use scale_info::prelude::string::String;
+
+pub fn migrate_remove_zero_stakes<T: Config>() -> Weight {
+    let migration_name = b"remove_zero_stakes_v1".to_vec();
+    let mut weight = T::DbWeight::get().reads(1);
+
+    // Check if the migration has already run
+    if HasMigrationRun::<T>::get(&migration_name) {
+        log::info!(
+            "Migration '{:?}' has already run. Skipping.",
+            migration_name
+        );
+        return weight;
+    }
+    log::info!(
+        "Running migration '{}'",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    // Iterate through all the stake entries
+    Stake::<T>::iter().for_each(|(hotkey, coldkey, stake)| {
+        if stake == 0 {
+            log::info!(
+                "Removing zero stake for hotkey: {:?}, coldkey: {:?}",
+                hotkey,
+                coldkey
+            );
+            Stake::<T>::remove(hotkey.clone(), coldkey.clone());
+
+            weight = weight.saturating_add(T::DbWeight::get().writes(1));
+        }
+        weight = weight.saturating_add(T::DbWeight::get().reads(1));
+    });
+
+    // Mark the migration as completed
+    HasMigrationRun::<T>::insert(&migration_name, true);
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+    log::info!(
+        "Migration '{:?}' completed. All zero stakes removed.",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    weight
+}

--- a/pallets/subtensor/src/migrations/mod.rs
+++ b/pallets/subtensor/src/migrations/mod.rs
@@ -7,6 +7,7 @@ pub mod migrate_fix_total_coldkey_stake;
 pub mod migrate_init_total_issuance;
 pub mod migrate_populate_owned_hotkeys;
 pub mod migrate_populate_staking_hotkeys;
+pub mod migrate_remove_zero_stake;
 pub mod migrate_to_v1_separate_emission;
 pub mod migrate_to_v2_fixed_total_stake;
 pub mod migrate_total_issuance;

--- a/pallets/subtensor/src/staking/helpers.rs
+++ b/pallets/subtensor/src/staking/helpers.rs
@@ -260,14 +260,15 @@ impl<T: Config> Pallet<T> {
             hotkey,
             TotalHotkeyStake::<T>::get(hotkey).saturating_sub(decrement),
         );
-        Stake::<T>::insert(
-            hotkey,
-            coldkey,
-            Stake::<T>::get(hotkey, coldkey).saturating_sub(decrement),
-        );
         TotalStake::<T>::put(TotalStake::<T>::get().saturating_sub(decrement));
 
-        // TODO: Tech debt: Remove StakingHotkeys entry if stake goes to 0
+        let new_stake = Stake::<T>::get(hotkey, coldkey).saturating_sub(decrement);
+
+        if new_stake == 0 {
+            Stake::<T>::remove(hotkey, coldkey);
+        } else {
+            Stake::<T>::insert(hotkey, coldkey, new_stake);
+        }
     }
 
     /// Empties the stake associated with a given coldkey-hotkey account pairing.

--- a/pallets/subtensor/tests/staking.rs
+++ b/pallets/subtensor/tests/staking.rs
@@ -2315,11 +2315,11 @@ fn test_migrate_remove_zero_stakes() {
         let hotkey1 = U256::from(3);
         let hotkey2 = U256::from(4);
 
-        Stake::<Test>::insert(&hotkey1, &coldkey1, 0);
-        Stake::<Test>::insert(&hotkey2, &coldkey2, 100);
+        Stake::<Test>::insert(hotkey1, coldkey1, 0);
+        Stake::<Test>::insert(hotkey2, coldkey2, 100);
 
-        assert_eq!(Stake::<Test>::get(&hotkey1, &coldkey1), 0);
-        assert_eq!(Stake::<Test>::get(&hotkey2, &coldkey2), 100);
+        assert_eq!(Stake::<Test>::get(hotkey1, coldkey1), 0);
+        assert_eq!(Stake::<Test>::get(hotkey2, coldkey2), 100);
 
         assert!(!HasMigrationRun::<Test>::get(
             b"remove_zero_stakes_v1".to_vec()
@@ -2334,11 +2334,11 @@ fn test_migrate_remove_zero_stakes() {
             b"remove_zero_stakes_v1".to_vec()
         ));
 
-        assert_eq!(Stake::<Test>::get(&hotkey1, &coldkey1), 0); // Default is 0
-        assert!(!Stake::<Test>::contains_key(&hotkey1, &coldkey1));
+        assert_eq!(Stake::<Test>::get(hotkey1, coldkey1), 0); // Default is 0
+        assert!(!Stake::<Test>::contains_key(hotkey1, coldkey1));
 
-        assert_eq!(Stake::<Test>::get(&hotkey2, &coldkey2), 100);
-        assert!(Stake::<Test>::contains_key(&hotkey2, &coldkey2));
+        assert_eq!(Stake::<Test>::get(hotkey2, coldkey2), 100);
+        assert!(Stake::<Test>::contains_key(hotkey2, coldkey2));
 
         assert!(
             weight != Weight::zero(),
@@ -2353,16 +2353,16 @@ fn test_decrease_stake_non_zero_stake() {
         let hotkey = U256::from(1);
         let coldkey = U256::from(2);
 
-        TotalColdkeyStake::<Test>::insert(&coldkey, 200);
-        TotalHotkeyStake::<Test>::insert(&hotkey, 150);
-        Stake::<Test>::insert(&hotkey, &coldkey, 100);
+        TotalColdkeyStake::<Test>::insert(coldkey, 200);
+        TotalHotkeyStake::<Test>::insert(hotkey, 150);
+        Stake::<Test>::insert(hotkey, coldkey, 100);
         TotalStake::<Test>::put(300);
 
         SubtensorModule::decrease_stake_on_coldkey_hotkey_account(&coldkey, &hotkey, 50);
 
-        assert_eq!(TotalColdkeyStake::<Test>::get(&coldkey), 150);
-        assert_eq!(TotalHotkeyStake::<Test>::get(&hotkey), 100);
-        assert_eq!(Stake::<Test>::get(&hotkey, &coldkey), 50);
+        assert_eq!(TotalColdkeyStake::<Test>::get(coldkey), 150);
+        assert_eq!(TotalHotkeyStake::<Test>::get(hotkey), 100);
+        assert_eq!(Stake::<Test>::get(hotkey, coldkey), 50);
         assert_eq!(TotalStake::<Test>::get(), 250);
     });
 }
@@ -2374,18 +2374,18 @@ fn test_decrease_stake_to_zero() {
         let coldkey = U256::from(2);
 
         // Insert initial stake
-        TotalColdkeyStake::<Test>::insert(&coldkey, 150);
-        TotalHotkeyStake::<Test>::insert(&hotkey, 100);
-        Stake::<Test>::insert(&hotkey, &coldkey, 50);
+        TotalColdkeyStake::<Test>::insert(coldkey, 150);
+        TotalHotkeyStake::<Test>::insert(hotkey, 100);
+        Stake::<Test>::insert(hotkey, coldkey, 50);
         TotalStake::<Test>::put(250);
 
         // Decrease stake to zero
         SubtensorModule::decrease_stake_on_coldkey_hotkey_account(&coldkey, &hotkey, 50);
 
         // Check that the stake is removed
-        assert_eq!(TotalColdkeyStake::<Test>::get(&coldkey), 100);
-        assert_eq!(TotalHotkeyStake::<Test>::get(&hotkey), 50);
-        assert!(!Stake::<Test>::contains_key(&hotkey, &coldkey));
+        assert_eq!(TotalColdkeyStake::<Test>::get(coldkey), 100);
+        assert_eq!(TotalHotkeyStake::<Test>::get(hotkey), 50);
+        assert!(!Stake::<Test>::contains_key(hotkey, coldkey));
         assert_eq!(TotalStake::<Test>::get(), 200);
     });
 }
@@ -2397,18 +2397,18 @@ fn test_decrease_stake_more_than_available() {
         let coldkey = U256::from(2);
 
         // Insert initial stake
-        TotalColdkeyStake::<Test>::insert(&coldkey, 80);
-        TotalHotkeyStake::<Test>::insert(&hotkey, 70);
-        Stake::<Test>::insert(&hotkey, &coldkey, 60);
+        TotalColdkeyStake::<Test>::insert(coldkey, 80);
+        TotalHotkeyStake::<Test>::insert(hotkey, 70);
+        Stake::<Test>::insert(hotkey, coldkey, 60);
         TotalStake::<Test>::put(150);
 
         // Decrease by more than available stake
         SubtensorModule::decrease_stake_on_coldkey_hotkey_account(&coldkey, &hotkey, 100);
 
         // Check that the stake is zero and removed
-        assert_eq!(TotalColdkeyStake::<Test>::get(&coldkey), 0);
-        assert_eq!(TotalHotkeyStake::<Test>::get(&hotkey), 0);
-        assert!(!Stake::<Test>::contains_key(&hotkey, &coldkey));
+        assert_eq!(TotalColdkeyStake::<Test>::get(coldkey), 0);
+        assert_eq!(TotalHotkeyStake::<Test>::get(hotkey), 0);
+        assert!(!Stake::<Test>::contains_key(hotkey, coldkey));
         assert_eq!(TotalStake::<Test>::get(), 50);
     });
 }
@@ -2420,18 +2420,18 @@ fn test_decrease_stake_no_existing_stake() {
         let coldkey = U256::from(2);
 
         // Insert zero stake for coldkey and hotkey
-        TotalColdkeyStake::<Test>::insert(&coldkey, 0);
-        TotalHotkeyStake::<Test>::insert(&hotkey, 0);
-        Stake::<Test>::remove(&hotkey, &coldkey);
+        TotalColdkeyStake::<Test>::insert(coldkey, 0);
+        TotalHotkeyStake::<Test>::insert(hotkey, 0);
+        Stake::<Test>::remove(hotkey, coldkey);
         TotalStake::<Test>::put(0);
 
         // Try to decrease stake when no stake exists
         SubtensorModule::decrease_stake_on_coldkey_hotkey_account(&coldkey, &hotkey, 10);
 
         // Assert no changes were made
-        assert_eq!(TotalColdkeyStake::<Test>::get(&coldkey), 0);
-        assert_eq!(TotalHotkeyStake::<Test>::get(&hotkey), 0);
-        assert!(!Stake::<Test>::contains_key(&hotkey, &coldkey));
+        assert_eq!(TotalColdkeyStake::<Test>::get(coldkey), 0);
+        assert_eq!(TotalHotkeyStake::<Test>::get(hotkey), 0);
+        assert!(!Stake::<Test>::contains_key(hotkey, coldkey));
         assert_eq!(TotalStake::<Test>::get(), 0);
     });
 }

--- a/pallets/subtensor/tests/staking.rs
+++ b/pallets/subtensor/tests/staking.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::arithmetic_side_effects)]
 
-use frame_support::{assert_err, assert_noop, assert_ok, traits::Currency};
+use frame_support::{assert_err, assert_noop, assert_ok, pallet_prelude::Weight, traits::Currency};
 use frame_system::Config;
 mod mock;
 use frame_support::dispatch::{DispatchClass, DispatchInfo, GetDispatchInfo, Pays};
@@ -2304,5 +2304,134 @@ fn test_get_total_delegated_stake_exclude_owner_stake() {
             "Delegated stake should exclude owner's stake. Expected: {}, Actual: {}",
             expected_delegated_stake, actual_delegated_stake
         );
+    });
+}
+
+#[test]
+fn test_migrate_remove_zero_stakes() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey1 = U256::from(1);
+        let coldkey2 = U256::from(2);
+        let hotkey1 = U256::from(3);
+        let hotkey2 = U256::from(4);
+
+        Stake::<Test>::insert(&hotkey1, &coldkey1, 0);
+        Stake::<Test>::insert(&hotkey2, &coldkey2, 100);
+
+        assert_eq!(Stake::<Test>::get(&hotkey1, &coldkey1), 0);
+        assert_eq!(Stake::<Test>::get(&hotkey2, &coldkey2), 100);
+
+        assert!(!HasMigrationRun::<Test>::get(
+            b"remove_zero_stakes_v1".to_vec()
+        ));
+
+        let weight =
+            pallet_subtensor::migrations::migrate_remove_zero_stake::migrate_remove_zero_stakes::<
+                Test,
+            >();
+
+        assert!(HasMigrationRun::<Test>::get(
+            b"remove_zero_stakes_v1".to_vec()
+        ));
+
+        assert_eq!(Stake::<Test>::get(&hotkey1, &coldkey1), 0); // Default is 0
+        assert!(!Stake::<Test>::contains_key(&hotkey1, &coldkey1));
+
+        assert_eq!(Stake::<Test>::get(&hotkey2, &coldkey2), 100);
+        assert!(Stake::<Test>::contains_key(&hotkey2, &coldkey2));
+
+        assert!(
+            weight != Weight::zero(),
+            "Migration weight should be non-zero"
+        );
+    });
+}
+
+#[test]
+fn test_decrease_stake_non_zero_stake() {
+    new_test_ext(1).execute_with(|| {
+        let hotkey = U256::from(1);
+        let coldkey = U256::from(2);
+
+        TotalColdkeyStake::<Test>::insert(&coldkey, 200);
+        TotalHotkeyStake::<Test>::insert(&hotkey, 150);
+        Stake::<Test>::insert(&hotkey, &coldkey, 100);
+        TotalStake::<Test>::put(300);
+
+        SubtensorModule::decrease_stake_on_coldkey_hotkey_account(&coldkey, &hotkey, 50);
+
+        assert_eq!(TotalColdkeyStake::<Test>::get(&coldkey), 150);
+        assert_eq!(TotalHotkeyStake::<Test>::get(&hotkey), 100);
+        assert_eq!(Stake::<Test>::get(&hotkey, &coldkey), 50);
+        assert_eq!(TotalStake::<Test>::get(), 250);
+    });
+}
+
+#[test]
+fn test_decrease_stake_to_zero() {
+    new_test_ext(1).execute_with(|| {
+        let hotkey = U256::from(1);
+        let coldkey = U256::from(2);
+
+        // Insert initial stake
+        TotalColdkeyStake::<Test>::insert(&coldkey, 150);
+        TotalHotkeyStake::<Test>::insert(&hotkey, 100);
+        Stake::<Test>::insert(&hotkey, &coldkey, 50);
+        TotalStake::<Test>::put(250);
+
+        // Decrease stake to zero
+        SubtensorModule::decrease_stake_on_coldkey_hotkey_account(&coldkey, &hotkey, 50);
+
+        // Check that the stake is removed
+        assert_eq!(TotalColdkeyStake::<Test>::get(&coldkey), 100);
+        assert_eq!(TotalHotkeyStake::<Test>::get(&hotkey), 50);
+        assert!(!Stake::<Test>::contains_key(&hotkey, &coldkey));
+        assert_eq!(TotalStake::<Test>::get(), 200);
+    });
+}
+
+#[test]
+fn test_decrease_stake_more_than_available() {
+    new_test_ext(1).execute_with(|| {
+        let hotkey = U256::from(1);
+        let coldkey = U256::from(2);
+
+        // Insert initial stake
+        TotalColdkeyStake::<Test>::insert(&coldkey, 80);
+        TotalHotkeyStake::<Test>::insert(&hotkey, 70);
+        Stake::<Test>::insert(&hotkey, &coldkey, 60);
+        TotalStake::<Test>::put(150);
+
+        // Decrease by more than available stake
+        SubtensorModule::decrease_stake_on_coldkey_hotkey_account(&coldkey, &hotkey, 100);
+
+        // Check that the stake is zero and removed
+        assert_eq!(TotalColdkeyStake::<Test>::get(&coldkey), 0);
+        assert_eq!(TotalHotkeyStake::<Test>::get(&hotkey), 0);
+        assert!(!Stake::<Test>::contains_key(&hotkey, &coldkey));
+        assert_eq!(TotalStake::<Test>::get(), 50);
+    });
+}
+
+#[test]
+fn test_decrease_stake_no_existing_stake() {
+    new_test_ext(1).execute_with(|| {
+        let hotkey = U256::from(1);
+        let coldkey = U256::from(2);
+
+        // Insert zero stake for coldkey and hotkey
+        TotalColdkeyStake::<Test>::insert(&coldkey, 0);
+        TotalHotkeyStake::<Test>::insert(&hotkey, 0);
+        Stake::<Test>::remove(&hotkey, &coldkey);
+        TotalStake::<Test>::put(0);
+
+        // Try to decrease stake when no stake exists
+        SubtensorModule::decrease_stake_on_coldkey_hotkey_account(&coldkey, &hotkey, 10);
+
+        // Assert no changes were made
+        assert_eq!(TotalColdkeyStake::<Test>::get(&coldkey), 0);
+        assert_eq!(TotalHotkeyStake::<Test>::get(&hotkey), 0);
+        assert!(!Stake::<Test>::contains_key(&hotkey, &coldkey));
+        assert_eq!(TotalStake::<Test>::get(), 0);
     });
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -142,7 +142,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 196,
+    spec_version: 197,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
This PR:
- Adds unstaking to `remove_network`
- Adds migration to remove all stake entries with 0 stake.
- Adds unit tests for `remove_network` and `remove_zero_stakes_v1` migration

## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):
