### PR TITLE
add cleared amount in remove_stake

### DIFF
--- a/pallets/subtensor/src/staking/helpers.rs
+++ b/pallets/subtensor/src/staking/helpers.rs
@@ -305,7 +305,7 @@ impl<T: Config> Pallet<T> {
         hotkey: &T::AccountId,
         coldkey: &T::AccountId,
         stake: u64,
-    ) {
+    ) -> u64 {
         // Verify if the account is a nominator account by checking ownership of the hotkey by the coldkey.
         if !Self::coldkey_owns_hotkey(coldkey, hotkey) {
             // If the stake is below the minimum required, it's considered a small nomination and needs to be cleared.
@@ -315,8 +315,10 @@ impl<T: Config> Pallet<T> {
                 let cleared_stake = Self::empty_stake_on_coldkey_hotkey_account(coldkey, hotkey);
                 // Add the stake to the coldkey account.
                 Self::add_balance_to_coldkey_account(coldkey, cleared_stake);
+                return cleared_stake;
             }
         }
+        0
     }
 
     /// Clears small nominations for all accounts.

--- a/pallets/subtensor/src/staking/remove_stake.rs
+++ b/pallets/subtensor/src/staking/remove_stake.rs
@@ -83,7 +83,8 @@ impl<T: Config> Pallet<T> {
         // This only applies to nominator stakes.
         // If the coldkey does not own the hotkey, it's a nominator stake.
         let new_stake = Self::get_stake_for_coldkey_and_hotkey(&coldkey, &hotkey);
-        Self::clear_small_nomination_if_required(&hotkey, &coldkey, new_stake);
+        let cleared_stake = Self::clear_small_nomination_if_required(&hotkey, &coldkey, new_stake);
+        let stake_removed = stake_to_be_removed.saturating_add(cleared_stake);
 
         // Set last block for rate limiting
         let block: u64 = Self::get_current_block_as_u64();
@@ -97,11 +98,12 @@ impl<T: Config> Pallet<T> {
             block,
         );
         log::debug!(
-            "StakeRemoved( hotkey:{:?}, stake_to_be_removed:{:?} )",
+            "StakeRemoved( hotkey:{:?}, stake_to_be_removed:{:?} stake_removed:{:?} )",
             hotkey,
-            stake_to_be_removed
+            stake_to_be_removed,
+            stake_removed
         );
-        Self::deposit_event(Event::StakeRemoved(hotkey, stake_to_be_removed));
+        Self::deposit_event(Event::StakeRemoved(hotkey, stake_removed));
 
         // Done and ok.
         Ok(())


### PR DESCRIPTION
## Description
Currently, only the user requested amount is emitted in the event `StakeRemoved`.
In the new runtime upgrade, when the staked amount is less than the minimum amount(set to 0.1TAO at the moment), it gets cleared automatically.

In this PR, I take the cleared amount into consideration in `remove_stake` extrinsic.


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
