### PR TITLE
Hotfix/pending hotkey emission on swap

### DIFF
--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -70,7 +70,9 @@ mod hooks {
                 // Storage version v8 -> v9
                 .saturating_add(migrations::migrate_fix_total_coldkey_stake::migrate_fix_total_coldkey_stake::<T>())
                 // Migrate Delegate Ids on chain
-                .saturating_add(migrations::migrate_chain_identity::migrate_set_hotkey_identities::<T>());
+                .saturating_add(migrations::migrate_chain_identity::migrate_set_hotkey_identities::<T>())
+				// Fix pending emissions
+				.saturating_add(migrations::migrate_fix_pending_emission::migrate_fix_pending_emission::<T>());
             weight
         }
 

--- a/pallets/subtensor/src/migrations/migrate_fix_pending_emission.rs
+++ b/pallets/subtensor/src/migrations/migrate_fix_pending_emission.rs
@@ -1,0 +1,155 @@
+use super::*;
+use alloc::string::String;
+use frame_support::{traits::Get, weights::Weight};
+use sp_core::crypto::Ss58Codec;
+use sp_runtime::AccountId32;
+
+fn swap_pending_emissions<T: Config>(
+    old_hotkey: &T::AccountId,
+    new_hotkey: &T::AccountId,
+) -> Weight {
+    let mut weight = T::DbWeight::get().reads(0);
+
+    // Get the pending emissions for the old hotkey
+    let pending_emissions = PendingdHotkeyEmission::<T>::get(old_hotkey);
+    weight.saturating_accrue(T::DbWeight::get().reads(1));
+
+    // Remove the pending emissions for the old hotkey
+    PendingdHotkeyEmission::<T>::remove(old_hotkey);
+    weight.saturating_accrue(T::DbWeight::get().writes(1));
+
+    // Add the pending emissions for the new hotkey
+    PendingdHotkeyEmission::<T>::insert(new_hotkey, pending_emissions);
+    weight.saturating_accrue(T::DbWeight::get().writes(1));
+
+    // Swap the last LastAddStakeIncrease
+    let old_coldkey_entries: Vec<(T::AccountId, u64)> =
+        LastAddStakeIncrease::<T>::iter_prefix(old_hotkey).collect();
+    if !old_coldkey_entries.is_empty() {
+        for (coldkey, last_add_stake_increase) in old_coldkey_entries {
+            LastAddStakeIncrease::<T>::remove(old_hotkey, &coldkey);
+            LastAddStakeIncrease::<T>::insert(new_hotkey, &coldkey, last_add_stake_increase);
+            weight.saturating_accrue(T::DbWeight::get().reads_writes(1, 2));
+        }
+    }
+
+    weight
+}
+
+fn get_account_id_from_ss58<T: Config>(ss58_str: &str) -> T::AccountId {
+    let account = AccountId32::from_ss58check(ss58_str).unwrap();
+    let onchain_account = T::AccountId::decode(&mut account.as_ref()).unwrap();
+
+    onchain_account
+}
+
+fn unstake_old_hotkey_and_move_to_pending<T: Config>(
+    old_hotkey: &T::AccountId,
+    new_hotkey: &T::AccountId,
+) -> Weight {
+    let mut weight = T::DbWeight::get().reads(0);
+    let null_account = DefaultAccount::<T>::get();
+    weight.saturating_accrue(T::DbWeight::get().reads(1));
+
+    // Get the pending emissions for the new hotkey
+    let pending_emissions = PendingdHotkeyEmission::<T>::get(new_hotkey);
+    weight.saturating_accrue(T::DbWeight::get().reads(1));
+
+    // Get the stake for the 0x000 key
+    let null_stake = Stake::<T>::get(&old_hotkey, &null_account);
+    weight.saturating_accrue(T::DbWeight::get().reads(1));
+    // Remove
+    Stake::<T>::remove(&old_hotkey, &null_account);
+    weight.saturating_accrue(T::DbWeight::get().writes(1));
+
+    let new_total_coldkey_stake =
+        TotalColdkeyStake::<T>::get(old_hotkey).saturating_sub(null_stake);
+    if new_total_coldkey_stake == 0 {
+        TotalColdkeyStake::<T>::remove(old_hotkey);
+    } else {
+        TotalColdkeyStake::<T>::insert(old_hotkey, new_total_coldkey_stake);
+    }
+    weight.saturating_accrue(T::DbWeight::get().reads_writes(1, 1));
+
+    let new_total_hotkey_stake = TotalHotkeyStake::<T>::get(old_hotkey).saturating_sub(null_stake);
+    if new_total_hotkey_stake == 0 {
+        TotalHotkeyStake::<T>::remove(old_hotkey);
+    } else {
+        TotalHotkeyStake::<T>::insert(old_hotkey, new_total_hotkey_stake);
+    }
+    weight.saturating_accrue(T::DbWeight::get().reads_writes(1, 1));
+
+    TotalStake::<T>::put(TotalStake::<T>::get().saturating_sub(null_stake));
+    weight.saturating_accrue(T::DbWeight::get().reads_writes(1, 1));
+
+    // Add stake to the pending emissions for the new hotkey
+    PendingdHotkeyEmission::<T>::insert(new_hotkey, pending_emissions.saturating_add(null_stake));
+    weight.saturating_accrue(T::DbWeight::get().writes(1));
+
+    weight
+}
+
+pub fn do_migrate_fix_pending_emission<T: Config>() -> Weight {
+    // Initialize the weight with one read operation.
+    let mut weight = T::DbWeight::get().reads(1);
+
+    let taostats_old_hotkey = "5Hddm3iBFD2GLT5ik7LZnT3XJUnRnN8PoeCFgGQgawUVKNm8";
+    let taostats_new_hotkey = "5GKH9FPPnWSUoeeTJp19wVtd84XqFW4pyK2ijV2GsFbhTrP1";
+
+    let taostats_old_hk_account: T::AccountId = get_account_id_from_ss58::<T>(taostats_old_hotkey);
+    let taostats_new_hk_account: T::AccountId = get_account_id_from_ss58::<T>(taostats_new_hotkey);
+
+    weight.saturating_accrue(unstake_old_hotkey_and_move_to_pending::<T>(
+        &taostats_old_hk_account,
+        &taostats_new_hk_account,
+    ));
+
+    let datura_old_hotkey = "5FKstHjZkh4v3qAMSBa1oJcHCLjxYZ8SNTSz1opTv4hR7gVB";
+    let datura_new_hotkey = "5GP7c3fFazW9GXK8Up3qgu2DJBk8inu4aK9TZy3RuoSWVCMi";
+
+    let datura_old_hk_account: T::AccountId = get_account_id_from_ss58::<T>(datura_old_hotkey);
+    let datura_new_hk_account: T::AccountId = get_account_id_from_ss58::<T>(datura_new_hotkey);
+
+    weight.saturating_accrue(swap_pending_emissions::<T>(
+        &datura_old_hk_account,
+        &datura_new_hk_account,
+    ));
+
+    weight
+}
+// Public migrate function to be called by Lib.rs on upgrade.
+pub fn migrate_fix_pending_emission<T: Config>() -> Weight {
+    let migration_name = b"fix_pending_emission".to_vec();
+
+    // Initialize the weight with one read operation.
+    let mut weight = T::DbWeight::get().reads(1);
+
+    // Check if the migration has already run
+    if HasMigrationRun::<T>::get(&migration_name) {
+        log::info!(
+            "Migration '{:?}' has already run. Skipping.",
+            migration_name
+        );
+        return Weight::zero();
+    }
+
+    log::info!(
+        "Running migration '{}'",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    // Run the migration
+    weight.saturating_accrue(do_migrate_fix_pending_emission::<T>());
+
+    // Mark the migration as completed
+    HasMigrationRun::<T>::insert(&migration_name, true);
+    weight.saturating_accrue(T::DbWeight::get().writes(1));
+
+    log::info!(
+        "Migration '{:?}' completed. Marked in storage.",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    // Return the migration weight.
+    weight
+}

--- a/pallets/subtensor/src/migrations/migrate_fix_pending_emission.rs
+++ b/pallets/subtensor/src/migrations/migrate_fix_pending_emission.rs
@@ -22,17 +22,6 @@ fn swap_pending_emissions<T: Config>(
     PendingdHotkeyEmission::<T>::insert(new_hotkey, pending_emissions);
     weight.saturating_accrue(T::DbWeight::get().writes(1));
 
-    // Swap the last LastAddStakeIncrease
-    let old_coldkey_entries: Vec<(T::AccountId, u64)> =
-        LastAddStakeIncrease::<T>::iter_prefix(old_hotkey).collect();
-    if !old_coldkey_entries.is_empty() {
-        for (coldkey, last_add_stake_increase) in old_coldkey_entries {
-            LastAddStakeIncrease::<T>::remove(old_hotkey, &coldkey);
-            LastAddStakeIncrease::<T>::insert(new_hotkey, &coldkey, last_add_stake_increase);
-            weight.saturating_accrue(T::DbWeight::get().reads_writes(1, 2));
-        }
-    }
-
     weight
 }
 

--- a/pallets/subtensor/src/migrations/mod.rs
+++ b/pallets/subtensor/src/migrations/mod.rs
@@ -3,6 +3,7 @@ pub mod migrate_chain_identity;
 pub mod migrate_create_root_network;
 pub mod migrate_delete_subnet_21;
 pub mod migrate_delete_subnet_3;
+pub mod migrate_fix_pending_emission;
 pub mod migrate_fix_total_coldkey_stake;
 pub mod migrate_init_total_issuance;
 pub mod migrate_populate_owned_hotkeys;

--- a/pallets/subtensor/src/swap/swap_coldkey.rs
+++ b/pallets/subtensor/src/swap/swap_coldkey.rs
@@ -169,7 +169,15 @@ impl<T: Config> Pallet<T> {
             weight.saturating_accrue(T::DbWeight::get().reads_writes(2, 2));
         }
 
-        // 4. Swap total coldkey stake.
+        // 4. Swap LastAddStakeIncrease.
+        for hotkey in StakingHotkeys::<T>::get(old_coldkey) {
+            let last_add_stake_increase = LastAddStakeIncrease::<T>::get(&hotkey, old_coldkey);
+            LastAddStakeIncrease::<T>::remove(&hotkey, old_coldkey);
+            LastAddStakeIncrease::<T>::insert(&hotkey, new_coldkey, last_add_stake_increase);
+            weight.saturating_accrue(T::DbWeight::get().reads_writes(1, 2));
+        }
+
+        // 5. Swap total coldkey stake.
         // TotalColdkeyStake: MAP ( coldkey ) --> u64 | Total stake of the coldkey.
         let old_coldkey_stake: u64 = TotalColdkeyStake::<T>::get(old_coldkey);
         // Get the stake of the new coldkey.
@@ -183,7 +191,7 @@ impl<T: Config> Pallet<T> {
         );
         weight.saturating_accrue(T::DbWeight::get().reads_writes(2, 2));
 
-        // 5. Swap StakingHotkeys.
+        // 6. Swap StakingHotkeys.
         // StakingHotkeys: MAP ( coldkey ) --> Vec<hotkeys> | Hotkeys staking for the coldkey.
         let old_staking_hotkeys: Vec<T::AccountId> = StakingHotkeys::<T>::get(old_coldkey);
         let mut new_staking_hotkeys: Vec<T::AccountId> = StakingHotkeys::<T>::get(new_coldkey);
@@ -197,7 +205,7 @@ impl<T: Config> Pallet<T> {
         StakingHotkeys::<T>::insert(new_coldkey, new_staking_hotkeys);
         weight.saturating_accrue(T::DbWeight::get().reads_writes(2, 2));
 
-        // 6. Swap hotkey owners.
+        // 7. Swap hotkey owners.
         // Owner: MAP ( hotkey ) --> coldkey | Owner of the hotkey.
         // OwnedHotkeys: MAP ( coldkey ) --> Vec<hotkeys> | Hotkeys owned by the coldkey.
         let old_owned_hotkeys: Vec<T::AccountId> = OwnedHotkeys::<T>::get(old_coldkey);
@@ -216,7 +224,7 @@ impl<T: Config> Pallet<T> {
         OwnedHotkeys::<T>::insert(new_coldkey, new_owned_hotkeys);
         weight.saturating_accrue(T::DbWeight::get().reads_writes(2, 2));
 
-        // 7. Transfer remaining balance.
+        // 8. Transfer remaining balance.
         // Balance: MAP ( coldkey ) --> u64 | Balance of the coldkey.
         // Transfer any remaining balance from old_coldkey to new_coldkey
         let remaining_balance = Self::get_coldkey_balance(old_coldkey);

--- a/pallets/subtensor/src/swap/swap_hotkey.rs
+++ b/pallets/subtensor/src/swap/swap_hotkey.rs
@@ -206,21 +206,41 @@ impl<T: Config> Pallet<T> {
             Delegates::<T>::insert(new_hotkey, old_delegate_take);
             weight.saturating_accrue(T::DbWeight::get().reads_writes(2, 2));
         }
-        // 9. Swap all subnet specific info.
+
+        // 9.1. swap PendingdHotkeyEmission
+        if PendingdHotkeyEmission::<T>::contains_key(old_hotkey) {
+            let old_pending_hotkey_emission = PendingdHotkeyEmission::<T>::get(old_hotkey);
+            PendingdHotkeyEmission::<T>::remove(old_hotkey);
+            PendingdHotkeyEmission::<T>::insert(new_hotkey, old_pending_hotkey_emission);
+            weight.saturating_accrue(T::DbWeight::get().reads_writes(2, 2));
+        }
+        // 9.2. swap LastAddStakeIncrease
+        // Swap double map prefix
+        let old_coldkey_entries: Vec<(T::AccountId, u64)> =
+            LastAddStakeIncrease::<T>::iter_prefix(old_hotkey).collect();
+        if !old_coldkey_entries.is_empty() {
+            for (coldkey, last_add_stake_increase) in old_coldkey_entries {
+                LastAddStakeIncrease::<T>::remove(old_hotkey, &coldkey);
+                LastAddStakeIncrease::<T>::insert(new_hotkey, &coldkey, last_add_stake_increase);
+                weight.saturating_accrue(T::DbWeight::get().reads_writes(1, 2));
+            }
+        }
+
+        // 10. Swap all subnet specific info.
         let all_netuids: Vec<u16> = Self::get_all_subnet_netuids();
         for netuid in all_netuids {
-            // 9.1 Remove the previous hotkey and insert the new hotkey from membership.
+            // 10.1 Remove the previous hotkey and insert the new hotkey from membership.
             // IsNetworkMember( hotkey, netuid ) -> bool -- is the hotkey a subnet member.
             let is_network_member: bool = IsNetworkMember::<T>::get(old_hotkey, netuid);
             IsNetworkMember::<T>::remove(old_hotkey, netuid);
             IsNetworkMember::<T>::insert(new_hotkey, netuid, is_network_member);
             weight.saturating_accrue(T::DbWeight::get().reads_writes(1, 2));
 
-            // 9.2 Swap Uids + Keys.
+            // 10.2 Swap Uids + Keys.
             // Keys( netuid, hotkey ) -> uid -- the uid the hotkey has in the network if it is a member.
             // Uids( netuid, hotkey ) -> uid -- the uids that the hotkey has.
             if is_network_member {
-                // 9.2.1 Swap the UIDS
+                // 10.2.1 Swap the UIDS
                 if let Ok(old_uid) = Uids::<T>::try_get(netuid, old_hotkey) {
                     Uids::<T>::remove(netuid, old_hotkey);
                     Uids::<T>::insert(netuid, new_hotkey, old_uid);
@@ -232,7 +252,7 @@ impl<T: Config> Pallet<T> {
                 }
             }
 
-            // 9.3 Swap Prometheus.
+            // 10.3 Swap Prometheus.
             // Prometheus( netuid, hotkey ) -> prometheus -- the prometheus data that a hotkey has in the network.
             if is_network_member {
                 if let Ok(old_prometheus_info) = Prometheus::<T>::try_get(netuid, old_hotkey) {
@@ -242,7 +262,7 @@ impl<T: Config> Pallet<T> {
                 }
             }
 
-            // 9.4. Swap axons.
+            // 10.4. Swap axons.
             // Axons( netuid, hotkey ) -> axon -- the axon that the hotkey has.
             if is_network_member {
                 if let Ok(old_axon_info) = Axons::<T>::try_get(netuid, old_hotkey) {
@@ -252,7 +272,7 @@ impl<T: Config> Pallet<T> {
                 }
             }
 
-            // 9.5 Swap WeightCommits
+            // 10.5 Swap WeightCommits
             // WeightCommits( hotkey ) --> Vec<u64> -- the weight commits for the hotkey.
             if is_network_member {
                 if let Ok(old_weight_commits) = WeightCommits::<T>::try_get(netuid, old_hotkey) {
@@ -262,7 +282,7 @@ impl<T: Config> Pallet<T> {
                 }
             }
 
-            // 9.6. Swap the subnet loaded emission.
+            // 10.6. Swap the subnet loaded emission.
             // LoadedEmission( netuid ) --> Vec<(hotkey, u64)> -- the loaded emission for the subnet.
             if is_network_member {
                 if let Some(mut old_loaded_emission) = LoadedEmission::<T>::get(netuid) {
@@ -278,7 +298,7 @@ impl<T: Config> Pallet<T> {
             }
         }
 
-        // 10. Swap Stake.
+        // 11. Swap Stake.
         // Stake( hotkey, coldkey ) -> stake -- the stake that the hotkey controls on behalf of the coldkey.
         let stakes: Vec<(T::AccountId, u64)> = Stake::<T>::iter_prefix(old_hotkey).collect();
         // Clear the entire old prefix here.
@@ -308,7 +328,7 @@ impl<T: Config> Pallet<T> {
             weight.saturating_accrue(T::DbWeight::get().reads_writes(1, 1));
         }
 
-        // 11. Swap ChildKeys.
+        // 12. Swap ChildKeys.
         // ChildKeys( parent, netuid ) --> Vec<(proportion,child)> -- the child keys of the parent.
         for netuid in Self::get_all_subnet_netuids() {
             // Get the children of the old hotkey for this subnet
@@ -319,7 +339,7 @@ impl<T: Config> Pallet<T> {
             ChildKeys::<T>::insert(new_hotkey, netuid, my_children);
         }
 
-        // 12. Swap ParentKeys.
+        // 13. Swap ParentKeys.
         // ParentKeys( child, netuid ) --> Vec<(proportion,parent)> -- the parent keys of the child.
         for netuid in Self::get_all_subnet_netuids() {
             // Get the parents of the old hotkey for this subnet

--- a/pallets/subtensor/tests/migration.rs
+++ b/pallets/subtensor/tests/migration.rs
@@ -464,7 +464,7 @@ fn test_migrate_fix_pending_emissions() {
         let migration_name = "fix_pending_emission";
 
         let null_account = U256::from(0); // The null account
-        let rand_coldkeys = vec![U256::from(1), U256::from(2), U256::from(3), U256::from(4)];
+        let rand_coldkeys = [U256::from(1), U256::from(2), U256::from(3), U256::from(4)];
 
         let taostats_old_hotkey = "5Hddm3iBFD2GLT5ik7LZnT3XJUnRnN8PoeCFgGQgawUVKNm8";
         let taostats_new_hotkey = "5GKH9FPPnWSUoeeTJp19wVtd84XqFW4pyK2ijV2GsFbhTrP1";
@@ -479,17 +479,17 @@ fn test_migrate_fix_pending_emissions() {
         let datura_new_hk_account: AccountId = get_account_id_from_ss58(datura_new_hotkey);
 
         // Setup the old Datura hotkey with a pending emission
-        PendingdHotkeyEmission::<Test>::insert(&datura_old_hk_account, 10_000);
+        PendingdHotkeyEmission::<Test>::insert(datura_old_hk_account, 10_000);
         // Setup the NEW Datura hotkey with a pending emission
-        PendingdHotkeyEmission::<Test>::insert(&datura_new_hk_account, 123_456_789);
+        PendingdHotkeyEmission::<Test>::insert(datura_new_hk_account, 123_456_789);
         let expected_datura_new_hk_pending_emission: u64 = 123_456_789 + 10_000;
 
         // Setup the old TaoStats hotkey with a pending emission
-        PendingdHotkeyEmission::<Test>::insert(&taostats_old_hk_account, 987_654);
+        PendingdHotkeyEmission::<Test>::insert(taostats_old_hk_account, 987_654);
         // Setup the new TaoStats hotkey with a pending emission
-        PendingdHotkeyEmission::<Test>::insert(&taostats_new_hk_account, 100_000);
+        PendingdHotkeyEmission::<Test>::insert(taostats_new_hk_account, 100_000);
         // Setup the old TaoStats hotkey with a null-key stake entry
-        Stake::<Test>::insert(&taostats_old_hk_account, &null_account, 123_456_789);
+        Stake::<Test>::insert(taostats_old_hk_account, null_account, 123_456_789);
         let expected_taostats_new_hk_pending_emission: u64 = 987_654 + 100_000 + 123_456_789;
 
         // Run migration

--- a/pallets/subtensor/tests/swap_coldkey.rs
+++ b/pallets/subtensor/tests/swap_coldkey.rs
@@ -1660,17 +1660,17 @@ fn test_coldkey_swap_last_add_stake_increase() {
             100_000
         ));
         // Check LastAddStakeIncrease
-        assert_eq!(LastAddStakeIncrease::<Test>::get(&hotkey, &old_coldkey), 10); // Just added stake
+        assert_eq!(LastAddStakeIncrease::<Test>::get(hotkey, old_coldkey), 10); // Just added stake
 
         // Check the same for the new coldkey
-        assert_eq!(LastAddStakeIncrease::<Test>::get(&hotkey, &new_coldkey), 0); // No stake added ever
+        assert_eq!(LastAddStakeIncrease::<Test>::get(hotkey, new_coldkey), 0); // No stake added ever
 
         // Perform the coldkey swap
         assert_ok!(SubtensorModule::do_swap_coldkey(&old_coldkey, &new_coldkey));
 
         // Check the LastAddStakeIncrease for the hotkey
-        assert_eq!(LastAddStakeIncrease::<Test>::get(&hotkey, &new_coldkey), 10); // Matches the old coldkey
-        assert_eq!(LastAddStakeIncrease::<Test>::get(&hotkey, &old_coldkey), 0);
+        assert_eq!(LastAddStakeIncrease::<Test>::get(hotkey, new_coldkey), 10); // Matches the old coldkey
+        assert_eq!(LastAddStakeIncrease::<Test>::get(hotkey, old_coldkey), 0);
         // Should be reset to 0 (empty)
     });
 }

--- a/pallets/subtensor/tests/swap_hotkey.rs
+++ b/pallets/subtensor/tests/swap_hotkey.rs
@@ -1132,24 +1132,24 @@ fn test_swap_hotkey_with_pending_emissions() {
         add_network(netuid, 0, 1);
 
         // Set up pending emissions
-        PendingdHotkeyEmission::<Test>::insert(&old_hotkey, pending_emission);
+        PendingdHotkeyEmission::<Test>::insert(old_hotkey, pending_emission);
         // Verify the pending emissions are set
         assert_eq!(
-            PendingdHotkeyEmission::<Test>::get(&old_hotkey),
+            PendingdHotkeyEmission::<Test>::get(old_hotkey),
             pending_emission
         );
         // Verify the new hotkey does not have any pending emissions
-        assert!(!PendingdHotkeyEmission::<Test>::contains_key(&new_hotkey));
+        assert!(!PendingdHotkeyEmission::<Test>::contains_key(new_hotkey));
 
         // Perform the swap
         SubtensorModule::perform_hotkey_swap(&old_hotkey, &new_hotkey, &coldkey, &mut weight);
 
         // Verify the pending emissions are transferred
         assert_eq!(
-            PendingdHotkeyEmission::<Test>::get(&new_hotkey),
+            PendingdHotkeyEmission::<Test>::get(new_hotkey),
             pending_emission
         );
-        assert!(!PendingdHotkeyEmission::<Test>::contains_key(&old_hotkey));
+        assert!(!PendingdHotkeyEmission::<Test>::contains_key(old_hotkey));
     });
 }
 
@@ -1160,7 +1160,7 @@ fn test_swap_hotkeys_last_add_stake_increase() {
         let old_hotkey = U256::from(1);
         let new_hotkey = U256::from(2);
         let coldkey = U256::from(3);
-        let new_coldkeys = vec![U256::from(4), U256::from(5)];
+        let new_coldkeys = [U256::from(4), U256::from(5)];
         let netuid = 0u16;
         let mut weight = Weight::zero();
 
@@ -1171,10 +1171,10 @@ fn test_swap_hotkeys_last_add_stake_increase() {
 
         // Setup LastAddStakeIncrease map
         for new_coldkey in new_coldkeys.iter() {
-            LastAddStakeIncrease::<Test>::insert(&old_hotkey, &new_coldkey, 100);
+            LastAddStakeIncrease::<Test>::insert(old_hotkey, new_coldkey, 100);
         }
         // Verify the LastAddStakeIncrease map is empty for the new hotkey
-        assert!(LastAddStakeIncrease::<Test>::iter_prefix(&new_hotkey)
+        assert!(LastAddStakeIncrease::<Test>::iter_prefix(new_hotkey)
             .next()
             .is_none());
 
@@ -1184,12 +1184,12 @@ fn test_swap_hotkeys_last_add_stake_increase() {
         // Verify the LastAddStakeIncrease map is transferred
         for new_coldkey in new_coldkeys.iter() {
             assert_eq!(
-                LastAddStakeIncrease::<Test>::get(&new_hotkey, &new_coldkey),
+                LastAddStakeIncrease::<Test>::get(new_hotkey, new_coldkey),
                 100
             );
             assert!(!LastAddStakeIncrease::<Test>::contains_key(
-                &old_hotkey,
-                &new_coldkey
+                old_hotkey,
+                new_coldkey
             ));
         }
     });

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -142,7 +142,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 196,
+    spec_version: 199,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -142,7 +142,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 199,
+    spec_version: 196,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
This hotfixes an issue with the hotkeyswap and the new`PendingdHotkeyEmission` maps.

Currently any hotkeys that swap will lose the pending hotkey emission, being recorded as an entry in the `Stake` map `Stake(old_hotkey, 0x0000)` (default AccountId). 

This PR fixes the swap functions for coldkey and hotkey and adds a migration for two known hotkey swaps.

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
