### PR TITLE
Remove node requirement to build with `runtime-benchmarks`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY . /build
 WORKDIR /build
 
 # Build the project
-RUN cargo build -p node-subtensor --profile production  --features="runtime-benchmarks metadata-hash" --locked
+RUN cargo build -p node-subtensor --profile production  --features="metadata-hash" --locked
 
 # Verify the binary was produced
 RUN test -e /build/target/production/node-subtensor

--- a/justfile
+++ b/justfile
@@ -51,4 +51,4 @@ lint:
 
 production:
   @echo "Running cargo build with metadata-hash generation..."
-  cargo +{{RUSTV}} build --profile production --features="runtime-benchmarks metadata-hash"
+  cargo +{{RUSTV}} build --profile production --features="metadata-hash"

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -36,12 +36,12 @@ impl HostFunctions for ExecutorDispatch {
 }
 
 impl sc_executor::NativeExecutionDispatch for ExecutorDispatch {
-    // Only enable the benchmarking host functions when we actually want to benchmark.
-    #[cfg(feature = "runtime-benchmarks")]
+    // Always enable runtime benchmark host functions, the genesis state
+    // was built with them so we're stuck with them forever.
+    //
+    // They're just a noop, never actually get used if the runtime was not compiled with
+    // `runtime-benchmarks`.
     type ExtendHostFunctions = frame_benchmarking::benchmarking::HostFunctions;
-    // Otherwise we only use the default Substrate host functions.
-    #[cfg(not(feature = "runtime-benchmarks"))]
-    type ExtendHostFunctions = ();
 
     fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
         node_subtensor_runtime::api::dispatch(method, data)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,2 +1,1 @@
-cargo build --profile production --features "runtime-benchmarks metadata-hash"
-
+cargo build --profile production --features "metadata-hash"

--- a/scripts/localnet.sh
+++ b/scripts/localnet.sh
@@ -3,10 +3,10 @@
 # Check if `--no-purge` passed as a parameter
 NO_PURGE=0
 for arg in "$@"; do
-    if [ "$arg" = "--no-purge" ]; then
-        NO_PURGE=1
-        break
-    fi
+  if [ "$arg" = "--no-purge" ]; then
+    NO_PURGE=1
+    break
+  fi
 done
 
 # Determine the directory this script resides in. This allows invoking it from any location.
@@ -25,13 +25,13 @@ if [ "$fast_blocks" == "False" ]; then
   echo "fast_blocks is Off"
   : "${CHAIN:=local}"
   : "${BUILD_BINARY:=1}"
-  : "${FEATURES:="pow-faucet runtime-benchmarks"}"
+  : "${FEATURES:="pow-faucet"}"
 else
   # Block of code to execute if fast_blocks is not False
   echo "fast_blocks is On"
   : "${CHAIN:=local}"
   : "${BUILD_BINARY:=1}"
-  : "${FEATURES:="pow-faucet runtime-benchmarks fast-blocks"}"
+  : "${FEATURES:="pow-faucet fast-blocks"}"
 fi
 
 SPEC_PATH="${SCRIPT_DIR}/specs/"


### PR DESCRIPTION
The genesis runtime was built with the `runtime-benchmarks` feature, making it expect the node to always expose benchmarking host functions even though they're never used.

Even though the current runtime wasm is no longer built with `runtime-benchmarks`, the node uses old wasm blobs during sync so it is necessary to keep them exposed.

To solve this to date, we just have been always compiling with the `runtime-benchmarks` feature.

This PR removes this feature requirement by including benchmark host functions in regular builds.