### PR TITLE
hotfix: return total stake on subnet taking into consideration childkeys

### DIFF
--- a/pallets/subtensor/src/epoch/run_epoch.rs
+++ b/pallets/subtensor/src/epoch/run_epoch.rs
@@ -86,6 +86,39 @@ impl<T: Config> Pallet<T> {
         finalized_stake
     }
 
+    /// Calculates the total stake for a hotkey across all subnets.
+    ///
+    /// This function iterates through all subnets and accumulates the stake
+    /// for the given hotkey on each subnet.
+    ///
+    /// # Arguments
+    ///
+    /// * `hotkey` - The AccountId of the hotkey to calculate the total stake for.
+    ///
+    /// # Returns
+    ///
+    /// * `u64` - The total stake for the hotkey across all subnets.
+    ///
+   
+    pub fn get_total_stake_for_hotkey_on_subnets(hotkey: &T::AccountId) -> u64 {
+        // Get the list of all subnets
+        let subnet_list: Vec<u16> = Self::get_all_subnet_netuids();
+        
+        // Initialize the total stake
+        let mut total_stake: u64 = 0;
+
+        // Iterate through all subnets and accumulate the stake
+        for netuid in subnet_list {
+            // Get the stake for the hotkey on this subnet
+            let subnet_stake: u64 = Self::get_stake_for_hotkey_on_subnet(hotkey, netuid);
+            
+            // Add the subnet stake to the total stake using saturating addition
+            total_stake = total_stake.saturating_add(subnet_stake);
+        }
+
+        // Return the total stake
+        total_stake
+    }
     /// Calculates reward consensus and returns the emissions for uids/hotkeys in a given `netuid`.
     /// (Dense version used only for testing purposes.)
     #[allow(clippy::indexing_slicing)]

--- a/pallets/subtensor/src/rpc_info/delegate_info.rs
+++ b/pallets/subtensor/src/rpc_info/delegate_info.rs
@@ -60,7 +60,7 @@ impl<T: Config> Pallet<T> {
         let owner = Self::get_owning_coldkey_for_hotkey(&delegate.clone());
         let take: Compact<u16> = <Delegates<T>>::get(delegate.clone()).into();
 
-        let total_stake: U64F64 = Self::get_total_stake_for_hotkey(&delegate.clone()).into();
+        let total_stake: U64F64 = Self::get_total_stake_for_hotkey_on_subnets(&delegate.clone()).into();
 
         let return_per_1000: U64F64 = if total_stake > U64F64::from_num(0) {
             emissions_per_day


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->

This PR:

- creates a helper function `get_total_stake_for_hotkey_on_subnets` to return the total stake for hotkeys across subnets . This takes into account childkey contributions.
- replace get_total_hotkey_stake in the delegate info rpc.
- 
## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.