### PR TITLE
Allow tiny TI delta

### DIFF
--- a/pallets/subtensor/src/utils/try_state.rs
+++ b/pallets/subtensor/src/utils/try_state.rs
@@ -38,10 +38,20 @@ impl<T: Config> Pallet<T> {
             .saturating_add(total_staked)
             .saturating_add(total_subnet_locked);
 
-        // Verify that the calculated total issuance matches the stored TotalIssuance
+        // Verify the diff between calculated TI and actual TI is less than delta
+        //
+        // These values can be off slightly due to float rounding errors.
+        // They are corrected every runtime upgrade.
+        const DELTA: u64 = 1000;
+        let diff = if TotalIssuance::<T>::get() > expected_total_issuance {
+            TotalIssuance::<T>::get().checked_sub(expected_total_issuance)
+        } else {
+            expected_total_issuance.checked_sub(TotalIssuance::<T>::get())
+        }
+        .expect("LHS > RHS");
         ensure!(
-            TotalIssuance::<T>::get() == expected_total_issuance,
-            "TotalIssuance accounting discrepancy",
+            diff <= DELTA,
+            "TotalIssuance diff greater than allowable delta",
         );
 
         Ok(())

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1081,10 +1081,13 @@ pub type SignedExtra = (
     frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 );
 
-type Migrations =
+type Migrations = (
+    // Leave this migration in the runtime, so every runtime upgrade tiny rounding errors (fractions of fractions
+    // of a cent) are cleaned up. These tiny rounding errors occur due to floating point coversion.
     pallet_subtensor::migrations::migrate_init_total_issuance::initialise_total_issuance::Migration<
         Runtime,
-    >;
+    >,
+);
 
 // Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic =


### PR DESCRIPTION
Closes https://github.com/opentensor/subtensor/issues/816

Tiny rounding errors occur during runtime operation due to floating point arithmetic. Allow up to 1k RAO (fractions of fractions of a cent) delta in expected and actual TI before failing the try-state invariant. 