### PR TITLE
Fix Nodes Syncing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY . /build
 WORKDIR /build
 
 # Build the project
-RUN cargo build -p node-subtensor --profile production  --features="runtime-benchmarks metadata-hash" --locked
+RUN cargo build -p node-subtensor --profile production  --features="metadata-hash" --locked
 
 # Verify the binary was produced
 RUN test -e /build/target/production/node-subtensor

--- a/justfile
+++ b/justfile
@@ -51,4 +51,4 @@ lint:
 
 production:
   @echo "Running cargo build with metadata-hash generation..."
-  cargo +{{RUSTV}} build --profile production --features="metadata-hash"
+  cargo +{{RUSTV}} build -p node-subtensor --profile production --features="metadata-hash"

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -36,12 +36,12 @@ impl HostFunctions for ExecutorDispatch {
 }
 
 impl sc_executor::NativeExecutionDispatch for ExecutorDispatch {
-    // Only enable the benchmarking host functions when we actually want to benchmark.
-    #[cfg(feature = "runtime-benchmarks")]
+    // Always enable runtime benchmark host functions, the genesis state
+    // was built with them so we're stuck with them forever.
+    //
+    // They're just a noop, never actually get used if the runtime was not compiled with
+    // `runtime-benchmarks`.
     type ExtendHostFunctions = frame_benchmarking::benchmarking::HostFunctions;
-    // Otherwise we only use the default Substrate host functions.
-    #[cfg(not(feature = "runtime-benchmarks"))]
-    type ExtendHostFunctions = ();
 
     fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
         node_subtensor_runtime::api::dispatch(method, data)

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -142,7 +142,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 202,
+    spec_version: 203,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,2 +1,1 @@
 cargo build --profile production --features "metadata-hash"
-

--- a/scripts/localnet.sh
+++ b/scripts/localnet.sh
@@ -3,10 +3,10 @@
 # Check if `--no-purge` passed as a parameter
 NO_PURGE=0
 for arg in "$@"; do
-    if [ "$arg" = "--no-purge" ]; then
-        NO_PURGE=1
-        break
-    fi
+  if [ "$arg" = "--no-purge" ]; then
+    NO_PURGE=1
+    break
+  fi
 done
 
 # Determine the directory this script resides in. This allows invoking it from any location.
@@ -25,13 +25,13 @@ if [ "$fast_blocks" == "False" ]; then
   echo "fast_blocks is Off"
   : "${CHAIN:=local}"
   : "${BUILD_BINARY:=1}"
-  : "${FEATURES:="pow-faucet runtime-benchmarks"}"
+  : "${FEATURES:="pow-faucet"}"
 else
   # Block of code to execute if fast_blocks is not False
   echo "fast_blocks is On"
   : "${CHAIN:=local}"
   : "${BUILD_BINARY:=1}"
-  : "${FEATURES:="pow-faucet runtime-benchmarks fast-blocks"}"
+  : "${FEATURES:="pow-faucet fast-blocks"}"
 fi
 
 SPEC_PATH="${SCRIPT_DIR}/specs/"


### PR DESCRIPTION
Remove node requirement to build with `runtime-benchmarks`

## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->

This PR adds the commit that exposes the runtime bechmarks extrinsics , so that new nodes can sync. This was taken out of the lastest upgrade due to the `--runtime-benchmarks` feature bloating the wasm binary , making it impossible to upgrade the chain. 


## Related Issue(s)

- Closes https://github.com/opentensor/subtensor/issues/824

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.