### PR TITLE
Updated release occurrences with production to match the new --profile flag

### DIFF
--- a/scripts/localnet.sh
+++ b/scripts/localnet.sh
@@ -17,7 +17,7 @@ BASE_DIR="$SCRIPT_DIR/.."
 
 # get parameters
 # Get the value of fast_blocks from the first argument
-fast_blocks=${1:-"True"}
+fast_blocks=${1:-"False"}
 
 # Check the value of fast_blocks
 if [ "$fast_blocks" == "False" ]; then

--- a/scripts/localnet.sh
+++ b/scripts/localnet.sh
@@ -48,26 +48,26 @@ fi
 
 if [[ $BUILD_BINARY == "1" ]]; then
   echo "*** Building substrate binary..."
-  cargo build --workspace --profile=release --features "$FEATURES" --manifest-path "$BASE_DIR/Cargo.toml"
+  cargo build --workspace --profile=production --features "$FEATURES" --manifest-path "$BASE_DIR/Cargo.toml"
   echo "*** Binary compiled"
 fi
 
 echo "*** Building chainspec..."
-"$BASE_DIR/target/release/node-subtensor" build-spec --disable-default-bootnode --raw --chain $CHAIN >$FULL_PATH
+"$BASE_DIR/target/production/node-subtensor" build-spec --disable-default-bootnode --raw --chain $CHAIN >$FULL_PATH
 echo "*** Chainspec built and output to file"
 
 if [ $NO_PURGE -eq 1 ]; then
   echo "*** Purging previous state skipped..."
 else
   echo "*** Purging previous state..."
-  "$BASE_DIR/target/release/node-subtensor" purge-chain -y --base-path /tmp/bob --chain="$FULL_PATH" >/dev/null 2>&1
-  "$BASE_DIR/target/release/node-subtensor" purge-chain -y --base-path /tmp/alice --chain="$FULL_PATH" >/dev/null 2>&1
+  "$BASE_DIR/target/production/node-subtensor" purge-chain -y --base-path /tmp/bob --chain="$FULL_PATH" >/dev/null 2>&1
+  "$BASE_DIR/target/production/node-subtensor" purge-chain -y --base-path /tmp/alice --chain="$FULL_PATH" >/dev/null 2>&1
   echo "*** Previous chainstate purged"
 fi
 
 echo "*** Starting localnet nodes..."
 alice_start=(
-  "$BASE_DIR/target/release/node-subtensor"
+  "$BASE_DIR/target/production/node-subtensor"
   --base-path /tmp/alice
   --chain="$FULL_PATH"
   --alice
@@ -80,7 +80,7 @@ alice_start=(
 )
 
 bob_start=(
-  "$BASE_DIR"/target/release/node-subtensor
+  "$BASE_DIR"/target/production/node-subtensor
   --base-path /tmp/bob
   --chain="$FULL_PATH"
   --bob


### PR DESCRIPTION
Hello, made some edits to the script.

1. Replaced 'release' occurrences with 'production' to match the new --profile=production flag.
2. Switched fast blocks off. Caused issue when using script to build.