### PR TITLE
forbid `as_u*` method calls in linting

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -59,6 +59,7 @@ fn main() {
             }
         };
 
+        track_lint(ForbidAsPrimitiveConversion::lint(&parsed_file));
         track_lint(RequireFreezeStruct::lint(&parsed_file));
         track_lint(RequireExplicitPalletIndex::lint(&parsed_file));
     });

--- a/support/linting/src/forbid_as_primitive.rs
+++ b/support/linting/src/forbid_as_primitive.rs
@@ -1,0 +1,78 @@
+use super::*;
+use syn::{visit::Visit, ExprMethodCall, File, Ident};
+
+pub struct ForbidAsPrimitiveConversion;
+
+impl Lint for ForbidAsPrimitiveConversion {
+    fn lint(source: &File) -> Result {
+        let mut visitor = AsPrimitiveVisitor::default();
+
+        visitor.visit_file(source);
+
+        if !visitor.errors.is_empty() {
+            return Err(visitor.errors);
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct AsPrimitiveVisitor {
+    errors: Vec<syn::Error>,
+}
+
+impl<'ast> Visit<'ast> for AsPrimitiveVisitor {
+    fn visit_expr_method_call(&mut self, node: &'ast ExprMethodCall) {
+        if is_as_primitive(&node.method) {
+            self.errors.push(syn::Error::new(
+                node.method.span(),
+                "Using 'as_*()' methods is banned to avoid accidental panics. Use `try_into()` instead.",
+            ));
+        }
+
+        syn::visit::visit_expr_method_call(self, node);
+    }
+}
+
+fn is_as_primitive(ident: &Ident) -> bool {
+    match ident.to_string().as_str() {
+        "as_u32" | "as_u64" | "as_u128" | "as_usize" => true,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lint(input: &str) -> Result {
+        let expr: ExprMethodCall = syn::parse_str(input).expect("should only use on a method call");
+        let mut visitor = AsPrimitiveVisitor::default();
+        visitor.visit_expr_method_call(&expr);
+        if !visitor.errors.is_empty() {
+            return Err(visitor.errors);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_as_primitives() {
+        let input = r#"x.as_u32()"#;
+        assert!(lint(input).is_err());
+        let input = r#"x.as_u64()"#;
+        assert!(lint(input).is_err());
+        let input = r#"x.as_u128()"#;
+        assert!(lint(input).is_err());
+        let input = r#"x.as_usize()"#;
+        assert!(lint(input).is_err());
+    }
+
+    #[test]
+    fn test_non_as_primitives() {
+        let input = r#"x.as_ref()"#;
+        assert!(lint(input).is_ok());
+        let input = r#"x.as_slice()"#;
+        assert!(lint(input).is_ok());
+    }
+}

--- a/support/linting/src/forbid_as_primitive.rs
+++ b/support/linting/src/forbid_as_primitive.rs
@@ -36,10 +36,7 @@ impl<'ast> Visit<'ast> for AsPrimitiveVisitor {
 }
 
 fn is_as_primitive(ident: &Ident) -> bool {
-    match ident.to_string().as_str() {
-        "as_u32" | "as_u64" | "as_u128" | "as_usize" => true,
-        _ => false,
-    }
+    matches!(ident.to_string().as_str(), "as_u32" | "as_u64" | "as_u128" | "as_usize")
 }
 
 #[cfg(test)]

--- a/support/linting/src/forbid_as_primitive.rs
+++ b/support/linting/src/forbid_as_primitive.rs
@@ -36,7 +36,10 @@ impl<'ast> Visit<'ast> for AsPrimitiveVisitor {
 }
 
 fn is_as_primitive(ident: &Ident) -> bool {
-    matches!(ident.to_string().as_str(), "as_u32" | "as_u64" | "as_u128" | "as_usize")
+    matches!(
+        ident.to_string().as_str(),
+        "as_u32" | "as_u64" | "as_u128" | "as_usize"
+    )
 }
 
 #[cfg(test)]

--- a/support/linting/src/lib.rs
+++ b/support/linting/src/lib.rs
@@ -1,8 +1,10 @@
 pub mod lint;
 pub use lint::*;
 
+mod forbid_as_primitive;
 mod pallet_index;
 mod require_freeze_struct;
 
+pub use forbid_as_primitive::ForbidAsPrimitiveConversion;
 pub use pallet_index::RequireExplicitPalletIndex;
 pub use require_freeze_struct::RequireFreezeStruct;


### PR DESCRIPTION
Closes #841

## Description
Add custom lint to forbid certain `as_*()` conversions to avoid accidental panics.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please describe): linting