### PR TITLE
Add TestnetTotalSupplyOverride

### DIFF
--- a/pallets/subtensor/src/coinbase/root.rs
+++ b/pallets/subtensor/src/coinbase/root.rs
@@ -151,7 +151,12 @@ impl<T: Config> Pallet<T> {
         let total_issuance: I96F32 = I96F32::from_num(issuance);
         // Check to prevent division by zero when the total supply is reached
         // and creating an issuance greater than the total supply.
-        if total_issuance >= I96F32::from_num(TotalSupply::<T>::get()) {
+        let total_supply = if let Some(override_supply) = TestnetTotalSupplyOverride::<T>::get() {
+            override_supply
+        } else {
+            TotalSupply::<T>::get()
+        };
+        if total_issuance >= I96F32::from_num(total_supply) {
             return Ok(0);
         }
         // Calculate the logarithmic residual of the issuance against half the total supply.
@@ -163,7 +168,7 @@ impl<T: Config> Pallet<T> {
                             total_issuance
                                 .checked_div(
                                     I96F32::from_num(2.0)
-                                        .saturating_mul(I96F32::from_num(10_500_000_000_000_000.0)),
+                                        .saturating_mul(I96F32::from_num(total_supply / 2)),
                                 )
                                 .ok_or("Logarithm calculation failed")?,
                         )

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -224,6 +224,11 @@ pub mod pallet {
         21_000_000_000_000_000
     }
     #[pallet::type_value]
+    /// Default minimum stake for weights.
+    pub fn DefaultTestnetTotalSupplyOverride<T: Config>() -> Option<u64> {
+        None
+    }
+    #[pallet::type_value]
     /// Default Delegate Take.
     pub fn DefaultDelegateTake<T: Config>() -> u16 {
         T::InitialDefaultDelegateTake::get()
@@ -1264,6 +1269,9 @@ pub mod pallet {
         (H256, u64),
         OptionQuery,
     >;
+    #[pallet::storage]
+    /// ITEM( testnet_total_supply_override )
+    pub type TestnetTotalSupplyOverride<T> = StorageValue<_, Option<u64>, ValueQuery, DefaultTestnetTotalSupplyOverride<T>>;
 
     /// ==================
     /// ==== Genesis =====

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1271,7 +1271,8 @@ pub mod pallet {
     >;
     #[pallet::storage]
     /// ITEM( testnet_total_supply_override )
-    pub type TestnetTotalSupplyOverride<T> = StorageValue<_, Option<u64>, ValueQuery, DefaultTestnetTotalSupplyOverride<T>>;
+    pub type TestnetTotalSupplyOverride<T> =
+        StorageValue<_, Option<u64>, ValueQuery, DefaultTestnetTotalSupplyOverride<T>>;
 
     /// ==================
     /// ==== Genesis =====

--- a/pallets/subtensor/tests/root.rs
+++ b/pallets/subtensor/tests/root.rs
@@ -909,25 +909,30 @@ fn test_issuance_testnet_override() {
         let block_emission_0 = SubtensorModule::get_block_emission_for_issuance(0u64).unwrap();
         assert_eq!(block_emission_0, 1_000_000_000);
 
-        let block_emission_21m = SubtensorModule::get_block_emission_for_issuance(21_000_000_000_000_000u64).unwrap();
+        let block_emission_21m =
+            SubtensorModule::get_block_emission_for_issuance(21_000_000_000_000_000u64).unwrap();
         assert_eq!(block_emission_21m, 0);
 
         // Override total supply to 2B
         pallet_subtensor::TestnetTotalSupplyOverride::<Test>::set(Some(2_000_000_000_000_000_000));
 
-        let block_emission_0_override = SubtensorModule::get_block_emission_for_issuance(0u64).unwrap();
+        let block_emission_0_override =
+            SubtensorModule::get_block_emission_for_issuance(0u64).unwrap();
         assert_eq!(block_emission_0_override, 1_000_000_000);
 
-        let block_emission_21m_override = SubtensorModule::get_block_emission_for_issuance(21_000_000_000_000_000u64).unwrap();
+        let block_emission_21m_override =
+            SubtensorModule::get_block_emission_for_issuance(21_000_000_000_000_000u64).unwrap();
         assert_eq!(block_emission_21m_override, 1_000_000_000);
 
-        let block_emission_1b_override = SubtensorModule::get_block_emission_for_issuance(1_000_000_000_000_000_000u64).unwrap();
+        let block_emission_1b_override =
+            SubtensorModule::get_block_emission_for_issuance(1_000_000_000_000_000_000u64).unwrap();
         assert_eq!(block_emission_1b_override, 500_000_000); // one halving occurs
 
         // Override total supply to u64::MAX
         pallet_subtensor::TestnetTotalSupplyOverride::<Test>::set(Some(u64::MAX));
 
-        let block_emission_1b_override_u64max = SubtensorModule::get_block_emission_for_issuance(1_000_000_000_000_000_000u64).unwrap();
+        let block_emission_1b_override_u64max =
+            SubtensorModule::get_block_emission_for_issuance(1_000_000_000_000_000_000u64).unwrap();
         assert_eq!(block_emission_1b_override_u64max, 1_000_000_000);
     })
 }

--- a/pallets/subtensor/tests/root.rs
+++ b/pallets/subtensor/tests/root.rs
@@ -904,6 +904,35 @@ fn test_get_emission_across_entire_issuance_range() {
 }
 
 #[test]
+fn test_issuance_testnet_override() {
+    new_test_ext(1).execute_with(|| {
+        let block_emission_0 = SubtensorModule::get_block_emission_for_issuance(0u64).unwrap();
+        assert_eq!(block_emission_0, 1_000_000_000);
+
+        let block_emission_21m = SubtensorModule::get_block_emission_for_issuance(21_000_000_000_000_000u64).unwrap();
+        assert_eq!(block_emission_21m, 0);
+
+        // Override total supply to 2B
+        pallet_subtensor::TestnetTotalSupplyOverride::<Test>::set(Some(2_000_000_000_000_000_000));
+
+        let block_emission_0_override = SubtensorModule::get_block_emission_for_issuance(0u64).unwrap();
+        assert_eq!(block_emission_0_override, 1_000_000_000);
+
+        let block_emission_21m_override = SubtensorModule::get_block_emission_for_issuance(21_000_000_000_000_000u64).unwrap();
+        assert_eq!(block_emission_21m_override, 1_000_000_000);
+
+        let block_emission_1b_override = SubtensorModule::get_block_emission_for_issuance(1_000_000_000_000_000_000u64).unwrap();
+        assert_eq!(block_emission_1b_override, 500_000_000); // one halving occurs
+
+        // Override total supply to u64::MAX
+        pallet_subtensor::TestnetTotalSupplyOverride::<Test>::set(Some(u64::MAX));
+
+        let block_emission_1b_override_u64max = SubtensorModule::get_block_emission_for_issuance(1_000_000_000_000_000_000u64).unwrap();
+        assert_eq!(block_emission_1b_override_u64max, 1_000_000_000);
+    })
+}
+
+#[test]
 fn test_dissolve_network_ok() {
     new_test_ext(1).execute_with(|| {
         let netuid: u16 = 30;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -146,7 +146,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 197,
+    spec_version: 198,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
Need this option to override total supply on a testnet

## Related Issue(s)

- Closes [#[849]](https://github.com/opentensor/subtensor/issues/849)

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/88c4cf4d-a3e6-45ca-8967-2ebc4a58404a)
![image](https://github.com/user-attachments/assets/55cd5eb7-2e9b-4d69-95ad-a04829800477)

## Additional Notes

n/a