### PR TITLE
Fix: Hotkey swap causes parent key to lose emissions from children

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -209,6 +209,12 @@ pub mod pallet {
     }
 
     #[pallet::type_value]
+    /// Default limit for number of childkeys on one hotkey
+    pub fn DefaultChildKeyLimit<T: Config>() -> u16 {
+        5
+    }
+
+    #[pallet::type_value]
     /// Default minimum childkey take.
     pub fn DefaultMinChildKeyTake<T: Config>() -> u16 {
         T::InitialMinChildKeyTake::get()

--- a/pallets/subtensor/src/staking/set_children.rs
+++ b/pallets/subtensor/src/staking/set_children.rs
@@ -1,4 +1,5 @@
 use super::*;
+use frame_support::traits::Get;
 
 impl<T: Config> Pallet<T> {
     /// ---- The implementation for the extrinsic do_set_child_singular: Sets a single child.
@@ -96,7 +97,10 @@ impl<T: Config> Pallet<T> {
         );
 
         // --- 4.1. Ensure that the number of children does not exceed 5.
-        ensure!(children.len() <= 5, Error::<T>::TooManyChildren);
+        ensure!(
+            children.len() <= DefaultChildKeyLimit::<T>::get() as usize,
+            Error::<T>::TooManyChildren
+        );
 
         // --- 5. Ensure that each child is not the hotkey.
         for (_, child_i) in &children {


### PR DESCRIPTION
## Description
On hotkey swap:
- Merge lists of childkeys for old and new hotkey
- For duplicate keys add proportions
- If total proportions for two lists go over 1.0, re-normalize
- Add tests

## Related Issue(s)

- Possibly closes #[860](https://github.com/opentensor/subtensor/issues/860)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

n/a

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

n/a

## Additional Notes

n/a