### PR TITLE
Improve try-runtime ci

### DIFF
--- a/.github/workflows/check-devnet.yml
+++ b/.github/workflows/check-devnet.yml
@@ -39,18 +39,3 @@ jobs:
           echo "network spec_version: $spec_version"
           if (( $(echo "$local_spec_version <= $spec_version" | bc -l) )); then echo "$local_spec_version ≯ $spec_version ❌"; exit 1; fi
           echo "$local_spec_version > $spec_version ✅"
-
-  check-devnet-migrations:
-    name: check devnet migrations
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
-
-      - name: Run Try Runtime Checks
-        uses: "paritytech/try-runtime-gha@v0.1.0"
-        with:
-          runtime-package: "node-subtensor-runtime"
-          node-uri: "wss://dev.chain.opentensor.ai:443"
-          checks: "pre-and-post"
-          extra-args: "--disable-spec-version-check --no-weight-warnings"

--- a/.github/workflows/check-finney.yml
+++ b/.github/workflows/check-finney.yml
@@ -39,17 +39,3 @@ jobs:
           echo "network spec_version: $spec_version"
           if (( $(echo "$local_spec_version <= $spec_version" | bc -l) )); then echo "$local_spec_version ≯ $spec_version ❌"; exit 1; fi
           echo "$local_spec_version > $spec_version ✅"
-
-  check-finney-migrations:
-    name: check finney migrations
-    runs-on: SubtensorCI
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-      - name: Run Try Runtime Checks
-        uses: "paritytech/try-runtime-gha@v0.1.0"
-        with:
-          runtime-package: "node-subtensor-runtime"
-          node-uri: "wss://entrypoint-finney.opentensor.ai:443"
-          checks: "pre-and-post"
-          extra-args: "--disable-spec-version-check --no-weight-warnings"

--- a/.github/workflows/check-testnet.yml
+++ b/.github/workflows/check-testnet.yml
@@ -39,18 +39,3 @@ jobs:
           echo "network spec_version: $spec_version"
           if (( $(echo "$local_spec_version <= $spec_version" | bc -l) )); then echo "$local_spec_version ≯ $spec_version ❌"; exit 1; fi
           echo "$local_spec_version > $spec_version ✅"
-
-  check-testnet-migrations:
-    name: check testnet migrations
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
-
-      - name: Run Try Runtime Checks
-        uses: "paritytech/try-runtime-gha@v0.1.0"
-        with:
-          runtime-package: "node-subtensor-runtime"
-          node-uri: "wss://test.chain.opentensor.ai:443"
-          checks: "pre-and-post"
-          extra-args: "--disable-spec-version-check --no-weight-warnings"

--- a/.github/workflows/try-runtime.yml
+++ b/.github/workflows/try-runtime.yml
@@ -1,0 +1,54 @@
+name: Try Runtime
+
+on:
+  pull_request:
+    branches: [main, devnet-ready, devnet, testnet, finney]
+    types: [labeled, unlabeled, synchronize]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check-devnet:
+    name: check devnet
+    runs-on: SubtensorCI
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Run Try Runtime Checks
+        uses: "paritytech/try-runtime-gha@v0.1.0"
+        with:
+          runtime-package: "node-subtensor-runtime"
+          node-uri: "wss://dev.chain.opentensor.ai:443"
+          checks: "all"
+          extra-args: "--disable-spec-version-check --no-weight-warnings"
+
+  check-testnet:
+    name: check testnet
+    runs-on: SubtensorCI
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Run Try Runtime Checks
+        uses: "paritytech/try-runtime-gha@v0.1.0"
+        with:
+          runtime-package: "node-subtensor-runtime"
+          node-uri: "wss://test.chain.opentensor.ai:443"
+          checks: "all"
+          extra-args: "--disable-spec-version-check --no-weight-warnings"
+
+  check-finney:
+    name: check finney
+    runs-on: SubtensorCI
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Run Try Runtime Checks
+        uses: "paritytech/try-runtime-gha@v0.1.0"
+        with:
+          runtime-package: "node-subtensor-runtime"
+          node-uri: "wss://archive.chain.opentensor.ai:443"
+          checks: "all"
+          extra-args: "--disable-spec-version-check --no-weight-warnings"


### PR DESCRIPTION
We've fixed `try-state` so we can enable those checks, also we need to check the runtimes against finney and testnet at every stage not just before merging there