### PR TITLE
Optimize rao hotkey drain

### DIFF
--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -167,12 +167,7 @@ impl<T: Config> Pallet<T> {
         // The hotkey takes a proportion of the emission, the remainder is drained through to the nominators.
         // We keep track of the last stake increase event for accounting purposes.
         // hotkeys --> nominators.
-        let emission_tempo: u64 = Self::get_hotkey_emission_tempo();
-        for (hotkey, netuid_i, hotkey_emission) in PendingHotkeyEmissionOnNetuid::<T>::iter() {
-            if Self::should_drain_hotkey(&hotkey, current_block, emission_tempo) {
-                Self::drain_hotkey_emission(&hotkey, netuid_i, hotkey_emission, current_block);
-            }
-        }
+        Self::drain_hotkey_emission(current_block);
     }
 
     /// Distributes the owner payment
@@ -255,17 +250,19 @@ impl<T: Config> Pallet<T> {
         let mut total_alpha: I96F32 = I96F32::from_num(0);
         let mut contributions: Vec<(T::AccountId, I96F32, I96F32)> = Vec::new();
 
+        let current_block = Self::get_current_block_as_u64();
+        let min_required_block_diff = 2u64.saturating_mul(Self::get_tempo(netuid) as u64);
+
         // Calculate total global and alpha (subnet-specific) stakes from all parents
         for (proportion, parent) in Self::get_parents(hotkey, netuid) {
             // Get the last block this parent added some stake
             let stake_add_block =
-                LastAddStakeIncrease::<T>::get(&hotkey, Self::get_coldkey_for_hotkey(hotkey));
+                LastAddStakeIncrease::<T>::get(&hotkey, Self::get_coldkey_for_hotkey(&parent));
+            let stake_added_block_diff = current_block.saturating_sub(stake_add_block);
 
             // If the last block this parent added any stake is old enough (older than two subnet tempos),
             // consider this parent's contribution
-            if Self::get_current_block_as_u64().saturating_sub(stake_add_block)
-                >= 2u64.saturating_mul(Self::get_tempo(netuid) as u64)
-            {
+            if stake_added_block_diff >= min_required_block_diff {
                 // Convert the parent's stake proportion to a fractional value
                 let parent_proportion: I96F32 =
                     I96F32::from_num(proportion).saturating_div(I96F32::from_num(u64::MAX));
@@ -373,8 +370,8 @@ impl<T: Config> Pallet<T> {
         hotkey: &T::AccountId,
         netuid: u16,
         emission: u64,
-        _block_number: u64,
-        emission_tuples: &mut Vec<(T::AccountId, T::AccountId, u16, u64)>,
+        current_block: u64,
+        emission_tuples: &mut BTreeMap<(T::AccountId, T::AccountId), Vec<(u16, u64)>>,
     ) {
         // Calculate the hotkey's share of the emission based on its delegation status
         let emission: I96F32 = I96F32::from_num(emission);
@@ -391,16 +388,17 @@ impl<T: Config> Pallet<T> {
         let mut total_alpha: I96F32 = I96F32::from_num(0);
         let mut contributions: Vec<(T::AccountId, I96F32, I96F32)> = Vec::new();
 
+        let hotkey_tempo = HotkeyEmissionTempo::<T>::get();
+
         // Calculate total global and alpha scores for all nominators
         for (nominator, _) in Stake::<T>::iter_prefix(hotkey) {
             // Get the last block this nominator added some stake to this hotkey
             let stake_add_block = LastAddStakeIncrease::<T>::get(&hotkey, &nominator);
+            let stake_added_block_diff: u64 = current_block.saturating_sub(stake_add_block);
 
             // If the last block this nominator added any stake is old enough (older than one hotkey tempo),
             // consider this nominator's contribution
-            if Self::get_current_block_as_u64().saturating_sub(stake_add_block)
-                >= HotkeyEmissionTempo::<T>::get()
-            {
+            if stake_added_block_diff >= hotkey_tempo {
                 let alpha_contribution: I96F32 =
                     I96F32::from_num(Alpha::<T>::get((&hotkey, nominator.clone(), netuid)));
                 let global_contribution: I96F32 =
@@ -435,12 +433,10 @@ impl<T: Config> Pallet<T> {
                 if total_emission > 0 {
                     // Record the emission for this nominator
                     to_nominators = to_nominators.saturating_add(total_emission);
-                    emission_tuples.push((
-                        hotkey.clone(),
-                        nominator.clone(),
-                        netuid,
-                        total_emission,
-                    ));
+                    emission_tuples
+                        .entry((hotkey.clone(), nominator.clone()))
+                        .or_insert_with(Vec::new)
+                        .push((netuid, total_emission));
                 }
             }
         }
@@ -448,12 +444,11 @@ impl<T: Config> Pallet<T> {
         // Get the last block the neuron owner added some stake to this hotkey
         let stake_add_block =
             LastAddStakeIncrease::<T>::get(&hotkey, Self::get_coldkey_for_hotkey(hotkey));
+        let stake_added_block_diff: u64 = current_block.saturating_sub(stake_add_block);
 
         // If the last block this nominator added any stake is old enough (older than one hotkey tempo),
         // consider this nominator's contribution
-        if Self::get_current_block_as_u64().saturating_sub(stake_add_block)
-            >= HotkeyEmissionTempo::<T>::get()
-        {
+        if stake_added_block_diff >= hotkey_tempo {
             // Calculate and distribute the remaining emission to the hotkey
             let hotkey_owner: T::AccountId = Owner::<T>::get(hotkey);
             let remainder: u64 = emission
@@ -461,12 +456,10 @@ impl<T: Config> Pallet<T> {
                 .saturating_sub(hotkey_take.to_num::<u64>())
                 .saturating_sub(to_nominators);
             let final_hotkey_emission: u64 = hotkey_take.to_num::<u64>().saturating_add(remainder);
-            emission_tuples.push((
-                hotkey.clone(),
-                hotkey_owner.clone(),
-                netuid,
-                final_hotkey_emission,
-            ));
+            emission_tuples
+                .entry((hotkey.clone(), hotkey_owner.clone()))
+                .or_insert_with(Vec::new)
+                .push((netuid, final_hotkey_emission));
         }
     }
 
@@ -539,27 +532,23 @@ impl<T: Config> Pallet<T> {
     ///   - `u64`: The emission value to be added.
     /// * `block` - The current block number.
     pub fn accumulate_nominator_emission(
-        nominator_tuples: &mut Vec<(T::AccountId, T::AccountId, u16, u64)>,
+        nominator_tuples: &mut BTreeMap<(T::AccountId, T::AccountId), Vec<(u16, u64)>>,
         block: u64,
     ) {
-        // Track processed hotkeys to avoid redundant updates
-        let mut processed_hotkeys: BTreeMap<T::AccountId, ()> = BTreeMap::new();
+        // Iterate over each tuple in the nominator_tuples map
+        for ((hotkey, coldkey), emission_vec) in nominator_tuples {
+            LastHotkeyEmissionDrain::<T>::insert(hotkey.clone(), block);
 
-        // Iterate over each tuple in the nominator_tuples vector
-        for (hotkey, coldkey, netuid, emission) in nominator_tuples {
-            // If the emission value is greater than 0, update the subnet emission
-            if *emission > 0 {
-                Self::emit_into_subnet(hotkey, coldkey, *netuid, *emission);
-                // Record the last emission value for the hotkey-coldkey pair on the subnet
-                LastHotkeyColdkeyEmissionOnNetuid::<T>::insert(
-                    (hotkey.clone(), coldkey.clone(), *netuid),
-                    *emission,
-                );
-            }
-            // If the hotkey has not been processed yet, update the last emission drain block
-            if !processed_hotkeys.contains_key(hotkey) {
-                LastHotkeyEmissionDrain::<T>::insert(hotkey.clone(), block);
-                processed_hotkeys.insert(hotkey.clone(), ());
+            for (netuid, emission) in emission_vec {
+                // If the emission value is greater than 0, update the subnet emission
+                if *emission > 0 {
+                    Self::emit_into_subnet(hotkey, coldkey, *netuid, *emission);
+                    // Record the last emission value for the hotkey-coldkey pair on the subnet
+                    LastHotkeyColdkeyEmissionOnNetuid::<T>::insert(
+                        (hotkey.clone(), coldkey.clone(), *netuid),
+                        *emission,
+                    );
+                }
             }
         }
     }
@@ -582,34 +571,38 @@ impl<T: Config> Pallet<T> {
     ///
     /// This function ensures that emissions are fairly distributed according to stake proportions and delegation agreements, and it updates the necessary records to reflect these changes.
     ///
-    pub fn drain_hotkey_emission(
-        hotkey: &T::AccountId,
-        netuid: u16,
-        emission: u64,
-        block_number: u64,
-    ) {
-        let mut nominator_emission: Vec<(T::AccountId, T::AccountId, u16, u64)> = vec![];
+    pub fn drain_hotkey_emission(current_block: u64) {
+        // Nominator emission will not allow duplicate hotkey-coldkey pairs. Each entry for an individual
+        // hotkey-coldkey pair is a vector of (netuid, emission) tuples.
+        let mut nominator_emission: BTreeMap<(T::AccountId, T::AccountId), Vec<(u16, u64)>> =
+            BTreeMap::new();
 
-        // Remove the hotkey emission from the pending emissions.
-        PendingHotkeyEmissionOnNetuid::<T>::remove(&hotkey, netuid);
+        let emission_tempo: u64 = Self::get_hotkey_emission_tempo();
 
-        // Drain the hotkey emission.
-        Self::source_nominator_emission(
-            hotkey,
-            netuid,
-            emission,
-            block_number,
-            &mut nominator_emission,
-        );
-        Self::accumulate_nominator_emission(&mut nominator_emission, block_number);
+        for (hotkey, netuid, hotkey_emission) in PendingHotkeyEmissionOnNetuid::<T>::iter() {
+            if Self::should_drain_hotkey(&hotkey, current_block, emission_tempo) {
+                // Remove the hotkey emission from the pending emissions.
+                PendingHotkeyEmissionOnNetuid::<T>::remove(&hotkey, netuid);
 
-        log::debug!(
-            "Drained hotkey emission for hotkey {:?} for netuid {:?} on block {:?}: {:?}",
-            hotkey,
-            netuid,
-            block_number,
-            emission,
-        );
+                // Drain the hotkey emission.
+                Self::source_nominator_emission(
+                    &hotkey,
+                    netuid,
+                    hotkey_emission,
+                    current_block,
+                    &mut nominator_emission,
+                );
+
+                log::debug!(
+                    "Drained hotkey emission for hotkey {:?} for netuid {:?} on block {:?}: {:?}",
+                    hotkey,
+                    netuid,
+                    current_block,
+                    hotkey_emission,
+                );
+            }
+        }
+        Self::accumulate_nominator_emission(&mut nominator_emission, current_block);
     }
 
     ///////////////

--- a/pallets/subtensor/tests/emission.rs
+++ b/pallets/subtensor/tests/emission.rs
@@ -1,4 +1,6 @@
 mod mock;
+use std::collections::BTreeMap;
+
 use crate::mock::*;
 use pallet_subtensor::*;
 use sp_core::U256;
@@ -289,7 +291,7 @@ fn test_basic_emission_distribution() {
         SubtensorModule::stake_into_subnet(&hotkey, &nominator2, netuid, 500);
         Delegates::<Test>::insert(hotkey, 16384); // 25% take
 
-        let mut emission_tuples = Vec::new();
+        let mut emission_tuples: BTreeMap<(U256, U256), Vec<(u16, u64)>> = BTreeMap::new();
         SubtensorModule::source_nominator_emission(
             &hotkey,
             netuid,
@@ -299,36 +301,43 @@ fn test_basic_emission_distribution() {
         );
 
         assert_eq!(emission_tuples.len(), 3);
-        let total_distributed: u64 = emission_tuples.iter().map(|(_, _, _, amount)| amount).sum();
+        let total_distributed: u64 = emission_tuples
+            .iter()
+            .map(|((_, _), emission_vec)| {
+                emission_vec.iter().map(|(_, amount)| *amount).sum::<u64>()
+            })
+            .sum();
         assert_eq!(total_distributed, emission);
 
         // Check hotkey take
         let hotkey_emission: u64 = emission_tuples
             .iter()
-            .filter(|(h, _, _, _)| h == &hotkey)
-            .map(|(_, _, _, amount)| amount)
+            .filter(|((h, _), _)| h == &hotkey)
+            .map(|((_, _), emission_vec)| {
+                emission_vec.iter().map(|(_, amount)| *amount).sum::<u64>()
+            })
             .sum();
         assert!(hotkey_emission > 0);
 
         // Log the emission tuples
         println!("Emission tuples:");
-        for (hotkey, nominator, netuid, amount) in &emission_tuples {
+        for ((hotkey, nominator), emission_vec) in &emission_tuples {
             println!(
-                "Hotkey: {:?}, Nominator: {:?}, Netuid: {}, Amount: {}",
-                hotkey, nominator, netuid, amount
+                "Hotkey: {:?}, Nominator: {:?}, emissions by netuid: {:?}",
+                hotkey, nominator, emission_vec
             );
         }
 
         // Check nominator distributions
-        let nominator1_emission: u64 = *emission_tuples
+        let nominator1_emission: u64 = emission_tuples
             .iter()
-            .find(|(_, n, _, _)| n == &nominator1)
-            .map(|(_, _, _, amount)| amount)
+            .find(|((_, n), _)| n == &nominator1)
+            .map(|((_, _), emission_vec)| emission_vec[0].1)
             .unwrap();
-        let nominator2_emission: u64 = *emission_tuples
+        let nominator2_emission: u64 = emission_tuples
             .iter()
-            .find(|(_, n, _, _)| n == &nominator2)
-            .map(|(_, _, _, amount)| amount)
+            .find(|((_, n), _)| n == &nominator2)
+            .map(|((_, _), emission_vec)| emission_vec[0].1)
             .unwrap();
         assert!(nominator1_emission > 0);
         assert!(nominator2_emission > 0);
@@ -352,7 +361,7 @@ fn test_hotkey_take_calculation() {
             Delegates::<Test>::insert(hotkey, delegation);
             SubtensorModule::stake_into_subnet(&hotkey, &nominator, netuid, 500);
 
-            let mut emission_tuples = Vec::new();
+            let mut emission_tuples: BTreeMap<(U256, U256), Vec<(u16, u64)>> = BTreeMap::new();
             SubtensorModule::source_nominator_emission(
                 &hotkey,
                 netuid,
@@ -363,9 +372,9 @@ fn test_hotkey_take_calculation() {
 
             let hotkey_emission: u64 = emission_tuples
                 .iter()
-                .filter(|(h, _, _, _)| h == &hotkey)
+                .filter(|((h, c), _)| h == &hotkey && c == &U256::from(0))
                 .last()
-                .map(|(_, _, _, amount)| *amount)
+                .map(|((_, _), emission_vec)| emission_vec[0].1)
                 .unwrap_or(0);
             let emission_fixed = I96F32::from_num(emission);
             let delegation_fixed = I96F32::from_num(delegation);
@@ -401,7 +410,7 @@ fn test_nominator_distribution() {
         SubtensorModule::stake_into_subnet(&hotkey, &nominator3, netuid, 200);
         Delegates::<Test>::insert(hotkey, 0); // No hotkey take
 
-        let mut emission_tuples = Vec::new();
+        let mut emission_tuples: BTreeMap<(U256, U256), Vec<(u16, u64)>> = BTreeMap::new();
         SubtensorModule::source_nominator_emission(
             &hotkey,
             netuid,
@@ -412,31 +421,30 @@ fn test_nominator_distribution() {
 
         let nominator1_emission = emission_tuples
             .iter()
-            .find(|(_, n, _, _)| n == &nominator1)
-            .map(|(_, _, _, amount)| amount)
+            .find(|((_, n), _)| n == &nominator1)
+            .map(|((_, _), ev)| ev[0].1)
             .unwrap();
         let nominator2_emission = emission_tuples
             .iter()
-            .find(|(_, n, _, _)| n == &nominator2)
-            .map(|(_, _, _, amount)| amount)
+            .find(|((_, n), _)| n == &nominator2)
+            .map(|((_, _), ev)| ev[0].1)
             .unwrap();
         let nominator3_emission = emission_tuples
             .iter()
-            .find(|(_, n, _, _)| n == &nominator3)
-            .map(|(_, _, _, amount)| amount)
+            .find(|((_, n), _)| n == &nominator3)
+            .map(|((_, _), ev)| ev[0].1)
             .unwrap();
         let remainder: u64 = emission_tuples
             .iter()
-            .filter(|(h, _, _, _)| h == &hotkey)
-            .last()
-            .map(|(_, _, _, amount)| *amount)
-            .unwrap_or(0);
+            .find(|((h, c), _)| h == &hotkey && c == &U256::from(0))
+            .map(|((_, _), ev)| ev[0].1)
+            .unwrap();
 
         // Check proportional distribution
         assert!(nominator1_emission > nominator2_emission);
         assert!(nominator2_emission > nominator3_emission);
         assert_eq!(
-            *nominator1_emission + *nominator2_emission + *nominator3_emission,
+            nominator1_emission + nominator2_emission + nominator3_emission,
             emission - remainder
         );
 
@@ -473,7 +481,7 @@ fn test_global_and_alpha_weight_distribution() {
         SubtensorModule::stake_into_subnet(&hotkey, &nominator, netuid, 1000);
         Delegates::<Test>::insert(hotkey, 0); // No hotkey take
 
-        let mut emission_tuples = Vec::new();
+        let mut emission_tuples: BTreeMap<(U256, U256), Vec<(u16, u64)>> = BTreeMap::new();
         SubtensorModule::source_nominator_emission(
             &hotkey,
             netuid,
@@ -484,8 +492,8 @@ fn test_global_and_alpha_weight_distribution() {
 
         let nominator_emission = emission_tuples
             .iter()
-            .find(|(_, n, _, _)| n == &nominator)
-            .map(|(_, _, _, amount)| amount)
+            .find(|((_, n), _)| n == &nominator)
+            .map(|((_, _), ev)| ev[0].1)
             .unwrap();
 
         // Check if the distribution is close to expected
@@ -493,7 +501,7 @@ fn test_global_and_alpha_weight_distribution() {
         let expected_alpha = (emission as f64 * 0.7) as u64;
         let total_expected = expected_global + expected_alpha;
 
-        assert!((*nominator_emission as i64 - total_expected as i64).abs() <= 1);
+        assert!((nominator_emission as i64 - total_expected as i64).abs() <= 1);
     });
 }
 
@@ -512,7 +520,7 @@ fn test_zero_stake_scenario() {
         SubtensorModule::stake_into_subnet(&hotkey, &nominator, netuid, 0);
         Delegates::<Test>::insert(hotkey, 0);
 
-        let mut emission_tuples = Vec::new();
+        let mut emission_tuples: BTreeMap<(U256, U256), Vec<(u16, u64)>> = BTreeMap::new();
         SubtensorModule::source_nominator_emission(
             &hotkey,
             netuid,
@@ -523,9 +531,10 @@ fn test_zero_stake_scenario() {
 
         // Check that no errors occurred and all emission went to hotkey
         assert_eq!(emission_tuples.len(), 1);
-        let (_, recipient, _, amount) = &emission_tuples[0];
-        assert_eq!(recipient, &Owner::<Test>::get(hotkey));
-        assert_eq!(*amount, emission);
+        let recipient = emission_tuples.keys().next().unwrap().1;
+        let amount = emission_tuples.values().next().unwrap()[0].1;
+        assert_eq!(recipient, Owner::<Test>::get(hotkey));
+        assert_eq!(amount, emission);
     });
 }
 
@@ -543,7 +552,7 @@ fn test_single_nominator_scenario() {
         SubtensorModule::stake_into_subnet(&hotkey, &nominator, netuid, 1000);
         Delegates::<Test>::insert(hotkey, 0);
 
-        let mut emission_tuples = Vec::new();
+        let mut emission_tuples: BTreeMap<(U256, U256), Vec<(u16, u64)>> = BTreeMap::new();
         SubtensorModule::source_nominator_emission(
             &hotkey,
             netuid,
@@ -553,9 +562,10 @@ fn test_single_nominator_scenario() {
         );
 
         assert_eq!(emission_tuples.len(), 2); // with delegate and nominator position.
-        let (_, recipient, _, amount) = &emission_tuples[0];
-        assert_eq!(recipient, &nominator);
-        assert_eq!(*amount, emission);
+        let recipient = emission_tuples.keys().nth(1).unwrap().1;
+        let amount = emission_tuples.values().nth(1).unwrap()[0].1;
+        assert_eq!(recipient, nominator);
+        assert_eq!(amount, emission);
     });
 }
 
@@ -576,7 +586,7 @@ fn test_maximum_nominators_scenario() {
         }
         Delegates::<Test>::insert(hotkey, 0);
 
-        let mut emission_tuples = Vec::new();
+        let mut emission_tuples: BTreeMap<(U256, U256), Vec<(u16, u64)>> = BTreeMap::new();
         SubtensorModule::source_nominator_emission(
             &hotkey,
             netuid,
@@ -586,7 +596,10 @@ fn test_maximum_nominators_scenario() {
         );
 
         assert_eq!(emission_tuples.len(), max_nominators + 1);
-        let total_distributed: u64 = emission_tuples.iter().map(|(_, _, _, amount)| amount).sum();
+        let total_distributed: u64 = emission_tuples
+            .iter()
+            .map(|(_, ev)| ev.iter().map(|(_, amount)| amount).sum::<u64>())
+            .sum();
         assert_eq!(total_distributed, emission);
     });
 }
@@ -607,7 +620,7 @@ fn test_rounding_and_precision() {
         SubtensorModule::stake_into_subnet(&hotkey, &nominator2, netuid, 666667);
         Delegates::<Test>::insert(hotkey, 0);
 
-        let mut emission_tuples = Vec::new();
+        let mut emission_tuples: BTreeMap<(U256, U256), Vec<(u16, u64)>> = BTreeMap::new();
         SubtensorModule::source_nominator_emission(
             &hotkey,
             netuid,
@@ -616,7 +629,10 @@ fn test_rounding_and_precision() {
             &mut emission_tuples,
         );
 
-        let total_distributed: u64 = emission_tuples.iter().map(|(_, _, _, amount)| amount).sum();
+        let total_distributed: u64 = emission_tuples
+            .iter()
+            .map(|(_, ev)| ev.iter().map(|(_, amount)| amount).sum::<u64>())
+            .sum();
         assert_eq!(
             total_distributed, emission,
             "Total distributed should equal the original emission"
@@ -624,17 +640,17 @@ fn test_rounding_and_precision() {
 
         let nominator1_emission = emission_tuples
             .iter()
-            .find(|(_, n, _, _)| n == &nominator1)
-            .map(|(_, _, _, amount)| amount)
+            .find(|((_, n), _)| n == &nominator1)
+            .map(|((_, _), ev)| ev[0].1)
             .unwrap();
         let nominator2_emission = emission_tuples
             .iter()
-            .find(|(_, n, _, _)| n == &nominator2)
-            .map(|(_, _, _, amount)| amount)
+            .find(|((_, n), _)| n == &nominator2)
+            .map(|((_, _), ev)| ev[0].1)
             .unwrap();
 
         assert!(
-            nominator1_emission > &0 && nominator2_emission > &0,
+            nominator1_emission > 0 && nominator2_emission > 0,
             "Both nominators should receive non-zero emissions"
         );
         assert!(
@@ -658,7 +674,7 @@ fn test_emission_tuple_generation() {
         SubtensorModule::stake_into_subnet(&hotkey, &nominator, netuid, 1000);
         Delegates::<Test>::insert(hotkey, 16384); // 25% take
 
-        let mut emission_tuples = Vec::new();
+        let mut emission_tuples: BTreeMap<(U256, U256), Vec<(u16, u64)>> = BTreeMap::new();
         SubtensorModule::source_nominator_emission(
             &hotkey,
             netuid,
@@ -675,25 +691,29 @@ fn test_emission_tuple_generation() {
 
         let nominator_tuple = emission_tuples
             .iter()
-            .find(|(h, n, net, _)| h == &hotkey && n == &nominator && *net == netuid)
+            .find(|((h, n), ev)| {
+                h == &hotkey && n == &nominator && ev.iter().any(|(net, _)| *net == netuid)
+            })
             .expect("Nominator tuple should exist");
         let hotkey_tuple = emission_tuples
             .iter()
-            .find(|(h, n, net, _)| {
-                h == &hotkey && n == &Owner::<Test>::get(hotkey) && *net == netuid
+            .find(|((h, n), ev)| {
+                h == &hotkey
+                    && n == &Owner::<Test>::get(hotkey)
+                    && ev.iter().any(|(net, _)| *net == netuid)
             })
             .expect("Hotkey tuple should exist");
 
         assert!(
-            nominator_tuple.3 > 0,
+            nominator_tuple.1[0].1 > 0,
             "Nominator should receive non-zero emission"
         );
         assert!(
-            hotkey_tuple.3 > 0,
+            hotkey_tuple.1[0].1 > 0,
             "Hotkey should receive non-zero emission"
         );
         assert_eq!(
-            nominator_tuple.3 + hotkey_tuple.3,
+            nominator_tuple.1[0].1 + hotkey_tuple.1[0].1,
             emission,
             "Sum of emissions should equal total emission"
         );
@@ -716,7 +736,7 @@ fn test_remainder_distribution() {
         SubtensorModule::stake_into_subnet(&hotkey, &nominator2, netuid, 666);
         Delegates::<Test>::insert(hotkey, 16384); // 25% take
 
-        let mut emission_tuples = Vec::new();
+        let mut emission_tuples: BTreeMap<(U256, U256), Vec<(u16, u64)>> = BTreeMap::new();
         SubtensorModule::source_nominator_emission(
             &hotkey,
             netuid,
@@ -727,21 +747,24 @@ fn test_remainder_distribution() {
 
         let hotkey_emission = emission_tuples
             .iter()
-            .find(|(h, n, _, _)| h == &hotkey && n == &Owner::<Test>::get(hotkey))
-            .map(|(_, _, _, amount)| amount)
+            .find(|((h, n), _)| h == &hotkey && n == &Owner::<Test>::get(hotkey))
+            .map(|(_, ev)| ev.iter().map(|(_, amount)| amount).sum::<u64>())
             .unwrap();
         let expected_hotkey_take = (emission as u128 * 16384u128 / 65535u128) as u64;
 
         assert!(
-            hotkey_emission >= &expected_hotkey_take,
+            hotkey_emission >= expected_hotkey_take,
             "Hotkey emission should be at least the expected take"
         );
         assert!(
-            hotkey_emission > &expected_hotkey_take,
+            hotkey_emission > expected_hotkey_take,
             "Hotkey emission should include some remainder"
         );
 
-        let total_distributed: u64 = emission_tuples.iter().map(|(_, _, _, amount)| amount).sum();
+        let total_distributed: u64 = emission_tuples
+            .iter()
+            .map(|(_, ev)| ev.iter().map(|(_, amount)| amount).sum::<u64>())
+            .sum();
         assert_eq!(
             total_distributed, emission,
             "Total distributed should equal the original emission"
@@ -763,7 +786,7 @@ fn test_different_network_ids_scenario() {
             SubtensorModule::stake_into_subnet(&hotkey, &nominator, netuid, 1000);
             Delegates::<Test>::insert(hotkey, 16384); // 25% take
 
-            let mut emission_tuples = Vec::new();
+            let mut emission_tuples: BTreeMap<(U256, U256), Vec<(u16, u64)>> = BTreeMap::new();
             SubtensorModule::source_nominator_emission(
                 &hotkey,
                 netuid,
@@ -779,8 +802,10 @@ fn test_different_network_ids_scenario() {
                 netuid
             );
 
-            let total_distributed: u64 =
-                emission_tuples.iter().map(|(_, _, _, amount)| amount).sum();
+            let total_distributed: u64 = emission_tuples
+                .iter()
+                .map(|(_, ev)| ev.iter().map(|(_, amount)| amount).sum::<u64>())
+                .sum();
             assert_eq!(
                 total_distributed, emission,
                 "Total distributed should equal the original emission for netuid {}",
@@ -804,7 +829,7 @@ fn test_large_emission_values() {
         SubtensorModule::stake_into_subnet(&hotkey, &nominator, netuid, u64::MAX);
         Delegates::<Test>::insert(hotkey, 16384); // 25% take
 
-        let mut emission_tuples = Vec::new();
+        let mut emission_tuples: BTreeMap<(U256, U256), Vec<(u16, u64)>> = BTreeMap::new();
         SubtensorModule::source_nominator_emission(
             &hotkey,
             netuid,
@@ -819,7 +844,10 @@ fn test_large_emission_values() {
             "Should generate 2 tuples even with max emission"
         );
 
-        let total_distributed: u64 = emission_tuples.iter().map(|(_, _, _, amount)| amount).sum();
+        let total_distributed: u64 = emission_tuples
+            .iter()
+            .map(|(_, ev)| ev.iter().map(|(_, amount)| amount).sum::<u64>())
+            .sum();
         assert_eq!(
             total_distributed, emission,
             "Total distributed should equal the original emission even with max value"
@@ -827,21 +855,21 @@ fn test_large_emission_values() {
 
         let hotkey_emission = emission_tuples
             .iter()
-            .find(|(h, n, _, _)| h == &hotkey && n == &Owner::<Test>::get(hotkey))
-            .map(|(_, _, _, amount)| amount)
+            .find(|((h, n), _)| h == &hotkey && n == &Owner::<Test>::get(hotkey))
+            .map(|(_, ev)| ev.iter().map(|(_, amount)| amount).sum::<u64>())
             .unwrap();
         let nominator_emission = emission_tuples
             .iter()
-            .find(|(h, n, _, _)| h == &hotkey && n == &nominator)
-            .map(|(_, _, _, amount)| amount)
+            .find(|((h, n), _)| h == &hotkey && n == &nominator)
+            .map(|(_, ev)| ev.iter().map(|(_, amount)| amount).sum::<u64>())
             .unwrap();
 
         assert!(
-            hotkey_emission > &0,
+            hotkey_emission > 0,
             "Hotkey should receive non-zero emission even with max value"
         );
         assert!(
-            nominator_emission > &0,
+            nominator_emission > 0,
             "Nominator should receive non-zero emission even with max value"
         );
     });
@@ -860,7 +888,7 @@ fn test_small_emission_values() {
         SubtensorModule::stake_into_subnet(&hotkey, &nominator, netuid, 1000);
         Delegates::<Test>::insert(hotkey, 16384); // 25% take
 
-        let mut emission_tuples = Vec::new();
+        let mut emission_tuples: BTreeMap<(U256, U256), Vec<(u16, u64)>> = BTreeMap::new();
         SubtensorModule::source_nominator_emission(
             &hotkey,
             netuid,
@@ -875,7 +903,10 @@ fn test_small_emission_values() {
             "Should generate 2 tuples even with small emission"
         );
 
-        let total_distributed: u64 = emission_tuples.iter().map(|(_, _, _, amount)| amount).sum();
+        let total_distributed: u64 = emission_tuples
+            .iter()
+            .map(|(_, ev)| ev.iter().map(|(_, amount)| amount).sum::<u64>())
+            .sum();
         assert_eq!(
             total_distributed, emission,
             "Total distributed should equal the original emission even with small value"
@@ -883,11 +914,11 @@ fn test_small_emission_values() {
 
         let hotkey_emission = emission_tuples
             .iter()
-            .find(|(h, n, _, _)| h == &hotkey && n == &Owner::<Test>::get(hotkey))
-            .map(|(_, _, _, amount)| amount)
+            .find(|((h, n), _)| h == &hotkey && n == &Owner::<Test>::get(hotkey))
+            .map(|(_, ev)| ev.iter().map(|(_, amount)| amount).sum::<u64>())
             .unwrap();
         assert!(
-            *hotkey_emission == 0 || *hotkey_emission == 1,
+            hotkey_emission == 0 || hotkey_emission == 1,
             "Hotkey emission should be 0 or 1 with small value"
         );
     });
@@ -907,11 +938,11 @@ fn test_consistency_across_multiple_calls() {
         SubtensorModule::stake_into_subnet(&hotkey, &nominator, netuid, 1000);
         Delegates::<Test>::insert(hotkey, 16384); // 25% take
 
-        let mut first_result = Vec::new();
+        let mut first_result: BTreeMap<(U256, U256), Vec<(u16, u64)>> = BTreeMap::new();
         SubtensorModule::source_nominator_emission(&hotkey, netuid, emission, 0, &mut first_result);
 
         for _ in 0..10 {
-            let mut current_result = Vec::new();
+            let mut current_result: BTreeMap<(U256, U256), Vec<(u16, u64)>> = BTreeMap::new();
             SubtensorModule::source_nominator_emission(
                 &hotkey,
                 netuid,
@@ -946,7 +977,7 @@ fn test_performance_with_many_nominators() {
         Delegates::<Test>::insert(hotkey, 16384); // 25% take
 
         let start_time = std::time::Instant::now();
-        let mut emission_tuples = Vec::new();
+        let mut emission_tuples: BTreeMap<(U256, U256), Vec<(u16, u64)>> = BTreeMap::new();
         SubtensorModule::source_nominator_emission(
             &hotkey,
             netuid,
@@ -962,7 +993,10 @@ fn test_performance_with_many_nominators() {
             "Should generate tuples for all nominators plus hotkey"
         );
 
-        let total_distributed: u64 = emission_tuples.iter().map(|(_, _, _, amount)| amount).sum();
+        let total_distributed: u64 = emission_tuples
+            .iter()
+            .map(|(_, ev)| ev.iter().map(|(_, amount)| amount).sum::<u64>())
+            .sum();
         assert_eq!(
             total_distributed, emission,
             "Total distributed should equal the original emission"
@@ -1781,7 +1815,7 @@ fn test_fast_stake_unstake_protection_source_nominator() {
         Delegates::<Test>::insert(&hotkey, 16384); // 25% take
         HotkeyEmissionTempo::<Test>::put(10);
 
-        let mut emission_tuples = Vec::new();
+        let mut emission_tuples: BTreeMap<(U256, U256), Vec<(u16, u64)>> = BTreeMap::new();
         SubtensorModule::source_nominator_emission(
             &hotkey,
             netuid,


### PR DESCRIPTION
## Description

When `source_nominator_emission` is run, avoid duplicates of hotkey-coldkey pairs in the produced `emission_tuples`. This allows to:
- Reduce the number of db writes in `accumulate_nominator_emission` when the emission is written into the state, and
- Remove checking for duplicates in `accumulate_nominator_emission` when `LastHotkeyEmissionDrain` is set for each nominator, which is O(n log(n)) operation, where n is the number of nominators

## Related Issue(s)

- Closes #877 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please describe): optimization

## Breaking Change

n/a

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

n/a

## Additional Notes

n/a