### PR TITLE
Use alpha for stake in neuron info

### DIFF
--- a/pallets/subtensor/src/rpc_info/neuron_info.rs
+++ b/pallets/subtensor/src/rpc_info/neuron_info.rs
@@ -1,6 +1,5 @@
 use super::*;
 use frame_support::pallet_prelude::{Decode, Encode};
-use frame_support::storage::IterableStorageDoubleMap;
 extern crate alloc;
 use codec::Compact;
 
@@ -117,8 +116,12 @@ impl<T: Config> Pallet<T> {
                 }
             })
             .collect::<Vec<(Compact<u16>, Compact<u16>)>>();
-        let stake_weight: u64 = Self::get_stake_weight(netuid, uid) as u64;
-        let stake: Vec<(T::AccountId, Compact<u64>)> = vec![(coldkey.clone(), stake_weight.into())];
+
+        let stake: Vec<(T::AccountId, Compact<u64>)> = vec![(
+            coldkey.clone(),
+            Alpha::<T>::get((&hotkey, coldkey.clone(), netuid)).into(),
+        )];
+
         let neuron = NeuronInfo {
             hotkey: hotkey.clone(),
             coldkey: coldkey.clone(),
@@ -177,12 +180,10 @@ impl<T: Config> Pallet<T> {
         let last_update = Self::get_last_update_for_uid(netuid, uid);
         let validator_permit = Self::get_validator_permit_for_uid(netuid, uid);
 
-        let stake: Vec<(T::AccountId, Compact<u64>)> =
-            <Stake<T> as IterableStorageDoubleMap<T::AccountId, T::AccountId, u64>>::iter_prefix(
-                hotkey.clone(),
-            )
-            .map(|(coldkey, stake)| (coldkey, stake.into()))
-            .collect();
+        let stake: Vec<(T::AccountId, Compact<u64>)> = vec![(
+            coldkey.clone(),
+            Alpha::<T>::get((&hotkey, coldkey.clone(), netuid)).into(),
+        )];
 
         let neuron = NeuronInfoLite {
             hotkey: hotkey.clone(),

--- a/pallets/subtensor/src/rpc_info/neuron_info.rs
+++ b/pallets/subtensor/src/rpc_info/neuron_info.rs
@@ -28,6 +28,12 @@ pub struct NeuronInfo<T: Config> {
     pruning_score: Compact<u16>,
 }
 
+impl<T: Config> NeuronInfo<T> {
+    pub fn stake(&self) -> &[(T::AccountId, Compact<u64>)] {
+        &self.stake
+    }
+}
+
 #[freeze_struct("c21f0f4f22bcb2a1")]
 #[derive(Decode, Encode, PartialEq, Eq, Clone, Debug)]
 pub struct NeuronInfoLite<T: Config> {
@@ -50,6 +56,12 @@ pub struct NeuronInfoLite<T: Config> {
     validator_permit: bool,
     // has no weights or bonds
     pruning_score: Compact<u16>,
+}
+
+impl<T: Config> NeuronInfoLite<T> {
+    pub fn stake(&self) -> &[(T::AccountId, Compact<u64>)] {
+        &self.stake
+    }
 }
 
 impl<T: Config> Pallet<T> {

--- a/pallets/subtensor/src/rpc_info/stake_info.rs
+++ b/pallets/subtensor/src/rpc_info/stake_info.rs
@@ -18,6 +18,12 @@ pub struct StakeInfo<T: Config> {
     is_registered: bool,
 }
 
+impl<T: Config> StakeInfo<T> {
+    pub fn stake(&self) -> Compact<u64> {
+        self.stake
+    }
+}
+
 impl<T: Config> Pallet<T> {
     fn _get_stake_info_for_coldkeys(
         coldkeys: Vec<T::AccountId>,

--- a/pallets/subtensor/src/rpc_info/stake_info.rs
+++ b/pallets/subtensor/src/rpc_info/stake_info.rs
@@ -33,12 +33,9 @@ impl<T: Config> Pallet<T> {
             let mut stake_info_for_coldkey: Vec<StakeInfo<T>> = Vec::new();
             for netuid_i in netuids.iter() {
                 for hotkey_i in staking_hotkeys.iter() {
-                    let alpha: u64 =
-                        Alpha::<T>::get((hotkey_i, coldkey_i, netuid_i));
+                    let alpha: u64 = Alpha::<T>::get((hotkey_i, coldkey_i, netuid_i));
                     let emission: u64 = LastHotkeyColdkeyEmissionOnNetuid::<T>::get((
-                        hotkey_i,
-                        coldkey_i,
-                        *netuid_i,
+                        hotkey_i, coldkey_i, *netuid_i,
                     ));
                     let drain: u64 = LastHotkeyEmissionDrain::<T>::get(hotkey_i);
                     let is_registered: bool =

--- a/pallets/subtensor/src/rpc_info/stake_info.rs
+++ b/pallets/subtensor/src/rpc_info/stake_info.rs
@@ -27,22 +27,22 @@ impl<T: Config> Pallet<T> {
         }
         let netuids: Vec<u16> = Self::get_all_subnet_netuids();
         let mut stake_info: Vec<(T::AccountId, Vec<StakeInfo<T>>)> = Vec::new();
-        for coldkey_i in coldkeys.clone().iter() {
+        for coldkey_i in coldkeys.iter() {
             // Get all hotkeys associated with this coldkey.
-            let staking_hotkeys = StakingHotkeys::<T>::get(coldkey_i.clone());
+            let staking_hotkeys = StakingHotkeys::<T>::get(coldkey_i);
             let mut stake_info_for_coldkey: Vec<StakeInfo<T>> = Vec::new();
-            for netuid_i in netuids.clone().iter() {
-                for hotkey_i in staking_hotkeys.clone().iter() {
+            for netuid_i in netuids.iter() {
+                for hotkey_i in staking_hotkeys.iter() {
                     let alpha: u64 =
-                        Alpha::<T>::get((hotkey_i.clone(), coldkey_i.clone(), netuid_i));
+                        Alpha::<T>::get((hotkey_i, coldkey_i, netuid_i));
                     let emission: u64 = LastHotkeyColdkeyEmissionOnNetuid::<T>::get((
-                        hotkey_i.clone(),
-                        coldkey_i.clone(),
+                        hotkey_i,
+                        coldkey_i,
                         *netuid_i,
                     ));
-                    let drain: u64 = LastHotkeyEmissionDrain::<T>::get(hotkey_i.clone());
+                    let drain: u64 = LastHotkeyEmissionDrain::<T>::get(hotkey_i);
                     let is_registered: bool =
-                        Self::is_hotkey_registered_on_network(*netuid_i, &hotkey_i);
+                        Self::is_hotkey_registered_on_network(*netuid_i, hotkey_i);
                     stake_info_for_coldkey.push(StakeInfo {
                         hotkey: hotkey_i.clone(),
                         coldkey: coldkey_i.clone(),


### PR DESCRIPTION
## Description

This PR fixes inconsistency issues related to staking values returned by RPC's `NeuronInfoRuntimeApi` and `StakeInfoRuntimeApi`.

Getters for the `stake` values are added to `NeuronInfo`, `NeuronInfoLite` and `StakeInfo`, because there is no other way to test this values in the integration tests.


## Related Issue(s)

- Closes #879

## Type of Change
<!--
Please check the relevant options:
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):


## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


## Additional Notes

It would be better to introduce different types for TAO and Alpha balances, so these kinds of errors would be discoverable at the compilation time (#887).

Also, to prevent possible inconsistencies between `NeuronInfo` and `NeuronInfoLite` it would be better to make `NeuronInfoLite` a part of `NeuronInfo`, instead of duplicating information between them.

Allowing unit/module tests would help with private API testing. In case the module tests are not possible, another option could be a cargo feature, which would make API dedicated to tests being compiled for tests only (`#[cfg(test)]` doesn't work for the integration tests).