### PR TITLE
Commit reveal 2 Improvements

### DIFF
--- a/pallets/admin-utils/src/benchmarking.rs
+++ b/pallets/admin-utils/src/benchmarking.rs
@@ -228,14 +228,14 @@ mod benchmarks {
     }
 
     #[benchmark]
-    fn sudo_set_commit_reveal_weights_periods() {
+    fn sudo_set_commit_reveal_weights_interval() {
         pallet_subtensor::Pallet::<T>::init_new_network(
             1u16, /*netuid*/
             1u16, /*sudo_tempo*/
         );
 
         #[extrinsic_call]
-		_(RawOrigin::Root, 1u16/*netuid*/, 3u64/*interval*/)/*set_commit_reveal_weights_periods()*/;
+		_(RawOrigin::Root, 1u16/*netuid*/, 3u64/*interval*/)/*sudo_set_commit_reveal_weights_interval()*/;
     }
 
     #[benchmark]

--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -1187,7 +1187,7 @@ pub mod pallet {
         ///
         /// # Weight
         /// Weight is handled by the `#[pallet::weight]` attribute.
-        #[pallet::call_index(56)]
+        #[pallet::call_index(57)]
         #[pallet::weight(T::WeightInfo::sudo_set_commit_reveal_weights_interval())]
         pub fn sudo_set_commit_reveal_weights_interval(
             origin: OriginFor<T>,

--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -1188,11 +1188,11 @@ pub mod pallet {
         /// # Weight
         /// Weight is handled by the `#[pallet::weight]` attribute.
         #[pallet::call_index(56)]
-        #[pallet::weight(T::WeightInfo::sudo_set_commit_reveal_weights_periods())]
-        pub fn sudo_set_commit_reveal_weights_periods(
+        #[pallet::weight(T::WeightInfo::sudo_set_commit_reveal_weights_interval())]
+        pub fn sudo_set_commit_reveal_weights_interval(
             origin: OriginFor<T>,
             netuid: u16,
-            periods: u64,
+            interval: u64,
         ) -> DispatchResult {
             pallet_subtensor::Pallet::<T>::ensure_subnet_owner_or_root(origin, netuid)?;
 
@@ -1201,11 +1201,11 @@ pub mod pallet {
                 Error::<T>::SubnetDoesNotExist
             );
 
-            pallet_subtensor::Pallet::<T>::set_reveal_period(netuid, periods);
+            pallet_subtensor::Pallet::<T>::set_reveal_period(netuid, interval);
             log::debug!(
-                "SetWeightCommitPeriods( netuid: {:?}, periods: {:?} ) ",
+                "SetWeightCommitInterval( netuid: {:?}, interval: {:?} ) ",
                 netuid,
-                periods
+                interval
             );
             Ok(())
         }

--- a/pallets/admin-utils/src/weights.rs
+++ b/pallets/admin-utils/src/weights.rs
@@ -60,7 +60,7 @@ pub trait WeightInfo {
 	fn sudo_set_min_burn() -> Weight;
 	fn sudo_set_network_registration_allowed() -> Weight;
 	fn sudo_set_tempo() -> Weight;
-	fn sudo_set_commit_reveal_weights_periods() -> Weight;
+	fn sudo_set_commit_reveal_weights_interval() -> Weight;
 	fn sudo_set_commit_reveal_weights_enabled() -> Weight;
 }
 
@@ -413,7 +413,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
-	fn sudo_set_commit_reveal_weights_periods() -> Weight {
+	fn sudo_set_commit_reveal_weights_interval() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `456`
 		//  Estimated: `3921`
@@ -781,7 +781,7 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
-	fn sudo_set_commit_reveal_weights_periods() -> Weight {
+	fn sudo_set_commit_reveal_weights_interval() -> Weight {
 		// -- Extrinsic Time --
 		// Model:
 		// Time ~=    19.38

--- a/pallets/admin-utils/tests/tests.rs
+++ b/pallets/admin-utils/tests/tests.rs
@@ -1414,7 +1414,7 @@ fn test_sudo_set_dissolve_network_schedule_duration() {
 }
 
 #[test]
-fn sudo_set_commit_reveal_weights_periods() {
+fn sudo_set_commit_reveal_weights_interval() {
     new_test_ext().execute_with(|| {
         let netuid: u16 = 1;
         add_network(netuid, 10);
@@ -1422,7 +1422,7 @@ fn sudo_set_commit_reveal_weights_periods() {
         let to_be_set = 55;
         let init_value = SubtensorModule::get_reveal_period(netuid);
 
-        assert_ok!(AdminUtils::sudo_set_commit_reveal_weights_periods(
+        assert_ok!(AdminUtils::sudo_set_commit_reveal_weights_interval(
             <<Test as Config>::RuntimeOrigin>::root(),
             netuid,
             to_be_set

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1251,7 +1251,7 @@ pub mod pallet {
     /// ITEM( weights_min_stake )
     pub type WeightsMinStake<T> = StorageValue<_, u64, ValueQuery, DefaultWeightsMinStake<T>>;
     #[pallet::storage]
-    /// --- MAP (netuid, who) --> VecDeque<(hash, commit_block)> | Stores a queue of commits for an account on a given netuid.
+    /// --- MAP (netuid, who) --> VecDeque<(hash, commit_block, first_reveal_block, last_reveal_block)> | Stores a queue of commits for an account on a given netuid.
     pub type WeightCommits<T: Config> = StorageDoubleMap<
         _,
         Twox64Concat,

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -569,7 +569,7 @@ pub mod pallet {
         0
     }
     #[pallet::type_value]
-    /// Default minimum stake for weights.
+    /// Default Reveal Period Epochs
     pub fn DefaultRevealPeriodEpochs<T: Config>() -> u64 {
         1
     }

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1258,7 +1258,7 @@ pub mod pallet {
         u16,
         Twox64Concat,
         T::AccountId,
-        VecDeque<(H256, u64)>,
+        VecDeque<(H256, u64, u64, u64)>,
         OptionQuery,
     >;
     #[pallet::storage]

--- a/pallets/subtensor/src/macros/errors.rs
+++ b/pallets/subtensor/src/macros/errors.rs
@@ -188,5 +188,7 @@ mod errors {
         RevealTooEarly,
         /// Attempted to batch reveal weights with mismatched vector input lenghts.
         InputLengthsUnequal,
+        /// A transactor exceeded the rate limit for setting weights.
+        CommittingWeightsTooFast,
     }
 }

--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -204,5 +204,25 @@ mod events {
         ColdkeySwapScheduleDurationSet(BlockNumberFor<T>),
         /// The duration of dissolve network has been set
         DissolveNetworkScheduleDurationSet(BlockNumberFor<T>),
+        /// Weights have been successfully committed.
+        ///
+        /// - **who**: The account ID of the user committing the weights.
+        /// - **netuid**: The network identifier.
+        /// - **commit_hash**: The hash representing the committed weights.
+        WeightsCommitted(T::AccountId, u16, H256),
+
+        /// Weights have been successfully revealed.
+        ///
+        /// - **who**: The account ID of the user revealing the weights.
+        /// - **netuid**: The network identifier.
+        /// - **commit_hash**: The hash of the revealed weights.
+        WeightsRevealed(T::AccountId, u16, H256),
+
+        /// Weights have been successfully batch revealed.
+        ///
+        /// - **who**: The account ID of the user revealing the weights.
+        /// - **netuid**: The network identifier.
+        /// - **revealed_hashes**: A vector of hashes representing each revealed weight set.
+        WeightsBatchRevealed(T::AccountId, u16, Vec<H256>),
     }
 }

--- a/pallets/subtensor/src/migrations/migrate_commit_reveal_v2.rs
+++ b/pallets/subtensor/src/migrations/migrate_commit_reveal_v2.rs
@@ -5,7 +5,7 @@ use scale_info::prelude::string::String;
 use sp_io::{hashing::twox_128, storage::clear_prefix, KillStorageResult};
 
 pub fn migrate_commit_reveal_2<T: Config>() -> Weight {
-    let migration_name = b"migrate_commit_reveal_2".to_vec();
+    let migration_name = b"migrate_commit_reveal_2_v2".to_vec();
     let mut weight = T::DbWeight::get().reads(1);
 
     if HasMigrationRun::<T>::get(&migration_name) {

--- a/pallets/subtensor/src/rpc_info/subnet_info.rs
+++ b/pallets/subtensor/src/rpc_info/subnet_info.rs
@@ -51,7 +51,7 @@ pub struct SubnetInfov2<T: Config> {
     identity: Option<SubnetIdentity>,
 }
 
-#[freeze_struct("4ceb81dfe8a8f96d")]
+#[freeze_struct("55b472510f10e76a")]
 #[derive(Decode, Encode, PartialEq, Eq, Clone, Debug)]
 pub struct SubnetHyperparams {
     rho: Compact<u16>,
@@ -76,7 +76,7 @@ pub struct SubnetHyperparams {
     max_validators: Compact<u16>,
     adjustment_alpha: Compact<u64>,
     difficulty: Compact<u64>,
-    commit_reveal_periods: Compact<u64>,
+    commit_reveal_weights_interval: Compact<u64>,
     commit_reveal_weights_enabled: bool,
     alpha_high: Compact<u16>,
     alpha_low: Compact<u16>,
@@ -280,7 +280,7 @@ impl<T: Config> Pallet<T> {
             max_validators: max_validators.into(),
             adjustment_alpha: adjustment_alpha.into(),
             difficulty: difficulty.into(),
-            commit_reveal_periods: commit_reveal_periods.into(),
+            commit_reveal_weights_interval: commit_reveal_periods.into(),
             commit_reveal_weights_enabled,
             alpha_high: alpha_high.into(),
             alpha_low: alpha_low.into(),

--- a/pallets/subtensor/src/subnets/weights.rs
+++ b/pallets/subtensor/src/subnets/weights.rs
@@ -505,10 +505,12 @@ impl<T: Config> Pallet<T> {
         // --- 9. Ensure the uid is not setting weights faster than the weights_set_rate_limit.
         let neuron_uid = Self::get_uid_for_net_and_hotkey(netuid, &hotkey)?;
         let current_block: u64 = Self::get_current_block_as_u64();
-        ensure!(
-            Self::check_rate_limit(netuid, neuron_uid, current_block),
-            Error::<T>::SettingWeightsTooFast
-        );
+        if !Self::get_commit_reveal_weights_enabled(netuid) {
+            ensure!(
+                Self::check_rate_limit(netuid, neuron_uid, current_block),
+                Error::<T>::SettingWeightsTooFast
+            );
+        }
 
         // --- 10. Check that the neuron uid is an allowed validator permitted to set non-self weights.
         ensure!(

--- a/pallets/subtensor/src/subnets/weights.rs
+++ b/pallets/subtensor/src/subnets/weights.rs
@@ -212,174 +212,180 @@ impl<T: Config> Pallet<T> {
         })
     }
 
-/// ---- The implementation for batch revealing committed weights.
-///
-/// # Args:
-/// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
-///   - The signature of the revealing hotkey.
-///
-/// * `netuid` (`u16`):
-///   - The u16 network identifier.
-///
-/// * `uids_list` (`Vec<Vec<u16>>`):
-///   - A list of uids for each set of weights being revealed.
-///
-/// * `values_list` (`Vec<Vec<u16>>`):
-///   - A list of values for each set of weights being revealed.
-///
-/// * `salts_list` (`Vec<Vec<u16>>`):
-///   - A list of salts used to generate the commit hashes.
-///
-/// * `version_keys` (`Vec<u64>`):
-///   - A list of network version keys.
-///
-/// # Raises:
-/// * `CommitRevealDisabled`:
-///   - Attempting to reveal weights when the commit-reveal mechanism is disabled.
-///
-/// * `NoWeightsCommitFound`:
-///   - Attempting to reveal weights without an existing commit.
-///
-/// * `ExpiredWeightCommit`:
-///   - Attempting to reveal a weight commit that has expired.
-///
-/// * `RevealTooEarly`:
-///   - Attempting to reveal weights outside the valid reveal period.
-///
-/// * `InvalidRevealCommitHashNotMatch`:
-///   - The revealed hash does not match any committed hash.
-///
-/// * `InputLengthsUnequal`:
-///   - The input vectors are of mismatched lengths.
-pub fn do_batch_reveal_weights(
-    origin: T::RuntimeOrigin,
-    netuid: u16,
-    uids_list: Vec<Vec<u16>>,
-    values_list: Vec<Vec<u16>>,
-    salts_list: Vec<Vec<u16>>,
-    version_keys: Vec<u64>,
-) -> DispatchResult {
-    // --- 1. Check that the input lists are of the same length.
-    let num_reveals = uids_list.len();
-    ensure!(
-        num_reveals == values_list.len()
-            && num_reveals == salts_list.len()
-            && num_reveals == version_keys.len(),
-        Error::<T>::InputLengthsUnequal
-    );
+    /// ---- The implementation for batch revealing committed weights.
+    ///
+    /// # Args:
+    /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
+    ///   - The signature of the revealing hotkey.
+    ///
+    /// * `netuid` (`u16`):
+    ///   - The u16 network identifier.
+    ///
+    /// * `uids_list` (`Vec<Vec<u16>>`):
+    ///   - A list of uids for each set of weights being revealed.
+    ///
+    /// * `values_list` (`Vec<Vec<u16>>`):
+    ///   - A list of values for each set of weights being revealed.
+    ///
+    /// * `salts_list` (`Vec<Vec<u16>>`):
+    ///   - A list of salts used to generate the commit hashes.
+    ///
+    /// * `version_keys` (`Vec<u64>`):
+    ///   - A list of network version keys.
+    ///
+    /// # Raises:
+    /// * `CommitRevealDisabled`:
+    ///   - Attempting to reveal weights when the commit-reveal mechanism is disabled.
+    ///
+    /// * `NoWeightsCommitFound`:
+    ///   - Attempting to reveal weights without an existing commit.
+    ///
+    /// * `ExpiredWeightCommit`:
+    ///   - Attempting to reveal a weight commit that has expired.
+    ///
+    /// * `RevealTooEarly`:
+    ///   - Attempting to reveal weights outside the valid reveal period.
+    ///
+    /// * `InvalidRevealCommitHashNotMatch`:
+    ///   - The revealed hash does not match any committed hash.
+    ///
+    /// * `InputLengthsUnequal`:
+    ///   - The input vectors are of mismatched lengths.
+    pub fn do_batch_reveal_weights(
+        origin: T::RuntimeOrigin,
+        netuid: u16,
+        uids_list: Vec<Vec<u16>>,
+        values_list: Vec<Vec<u16>>,
+        salts_list: Vec<Vec<u16>>,
+        version_keys: Vec<u64>,
+    ) -> DispatchResult {
+        // --- 1. Check that the input lists are of the same length.
+        let num_reveals = uids_list.len();
+        ensure!(
+            num_reveals == values_list.len()
+                && num_reveals == salts_list.len()
+                && num_reveals == version_keys.len(),
+            Error::<T>::InputLengthsUnequal
+        );
 
-    // --- 2. Check the caller's signature (hotkey).
-    let who = ensure_signed(origin.clone())?;
+        // --- 2. Check the caller's signature (hotkey).
+        let who = ensure_signed(origin.clone())?;
 
-    log::debug!(
-        "do_batch_reveal_weights( hotkey:{:?} netuid:{:?})",
-        who,
-        netuid
-    );
+        log::debug!(
+            "do_batch_reveal_weights( hotkey:{:?} netuid:{:?})",
+            who,
+            netuid
+        );
 
-    // --- 3. Ensure commit-reveal is enabled for the network.
-    ensure!(
-        Self::get_commit_reveal_weights_enabled(netuid),
-        Error::<T>::CommitRevealDisabled
-    );
+        // --- 3. Ensure commit-reveal is enabled for the network.
+        ensure!(
+            Self::get_commit_reveal_weights_enabled(netuid),
+            Error::<T>::CommitRevealDisabled
+        );
 
-    // --- 4. Mutate the WeightCommits to retrieve existing commits for the user.
-    WeightCommits::<T>::try_mutate_exists(netuid, &who, |maybe_commits| -> DispatchResult {
-        let commits = maybe_commits
-            .as_mut()
-            .ok_or(Error::<T>::NoWeightsCommitFound)?;
-
-        // --- 5. Remove any expired commits from the front of the queue, collecting their hashes.
-        let mut expired_hashes = Vec::new();
-        while let Some((hash, commit_block, _, _)) = commits.front() {
-            if Self::is_commit_expired(netuid, *commit_block) {
-                // Collect the expired commit hash
-                expired_hashes.push(*hash);
-                commits.pop_front();
-            } else {
-                break;
-            }
-        }
-
-        // --- 6. Prepare to collect all provided hashes and their corresponding reveals.
-        let mut provided_hashes = Vec::new();
-        let mut reveals = Vec::new();
-
-        for ((uids, values), (salt, version_key)) in uids_list
-            .into_iter()
-            .zip(values_list)
-            .zip(salts_list.into_iter().zip(version_keys))
-        {
-            // --- 6a. Hash the provided data.
-            let provided_hash: H256 = BlakeTwo256::hash_of(&(
-                who.clone(),
-                netuid,
-                uids.clone(),
-                values.clone(),
-                salt.clone(),
-                version_key,
-            ));
-            provided_hashes.push(provided_hash);
-            reveals.push((uids, values, version_key, provided_hash));
-        }
-
-        // --- 7. Validate all reveals first to ensure atomicity.
-        // This prevents partial updates if any reveal fails.
-        for (_uids, _values, _version_key, provided_hash) in &reveals {
-            // --- 7a. Check if the provided_hash is in the non-expired commits.
-            if !commits.iter().any(|(hash, _, _, _)| *hash == *provided_hash) {
-                // --- 7b. If not found, check if it matches any expired commits.
-                if expired_hashes.contains(provided_hash) {
-                    return Err(Error::<T>::ExpiredWeightCommit.into());
-                } else {
-                    return Err(Error::<T>::InvalidRevealCommitHashNotMatch.into());
-                }
-            }
-
-            // --- 7c. Find the commit corresponding to the provided_hash.
-            let commit = commits
-                .iter()
-                .find(|(hash, _, _, _)| *hash == *provided_hash)
+        // --- 4. Mutate the WeightCommits to retrieve existing commits for the user.
+        WeightCommits::<T>::try_mutate_exists(netuid, &who, |maybe_commits| -> DispatchResult {
+            let commits = maybe_commits
+                .as_mut()
                 .ok_or(Error::<T>::NoWeightsCommitFound)?;
 
-            // --- 7d. Check if the commit is within the reveal window.
-            let current_block: u64 = Self::get_current_block_as_u64();
-            let (_, _, first_reveal_block, last_reveal_block) = commit;
-            ensure!(
-                current_block >= *first_reveal_block && current_block <= *last_reveal_block,
-                Error::<T>::RevealTooEarly
-            );
-        }
-
-        // --- 8. All reveals are valid. Proceed to remove and process each reveal.
-        for (uids, values, version_key, provided_hash) in reveals {
-            // --- 8a. Find the position of the provided_hash.
-            if let Some(position) = commits.iter().position(|(hash, _, _, _)| *hash == provided_hash) {
-                // --- 8b. Remove the commit from the queue.
-                commits.remove(position);
-
-                // --- 8c. Proceed to set the revealed weights.
-                Self::do_set_weights(origin.clone(), netuid, uids, values, version_key)?;
-            } else {
-                // This case should not occur as we've already validated the existence of the hash.
-                // However, to ensure safety, we handle it.
-                if expired_hashes.contains(&provided_hash) {
-                    return Err(Error::<T>::ExpiredWeightCommit.into());
+            // --- 5. Remove any expired commits from the front of the queue, collecting their hashes.
+            let mut expired_hashes = Vec::new();
+            while let Some((hash, commit_block, _, _)) = commits.front() {
+                if Self::is_commit_expired(netuid, *commit_block) {
+                    // Collect the expired commit hash
+                    expired_hashes.push(*hash);
+                    commits.pop_front();
                 } else {
-                    return Err(Error::<T>::InvalidRevealCommitHashNotMatch.into());
+                    break;
                 }
             }
-        }
 
-        // --- 9. If the queue is now empty, remove the storage entry for the user.
-        if commits.is_empty() {
-            *maybe_commits = None;
-        }
+            // --- 6. Prepare to collect all provided hashes and their corresponding reveals.
+            let mut provided_hashes = Vec::new();
+            let mut reveals = Vec::new();
 
-        // --- 10. Return ok.
-        Ok(())
-    })
-}
+            for ((uids, values), (salt, version_key)) in uids_list
+                .into_iter()
+                .zip(values_list)
+                .zip(salts_list.into_iter().zip(version_keys))
+            {
+                // --- 6a. Hash the provided data.
+                let provided_hash: H256 = BlakeTwo256::hash_of(&(
+                    who.clone(),
+                    netuid,
+                    uids.clone(),
+                    values.clone(),
+                    salt.clone(),
+                    version_key,
+                ));
+                provided_hashes.push(provided_hash);
+                reveals.push((uids, values, version_key, provided_hash));
+            }
+
+            // --- 7. Validate all reveals first to ensure atomicity.
+            // This prevents partial updates if any reveal fails.
+            for (_uids, _values, _version_key, provided_hash) in &reveals {
+                // --- 7a. Check if the provided_hash is in the non-expired commits.
+                if !commits
+                    .iter()
+                    .any(|(hash, _, _, _)| *hash == *provided_hash)
+                {
+                    // --- 7b. If not found, check if it matches any expired commits.
+                    if expired_hashes.contains(provided_hash) {
+                        return Err(Error::<T>::ExpiredWeightCommit.into());
+                    } else {
+                        return Err(Error::<T>::InvalidRevealCommitHashNotMatch.into());
+                    }
+                }
+
+                // --- 7c. Find the commit corresponding to the provided_hash.
+                let commit = commits
+                    .iter()
+                    .find(|(hash, _, _, _)| *hash == *provided_hash)
+                    .ok_or(Error::<T>::NoWeightsCommitFound)?;
+
+                // --- 7d. Check if the commit is within the reveal window.
+                let current_block: u64 = Self::get_current_block_as_u64();
+                let (_, _, first_reveal_block, last_reveal_block) = commit;
+                ensure!(
+                    current_block >= *first_reveal_block && current_block <= *last_reveal_block,
+                    Error::<T>::RevealTooEarly
+                );
+            }
+
+            // --- 8. All reveals are valid. Proceed to remove and process each reveal.
+            for (uids, values, version_key, provided_hash) in reveals {
+                // --- 8a. Find the position of the provided_hash.
+                if let Some(position) = commits
+                    .iter()
+                    .position(|(hash, _, _, _)| *hash == provided_hash)
+                {
+                    // --- 8b. Remove the commit from the queue.
+                    commits.remove(position);
+
+                    // --- 8c. Proceed to set the revealed weights.
+                    Self::do_set_weights(origin.clone(), netuid, uids, values, version_key)?;
+                } else {
+                    // This case should not occur as we've already validated the existence of the hash.
+                    // However, to ensure safety, we handle it.
+                    if expired_hashes.contains(&provided_hash) {
+                        return Err(Error::<T>::ExpiredWeightCommit.into());
+                    } else {
+                        return Err(Error::<T>::InvalidRevealCommitHashNotMatch.into());
+                    }
+                }
+            }
+
+            // --- 9. If the queue is now empty, remove the storage entry for the user.
+            if commits.is_empty() {
+                *maybe_commits = None;
+            }
+
+            // --- 10. Return ok.
+            Ok(())
+        })
+    }
 
     /// ---- The implementation for the extrinsic set_weights.
     ///

--- a/pallets/subtensor/tests/migration.rs
+++ b/pallets/subtensor/tests/migration.rs
@@ -446,7 +446,7 @@ fn test_migrate_commit_reveal_2() {
         // ------------------------------
         // Step 1: Simulate Old Storage Entries
         // ------------------------------
-        const MIGRATION_NAME: &str = "migrate_commit_reveal_2";
+        const MIGRATION_NAME: &str = "migrate_commit_reveal_2_v2";
 
         let pallet_prefix = twox_128("SubtensorModule".as_bytes());
         let storage_prefix_interval = twox_128("WeightCommitRevealInterval".as_bytes());

--- a/pallets/subtensor/tests/swap_hotkey.rs
+++ b/pallets/subtensor/tests/swap_hotkey.rs
@@ -351,8 +351,8 @@ fn test_swap_weight_commits() {
         let new_hotkey = U256::from(2);
         let coldkey = U256::from(3);
         let netuid = 0u16;
-        let mut weight_commits: VecDeque<(H256, u64)> = VecDeque::new();
-        weight_commits.push_back((H256::from_low_u64_be(100), 200));
+        let mut weight_commits: VecDeque<(H256, u64, u64, u64)> = VecDeque::new();
+        weight_commits.push_back((H256::from_low_u64_be(100), 200, 1, 1));
         let mut weight = Weight::zero();
 
         add_network(netuid, 0, 1);

--- a/pallets/subtensor/tests/weights.rs
+++ b/pallets/subtensor/tests/weights.rs
@@ -4127,5 +4127,64 @@ fn test_commit_weights_rate_limit() {
             netuid,
             new_commit_hash
         ));
+
+        SubtensorModule::set_commit_reveal_weights_enabled(netuid, false);
+        let weights_keys: Vec<u16> = vec![0];
+        let weight_values: Vec<u16> = vec![1];
+
+        assert_err!(
+            SubtensorModule::set_weights(
+                RuntimeOrigin::signed(hotkey),
+                netuid,
+                weights_keys.clone(),
+                weight_values.clone(),
+                0
+            ),
+            Error::<Test>::SettingWeightsTooFast
+        );
+
+        step_block(10);
+
+        assert_ok!(SubtensorModule::set_weights(
+            RuntimeOrigin::signed(hotkey),
+            netuid,
+            weights_keys.clone(),
+            weight_values.clone(),
+            0
+        ));
+
+        assert_err!(
+            SubtensorModule::set_weights(
+                RuntimeOrigin::signed(hotkey),
+                netuid,
+                weights_keys.clone(),
+                weight_values.clone(),
+                0
+            ),
+            Error::<Test>::SettingWeightsTooFast
+        );
+
+        step_block(5);
+
+        assert_err!(
+            SubtensorModule::set_weights(
+                RuntimeOrigin::signed(hotkey),
+                netuid,
+                weights_keys.clone(),
+                weight_values.clone(),
+                0
+            ),
+            Error::<Test>::SettingWeightsTooFast
+        );
+
+        step_block(5);
+
+        assert_ok!(SubtensorModule::set_weights(
+            RuntimeOrigin::signed(hotkey),
+            netuid,
+            weights_keys.clone(),
+            weight_values.clone(),
+            0
+        ));
     });
 }

--- a/pallets/subtensor/tests/weights.rs
+++ b/pallets/subtensor/tests/weights.rs
@@ -2432,7 +2432,7 @@ fn test_expired_commits_handling_in_commit_and_reveal() {
         ));
 
         // 6. Verify that the number of unrevealed, non-expired commits is now 6
-        let commits: VecDeque<(H256, u64)> =
+        let commits: VecDeque<(H256, u64, u64, u64)> =
             pallet_subtensor::WeightCommits::<Test>::get(netuid, hotkey)
                 .expect("Expected a commit");
         assert_eq!(commits.len(), 6); // 5 non-expired commits from epoch 1 + new commit

--- a/pallets/subtensor/tests/weights.rs
+++ b/pallets/subtensor/tests/weights.rs
@@ -4090,7 +4090,8 @@ fn test_commit_weights_rate_limit() {
         SubtensorModule::set_validator_permit_for_uid(netuid, 1, true);
         SubtensorModule::set_commit_reveal_weights_enabled(netuid, true);
 
-        let neuron_uid = SubtensorModule::get_uid_for_net_and_hotkey(netuid, &hotkey).unwrap();
+        let neuron_uid =
+            SubtensorModule::get_uid_for_net_and_hotkey(netuid, &hotkey).expect("expected uid");
         SubtensorModule::set_last_update_for_uid(netuid, neuron_uid, 0);
 
         assert_ok!(SubtensorModule::commit_weights(


### PR DESCRIPTION
## Description

- Used the set_weights rate limit in `commit_weights`
- Added first and last reveal blocks to `WeightCommits` storage item.
- Reverted the new hyperparameter's name to the old. 
- Made order enforcement during batch_reveals more lenient. 
- Added commit-reveal related events