### PR TITLE
Return StakeWeight from NeuronInfoLite::stake

### DIFF
--- a/pallets/subtensor/src/rpc_info/neuron_info.rs
+++ b/pallets/subtensor/src/rpc_info/neuron_info.rs
@@ -1,6 +1,5 @@
 use super::*;
 use frame_support::pallet_prelude::{Decode, Encode};
-use frame_support::storage::IterableStorageDoubleMap;
 extern crate alloc;
 use codec::Compact;
 
@@ -177,13 +176,8 @@ impl<T: Config> Pallet<T> {
         let last_update = Self::get_last_update_for_uid(netuid, uid);
         let validator_permit = Self::get_validator_permit_for_uid(netuid, uid);
 
-        let stake: Vec<(T::AccountId, Compact<u64>)> =
-            <Stake<T> as IterableStorageDoubleMap<T::AccountId, T::AccountId, u64>>::iter_prefix(
-                hotkey.clone(),
-            )
-            .map(|(coldkey, stake)| (coldkey, stake.into()))
-            .collect();
-
+        let stake_weight: u64 = Self::get_stake_weight(netuid, uid) as u64;
+        let stake: Vec<(T::AccountId, Compact<u64>)> = vec![(coldkey.clone(), stake_weight.into())];
         let neuron = NeuronInfoLite {
             hotkey: hotkey.clone(),
             coldkey: coldkey.clone(),


### PR DESCRIPTION
## Description

It just fixes `NeuronInfoLite::stake` to return `StakeWeight` instead of `Stake` (why it must be `StakeWeight` has discussed [here](https://github.com/opentensor/subtensor/pull/888#issuecomment-2448167230)).


## Type of Change
<!--
Please check the relevant options:
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):


## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
