### PR TITLE
alice default port from 9946 to 9944 (for devnet-ready)

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -160,7 +160,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 204,
+    spec_version: 205,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -160,7 +160,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 203,
+    spec_version: 204,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/scripts/localnet.sh
+++ b/scripts/localnet.sh
@@ -76,7 +76,7 @@ alice_start=(
   --chain="$FULL_PATH"
   --alice
   --port 30334
-  --rpc-port 9946
+  --rpc-port 9944
   --validator
   --rpc-cors=all
   --allow-private-ipv4


### PR DESCRIPTION
Related bittensor SDK PR https://github.com/opentensor/bittensor/pull/2376