### PR TITLE
feat: add evm stake netuid parameter

### DIFF
--- a/runtime/src/precompiles/solidity/staking.abi
+++ b/runtime/src/precompiles/solidity/staking.abi
@@ -5,6 +5,11 @@
                 "internalType": "bytes32",
                 "name": "hotkey",
                 "type": "bytes32"
+            },
+            {
+                "internalType": "uint16",
+                "name": "netuid",
+                "type": "uint16"
             }
         ],
         "name": "addStake",
@@ -23,6 +28,11 @@
                 "internalType": "uint256",
                 "name": "amount",
                 "type": "uint256"
+            },
+            {
+                "internalType": "uint16",
+                "name": "netuid",
+                "type": "uint16"
             }
         ],
         "name": "removeStake",

--- a/runtime/src/precompiles/solidity/staking.sol
+++ b/runtime/src/precompiles/solidity/staking.sol
@@ -3,40 +3,43 @@ pragma solidity ^0.8.0;
 address constant ISTAKING_ADDRESS = 0x0000000000000000000000000000000000000801;
 
 interface IStaking {
-    /**
-     * @dev Adds a subtensor stake corresponding to the value sent with the transaction, associated 
-     * with the `hotkey`.
-     * 
-     * This function allows external accounts and contracts to stake TAO into the subtensor pallet,
-     * which effectively calls `add_stake` on the subtensor pallet with specified hotkey as a parameter
-     * and coldkey being the hashed address mapping of H160 sender address to Substrate ss58 address as 
-     * implemented in Frontier HashedAddressMapping: 
-     * https://github.com/polkadot-evm/frontier/blob/2e219e17a526125da003e64ef22ec037917083fa/frame/evm/src/lib.rs#L739
-     * 
-     * @param hotkey The hotkey public key (32 bytes).
-     *
-     * Requirements:
-     * - `hotkey` must be a valid hotkey registered on the network, ensuring that the stake is 
-     *   correctly attributed.
-     */
-    function addStake(bytes32 hotkey) external payable;
+  /**
+   * @dev Adds a subtensor stake corresponding to the value sent with the transaction, associated
+   * with the `hotkey`.
+   *
+   * This function allows external accounts and contracts to stake TAO into the subtensor pallet,
+   * which effectively calls `add_stake` on the subtensor pallet with specified hotkey as a parameter
+   * and coldkey being the hashed address mapping of H160 sender address to Substrate ss58 address as
+   * implemented in Frontier HashedAddressMapping:
+   * https://github.com/polkadot-evm/frontier/blob/2e219e17a526125da003e64ef22ec037917083fa/frame/evm/src/lib.rs#L739
+   *
+   * @param hotkey The hotkey public key (32 bytes).
+   * @param netuid The subnet to stake to (uint16). Currently a noop, functionality will be enabled with RAO.
+   *
+   * Requirements:
+   * - `hotkey` must be a valid hotkey registered on the network, ensuring that the stake is
+   *   correctly attributed.
+   */
+  function addStake(bytes32 hotkey, uint16 netuid) external payable;
 
-    /**
-     * @dev Removes a subtensor stake `amount` from the specified `hotkey`.
-     * 
-     * This function allows external accounts and contracts to unstake TAO from the subtensor pallet,
-     * which effectively calls `remove_stake` on the subtensor pallet with specified hotkey as a parameter
-     * and coldkey being the hashed address mapping of H160 sender address to Substrate ss58 address as 
-     * implemented in Frontier HashedAddressMapping: 
-     * https://github.com/polkadot-evm/frontier/blob/2e219e17a526125da003e64ef22ec037917083fa/frame/evm/src/lib.rs#L739
-     * 
-     * @param hotkey The hotkey public key (32 bytes).
-     * @param amount The amount to unstake in rao.
-     *
-     * Requirements:
-     * - `hotkey` must be a valid hotkey registered on the network, ensuring that the stake is 
-     *   correctly attributed.
-     * - The existing stake amount must be not lower than specified amount
-     */
-    function removeStake(bytes32 hotkey, uint256 amount) external;
+  /**
+   * @dev Removes a subtensor stake `amount` from the specified `hotkey`.
+   *
+   * This function allows external accounts and contracts to unstake TAO from the subtensor pallet,
+   * which effectively calls `remove_stake` on the subtensor pallet with specified hotkey as a parameter
+   * and coldkey being the hashed address mapping of H160 sender address to Substrate ss58 address as
+   * implemented in Frontier HashedAddressMapping:
+   * https://github.com/polkadot-evm/frontier/blob/2e219e17a526125da003e64ef22ec037917083fa/frame/evm/src/lib.rs#L739
+   *
+   * @param hotkey The hotkey public key (32 bytes).
+   * @param amount The amount to unstake in rao.
+   * @param netuid The subnet to stake to (uint16). Currently a noop, functionality will be enabled with RAO.
+
+   *
+   * Requirements:
+   * - `hotkey` must be a valid hotkey registered on the network, ensuring that the stake is
+   *   correctly attributed.
+   * - The existing stake amount must be not lower than specified amount
+   */
+  function removeStake(bytes32 hotkey, uint256 amount, uint16 netuid) external;
 }

--- a/runtime/src/precompiles/staking.rs
+++ b/runtime/src/precompiles/staking.rs
@@ -53,10 +53,10 @@ impl StakingPrecompile {
             .map_or_else(vec::Vec::new, |slice| slice.to_vec()); // Avoiding borrowing conflicts
 
         match method_id {
-            id if id == get_method_id("addStake(bytes32)") => {
+            id if id == get_method_id("addStake(bytes32,uint16)") => {
                 Self::add_stake(handle, &method_input)
             }
-            id if id == get_method_id("removeStake(bytes32,uint256)") => {
+            id if id == get_method_id("removeStake(bytes32,uint256,uint16)") => {
                 Self::remove_stake(handle, &method_input)
             }
             _ => Err(PrecompileFailure::Error {


### PR DESCRIPTION
Partial: https://github.com/opentensor/subtensor/issues/856

For the stake of simplicity, I made the netuid param a noop instead of forcing it to zero. 