### PR TITLE
Add key swaps & set_children to proxies

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -160,7 +160,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 206,
+    spec_version: 207,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -663,6 +663,10 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
                     | RuntimeCall::SubtensorModule(pallet_subtensor::Call::remove_stake { .. })
                     | RuntimeCall::SubtensorModule(pallet_subtensor::Call::burned_register { .. })
                     | RuntimeCall::SubtensorModule(pallet_subtensor::Call::root_register { .. })
+                    | RuntimeCall::SubtensorModule(
+                        pallet_subtensor::Call::schedule_swap_coldkey { .. }
+                    )
+                    | RuntimeCall::SubtensorModule(pallet_subtensor::Call::swap_hotkey { .. })
             ),
             ProxyType::Transfer => matches!(
                 c,
@@ -704,6 +708,7 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
                 c,
                 RuntimeCall::SubtensorModule(pallet_subtensor::Call::add_stake { .. })
                     | RuntimeCall::SubtensorModule(pallet_subtensor::Call::remove_stake { .. })
+                    | RuntimeCall::SubtensorModule(pallet_subtensor::Call::set_children { .. })
             ),
             ProxyType::Registration => matches!(
                 c,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -160,7 +160,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 207,
+    spec_version: 208,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,
@@ -645,7 +645,6 @@ pub enum ProxyType {
     RootWeights,
     ChildKeys,
     SudoUncheckedSetCode,
-
 }
 // Transfers below SMALL_TRANSFER_LIMIT are considered small transfers
 pub const SMALL_TRANSFER_LIMIT: Balance = 500_000_000; // 0.5 TAO

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -643,6 +643,7 @@ pub enum ProxyType {
     Transfer,
     SmallTransfer,
     RootWeights,
+    ChildKeys,
 }
 // Transfers below SMALL_TRANSFER_LIMIT are considered small transfers
 pub const SMALL_TRANSFER_LIMIT: Balance = 500_000_000; // 0.5 TAO
@@ -708,7 +709,6 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
                 c,
                 RuntimeCall::SubtensorModule(pallet_subtensor::Call::add_stake { .. })
                     | RuntimeCall::SubtensorModule(pallet_subtensor::Call::remove_stake { .. })
-                    | RuntimeCall::SubtensorModule(pallet_subtensor::Call::set_children { .. })
             ),
             ProxyType::Registration => matches!(
                 c,
@@ -718,6 +718,10 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
             ProxyType::RootWeights => matches!(
                 c,
                 RuntimeCall::SubtensorModule(pallet_subtensor::Call::set_root_weights { .. })
+            ),
+            ProxyType::ChildKeys => matches!(
+                c,
+                RuntimeCall::SubtensorModule(pallet_subtensor::Call::set_children { .. })
             ),
         }
     }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -722,6 +722,9 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
             ProxyType::ChildKeys => matches!(
                 c,
                 RuntimeCall::SubtensorModule(pallet_subtensor::Call::set_children { .. })
+                    | RuntimeCall::SubtensorModule(
+                        pallet_subtensor::Call::set_childkey_take { .. }
+                    )
             ),
         }
     }


### PR DESCRIPTION
## Description

Adds 
- `schedule_swap_coldkey` and `swap_hotkey` to the `NonFungibile` proxy type
-  `ChildKeys` ProxyType 
- `set_children` & `set_childkey_take` to the `ChildKeys` ProxyType.


## Related Issue(s)

- Closes #909

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):