### PR TITLE
Lint `ForbidKeysRemoveCall`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -60,6 +60,7 @@ fn main() {
         };
 
         track_lint(ForbidAsPrimitiveConversion::lint(&parsed_file));
+        track_lint(ForbidKeysRemoveCall::lint(&parsed_file));
         track_lint(RequireFreezeStruct::lint(&parsed_file));
         track_lint(RequireExplicitPalletIndex::lint(&parsed_file));
     });

--- a/pallets/subtensor/src/subnets/uids.rs
+++ b/pallets/subtensor/src/subnets/uids.rs
@@ -29,6 +29,7 @@ impl<T: Config> Pallet<T> {
         // 2. Remove previous set memberships.
         Uids::<T>::remove(netuid, old_hotkey.clone());
         IsNetworkMember::<T>::remove(old_hotkey.clone(), netuid);
+        #[allow(unknown_lints)]
         Keys::<T>::remove(netuid, uid_to_replace);
 
         // 2a. Check if the uid is registered in any other subnetworks.

--- a/support/linting/src/forbid_as_primitive.rs
+++ b/support/linting/src/forbid_as_primitive.rs
@@ -45,10 +45,11 @@ fn is_as_primitive(ident: &Ident) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use quote::quote;
 
-    fn lint(input: &str) -> Result {
-        let expr: ExprMethodCall = syn::parse_str(input).expect("should only use on a method call");
+    fn lint(input: proc_macro2::TokenStream) -> Result {
         let mut visitor = AsPrimitiveVisitor::default();
+        let expr: ExprMethodCall = syn::parse2(input).expect("should be a valid method call");
         visitor.visit_expr_method_call(&expr);
         if !visitor.errors.is_empty() {
             return Err(visitor.errors);
@@ -58,21 +59,21 @@ mod tests {
 
     #[test]
     fn test_as_primitives() {
-        let input = r#"x.as_u32()"#;
+        let input = quote! {x.as_u32() };
         assert!(lint(input).is_err());
-        let input = r#"x.as_u64()"#;
+        let input = quote! {x.as_u64() };
         assert!(lint(input).is_err());
-        let input = r#"x.as_u128()"#;
+        let input = quote! {x.as_u128() };
         assert!(lint(input).is_err());
-        let input = r#"x.as_usize()"#;
+        let input = quote! {x.as_usize() };
         assert!(lint(input).is_err());
     }
 
     #[test]
     fn test_non_as_primitives() {
-        let input = r#"x.as_ref()"#;
+        let input = quote! {x.as_ref() };
         assert!(lint(input).is_ok());
-        let input = r#"x.as_slice()"#;
+        let input = quote! {x.as_slice() };
         assert!(lint(input).is_ok());
     }
 }

--- a/support/linting/src/forbid_keys_remove.rs
+++ b/support/linting/src/forbid_keys_remove.rs
@@ -1,7 +1,7 @@
 use super::*;
 use syn::{
     punctuated::Punctuated, spanned::Spanned, token::Comma, visit::Visit, Expr, ExprCall, ExprPath,
-    File,
+    File, Path,
 };
 
 pub struct ForbidKeysRemoveCall;
@@ -26,25 +26,30 @@ struct KeysRemoveVisitor {
 
 impl<'ast> Visit<'ast> for KeysRemoveVisitor {
     fn visit_expr_call(&mut self, node: &'ast syn::ExprCall) {
-        let ExprCall { func, args, .. } = node;
-        if is_keys_remove_call(func, args) {
+        let ExprCall {
+            func, args, attrs, ..
+        } = node;
+
+        if is_keys_remove_call(func, args) && !is_allowed(attrs) {
             let msg = "Keys::<T>::remove()` is banned to prevent accidentally breaking \
-                the neuron sequence. If you need to replace neuron, try `SubtensorModule::replace_neuron()`";
+                the neuron sequence. If you need to replace neurons, try `SubtensorModule::replace_neuron()`";
             self.errors.push(syn::Error::new(node.func.span(), msg));
         }
     }
 }
 
 fn is_keys_remove_call(func: &Expr, args: &Punctuated<Expr, Comma>) -> bool {
-    let Expr::Path(ExprPath { path, .. }) = func else {
+    let Expr::Path(ExprPath {
+        path: Path { segments: func, .. },
+        ..
+    }) = func
+    else {
         return false;
     };
-    let func = &path.segments;
-    if func.len() != 2 || args.len() != 2 {
-        return false;
-    }
 
-    func[0].ident == "Keys"
+    func.len() == 2
+        && args.len() == 2
+        && func[0].ident == "Keys"
         && !func[0].arguments.is_none()
         && func[1].ident == "remove"
         && func[1].arguments.is_none()
@@ -89,6 +94,25 @@ mod tests {
         let input = r#"ParentKeys::remove(netuid, uid_to_replace)"#;
         assert!(lint(input).is_ok());
         let input = r#"ChildKeys::<T>::remove(netuid, uid_to_replace)"#;
+        assert!(lint(input).is_ok());
+    }
+
+    #[test]
+    fn test_keys_remove_allowed() {
+        let input = r#"
+        #[allow(unknown_lints)]
+        Keys::<T>::remove(netuid, uid_to_replace)
+        "#;
+        assert!(lint(input).is_ok());
+        let input = r#"
+        #[allow(unknown_lints)]
+        Keys::<U>::remove(netuid, uid_to_replace)
+        "#;
+        assert!(lint(input).is_ok());
+        let input = r#"
+        #[allow(unknown_lints)]
+        Keys::<U>::remove(1, "2".parse().unwrap(),)
+        "#;
         assert!(lint(input).is_ok());
     }
 }

--- a/support/linting/src/forbid_keys_remove.rs
+++ b/support/linting/src/forbid_keys_remove.rs
@@ -1,0 +1,94 @@
+use super::*;
+use syn::{
+    punctuated::Punctuated, spanned::Spanned, token::Comma, visit::Visit, Expr, ExprCall, ExprPath,
+    File,
+};
+
+pub struct ForbidKeysRemoveCall;
+
+impl Lint for ForbidKeysRemoveCall {
+    fn lint(source: &File) -> Result {
+        let mut visitor = KeysRemoveVisitor::default();
+        visitor.visit_file(source);
+
+        if visitor.errors.is_empty() {
+            Ok(())
+        } else {
+            Err(visitor.errors)
+        }
+    }
+}
+
+#[derive(Default)]
+struct KeysRemoveVisitor {
+    errors: Vec<syn::Error>,
+}
+
+impl<'ast> Visit<'ast> for KeysRemoveVisitor {
+    fn visit_expr_call(&mut self, node: &'ast syn::ExprCall) {
+        let ExprCall { func, args, .. } = node;
+        if is_keys_remove_call(func, args) {
+            let msg = "Keys::<T>::remove()` is banned to prevent accidentally breaking \
+                the neuron sequence. If you need to replace neuron, try `SubtensorModule::replace_neuron()`";
+            self.errors.push(syn::Error::new(node.func.span(), msg));
+        }
+    }
+}
+
+fn is_keys_remove_call(func: &Expr, args: &Punctuated<Expr, Comma>) -> bool {
+    let Expr::Path(ExprPath { path, .. }) = func else {
+        return false;
+    };
+    let func = &path.segments;
+    if func.len() != 2 || args.len() != 2 {
+        return false;
+    }
+
+    func[0].ident == "Keys"
+        && !func[0].arguments.is_none()
+        && func[1].ident == "remove"
+        && func[1].arguments.is_none()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lint(input: &str) -> Result {
+        let mut visitor = KeysRemoveVisitor::default();
+        visitor
+            .visit_expr_call(&syn::parse_str(input).expect("should only use on a function call"));
+
+        if visitor.errors.is_empty() {
+            Ok(())
+        } else {
+            Err(visitor.errors)
+        }
+    }
+
+    #[test]
+    fn test_keys_remove_forbidden() {
+        let input = r#"Keys::<T>::remove(netuid, uid_to_replace)"#;
+        assert!(lint(input).is_err());
+        let input = r#"Keys::<U>::remove(netuid, uid_to_replace)"#;
+        assert!(lint(input).is_err());
+        let input = r#"Keys::<U>::remove(1, "2".parse().unwrap(),)"#;
+        assert!(lint(input).is_err());
+    }
+
+    #[test]
+    fn test_non_keys_remove_not_forbidden() {
+        let input = r#"remove(netuid, uid_to_replace)"#;
+        assert!(lint(input).is_ok());
+        let input = r#"Keys::remove(netuid, uid_to_replace)"#;
+        assert!(lint(input).is_ok());
+        let input = r#"Keys::<T>::remove::<U>(netuid, uid_to_replace)"#;
+        assert!(lint(input).is_ok());
+        let input = r#"Keys::<T>::remove(netuid, uid_to_replace, third_wheel)"#;
+        assert!(lint(input).is_ok());
+        let input = r#"ParentKeys::remove(netuid, uid_to_replace)"#;
+        assert!(lint(input).is_ok());
+        let input = r#"ChildKeys::<T>::remove(netuid, uid_to_replace)"#;
+        assert!(lint(input).is_ok());
+    }
+}

--- a/support/linting/src/lib.rs
+++ b/support/linting/src/lib.rs
@@ -2,9 +2,11 @@ pub mod lint;
 pub use lint::*;
 
 mod forbid_as_primitive;
+mod forbid_keys_remove;
 mod pallet_index;
 mod require_freeze_struct;
 
 pub use forbid_as_primitive::ForbidAsPrimitiveConversion;
+pub use forbid_keys_remove::ForbidKeysRemoveCall;
 pub use pallet_index::RequireExplicitPalletIndex;
 pub use require_freeze_struct::RequireFreezeStruct;


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
Add a custom lint to forbid `Keys::<T>::remove()`

## Related Issue(s)

- Closes #915 

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please describe): lint