### PR TITLE
fix do_set_weights to use commit_block in commit reveal

### DIFF
--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -83,7 +83,15 @@ mod dispatches {
             version_key: u64,
         ) -> DispatchResult {
             if !Self::get_commit_reveal_weights_enabled(netuid) {
-                return Self::do_set_weights(origin, netuid, dests, weights, version_key);
+                let current_block: u64 = Self::get_current_block_as_u64();
+                return Self::do_set_weights(
+                    origin,
+                    netuid,
+                    dests,
+                    weights,
+                    version_key,
+                    current_block,
+                );
             }
 
             Err(Error::<T>::CommitRevealEnabled.into())

--- a/pallets/subtensor/tests/weights.rs
+++ b/pallets/subtensor/tests/weights.rs
@@ -1554,6 +1554,7 @@ fn test_commit_reveal_tempo_interval() {
             ),
             Error::<Test>::NoWeightsCommitFound
         );
+        assert_eq!(SubtensorModule::get_last_update(netuid)[1], 0);
 
         assert_ok!(SubtensorModule::commit_weights(
             RuntimeOrigin::signed(hotkey),
@@ -1575,6 +1576,7 @@ fn test_commit_reveal_tempo_interval() {
             ),
             Error::<Test>::ExpiredWeightCommit
         );
+        assert_eq!(SubtensorModule::get_last_update(netuid)[1], 105);
 
         assert_ok!(SubtensorModule::commit_weights(
             RuntimeOrigin::signed(hotkey),
@@ -1595,6 +1597,7 @@ fn test_commit_reveal_tempo_interval() {
             ),
             Error::<Test>::RevealTooEarly
         );
+        assert_eq!(SubtensorModule::get_last_update(netuid)[1], 301);
 
         step_epochs(1, netuid);
 
@@ -1606,6 +1609,7 @@ fn test_commit_reveal_tempo_interval() {
             salt,
             version_key,
         ));
+        assert_eq!(SubtensorModule::get_last_update(netuid)[1], 301);
     });
 }
 


### PR DESCRIPTION
## Description
Currently, do_set_weights sets last updated block to the current (reveal) block - this should be set to the weights commit block.
If not fixed, for concealment period > 1 tempo, the current implementation will unjustly distribute incentive whenever an uid re-registers between the commit and reveal block

## Related Issue(s)
N/A

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
