### PR TITLE
lower faucet diff to 100 on fast-blocks

### DIFF
--- a/pallets/subtensor/Cargo.toml
+++ b/pallets/subtensor/Cargo.toml
@@ -116,3 +116,4 @@ try-runtime = [
 	"pallet-collective/try-runtime"
 ]
 pow-faucet = []
+fast-blocks = []

--- a/pallets/subtensor/src/subnets/registration.rs
+++ b/pallets/subtensor/src/subnets/registration.rs
@@ -381,7 +381,12 @@ impl<T: Config> Pallet<T> {
         );
 
         // --- 3. Ensure the supplied work passes the difficulty.
-        let difficulty: U256 = U256::from(1_000); // Base faucet difficulty.
+        if !cfg!(feature = "fast-blocks") {
+            let difficulty: U256 = U256::from(1_000_000); // Base faucet difficulty.
+        } else {
+            let difficulty: U256 = U256::from(100); // Lowered for fast blocks
+        }
+
         let work_hash: H256 = Self::vec_to_hash(work.clone());
         ensure!(
             Self::hash_meets_difficulty(&work_hash, difficulty),

--- a/pallets/subtensor/src/subnets/registration.rs
+++ b/pallets/subtensor/src/subnets/registration.rs
@@ -381,7 +381,7 @@ impl<T: Config> Pallet<T> {
         );
 
         // --- 3. Ensure the supplied work passes the difficulty.
-        let difficulty: U256 = U256::from(1_000_000); // Base faucet difficulty.
+        let difficulty: U256 = U256::from(1_000); // Base faucet difficulty.
         let work_hash: H256 = Self::vec_to_hash(work.clone());
         ensure!(
             Self::hash_meets_difficulty(&work_hash, difficulty),

--- a/pallets/subtensor/src/subnets/registration.rs
+++ b/pallets/subtensor/src/subnets/registration.rs
@@ -381,11 +381,11 @@ impl<T: Config> Pallet<T> {
         );
 
         // --- 3. Ensure the supplied work passes the difficulty.
-        if !cfg!(feature = "fast-blocks") {
-            let difficulty: U256 = U256::from(1_000_000); // Base faucet difficulty.
+        let difficulty: U256 = if !cfg!(feature = "fast-blocks") {
+            U256::from(1_000_000) // Base faucet difficulty.
         } else {
-            let difficulty: U256 = U256::from(100); // Lowered for fast blocks
-        }
+            U256::from(100) // Lowered for fast blocks
+        };
 
         let work_hash: H256 = Self::vec_to_hash(work.clone());
         ensure!(

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -122,7 +122,9 @@ substrate-wasm-builder = { workspace = true, optional = true }
 [features]
 default = ["std"]
 pow-faucet = ["pallet-subtensor/pow-faucet"]
-fast-blocks = []
+fast-blocks = [
+	"pallet-subtensor/fast-blocks"
+]
 std = [
 	"frame-try-runtime?/std",
 	"frame-system-benchmarking?/std",


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
This PR lowers the faucet diff to `100` if the feature flag of `fast-blocks` is used. 
This allows the faucet to be used during e2e tests, etc., which use the `fast-blocks` flag and would be 
impacted by the faucet POW taking too long. 

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
