### PR TITLE
add bot warning when posting a hotfix PR

### DIFF
--- a/.github/workflows/hotfixes.yml
+++ b/.github/workflows/hotfixes.yml
@@ -38,7 +38,7 @@ jobs:
           COMMENT_BODY=$(cat <<EOF
           ## 🚨🚨🚨 HOTFIX DETECTED 🚨🚨🚨
 
-          It looks like you are trying to merge a hotfix PR into \`main\`. If this isn't what you wanted to do, and you just wanted to make a regular PR, please close this PR, base your changes off the \`devnet-ready\` branch and open a new PR into \`devnet ready\`.
+          It looks like you are trying to merge a hotfix PR into `main`. If this isn't what you wanted to do, and you just wanted to make a regular PR, please close this PR, base your changes off the `devnet-ready` branch and open a new PR into `devnet ready`.
 
           If you _are_ trying to merge a hotfix PR, please complete the following essential steps:
           1. [ ] go ahead and get this PR into `main` merged, so we can get the change in as quickly as possible!

--- a/.github/workflows/hotfixes.yml
+++ b/.github/workflows/hotfixes.yml
@@ -1,0 +1,62 @@
+name: Handle Hotfix PRs
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  handle-hotfix-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PR is a hotfix into `main`
+        if: >
+          github.event.pull_request.base.ref == 'main' &&
+          github.event.pull_request.head.ref != 'testnet'
+        run: |
+          echo "Hotfix PR detected. Proceeding to label and comment."
+
+      - name: Add `hotfix` label
+        if: >
+          github.event.pull_request.base.ref == 'main' &&
+          github.event.pull_request.head.ref != 'testnet'
+        run: |
+          curl -X POST \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels \
+          -d '{"labels":["hotfix"]}'
+
+      - name: Add hotfix bot comment
+        if: >
+          github.event.pull_request.base.ref == 'main' &&
+          github.event.pull_request.head.ref != 'testnet'
+        run: |
+          COMMENT_BODY=$(cat <<EOF
+          ## 🚨🚨🚨 HOTFIX DETECTED 🚨🚨🚨
+
+          It looks like you are trying to merge a hotfix PR into \`main\`. If this isn't what you wanted to do, and you just wanted to make a regular PR, please close this PR, base your changes off the \`devnet-ready\` branch and open a new PR into \`devnet ready\`.
+
+          If you _are_ trying to merge a hotfix PR, please complete the following essential steps:
+          1. [ ] go ahead and get this PR into `main` merged, so we can get the change in as quickly as possible!
+          2. [ ] merge `main` into `testnet`, bumping `spec_version`
+          3. [ ] deploy `testnet`
+          4. [ ] merge `testnet` into `devnet`, bumping `spec_version`
+          5. [ ] deploy `devnet`
+          6. [ ] merge `devnet` into `devnet-ready`
+
+
+          If you do not complete these steps, your hotfix may be inadvertently removed in the future when branches are promoted to \`main\`, so it is essential that you do so.
+          EOF
+          )
+
+          curl -X POST \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+          -d "$(jq -n --arg body "$COMMENT_BODY" '{body: $body}')"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Warning looks like this:

## 🚨🚨🚨 HOTFIX DETECTED 🚨🚨🚨

It looks like you are trying to merge a hotfix PR into `main`. If this isn't what you wanted to do, and you just wanted to make a regular PR, please close this PR, base your changes off the `devnet-ready` branch and open a new PR into `devnet ready`.


If you _are_ trying to merge a hotfix PR, please complete the following essential steps:
1. [ ] go ahead and get this PR into `main` merged, so we can get the change in as quickly as possible!
2. [ ] merge `main` into `testnet`, bumping `spec_version`
3. [ ] deploy `testnet`
4. [ ] merge `testnet` into `devnet`, bumping `spec_version`
5. [ ] deploy `devnet`
6. [ ] merge `devnet` into `devnet-ready`


If you do not complete these steps, your hotfix may be inadvertently removed in the future when branches are promoted to \`main\`, so it is essential that you do so.