### PR TITLE
Fix dev flag

### DIFF
--- a/node/src/chain_spec/localnet.rs
+++ b/node/src/chain_spec/localnet.rs
@@ -3,7 +3,7 @@
 
 use super::*;
 
-pub fn localnet_config() -> Result<ChainSpec, String> {
+pub fn localnet_config(single_authority: bool) -> Result<ChainSpec, String> {
     let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;
 
     // Give front-ends necessary data to present to users
@@ -32,11 +32,15 @@ pub fn localnet_config() -> Result<ChainSpec, String> {
     .with_genesis_config_patch(localnet_genesis(
         // Initial PoA authorities (Validators)
         // aura | grandpa
-        vec![
-            // Keys for debug
-            authority_keys_from_seed("Alice"),
-            authority_keys_from_seed("Bob"),
-        ],
+        if single_authority {
+            // single authority allows you to run the network using a single node
+            vec![authority_keys_from_seed("Alice")]
+        } else {
+            vec![
+                authority_keys_from_seed("Alice"),
+                authority_keys_from_seed("Bob"),
+            ]
+        },
         // Pre-funded accounts
         true,
     ))

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -41,7 +41,8 @@ impl SubstrateCli for Cli {
 
     fn load_spec(&self, id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
         Ok(match id {
-            "local" => Box::new(chain_spec::localnet::localnet_config()?),
+            "dev" => Box::new(chain_spec::localnet::localnet_config(true)?),
+            "local" => Box::new(chain_spec::localnet::localnet_config(false)?),
             "finney" => Box::new(chain_spec::finney::finney_mainnet_config()?),
             "devnet" => Box::new(chain_spec::devnet::devnet_config()?),
             "" | "test_finney" => Box::new(chain_spec::testnet::finney_testnet_config()?),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -160,7 +160,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 208,
+    spec_version: 209,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description

Simplifies running `localnet`, by fixing the `--dev` flag. With this flag, `localnet` will run with a single authority, so no need for multiple nodes to be running to produce blocks.


## Related Issue(s)

- Closes #881 

## Type of Change
<!--
Please check the relevant options:
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
