### PR TITLE
fix EVM <=> TAO balance transfer precision

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -36,7 +36,7 @@ jobs:
           key: ubuntu-latest-${{ env.RUST_BIN_DIR }}
 
       - name: Install cargo-audit
-        run: cargo install --version 0.20.1 cargo-audit
+        run: cargo install --version 0.20.1 --force cargo-audit
 
       - name: cargo audit
         run: cargo audit --ignore RUSTSEC-2024-0336 # rustls issue; wait for upstream to resolve this

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -23,13 +23,6 @@ jobs:
           sudo apt-get update &&
           sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
 
-      - name: Install Rust Stable
-        uses: actions-rs/toolchain@v1.0.6
-        with:
-          toolchain: stable
-          components: rustfmt, clippy
-          profile: minimal
-
       - name: Install cargo-audit
         run: cargo install --version 0.20.1 --force cargo-audit
 

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -38,5 +38,8 @@ jobs:
       - name: Install cargo-audit
         run: cargo install --version 0.20.1 --force cargo-audit
 
+      - name: Display cargo-audit --version
+        run: cargo audit --version
+
       - name: cargo audit
         run: cargo audit --ignore RUSTSEC-2024-0336 # rustls issue; wait for upstream to resolve this

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -30,11 +30,6 @@ jobs:
           components: rustfmt, clippy
           profile: minimal
 
-      - name: Utilize Shared Rust Cache
-        uses: Swatinem/rust-cache@v2.2.1
-        with:
-          key: ubuntu-latest-${{ env.RUST_BIN_DIR }}
-
       - name: Install cargo-audit
         run: cargo install --version 0.20.1 --force cargo-audit
 

--- a/.github/workflows/check-devnet.yml
+++ b/.github/workflows/check-devnet.yml
@@ -20,9 +20,6 @@ jobs:
           sudo apt-get install -y curl clang curl libssl-dev llvm \
                                   libudev-dev protobuf-compiler
 
-      - name: Set up Rust Toolchain
-        run: curl https://sh.rustup.rs -sSf | sh -s -- -y
-
       - name: Install substrate-spec-version
         run: cargo install substrate-spec-version
 

--- a/.github/workflows/check-finney.yml
+++ b/.github/workflows/check-finney.yml
@@ -20,9 +20,6 @@ jobs:
           sudo apt-get install -y curl clang curl libssl-dev llvm \
                                   libudev-dev protobuf-compiler
 
-      - name: Set up Rust Toolchain
-        run: curl https://sh.rustup.rs -sSf | sh -s -- -y
-
       - name: Install substrate-spec-version
         run: cargo install substrate-spec-version
 

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -43,9 +43,7 @@ jobs:
     env:
       RELEASE_NAME: development
       # RUSTFLAGS: -A warnings
-      RUSTV: ${{ matrix.rust-branch }}
       RUST_BACKTRACE: full
-      RUST_BIN_DIR: target/${{ matrix.rust-target }}
       SKIP_WASM_BUILD: 1
       TARGET: ${{ matrix.rust-target }}
     steps:
@@ -55,10 +53,10 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential
 
-      - name: Install Rust ${{ matrix.rust-branch }}
+      - name: Install Rust Nightly
         uses: actions-rs/toolchain@v1.0.6
         with:
-          toolchain: ${{ matrix.rust-branch }}
+          toolchain: nightly
           components: rustfmt
           profile: minimal
 
@@ -84,11 +82,10 @@ jobs:
     env:
       RELEASE_NAME: development
       # RUSTFLAGS: -A warnings
-      RUSTV: ${{ matrix.rust-branch }}
       RUST_BACKTRACE: full
-      RUST_BIN_DIR: target/${{ matrix.rust-target }}
       SKIP_WASM_BUILD: 1
       TARGET: ${{ matrix.rust-target }}
+      RUST_BIN_DIR: target/${{ matrix.rust-target }}
     steps:
       - name: Check-out repository under $GITHUB_WORKSPACE
         uses: actions/checkout@v4
@@ -97,13 +94,6 @@ jobs:
         run: |
           sudo apt-get update &&
           sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
-
-      - name: Install Rust ${{ matrix.rust-branch }}
-        uses: actions-rs/toolchain@v1.0.6
-        with:
-          toolchain: ${{ matrix.rust-branch }}
-          components: rustfmt, clippy
-          profile: minimal
 
       - name: Utilize Shared Rust Cache
         uses: Swatinem/rust-cache@v2.2.1
@@ -128,12 +118,11 @@ jobs:
           # - macos-latest
     env:
       RELEASE_NAME: development
-      RUSTV: ${{ matrix.rust-branch }}
       RUSTFLAGS: -D warnings
       RUST_BACKTRACE: full
-      RUST_BIN_DIR: target/${{ matrix.rust-target }}
       SKIP_WASM_BUILD: 1
       TARGET: ${{ matrix.rust-target }}
+      RUST_BIN_DIR: target/${{ matrix.rust-target }}
     steps:
       - name: Check-out repository under $GITHUB_WORKSPACE
         uses: actions/checkout@v4
@@ -166,8 +155,6 @@ jobs:
     runs-on: SubtensorCI
     strategy:
       matrix:
-        rust-branch:
-          - stable
         rust-target:
           - x86_64-unknown-linux-gnu
           # - x86_64-apple-darwin
@@ -180,7 +167,6 @@ jobs:
     env:
       RELEASE_NAME: development
       # RUSTFLAGS: -A warnings
-      RUSTV: ${{ matrix.rust-branch }}
       RUST_BACKTRACE: full
       RUST_BIN_DIR: target/${{ matrix.rust-target }}
       SKIP_WASM_BUILD: 1
@@ -193,13 +179,6 @@ jobs:
         run: |
           sudo apt-get update &&
           sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
-
-      - name: Install Rust ${{ matrix.rust-branch }}
-        uses: actions-rs/toolchain@v1.0.6
-        with:
-          toolchain: ${{ matrix.rust-branch }}
-          components: rustfmt, clippy
-          profile: minimal
 
       - name: Utilize Shared Rust Cache
         uses: Swatinem/rust-cache@v2.2.1
@@ -215,8 +194,6 @@ jobs:
     runs-on: SubtensorCI
     strategy:
       matrix:
-        rust-branch:
-          - stable
         rust-target:
           - x86_64-unknown-linux-gnu
           # - x86_64-apple-darwin
@@ -229,7 +206,6 @@ jobs:
     env:
       RELEASE_NAME: development
       # RUSTFLAGS: -A warnings
-      RUSTV: ${{ matrix.rust-branch }}
       RUST_BACKTRACE: full
       RUST_BIN_DIR: target/${{ matrix.rust-target }}
       SKIP_WASM_BUILD: 1
@@ -242,13 +218,6 @@ jobs:
         run: |
           sudo apt-get update &&
           sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
-
-      - name: Install Rust ${{ matrix.rust-branch }}
-        uses: actions-rs/toolchain@v1.0.6
-        with:
-          toolchain: ${{ matrix.rust-branch }}
-          components: rustfmt, clippy
-          profile: minimal
 
       - name: Utilize Rust shared cached
         uses: Swatinem/rust-cache@v2.2.1
@@ -278,7 +247,6 @@ jobs:
     env:
       RELEASE_NAME: development
       # RUSTFLAGS: -A warnings
-      RUSTV: ${{ matrix.rust-branch }}
       RUST_BACKTRACE: full
       RUST_BIN_DIR: target/${{ matrix.rust-target }}
       SKIP_WASM_BUILD: 1
@@ -291,13 +259,6 @@ jobs:
         run: |
           sudo apt-get update &&
           sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
-
-      - name: Install Rust ${{ matrix.rust-branch }}
-        uses: actions-rs/toolchain@v1.0.6
-        with:
-          toolchain: ${{ matrix.rust-branch }}
-          components: rustfmt, clippy
-          profile: minimal
 
       - name: Utilize Rust shared cached
         uses: Swatinem/rust-cache@v2.2.1
@@ -322,12 +283,6 @@ jobs:
     runs-on: SubtensorCI
 
     steps:
-      - name: Install stable Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-
       - name: Install Zepter
         run: cargo install --locked -q zepter && zepter --version
 

--- a/.github/workflows/check-testnet.yml
+++ b/.github/workflows/check-testnet.yml
@@ -20,9 +20,6 @@ jobs:
           sudo apt-get install -y curl clang curl libssl-dev llvm \
                                   libudev-dev protobuf-compiler
 
-      - name: Set up Rust Toolchain
-        run: curl https://sh.rustup.rs -sSf | sh -s -- -y
-
       - name: Install substrate-spec-version
         run: cargo install substrate-spec-version
 

--- a/.github/workflows/try-runtime.yml
+++ b/.github/workflows/try-runtime.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: SubtensorCI
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run Try Runtime Checks
         uses: "paritytech/try-runtime-gha@v0.1.0"
@@ -29,7 +29,7 @@ jobs:
     runs-on: SubtensorCI
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run Try Runtime Checks
         uses: "paritytech/try-runtime-gha@v0.1.0"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1121,20 +1121,16 @@ const EVM_DECIMALS_FACTOR: u64 = 1_000_000_000_u64;
 pub struct SubtensorEvmBalanceConverter;
 
 impl BalanceConverter for SubtensorEvmBalanceConverter {
-    /// Convert from Substrate balance to EVM balance
     fn into_evm_balance(value: U256) -> Option<U256> {
-        // Scale up by EVM_DECIMALS_FACTOR, ensuring no overflow
         value.checked_mul(U256::from(EVM_DECIMALS_FACTOR))
     }
 
-    /// Convert from EVM balance to Substrate balance
     fn into_substrate_balance(value: U256) -> Option<U256> {
-        // Scale down by EVM_DECIMALS_FACTOR, truncating precision safely
         value
             .checked_div(U256::from(EVM_DECIMALS_FACTOR))
             .and_then(|substrate_value| {
-                // Ensure the result fits in Substrate's Balance type (u128)
-                if substrate_value <= U256::from(u128::MAX) {
+                // Ensure the result fits within the Subtensor Balance type (u64)
+                if substrate_value <= U256::from(u64::MAX) {
                     Some(substrate_value)
                 } else {
                     None

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1121,15 +1121,26 @@ const EVM_DECIMALS_FACTOR: u64 = 1_000_000_000_u64;
 pub struct SubtensorEvmBalanceConverter;
 
 impl BalanceConverter for SubtensorEvmBalanceConverter {
+    /// Convert from Substrate balance (u64) to EVM balance (U256)
     fn into_evm_balance(value: U256) -> Option<U256> {
-        value.checked_mul(U256::from(EVM_DECIMALS_FACTOR))
+        value
+            .checked_mul(U256::from(EVM_DECIMALS_FACTOR))
+            .and_then(|evm_value| {
+                // Ensure the result fits within the maximum U256 value
+                if evm_value <= U256::MAX {
+                    Some(evm_value)
+                } else {
+                    None
+                }
+            })
     }
 
+    /// Convert from EVM balance (U256) to Substrate balance (u64)
     fn into_substrate_balance(value: U256) -> Option<U256> {
         value
             .checked_div(U256::from(EVM_DECIMALS_FACTOR))
             .and_then(|substrate_value| {
-                // Ensure the result fits within the Subtensor Balance type (u64)
+                // Ensure the result fits within the TAO balance type (u64)
                 if substrate_value <= U256::from(u64::MAX) {
                     Some(substrate_value)
                 } else {
@@ -2008,9 +2019,6 @@ impl_runtime_apis! {
     }
 }
 
-// #[cfg(test)]
-// mod tests {
-
 #[test]
 fn check_whitelist() {
     use crate::*;
@@ -2033,4 +2041,72 @@ fn check_whitelist() {
     // System Events
     assert!(whitelist.contains("26aa394eea5630e07c48ae0c9558cef780d41e5e16056765bc8461851072c9d7"));
 }
-// }
+
+#[test]
+fn test_into_substrate_balance_valid() {
+    // Valid conversion within u64 range
+    let evm_balance = U256::from(1_000_000_000_000_000_000u128); // 1 TAO in EVM
+    let expected_substrate_balance = U256::from(1_000_000_000u128); // 1 TAO in Substrate
+
+    let result = SubtensorEvmBalanceConverter::into_substrate_balance(evm_balance);
+    assert_eq!(result, Some(expected_substrate_balance));
+}
+
+#[test]
+fn test_into_substrate_balance_large_value() {
+    // Maximum valid balance for u64
+    let evm_balance = U256::from(u64::MAX) * U256::from(EVM_DECIMALS_FACTOR); // Max u64 TAO in EVM
+    let expected_substrate_balance = U256::from(u64::MAX);
+
+    let result = SubtensorEvmBalanceConverter::into_substrate_balance(evm_balance);
+    assert_eq!(result, Some(expected_substrate_balance));
+}
+
+#[test]
+fn test_into_substrate_balance_exceeds_u64() {
+    // EVM balance that exceeds u64 after conversion
+    let evm_balance = (U256::from(u64::MAX) + U256::from(1)) * U256::from(EVM_DECIMALS_FACTOR);
+
+    let result = SubtensorEvmBalanceConverter::into_substrate_balance(evm_balance);
+    assert_eq!(result, None); // Exceeds u64, should return None
+}
+
+#[test]
+fn test_into_substrate_balance_precision_loss() {
+    // EVM balance with precision loss
+    let evm_balance = U256::from(1_000_000_000_123_456_789u128); // 1 TAO + extra precision in EVM
+    let expected_substrate_balance = U256::from(1_000_000_000u128); // Truncated to 1 TAO in Substrate
+
+    let result = SubtensorEvmBalanceConverter::into_substrate_balance(evm_balance);
+    assert_eq!(result, Some(expected_substrate_balance));
+}
+
+#[test]
+fn test_into_substrate_balance_zero_value() {
+    // Zero balance should convert to zero
+    let evm_balance = U256::from(0);
+    let expected_substrate_balance = U256::from(0);
+
+    let result = SubtensorEvmBalanceConverter::into_substrate_balance(evm_balance);
+    assert_eq!(result, Some(expected_substrate_balance));
+}
+
+#[test]
+fn test_into_evm_balance_valid() {
+    // Valid conversion from Substrate to EVM
+    let substrate_balance = U256::from(1_000_000_000u128); // 1 TAO in Substrate
+    let expected_evm_balance = U256::from(1_000_000_000_000_000_000u128); // 1 TAO in EVM
+
+    let result = SubtensorEvmBalanceConverter::into_evm_balance(substrate_balance);
+    assert_eq!(result, Some(expected_evm_balance));
+}
+
+#[test]
+fn test_into_evm_balance_overflow() {
+    // Substrate balance larger than u64::MAX but valid within U256
+    let substrate_balance = U256::from(u64::MAX) + U256::from(1); // Large balance
+    let expected_evm_balance = substrate_balance * U256::from(EVM_DECIMALS_FACTOR);
+
+    let result = SubtensorEvmBalanceConverter::into_evm_balance(substrate_balance);
+    assert_eq!(result, Some(expected_evm_balance)); // Should return the scaled value
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1119,7 +1119,6 @@ parameter_types! {
 const EVM_DECIMALS_FACTOR: u64 = 1_000_000_000_u64;
 
 pub struct SubtensorEvmBalanceConverter;
-pub struct SubtensorEvmBalanceConverter;
 
 impl BalanceConverter for SubtensorEvmBalanceConverter {
     /// Convert from Substrate balance to EVM balance

--- a/runtime/src/precompiles/balance_transfer.rs
+++ b/runtime/src/precompiles/balance_transfer.rs
@@ -42,7 +42,7 @@ impl BalanceTransferPrecompile {
                 (amount / U256::from(PRECISION_FACTOR))
                     .try_into()
                     .map_err(|_| {
-                        tracing::error!(
+                        log::error!(
                             "Failed to convert amount {:?} to substrate balance type",
                             amount
                         );

--- a/runtime/src/precompiles/balance_transfer.rs
+++ b/runtime/src/precompiles/balance_transfer.rs
@@ -28,7 +28,7 @@ impl BalanceTransferPrecompile {
             // Use BalanceConverter to convert EVM amount to Substrate balance
             let amount_sub =
                 <Runtime as pallet_evm::Config>::BalanceConverter::into_substrate_balance(amount)
-                    .ok_or_else(|| ExitError::OutOfFund)?;
+                    .ok_or(ExitError::OutOfFund)?;
 
             if amount_sub.is_zero() {
                 return Ok(PrecompileOutput {

--- a/runtime/src/precompiles/balance_transfer.rs
+++ b/runtime/src/precompiles/balance_transfer.rs
@@ -4,7 +4,7 @@ use pallet_evm::{
     PrecompileOutput, PrecompileResult,
 };
 use sp_core::U256;
-use sp_runtime::traits::Dispatchable;
+use sp_runtime::traits::{Dispatchable, UniqueSaturatedInto};
 use sp_std::vec;
 
 use crate::{Runtime, RuntimeCall};

--- a/runtime/src/precompiles/balance_transfer.rs
+++ b/runtime/src/precompiles/balance_transfer.rs
@@ -7,7 +7,7 @@ use sp_core::U256;
 use sp_runtime::traits::{Dispatchable, UniqueSaturatedInto};
 use sp_std::vec;
 
-use crate::{Runtime, RuntimeCall};
+use crate::{Balance, Runtime, RuntimeCall};
 
 use crate::precompiles::{bytes_to_account_id, get_method_id, get_slice};
 

--- a/runtime/src/precompiles/balance_transfer.rs
+++ b/runtime/src/precompiles/balance_transfer.rs
@@ -38,16 +38,16 @@ impl BalanceTransferPrecompile {
             }
 
             // Adjust `amount` to substrate balance type
-            let amount_sub: <Runtime as pallet_evm::Config>::Balance = (amount
-                / U256::from(PRECISION_FACTOR))
-            .try_into()
-            .map_err(|_| {
-                log::error!(
-                    "Failed to convert amount {:?} to substrate balance type",
-                    amount
-                );
-                ExitError::OutOfFund
-            })?;
+            let amount_sub: Balance =
+                (amount / U256::from(PRECISION_FACTOR))
+                    .try_into()
+                    .map_err(|_| {
+                        tracing::error!(
+                            "Failed to convert amount {:?} to substrate balance type",
+                            amount
+                        );
+                        ExitError::OutOfFund
+                    })?;
 
             if amount_sub == 0 {
                 return Ok(PrecompileOutput {

--- a/runtime/src/precompiles/balance_transfer.rs
+++ b/runtime/src/precompiles/balance_transfer.rs
@@ -31,7 +31,7 @@ impl BalanceTransferPrecompile {
             // Calculate remainder to detect precision loss
             let remainder = amount % U256::from(PRECISION_FACTOR);
             if remainder > U256::zero() {
-                tracing::warn!(
+                log::warn!(
                     "Precision loss detected during transfer: lost {:?} wei",
                     remainder
                 );
@@ -42,7 +42,7 @@ impl BalanceTransferPrecompile {
                 / U256::from(PRECISION_FACTOR))
             .try_into()
             .map_err(|_| {
-                tracing::error!(
+                log::error!(
                     "Failed to convert amount {:?} to substrate balance type",
                     amount
                 );


### PR DESCRIPTION
Previously, the EVM integration imposed a maximum transfer limit of 18.4 TAO to avoid precision loss when converting between EVM (18 decimals) and Substrate (9 decimals).

This update removes the transfer limit by truncating excess decimals from the least significant end during the conversion. As a result, large transfers are now allowed. Infinitesimally small amounts of WEI (less than the precision of TAO) are discarded during this process, and a log entry is generated whenever such precision loss occurs.

also includes some CI fixes:
* cargo audit version locked for now to prevent regressions of the Cargo.lock parsing issue
* don't need to install rustup because it is pre-installed with stable already installed