### PR TITLE
Add RPC API for getting rate limits information

### DIFF
--- a/node/src/client.rs
+++ b/node/src/client.rs
@@ -51,6 +51,7 @@ pub trait RuntimeApiCollection<
     + subtensor_custom_rpc_runtime_api::NeuronInfoRuntimeApi<Block>
     + subtensor_custom_rpc_runtime_api::SubnetInfoRuntimeApi<Block>
     + subtensor_custom_rpc_runtime_api::SubnetRegistrationRuntimeApi<Block>
+    + subtensor_custom_rpc_runtime_api::RateLimitInfoRuntimeApi<Block>
 {
 }
 
@@ -71,6 +72,7 @@ where
         + subtensor_custom_rpc_runtime_api::DelegateInfoRuntimeApi<Block>
         + subtensor_custom_rpc_runtime_api::NeuronInfoRuntimeApi<Block>
         + subtensor_custom_rpc_runtime_api::SubnetInfoRuntimeApi<Block>
-        + subtensor_custom_rpc_runtime_api::SubnetRegistrationRuntimeApi<Block>,
+        + subtensor_custom_rpc_runtime_api::SubnetRegistrationRuntimeApi<Block>
+        + subtensor_custom_rpc_runtime_api::RateLimitInfoRuntimeApi<Block>,
 {
 }

--- a/pallets/subtensor/runtime-api/src/lib.rs
+++ b/pallets/subtensor/runtime-api/src/lib.rs
@@ -30,11 +30,21 @@ sp_api::decl_runtime_apis! {
     }
 
     pub trait StakeInfoRuntimeApi {
-        fn get_stake_info_for_coldkey( coldkey_account_vec: Vec<u8> ) -> Vec<u8>;
-        fn get_stake_info_for_coldkeys( coldkey_account_vecs: Vec<Vec<u8>> ) -> Vec<u8>;
+        fn get_stake_info_for_coldkey(coldkey_account_vec: Vec<u8>) -> Vec<u8>;
+        fn get_stake_info_for_coldkeys(coldkey_account_vecs: Vec<Vec<u8>>) -> Vec<u8>;
     }
 
     pub trait SubnetRegistrationRuntimeApi {
         fn get_network_registration_cost() -> u64;
+    }
+
+    /// API for getting transaction rate limits associated with coldkeys and hotkeys.
+    pub trait RateLimitInfoRuntimeApi {
+        /// Get transactions rate limits.
+        fn get_rate_limits() -> Vec<u8>;
+        /// Get transaction rate limits associated with the `hotkey`.
+        fn get_limited_tx_info_for_hotkey(hotkey: Vec<u8>, netuid: u16) -> Vec<u8>;
+        /// Get number of stakes associated with coldkey/hotkey pair, made during `StakeInterval`.
+        fn get_stakes_this_interval(coldkey: Vec<u8>, hotkey: Vec<u8>) -> u64;
     }
 }

--- a/pallets/subtensor/src/rpc_info/mod.rs
+++ b/pallets/subtensor/src/rpc_info/mod.rs
@@ -2,6 +2,7 @@ use super::*;
 pub mod delegate_info;
 pub mod dynamic_info;
 pub mod neuron_info;
+pub mod rate_limit_info;
 pub mod show_subnet;
 pub mod stake_info;
 pub mod subnet_info;

--- a/pallets/subtensor/src/rpc_info/rate_limit_info.rs
+++ b/pallets/subtensor/src/rpc_info/rate_limit_info.rs
@@ -1,14 +1,14 @@
-//! API for getting transaction rate limits associated with coldkeys and hotkeys.
-
+//! API for getting rate-limited transactions info.
 use codec::Compact;
 use frame_support::pallet_prelude::{Decode, Encode};
 
 use crate::{
-    utils::rate_limiting::TransactionType, Config, Pallet, TargetStakesPerInterval, TxRateLimit,
+    freeze_struct, utils::rate_limiting::TransactionType, Config, Pallet, TargetStakesPerInterval,
+    TxRateLimit,
 };
 
 /// Transaction rate limits.
-// #[freeze_struct("fe79d58173da662a")]
+#[freeze_struct("e3734bd0690f2da8")]
 #[derive(Decode, Encode, Clone, Debug)]
 pub struct RateLimits {
     transaction: Compact<u64>,
@@ -18,7 +18,7 @@ pub struct RateLimits {
 }
 
 /// Contains last blocks, when rate-limited transactions was evaluated.
-// #[freeze_struct("fe79d58173da662a")]
+#[freeze_struct("9154106cd720ce08")]
 #[derive(Decode, Encode, Clone, Debug)]
 pub struct HotkeyLimitedTxInfo<AccountId> {
     hotkey: AccountId,
@@ -48,7 +48,7 @@ impl<T: Config> Pallet<T> {
             Self::get_last_transaction_block(hotkey, netuid, &TransactionType::SetChildkeyTake)
                 .into();
         HotkeyLimitedTxInfo {
-            hotkey: hotkey.to_owned(),
+            hotkey: hotkey.clone(),
             last_block_set_children,
             last_block_set_childkey_take,
         }

--- a/pallets/subtensor/src/rpc_info/rate_limit_info.rs
+++ b/pallets/subtensor/src/rpc_info/rate_limit_info.rs
@@ -1,0 +1,56 @@
+//! API for getting transaction rate limits associated with coldkeys and hotkeys.
+
+use codec::Compact;
+use frame_support::pallet_prelude::{Decode, Encode};
+
+use crate::{
+    utils::rate_limiting::TransactionType, Config, Pallet, TargetStakesPerInterval, TxRateLimit,
+};
+
+/// Transaction rate limits.
+// #[freeze_struct("fe79d58173da662a")]
+#[derive(Decode, Encode, Clone, Debug)]
+pub struct RateLimits {
+    transaction: Compact<u64>,
+    set_children: Compact<u64>,
+    set_childkey_take: Compact<u64>,
+    stakes: Compact<u64>,
+}
+
+/// Contains last blocks, when rate-limited transactions was evaluated.
+// #[freeze_struct("fe79d58173da662a")]
+#[derive(Decode, Encode, Clone, Debug)]
+pub struct HotkeyLimitedTxInfo<AccountId> {
+    hotkey: AccountId,
+    last_block_set_children: Compact<u64>,
+    last_block_set_childkey_take: Compact<u64>,
+}
+
+impl<T: Config> Pallet<T> {
+    /// Get transactions rate limits.
+    pub fn get_rate_limits() -> RateLimits {
+        RateLimits {
+            transaction: TxRateLimit::<T>::get().into(),
+            set_children: Self::get_rate_limit(&TransactionType::SetChildren).into(),
+            set_childkey_take: Self::get_rate_limit(&TransactionType::SetChildkeyTake).into(),
+            stakes: TargetStakesPerInterval::<T>::get().into(),
+        }
+    }
+
+    /// Get transaction rate limits associated with the `hotkey`.
+    pub fn get_limited_tx_info_for_hotkey(
+        hotkey: &T::AccountId,
+        netuid: u16,
+    ) -> HotkeyLimitedTxInfo<T::AccountId> {
+        let last_block_set_children =
+            Self::get_last_transaction_block(hotkey, netuid, &TransactionType::SetChildren).into();
+        let last_block_set_childkey_take =
+            Self::get_last_transaction_block(hotkey, netuid, &TransactionType::SetChildkeyTake)
+                .into();
+        HotkeyLimitedTxInfo {
+            hotkey: hotkey.to_owned(),
+            last_block_set_children,
+            last_block_set_childkey_take,
+        }
+    }
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -34,6 +34,7 @@ use scale_info::TypeInfo;
 use smallvec::smallvec;
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
+use sp_core::hexdisplay::AsBytesRef;
 use sp_core::{
     crypto::{ByteArray, KeyTypeId},
     OpaqueMetadata, H160, H256, U256,
@@ -2012,6 +2013,24 @@ impl_runtime_apis! {
     impl subtensor_custom_rpc_runtime_api::SubnetRegistrationRuntimeApi<Block> for Runtime {
         fn get_network_registration_cost() -> u64 {
             SubtensorModule::get_network_lock_cost()
+        }
+    }
+
+    impl subtensor_custom_rpc_runtime_api::RateLimitInfoRuntimeApi<Block> for Runtime {
+        fn get_rate_limits() -> Vec<u8> {
+            SubtensorModule::get_rate_limits().encode()
+        }
+
+        fn get_limited_tx_info_for_hotkey(hotkey: Vec<u8>, netuid: u16) -> Vec<u8> {
+            let hotkey = AccountId::decode(&mut hotkey.as_bytes_ref()).expect("Could not decode account ID");
+            SubtensorModule::get_limited_tx_info_for_hotkey(&hotkey, netuid).encode()
+        }
+
+        fn get_stakes_this_interval(coldkey: Vec<u8>, hotkey: Vec<u8>) -> u64 {
+            let coldkey = AccountId::decode(&mut coldkey.as_bytes_ref()).expect("Could not decode account ID");
+            let hotkey = AccountId::decode(&mut hotkey.as_bytes_ref()).expect("Could not decode account ID");
+
+            SubtensorModule::get_stakes_this_interval_for_coldkey_hotkey(&coldkey, &hotkey)
         }
     }
 }


### PR DESCRIPTION
## Description

This PR adds `RateLimitInfoRuntimeApi`, which provides RPC methods to fetch information about rate-limited transactions. The intention behind it is to allow clients to build logic not based on request errors, but by actual values.


## Related Issue(s)

- Closes https://github.com/opentensor/subtensor/issues/892

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules