### PR TITLE
improve pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 ## Related Issue(s)
 
-- Closes #[issue number]
+* Closes #issue_number
 
 ## Type of Change
 <!--
@@ -16,15 +16,16 @@ Please check the relevant options:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Housekeeping (non-breaking change which makes codebase more maintainable, cleanup, refactoring, etc)
 - [ ] Documentation update
 - [ ] Other (please describe):
 
 ## Breaking Change
-
+<!--
 If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.
+-->
 
 ## Checklist
-
 <!--
 Please ensure the following tasks are completed before requesting a review:
 -->
@@ -38,10 +39,7 @@ Please ensure the following tasks are completed before requesting a review:
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published in downstream modules
 
-## Screenshots (if applicable)
-
-Please include any relevant screenshots or GIFs that demonstrate the changes made.
-
-## Additional Notes
-
+## Additional Info
+<!--
 Please provide any additional information or context that may be helpful for reviewers.
+-->


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
Hopefully could save everyone a little bit of time writing PRs.
* remove brackets in `closes`, it ain't work (less editing)
* add "housekeeping" item to type of change, which is a huge part of development (less typing)
* comment out some of the instructional text (less editing)
* remove screenshot section, PR rarely need a screenshot, and when it does screenshots fit perfectly in the additional info section (less editing, less noise)

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please describe): PR template