### PR TITLE
Add `fast-blocks` feature to node

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -106,25 +106,16 @@ subtensor-custom-rpc-runtime-api = { path = "../pallets/subtensor/runtime-api" }
 substrate-build-script-utils = { workspace = true }
 
 [features]
-default = [
-	"rocksdb",
-	"sql",
-	"txpool",
-]
-sql = [
-	"fc-db/sql",
-	"fc-mapping-sync/sql",
-]
+default = ["rocksdb", "sql", "txpool"]
+fast-blocks = ["node-subtensor-runtime/fast-blocks"]
+sql = ["fc-db/sql", "fc-mapping-sync/sql"]
 rocksdb = [
 	"sc-service/rocksdb",
 	"fc-db/rocksdb",
 	"fc-mapping-sync/rocksdb",
-	"fc-rpc/rocksdb"
+	"fc-rpc/rocksdb",
 ]
-txpool = [
-	"fc-rpc/txpool",
-	"fc-rpc-core/txpool"
-]
+txpool = ["fc-rpc/txpool", "fc-rpc-core/txpool"]
 
 # Dependencies that are only required if runtime benchmarking should be build.
 runtime-benchmarks = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,1 @@
-
+//! This crate exists for linting in CI. Look inside build.rs for reference.


### PR DESCRIPTION
## Description

This PR configures `fast-blocks` feature for the `node-subtensor` crate. Without it you can't just `cargo run` the node with `fast-blocks` - you need to build the runtime with `fast-blocks` first. With this feature, you can run the node with:

```
cargo run -p node-subtensor --features fast-blocks -- --dev
```

## Related Issue(s)

- Closes #977 

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):


## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules