### PR TITLE
Fix stake weight issues

### DIFF
--- a/pallets/subtensor/src/rpc_info/neuron_info.rs
+++ b/pallets/subtensor/src/rpc_info/neuron_info.rs
@@ -79,9 +79,9 @@ impl<T: Config> Pallet<T> {
 
         let axon_info = Self::get_axon_info(netuid, &hotkey.clone());
 
-        let prometheus_info = Self::get_prometheus_info(netuid, &hotkey.clone());
+        let prometheus_info = Self::get_prometheus_info(netuid, &hotkey);
 
-        let coldkey = Owner::<T>::get(hotkey.clone()).clone();
+        let coldkey = Owner::<T>::get(&hotkey).clone();
 
         let active = Self::get_active_for_uid(netuid, uid);
         let rank = Self::get_rank_for_uid(netuid, uid);
@@ -119,8 +119,8 @@ impl<T: Config> Pallet<T> {
         let stake_weight: u64 = Self::get_stake_weight(netuid, uid) as u64;
         let stake: Vec<(T::AccountId, Compact<u64>)> = vec![(coldkey.clone(), stake_weight.into())];
         let neuron = NeuronInfo {
-            hotkey: hotkey.clone(),
-            coldkey: coldkey.clone(),
+            hotkey,
+            coldkey,
             uid: uid.into(),
             netuid: netuid.into(),
             active,
@@ -179,8 +179,8 @@ impl<T: Config> Pallet<T> {
         let stake: Vec<(T::AccountId, Compact<u64>)> = vec![(coldkey.clone(), stake_weight.into())];
 
         let neuron = NeuronInfoLite {
-            hotkey: hotkey.clone(),
-            coldkey: coldkey.clone(),
+            hotkey,
+            coldkey,
             uid: uid.into(),
             netuid: netuid.into(),
             active,

--- a/pallets/subtensor/src/rpc_info/neuron_info.rs
+++ b/pallets/subtensor/src/rpc_info/neuron_info.rs
@@ -175,7 +175,6 @@ impl<T: Config> Pallet<T> {
         let pruning_score = Self::get_pruning_score_for_uid(netuid, uid);
         let last_update = Self::get_last_update_for_uid(netuid, uid);
         let validator_permit = Self::get_validator_permit_for_uid(netuid, uid);
-
         let stake_weight: u64 = Self::get_stake_weight(netuid, uid) as u64;
         let stake: Vec<(T::AccountId, Compact<u64>)> = vec![(coldkey.clone(), stake_weight.into())];
 

--- a/pallets/subtensor/src/rpc_info/neuron_info.rs
+++ b/pallets/subtensor/src/rpc_info/neuron_info.rs
@@ -176,10 +176,8 @@ impl<T: Config> Pallet<T> {
         let last_update = Self::get_last_update_for_uid(netuid, uid);
         let validator_permit = Self::get_validator_permit_for_uid(netuid, uid);
 
-        let stake: Vec<(T::AccountId, Compact<u64>)> = vec![(
-            coldkey.clone(),
-            Self::get_stake_for_hotkey_on_subnet(&hotkey, netuid).into(),
-        )];
+        let stake_weight: u64 = Self::get_stake_weight(netuid, uid) as u64;
+        let stake: Vec<(T::AccountId, Compact<u64>)> = vec![(coldkey.clone(), stake_weight.into())];
 
         let neuron = NeuronInfoLite {
             hotkey: hotkey.clone(),

--- a/pallets/subtensor/src/subnets/subnet.rs
+++ b/pallets/subtensor/src/subnets/subnet.rs
@@ -191,8 +191,10 @@ impl<T: Config> Pallet<T> {
         NetworkRegisteredAt::<T>::insert(netuid_to_register, current_block);
 
         // --- 14. Init the pool by putting the lock as the initial alpha.
-        SubnetTAO::<T>::insert(netuid_to_register, 1); // add the TAO to the pool.
-        SubnetAlphaIn::<T>::insert(netuid_to_register, 1); // Set the alpha in based on the lock.
+		// add the TAO to the pool.
+        SubnetTAO::<T>::insert(netuid_to_register, 1_000_000_000);
+		// Set the alpha in based on the lock.
+        SubnetAlphaIn::<T>::insert(netuid_to_register, 1_000_000_000);
         SubnetOwner::<T>::insert(netuid_to_register, coldkey.clone());
         SubnetOwnerHotkey::<T>::insert(netuid_to_register, hotkey.clone());
 

--- a/pallets/subtensor/src/subnets/subnet.rs
+++ b/pallets/subtensor/src/subnets/subnet.rs
@@ -191,9 +191,9 @@ impl<T: Config> Pallet<T> {
         NetworkRegisteredAt::<T>::insert(netuid_to_register, current_block);
 
         // --- 14. Init the pool by putting the lock as the initial alpha.
-		// add the TAO to the pool.
+        // add the TAO to the pool.
         SubnetTAO::<T>::insert(netuid_to_register, 1_000_000_000);
-		// Set the alpha in based on the lock.
+        // Set the alpha in based on the lock.
         SubnetAlphaIn::<T>::insert(netuid_to_register, 1_000_000_000);
         SubnetOwner::<T>::insert(netuid_to_register, coldkey.clone());
         SubnetOwnerHotkey::<T>::insert(netuid_to_register, hotkey.clone());

--- a/pallets/subtensor/tests/staking.rs
+++ b/pallets/subtensor/tests/staking.rs
@@ -2498,6 +2498,7 @@ fn test_anneal_global_weight() {
 // https://github.com/opentensor/subtensor/issues/925
 // cargo test -p pallet-subtensor --test staking -- test_stake_weight_should_not_be_affected_by_zero_stakes --exact --nocapture
 #[test]
+#[allow(clippy::indexing_slicing)]
 fn test_stake_weight_should_not_be_affected_by_zero_stakes() {
     new_test_ext(1).execute_with(|| {
         let registrar = AccountId::from(42); // SN Owner
@@ -2562,6 +2563,7 @@ fn test_stake_weight_should_not_be_affected_by_zero_stakes() {
 
 // cargo test -p pallet-subtensor --test staking -- test_stake_weight_no_subnet_stake --exact --nocapture
 #[test]
+#[allow(clippy::indexing_slicing)]
 fn test_stake_weight_no_subnet_stake() {
     new_test_ext(1).execute_with(|| {
         let registrar = AccountId::from(42); // SN Owner
@@ -2609,4 +2611,3 @@ fn test_stake_weight_no_subnet_stake() {
         );
     });
 }
-


### PR DESCRIPTION
## Description

This PR fixes issues related to `NeuronInfoApi` inconsistencies.  Currently `NeuronInfoLite` returns alpha, while `NeuronInfo` returns stake weight. This issue was discussed with @camfairchild and it was considered to use stake weights for stakes in `NeuronInfo`/`NeuronInfoLite`. 

The issue was discovered during debugging: https://github.com/opentensor/subtensor/issues/879

No changes needed anymore related to `NeuronInfoApi`. 

Also, during debugging, other issues were discovered ([comment in #925](https://github.com/opentensor/subtensor/issues/925#issuecomment-2460945448) and related [issue](https://github.com/opentensor/subtensor/issues/969)). This PR fixes these issues by changing initial TAO and Alpha for subnets to `1_000_000_000`.

Initially the work were done on `fix/neuron-info-lite-stake`, but that branch were made from `feat/rao-devnet-ready`, so this branch just applies the changes to the new `feat/rao-devnet-ready-2` branch.


## Related Issue(s)

- Closes #879, #925, #969

## Type of Change
<!--
Please check the relevant options:
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Changes

As bittensor wallet previously relied on wrong data and for them the issue seemed like API returned stake vs alpha, they should adapt their code to use stake weights instead.


## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules