### PR TITLE
fix remaining escapes in hotfix pr bot message

### DIFF
--- a/.github/workflows/hotfixes.yml
+++ b/.github/workflows/hotfixes.yml
@@ -38,7 +38,7 @@ jobs:
           COMMENT_BODY=$(cat <<EOF
           ## 🚨🚨🚨 HOTFIX DETECTED 🚨🚨🚨
 
-          It looks like you are trying to merge a hotfix PR into `main`. If this isn't what you wanted to do, and you just wanted to make a regular PR, please close this PR, base your changes off the `devnet-ready` branch and open a new PR into `devnet ready`.
+          It looks like you are trying to merge a hotfix PR into \`main\`. If this isn't what you wanted to do, and you just wanted to make a regular PR, please close this PR, base your changes off the \`devnet-ready\` branch and open a new PR into \`devnet ready\`.
 
           If you _are_ trying to merge a hotfix PR, please complete the following essential steps:
           1. [ ] go ahead and get this PR into \`main\` merged, so we can get the change in as quickly as possible!

--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -5,28 +5,28 @@ use substrate_fixed::types::I96F32;
 impl<T: Config> Pallet<T> {
     /// The `coinbase` function performs a four-part emission distribution process involving
     /// subnets, epochs, hotkeys, and nominators.
-    // It is divided into several steps, each handling a specific part of the distribution:
-
-    // Step 1: Compute the block-wise emission for each subnet.
-    // This involves calculating how much (TAO) should be emitted into each subnet using the
-    // root epoch function.
-
-    // Step 2: Accumulate the subnet block emission.
-    // After calculating the block-wise emission, these values are accumulated to keep track
-    // of how much each subnet should emit before the next distribution phase. This accumulation
-    // is a running total that gets updated each block.
-
-    // Step 3: Distribute the accumulated emissions through epochs.
-    // Subnets periodically distribute their accumulated emissions to hotkeys (active validators/miners)
-    // in the network on a `tempo` --- the time between epochs. This step runs Yuma consensus to
-    // determine how emissions are split among hotkeys based on their contributions and roles.
-    // The accumulation of hotkey emissions is done through the `accumulate_hotkey_emission` function.
-    // The function splits the rewards for a hotkey amongst itself and its `parents`. The parents are
-    // the hotkeys that are delegating their stake to the hotkey.
-
-    // Step 4: Further distribute emissions from hotkeys to nominators.
-    // Finally, the emissions received by hotkeys are further distributed to their nominators,
-    // who are stakeholders that support the hotkeys.
+    /// It is divided into several steps, each handling a specific part of the distribution:
+    ///
+    /// Step 1: Compute the block-wise emission for each subnet.
+    /// This involves calculating how much (TAO) should be emitted into each subnet using the
+    /// root epoch function.
+    ///
+    /// Step 2: Accumulate the subnet block emission.
+    /// After calculating the block-wise emission, these values are accumulated to keep track
+    /// of how much each subnet should emit before the next distribution phase. This accumulation
+    /// is a running total that gets updated each block.
+    ///
+    /// Step 3: Distribute the accumulated emissions through epochs.
+    /// Subnets periodically distribute their accumulated emissions to hotkeys (active validators/miners)
+    /// in the network on a `tempo` --- the time between epochs. This step runs Yuma consensus to
+    /// determine how emissions are split among hotkeys based on their contributions and roles.
+    /// The accumulation of hotkey emissions is done through the `accumulate_hotkey_emission` function.
+    /// The function splits the rewards for a hotkey amongst itself and its `parents`. The parents are
+    /// the hotkeys that are delegating their stake to the hotkey.
+    ///
+    /// Step 4: Further distribute emissions from hotkeys to nominators.
+    /// Finally, the emissions received by hotkeys are further distributed to their nominators,
+    /// who are stakeholders that support the hotkeys.
     pub fn run_coinbase() {
         // --- 0. Get current block.
         let current_block: u64 = Self::get_current_block_as_u64();

--- a/pallets/subtensor/src/epoch/math.rs
+++ b/pallets/subtensor/src/epoch/math.rs
@@ -113,7 +113,7 @@ pub fn vec_max_upscale_to_u16(vec: &[I32F32]) -> Vec<u16> {
                     })
                     .collect();
             }
-            return vec
+            vec
                 .iter()
                 .map(|e: &I32F32| {
                     e.saturating_mul(u16_max)
@@ -121,18 +121,18 @@ pub fn vec_max_upscale_to_u16(vec: &[I32F32]) -> Vec<u16> {
                         .round()
                         .to_num::<u16>()
                 })
-                .collect();
+                .collect()
         }
         None => {
             let sum: I32F32 = vec.iter().sum();
-            return vec
+            vec
                 .iter()
                 .map(|e: &I32F32| {
                     e.saturating_mul(u16_max)
                         .saturating_div(sum)
                         .to_num::<u16>()
                 })
-                .collect();
+                .collect()
         }
     }
 }
@@ -246,7 +246,7 @@ pub fn is_topk(vector: &[I32F32], k: usize) -> Vec<bool> {
 pub fn normalize(x: &[I32F32]) -> Vec<I32F32> {
     let x_sum: I32F32 = sum(x);
     if x_sum != I32F32::from_num(0.0_f32) {
-        return x.iter().map(|xi| xi.saturating_div(x_sum)).collect();
+        x.iter().map(|xi| xi.saturating_div(x_sum)).collect()
     } else {
         x.to_vec()
     }

--- a/pallets/subtensor/src/epoch/math.rs
+++ b/pallets/subtensor/src/epoch/math.rs
@@ -113,8 +113,7 @@ pub fn vec_max_upscale_to_u16(vec: &[I32F32]) -> Vec<u16> {
                     })
                     .collect();
             }
-            vec
-                .iter()
+            vec.iter()
                 .map(|e: &I32F32| {
                     e.saturating_mul(u16_max)
                         .saturating_div(*val)
@@ -125,8 +124,7 @@ pub fn vec_max_upscale_to_u16(vec: &[I32F32]) -> Vec<u16> {
         }
         None => {
             let sum: I32F32 = vec.iter().sum();
-            vec
-                .iter()
+            vec.iter()
                 .map(|e: &I32F32| {
                     e.saturating_mul(u16_max)
                         .saturating_div(sum)

--- a/pallets/subtensor/src/tests/epoch.rs
+++ b/pallets/subtensor/src/tests/epoch.rs
@@ -2835,7 +2835,7 @@ fn test_blocks_since_last_step() {
 //     println!("]");
 // }
 
-/// Helpers
+// Helpers
 
 /// Asserts that two I32F32 values are approximately equal within a given epsilon.
 ///

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1867,7 +1867,10 @@ impl_runtime_apis! {
             use frame_system_benchmarking::Pallet as SystemBench;
             use baseline::Pallet as BaselineBench;
 
+            #[allow(non_local_definitions)]
             impl frame_system_benchmarking::Config for Runtime {}
+
+            #[allow(non_local_definitions)]
             impl baseline::Config for Runtime {}
 
             use frame_support::traits::WhitelistedStorageKeys;


### PR DESCRIPTION
Fixes missing escape characters in the initial paragraph of the bot message

also fixes clippy with rust 1.83 updates