### PR TITLE
Add cargo profile env var to `scripts/localnet.sh`

### DIFF
--- a/scripts/localnet.sh
+++ b/scripts/localnet.sh
@@ -48,30 +48,30 @@ fi
 
 if [[ $BUILD_BINARY == "1" ]]; then
   echo "*** Building substrate binary..."
-  cargo build --workspace --profile=release --features "$FEATURES" --manifest-path "$BASE_DIR/Cargo.toml"
+  cargo build --workspace --profile="${CARGO_PROFILE:-release}" --features "$FEATURES" --manifest-path "$BASE_DIR/Cargo.toml"
   echo "*** Binary compiled"
 fi
 
 echo "*** Building chainspec..."
-"$BASE_DIR/target/release/node-subtensor" build-spec --disable-default-bootnode --raw --chain $CHAIN >$FULL_PATH
+"$BASE_DIR/target/${CARGO_PROFILE:-release}/node-subtensor" build-spec --disable-default-bootnode --raw --chain $CHAIN >$FULL_PATH
 echo "*** Chainspec built and output to file"
 
 # generate node keys
-$BASE_DIR/target/release/node-subtensor key generate-node-key --chain="$FULL_PATH" --base-path /tmp/alice
-$BASE_DIR/target/release/node-subtensor key generate-node-key --chain="$FULL_PATH" --base-path /tmp/bob
+"$BASE_DIR/target/${CARGO_PROFILE:-release}/node-subtensor" key generate-node-key --chain="$FULL_PATH" --base-path /tmp/alice
+"$BASE_DIR/target/${CARGO_PROFILE:-release}/node-subtensor" key generate-node-key --chain="$FULL_PATH" --base-path /tmp/bob
 
 if [ $NO_PURGE -eq 1 ]; then
   echo "*** Purging previous state skipped..."
 else
   echo "*** Purging previous state..."
-  "$BASE_DIR/target/release/node-subtensor" purge-chain -y --base-path /tmp/bob --chain="$FULL_PATH" >/dev/null 2>&1
-  "$BASE_DIR/target/release/node-subtensor" purge-chain -y --base-path /tmp/alice --chain="$FULL_PATH" >/dev/null 2>&1
+  "$BASE_DIR/target/${CARGO_PROFILE:-release}/node-subtensor" purge-chain -y --base-path /tmp/bob --chain="$FULL_PATH" >/dev/null 2>&1
+  "$BASE_DIR/target/${CARGO_PROFILE:-release}/node-subtensor" purge-chain -y --base-path /tmp/alice --chain="$FULL_PATH" >/dev/null 2>&1
   echo "*** Previous chainstate purged"
 fi
 
 echo "*** Starting localnet nodes..."
 alice_start=(
-  "$BASE_DIR/target/release/node-subtensor"
+  "$BASE_DIR/target/${CARGO_PROFILE:-release}/node-subtensor"
   --base-path /tmp/alice
   --chain="$FULL_PATH"
   --alice
@@ -85,7 +85,7 @@ alice_start=(
 )
 
 bob_start=(
-  "$BASE_DIR"/target/release/node-subtensor
+  "$BASE_DIR/target/${CARGO_PROFILE:-release}/node-subtensor"
   --base-path /tmp/bob
   --chain="$FULL_PATH"
   --bob


### PR DESCRIPTION
## Description
Step 5 of [bittensor-subnet-template/docs/running_on_staging.md](https://github.com/opentensor/bittensor-subnet-template/blob/main/docs/running_on_staging.md#5-initialize) says to build the subtensor with `--profile production` and then run `scripts/localnet.sh` which has a hardcoded profile `release`.
This PR allows running localnet with `CARGO_PROFILE` env variable, where the default goes back to `release`.

Usage example:
```
BUILD_BINARY=0 CARGO_PROFILE=production ./scripts/localnet.sh 
```

## Related Issue(s)
- Closes opentensor/bittensor-subnet-template#118

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code
- [ ] Not applicable - I have commented my code, particularly in hard-to-understand areas
- [ ] Not applicable - I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Not applicable - I have added tests that prove my fix is effective or that my feature works
- [ ] Not applicable - New and existing unit tests pass locally with my changes
- [ ] Not applicable - Any dependent changes have been merged and published in downstream modules

## Additional Notes
PR updating documentation:  opentensor/bittensor-subnet-template#137