### PR TITLE
Fix staking counter

### DIFF
--- a/pallets/subtensor/src/macros/errors.rs
+++ b/pallets/subtensor/src/macros/errors.rs
@@ -91,9 +91,7 @@ mod errors {
         /// A transactor exceeded the rate limit for setting or swapping hotkey.
         HotKeySetTxRateLimitExceeded,
         /// A transactor exceeded the rate limit for staking.
-        StakeRateLimitExceeded,
-        /// A transactor exceeded the rate limit for unstaking.
-        UnstakeRateLimitExceeded,
+        StakingRateLimitExceeded,
         /// Registration is disabled.
         SubNetRegistrationDisabled,
         /// The number of registration attempts exceeded the allowed number in the interval.

--- a/pallets/subtensor/src/staking/add_stake.rs
+++ b/pallets/subtensor/src/staking/add_stake.rs
@@ -62,19 +62,6 @@ impl<T: Config> Pallet<T> {
             Error::<T>::HotKeyNotDelegateAndSignerNotOwnHotKey
         );
 
-        // Ensure we don't exceed stake rate limit
-        let stakes_this_interval =
-            Self::get_stakes_this_interval_for_coldkey_hotkey(&coldkey, &hotkey);
-        ensure!(
-            stakes_this_interval < Self::get_target_stakes_per_interval(),
-            Error::<T>::StakeRateLimitExceeded
-        );
-
-        // Track this addition in the stake delta.
-        StakeDeltaSinceLastEmissionDrain::<T>::mutate(&hotkey, &coldkey, |stake_delta| {
-            *stake_delta = stake_delta.saturating_add_unsigned(stake_to_be_added as u128);
-        });
-
         // If coldkey is not owner of the hotkey, it's a nomination stake.
         if !Self::coldkey_owns_hotkey(&coldkey, &hotkey) {
             let total_stake_after_add =
@@ -86,6 +73,8 @@ impl<T: Config> Pallet<T> {
             );
         }
 
+        Self::try_increase_staking_counter(&coldkey, &hotkey)?;
+
         // Ensure the remove operation from the coldkey is a success.
         let actual_amount_to_stake =
             Self::remove_balance_from_coldkey_account(&coldkey, stake_to_be_added)?;
@@ -93,17 +82,15 @@ impl<T: Config> Pallet<T> {
         // If we reach here, add the balance to the hotkey.
         Self::increase_stake_on_coldkey_hotkey_account(&coldkey, &hotkey, actual_amount_to_stake);
 
+        // Track this addition in the stake delta.
+        StakeDeltaSinceLastEmissionDrain::<T>::mutate(&hotkey, &coldkey, |stake_delta| {
+            *stake_delta = stake_delta.saturating_add_unsigned(stake_to_be_added as u128);
+        });
+
         // Set last block for rate limiting
-        let block: u64 = Self::get_current_block_as_u64();
+        let block = Self::get_current_block_as_u64();
         Self::set_last_tx_block(&coldkey, block);
 
-        // Emit the staking event.
-        Self::set_stakes_this_interval_for_coldkey_hotkey(
-            &coldkey,
-            &hotkey,
-            stakes_this_interval.saturating_add(1),
-            block,
-        );
         log::debug!(
             "StakeAdded( hotkey:{:?}, stake_to_be_added:{:?} )",
             hotkey,

--- a/pallets/subtensor/src/staking/helpers.rs
+++ b/pallets/subtensor/src/staking/helpers.rs
@@ -59,42 +59,6 @@ impl<T: Config> Pallet<T> {
         Stake::<T>::get(hotkey, coldkey)
     }
 
-    // Retrieves the total stakes for a given hotkey (account ID) for the current staking interval.
-    pub fn get_stakes_this_interval_for_coldkey_hotkey(
-        coldkey: &T::AccountId,
-        hotkey: &T::AccountId,
-    ) -> u64 {
-        // Retrieve the configured stake interval duration from storage.
-        let stake_interval = StakeInterval::<T>::get();
-
-        // Obtain the current block number as an unsigned 64-bit integer.
-        let current_block = Self::get_current_block_as_u64();
-
-        // Fetch the total stakes and the last block number when stakes were made for the hotkey.
-        let (stakes, block_last_staked_at) =
-            TotalHotkeyColdkeyStakesThisInterval::<T>::get(coldkey, hotkey);
-
-        // Calculate the block number after which the stakes for the hotkey should be reset.
-        let block_to_reset_after = block_last_staked_at.saturating_add(stake_interval);
-
-        // If the current block number is beyond the reset point,
-        // it indicates the end of the staking interval for the hotkey.
-        if block_to_reset_after <= current_block {
-            // Reset the stakes for this hotkey for the current interval.
-            Self::set_stakes_this_interval_for_coldkey_hotkey(
-                coldkey,
-                hotkey,
-                0,
-                block_last_staked_at,
-            );
-            // Return 0 as the stake amount since we've just reset the stakes.
-            return 0;
-        }
-
-        // If the staking interval has not yet ended, return the current stake amount.
-        stakes
-    }
-
     pub fn get_target_stakes_per_interval() -> u64 {
         TargetStakesPerInterval::<T>::get()
     }

--- a/pallets/subtensor/src/utils/misc.rs
+++ b/pallets/subtensor/src/utils/misc.rs
@@ -154,18 +154,36 @@ impl<T: Config> Pallet<T> {
             target_stakes_per_interval,
         ));
     }
-    pub fn set_stakes_this_interval_for_coldkey_hotkey(
+
+    // Counts staking events within the [`StakeInterval`]. It increases the counter by 1 in case no
+    // limit exceeded, otherwise returns an error.
+    pub(crate) fn try_increase_staking_counter(
         coldkey: &T::AccountId,
         hotkey: &T::AccountId,
-        stakes_this_interval: u64,
-        last_staked_block_number: u64,
-    ) {
-        TotalHotkeyColdkeyStakesThisInterval::<T>::insert(
-            coldkey,
-            hotkey,
-            (stakes_this_interval, last_staked_block_number),
+    ) -> DispatchResult {
+        let current_block = Self::get_current_block_as_u64();
+        let stake_interval = StakeInterval::<T>::get();
+        let stakes_limit = TargetStakesPerInterval::<T>::get();
+        let (stakes_count, last_staked_at) =
+            TotalHotkeyColdkeyStakesThisInterval::<T>::get(coldkey, hotkey);
+
+        if stakes_count == 0 || last_staked_at.saturating_add(stake_interval) <= current_block {
+            TotalHotkeyColdkeyStakesThisInterval::<T>::insert(coldkey, hotkey, (1, current_block));
+            return Ok(());
+        }
+
+        ensure!(
+            stakes_count < stakes_limit,
+            Error::<T>::StakingRateLimitExceeded
         );
+
+        TotalHotkeyColdkeyStakesThisInterval::<T>::mutate(coldkey, hotkey, |(count, _)| {
+            *count = count.saturating_add(1);
+        });
+
+        Ok(())
     }
+
     pub fn set_stake_interval(block: u64) {
         StakeInterval::<T>::set(block);
     }

--- a/pallets/subtensor/src/utils/misc.rs
+++ b/pallets/subtensor/src/utils/misc.rs
@@ -167,6 +167,7 @@ impl<T: Config> Pallet<T> {
         let (stakes_count, last_staked_at) =
             TotalHotkeyColdkeyStakesThisInterval::<T>::get(coldkey, hotkey);
 
+        // Reset staking counter if it's been stake_interval blocks since the first staking action of the series.
         if stakes_count == 0 || last_staked_at.saturating_add(stake_interval) <= current_block {
             TotalHotkeyColdkeyStakesThisInterval::<T>::insert(coldkey, hotkey, (1, current_block));
             return Ok(());

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -220,7 +220,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 216,
+    spec_version: 217,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description

- Fixes the issue, when the block of the last stake/unstake was reset to the current block.

- Removes `get_stakes_this_interval_for_coldkey_hotkey` and `set_stakes_this_interval_for_coldkey_hotkey` by 
  replacing it with `try_increase_staking_counter`.

  For a getter, `get_stakes_this_interval_for_coldkey_hotkey` has an unwanted side effect of mutating the storage.

  `set_stakes_this_interval_for_coldkey_hotkey` is just a storage setter.

  Both methods used only in `do_add_stake` and `do_remove_stake`.

- Replaces `StakeRateLimitExceeded` and `UnstakeRateLimitExceeded` error variants with `StakingRateLimitExceeded` as we don't separate rate limit logic and value between staking/unstaking.


## Related Issue(s)

- Closes #1091


## Type of Change
<!--
Please check the relevant options:
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):


## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules