### PR TITLE
Override childkey take to zero if sharing coldkey with parent

### DIFF
--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -357,6 +357,7 @@ impl<T: Config> Pallet<T> {
         mining_emission: u64,
     ) {
         // --- 1. First, calculate the hotkey's share of the emission.
+        let childkey_owner = Owner::<T>::get(hotkey);
         let childkey_take_proportion: I96F32 =
             I96F32::from_num(Self::get_childkey_take(hotkey, netuid))
                 .saturating_div(I96F32::from_num(u16::MAX));
@@ -387,9 +388,15 @@ impl<T: Config> Pallet<T> {
                     proportion_from_parent.saturating_mul(I96F32::from_num(validating_emission));
 
                 // --- 4.3 Childkey take as part of parent emission
-                let child_emission_take: u64 = childkey_take_proportion
-                    .saturating_mul(parent_emission)
-                    .to_num::<u64>();
+                // If parent and child coldkey is the same, do not apply childkey take
+                let parent_owner = Owner::<T>::get(&parent);
+                let child_emission_take: u64 = if parent_owner == childkey_owner {
+                    0
+                } else {
+                    childkey_take_proportion
+                        .saturating_mul(parent_emission)
+                        .to_num::<u64>()
+                };
                 total_childkey_take = total_childkey_take.saturating_add(child_emission_take);
                 // NOTE: Only the validation emission should be split amongst parents.
 

--- a/pallets/subtensor/src/tests/children.rs
+++ b/pallets/subtensor/src/tests/children.rs
@@ -3861,7 +3861,7 @@ fn test_childkey_take_same_coldkey() {
         step_block((hotkey_tempo * 2) as u16);
 
         // Verify how emission is split between keys
-        //   - Child stake is not increased
+        //   - Child stake is not increased (child & parent have same owner => no child-take)
         //   - Parent stake increased by 50% of total emission
         //   - Nominator stake increased by 50% of total emission
         let child_emission = crate::Stake::<Test>::get(child, coldkey);


### PR DESCRIPTION
## Description
If parent and child are sharing the same coldkey, the childkey take is ignored and overridden with zero.

## Related Issue(s)

n/a

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change
n/a

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

