### PR TITLE
Add childkey white list

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -311,6 +311,11 @@ pub mod pallet {
         vec![]
     }
     #[pallet::type_value]
+    /// Default account linkage
+    pub fn DefaultChildkeyWhitelist<T: Config>() -> Vec<T::AccountId> {
+        vec![]
+    }
+    #[pallet::type_value]
     /// Default pending childkeys
     pub fn DefaultPendingChildkeys<T: Config>() -> (Vec<(u64, T::AccountId)>, u64) {
         (vec![], 0)
@@ -875,6 +880,18 @@ pub mod pallet {
         Vec<(u64, T::AccountId)>,
         ValueQuery,
         DefaultAccountLinkage<T>,
+    >;
+    #[pallet::storage]
+    /// DMAP ( child, netuid ) --> Vec<coldkey>
+    pub type ChildkeyWhitelist<T: Config> = StorageDoubleMap<
+        _,
+        Blake2_128Concat,
+        T::AccountId,
+        Identity,
+        u16,
+        Vec<T::AccountId>,
+        ValueQuery,
+        DefaultChildkeyWhitelist<T>,
     >;
     #[pallet::storage] // --- DMAP ( cold ) --> Vec<hot> | Maps coldkey to hotkeys that stake to it
     pub type StakingHotkeys<T: Config> =

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -1487,9 +1487,9 @@ mod dispatches {
 
         /// User register a new subnetwork
         #[pallet::call_index(81)]
-        #[pallet::weight((Weight::from_parts(157_000_000, 0)
-                .saturating_add(T::DbWeight::get().reads(16))
-                .saturating_add(T::DbWeight::get().writes(30)), DispatchClass::Operational, Pays::No))]
+        #[pallet::weight((Weight::from_parts(100_000_000, 0)
+        .saturating_add(T::DbWeight::get().reads(2))
+        .saturating_add(T::DbWeight::get().writes(1)), DispatchClass::Operational, Pays::Yes))]
         pub fn set_childkey_whitelist(
             coldkey: OriginFor<T>,
             childkey: T::AccountId,

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -1484,5 +1484,19 @@ mod dispatches {
         ) -> DispatchResult {
             Self::user_add_network(origin, identity)
         }
+
+        /// User register a new subnetwork
+        #[pallet::call_index(81)]
+        #[pallet::weight((Weight::from_parts(157_000_000, 0)
+                .saturating_add(T::DbWeight::get().reads(16))
+                .saturating_add(T::DbWeight::get().writes(30)), DispatchClass::Operational, Pays::No))]
+        pub fn set_childkey_whitelist(
+            coldkey: OriginFor<T>,
+            childkey: T::AccountId,
+            netuid: u16,
+            coldkey_list: Vec<T::AccountId>,
+        ) -> DispatchResult {
+            Self::do_set_childkey_whitelist(coldkey, childkey, netuid, coldkey_list)
+        }
     }
 }

--- a/pallets/subtensor/src/macros/errors.rs
+++ b/pallets/subtensor/src/macros/errors.rs
@@ -179,5 +179,9 @@ mod errors {
         InputLengthsUnequal,
         /// A transactor exceeded the rate limit for setting weights.
         CommittingWeightsTooFast,
+        /// Too many entries in the white list
+        TooManyWhitelistEntries,
+        /// The coldkey is not whitelisted to add child.
+        ColdkeyIsNotWhitelisted,
     }
 }

--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -185,6 +185,8 @@ mod events {
         SetChildrenScheduled(T::AccountId, u16, u64, Vec<(u64, T::AccountId)>),
         /// The children of a hotkey have been set
         SetChildren(T::AccountId, u16, Vec<(u64, T::AccountId)>),
+        /// The whitelist for childkey is set
+        ChildkeyWhitelistSet(T::AccountId, u16, Vec<T::AccountId>),
         /// The hotkey emission tempo has been set
         HotkeyEmissionTempoSet(u64),
         /// The network maximum stake has been set

--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -72,6 +72,8 @@ mod hooks {
                 // Migrate Delegate Ids on chain
                 .saturating_add(migrations::migrate_chain_identity::migrate_set_hotkey_identities::<T>())
                 // Migrate Commit-Reval 2.0
+                .saturating_add(migrations::migrate_commit_reveal_v2::migrate_commit_reveal_2::<T>())
+                // Migrate rename WeightMinStake to WeightThreshold
                 .saturating_add(migrations::migrate_commit_reveal_v2::migrate_commit_reveal_2::<T>());
             weight
         }


### PR DESCRIPTION
## Description
Implements childkey white list feature:

- `set_childkey_whitelist` extrinsic that allows setting the white list of coldkeys that are allowed to child this key
- Additional check in `set_children` extrinsic that ensures that this white list is either empty (in which case anyone is allowed to add this childkey) or contains the coldkey of the new parent.

## Related Issue(s)

n/a

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

