### PR TITLE
Add prefunded ETH accounts to localnet chainspec

### DIFF
--- a/node/src/chain_spec/localnet.rs
+++ b/node/src/chain_spec/localnet.rs
@@ -79,12 +79,12 @@ fn localnet_genesis(
         ),
         // ETH
         (
-            // Alith
+            // Alith - 0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac
             AccountId::from_str("5Fghzk1AJt88PeFEzuRfXzbPchiBbsVGTTXcdx599VdZzkTA").unwrap(),
             2000000000000u128,
         ),
         (
-            // Baltathar
+            // Baltathar - 0x3Cd0A705a2DC65e5b1E1205896BaA2be8A07c6e0
             AccountId::from_str("5GeqNhKWj1KG78VHzbmo3ZjZgUTrCuWeamdgiA114XHGdaEr").unwrap(),
             2000000000000u128,
         ),

--- a/node/src/chain_spec/localnet.rs
+++ b/node/src/chain_spec/localnet.rs
@@ -77,6 +77,17 @@ fn localnet_genesis(
             get_account_id_from_seed::<sr25519::Public>("Ferdie"),
             2000000000000u128,
         ),
+        // ETH
+        (
+            // Alith
+            AccountId::from_str("5Fghzk1AJt88PeFEzuRfXzbPchiBbsVGTTXcdx599VdZzkTA").unwrap(),
+            2000000000000u128,
+        ),
+        (
+            // Baltathar
+            AccountId::from_str("5GeqNhKWj1KG78VHzbmo3ZjZgUTrCuWeamdgiA114XHGdaEr").unwrap(),
+            2000000000000u128,
+        ),
     ];
 
     // Check if the environment variable is set


### PR DESCRIPTION
## Description

Adds two well known ETH accounts, **Alith** and **Baltathar**, to `localnet` chainspec.


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.