### PR TITLE
Define EVM chain ID in localnet genesis

### DIFF
--- a/node/src/chain_spec/localnet.rs
+++ b/node/src/chain_spec/localnet.rs
@@ -120,5 +120,8 @@ fn localnet_genesis(
         "senateMembers": {
             "members": senate_members,
         },
+        "evmChainId": {
+            "chainId": 42,
+        },
     })
 }


### PR DESCRIPTION
## Description

Defines EVM chain ID for localnet to `42` (default to substrate), which simplifies testing as Metamask, for example, doesn't allow you to specify `0` for chain ID.


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.