### PR TITLE
skip stake info entry if none staked

### DIFF
--- a/pallets/subtensor/src/rpc_info/stake_info.rs
+++ b/pallets/subtensor/src/rpc_info/stake_info.rs
@@ -35,6 +35,9 @@ impl<T: Config> Pallet<T> {
                     let alpha: u64 = Self::get_stake_for_hotkey_and_coldkey_on_subnet(
                         hotkey_i, coldkey_i, *netuid_i,
                     );
+                    if alpha == 0 {
+                        continue;
+                    }
                     let emission: u64 = AlphaDividendsPerSubnet::<T>::get(*netuid_i, &hotkey_i);
                     let is_registered: bool =
                         Self::is_hotkey_registered_on_network(*netuid_i, hotkey_i);


### PR DESCRIPTION
This PR skips any StakeInfo entries that have zero stake.