### PR TITLE
make docker image builds trigger on key branches + ability to manually trigger

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,12 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      branch-or-tag:
+        description: "Branch or tag to use for the Docker image tag (optional)"
+        required: false
+        default: ""
+
   push:
     branches:
       - devnet-ready
@@ -40,21 +46,10 @@ jobs:
       - name: Determine Docker tag
         id: tag
         run: |
-          case "${{ github.ref_name }}" in
-            devnet-ready)
-              echo "tag=devnet-ready" >> $GITHUB_ENV
-              ;;
-            devnet)
-              echo "tag=devnet" >> $GITHUB_ENV
-              ;;
-            testnet)
-              echo "tag=testnet" >> $GITHUB_ENV
-              ;;
-            *)
-              echo "Branch not recognized for custom tagging."
-              exit 1
-              ;;
-          esac
+          # Use the provided branch-or-tag input or fallback to the current ref
+          branch_or_tag="${{ github.event.inputs.branch-or-tag || github.ref_name }}"
+          echo "Determined branch or tag: $branch_or_tag"
+          echo "tag=$branch_or_tag" >> $GITHUB_ENV
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,6 @@ jobs:
       - name: Determine Docker tag and ref
         id: tag
         run: |
-          # Use the provided branch-or-tag input or fallback to the current ref
           branch_or_tag="${{ github.event.inputs.branch-or-tag || github.ref_name }}"
           echo "Determined branch or tag: $branch_or_tag"
           echo "tag=$branch_or_tag" >> $GITHUB_ENV
@@ -61,4 +60,3 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:${{ env.tag }}
-            ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,11 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+  push:
+    branches:
+      - devnet-ready
+      - devnet
+      - testnet
 
 permissions:
   contents: read
@@ -32,11 +37,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ghcr.io/${{ github.repository }}
+      - name: Determine Docker tag
+        id: tag
+        run: |
+          case "${{ github.ref_name }}" in
+            devnet-ready)
+              echo "tag=devnet-ready" >> $GITHUB_ENV
+              ;;
+            devnet)
+              echo "tag=devnet" >> $GITHUB_ENV
+              ;;
+            testnet)
+              echo "tag=testnet" >> $GITHUB_ENV
+              ;;
+            *)
+              echo "Branch not recognized for custom tagging."
+              exit 1
+              ;;
+          esac
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
@@ -44,6 +62,5 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ steps.meta.outputs.tags }}
+            ghcr.io/${{ github.repository }}:${{ env.tag }}
             ghcr.io/${{ github.repository }}:latest
-          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       branch-or-tag:
-        description: "Branch or tag to use for the Docker image tag (optional)"
+        description: "Branch or tag to use for the Docker image tag and ref to checkout (optional)"
         required: false
         default: ""
 
@@ -27,8 +27,19 @@ jobs:
     runs-on: SubtensorCI
 
     steps:
+      - name: Determine Docker tag and ref
+        id: tag
+        run: |
+          # Use the provided branch-or-tag input or fallback to the current ref
+          branch_or_tag="${{ github.event.inputs.branch-or-tag || github.ref_name }}"
+          echo "Determined branch or tag: $branch_or_tag"
+          echo "tag=$branch_or_tag" >> $GITHUB_ENV
+          echo "ref=$branch_or_tag" >> $GITHUB_ENV
+
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.ref }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -42,14 +53,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Determine Docker tag
-        id: tag
-        run: |
-          # Use the provided branch-or-tag input or fallback to the current ref
-          branch_or_tag="${{ github.event.inputs.branch-or-tag || github.ref_name }}"
-          echo "Determined branch or tag: $branch_or_tag"
-          echo "tag=$branch_or_tag" >> $GITHUB_ENV
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4


### PR DESCRIPTION
This makes it so the current state of `devnet-ready`, `devnet`, and `testnet` is continuously deployed to docker hub using the branch names as the tag name.

It also makes it so we can manually trigger branches or tags to deploy to docker hub based on a workflow dispatch. Currently it _does not_ allow for deploying a branch/tag with a different branch/tag name in docker hub, however this could be added if it is desired later.