### PR TITLE
Send staking and unstaking fees to SubnetTAO

### DIFF
--- a/pallets/subtensor/src/staking/add_stake.rs
+++ b/pallets/subtensor/src/staking/add_stake.rs
@@ -74,7 +74,8 @@ impl<T: Config> Pallet<T> {
 
         // 6. Swap the stake into alpha on the subnet and increase counters.
         // Emit the staking event.
-        Self::stake_into_subnet(&hotkey, &coldkey, netuid, tao_staked);
+        let fee = DefaultMinStake::<T>::get();
+        Self::stake_into_subnet(&hotkey, &coldkey, netuid, tao_staked, fee);
 
         // Ok and return.
         Ok(())

--- a/pallets/subtensor/src/staking/helpers.rs
+++ b/pallets/subtensor/src/staking/helpers.rs
@@ -163,7 +163,8 @@ impl<T: Config> Pallet<T> {
                 // Log the clearing of a small nomination
                 // Remove the stake from the nominator account. (this is a more forceful unstake operation which )
                 // Actually deletes the staking account.
-                let cleared_stake = Self::unstake_from_subnet(hotkey, coldkey, netuid, stake);
+                // Do not apply any fees
+                let cleared_stake = Self::unstake_from_subnet(hotkey, coldkey, netuid, stake, 0);
                 // Add the stake to the coldkey account.
                 Self::add_balance_to_coldkey_account(coldkey, cleared_stake);
             }

--- a/pallets/subtensor/src/staking/move_stake.rs
+++ b/pallets/subtensor/src/staking/move_stake.rs
@@ -181,7 +181,9 @@ impl<T: Config> Pallet<T> {
         );
 
         // 6. Unstake from the origin coldkey; this returns an amount of TAO.
-        let origin_tao = Self::unstake_from_subnet(&hotkey, &coldkey, origin_netuid, alpha_amount);
+        let fee = DefaultMinStake::<T>::get().saturating_div(2);
+        let origin_tao =
+            Self::unstake_from_subnet(&hotkey, &coldkey, origin_netuid, alpha_amount, fee);
 
         // 7. Ensure the returned TAO meets a minimum stake requirement (if required).
         ensure!(
@@ -196,6 +198,7 @@ impl<T: Config> Pallet<T> {
             &destination_coldkey,
             destination_netuid,
             origin_tao,
+            fee,
         );
 
         // 9. Emit an event for logging/monitoring.

--- a/pallets/subtensor/src/staking/move_stake.rs
+++ b/pallets/subtensor/src/staking/move_stake.rs
@@ -68,11 +68,13 @@ impl<T: Config> Pallet<T> {
         );
 
         // --- 7. Unstake the amount of alpha from the origin subnet, converting it to TAO
+        let fee = DefaultMinStake::<T>::get().saturating_div(2); // fee is half of min stake because it is applied twice
         let origin_tao = Self::unstake_from_subnet(
             &origin_hotkey.clone(),
             &coldkey.clone(),
             origin_netuid,
             alpha_amount,
+            fee,
         );
 
         // Ensure origin_tao is at least DefaultMinStake
@@ -87,6 +89,7 @@ impl<T: Config> Pallet<T> {
             &coldkey.clone(),
             destination_netuid,
             origin_tao,
+            fee,
         );
 
         // --- 9. Log the event.
@@ -104,7 +107,7 @@ impl<T: Config> Pallet<T> {
             origin_netuid,
             destination_hotkey,
             destination_netuid,
-            origin_tao,
+            origin_tao.saturating_sub(fee),
         ));
 
         // -- 10. Ok and return.

--- a/pallets/subtensor/src/staking/remove_stake.rs
+++ b/pallets/subtensor/src/staking/remove_stake.rs
@@ -1,4 +1,5 @@
 use super::*;
+use sp_core::Get;
 
 impl<T: Config> Pallet<T> {
     /// ---- The implementation for the extrinsic remove_stake: Removes stake from a hotkey account and adds it onto a coldkey.
@@ -65,8 +66,9 @@ impl<T: Config> Pallet<T> {
         );
 
         // 6. Swap the alpba to tao and update counters for this subnet.
+        let fee = DefaultMinStake::<T>::get();
         let tao_unstaked: u64 =
-            Self::unstake_from_subnet(&hotkey, &coldkey, netuid, alpha_unstaked);
+            Self::unstake_from_subnet(&hotkey, &coldkey, netuid, alpha_unstaked, fee);
 
         // 7. We add the balance to the coldkey. If the above fails we will not credit this coldkey.
         Self::add_balance_to_coldkey_account(&coldkey, tao_unstaked);
@@ -80,10 +82,6 @@ impl<T: Config> Pallet<T> {
                 PendingChildKeys::<T>::remove(netuid, &hotkey);
             })
         }
-
-        // TODO: Regression
-        // Emit the unstaking event.
-        // Self::deposit_event(Event::StakeRemoved(hotkey, stake_to_be_removed));
 
         // Done and ok.
         Ok(())
@@ -119,6 +117,8 @@ impl<T: Config> Pallet<T> {
         origin: T::RuntimeOrigin,
         hotkey: T::AccountId,
     ) -> dispatch::DispatchResult {
+        let fee = DefaultMinStake::<T>::get();
+
         // 1. We check the transaction is signed by the caller and retrieve the T::AccountId coldkey information.
         let coldkey = ensure_signed(origin)?;
         log::info!("do_unstake_all( origin:{:?} hotkey:{:?} )", coldkey, hotkey);
@@ -141,7 +141,7 @@ impl<T: Config> Pallet<T> {
             if alpha_unstaked > 0 {
                 // Swap the alpha to tao and update counters for this subnet.
                 let tao_unstaked: u64 =
-                    Self::unstake_from_subnet(&hotkey, &coldkey, *netuid, alpha_unstaked);
+                    Self::unstake_from_subnet(&hotkey, &coldkey, *netuid, alpha_unstaked, fee);
 
                 // Add the balance to the coldkey. If the above fails we will not credit this coldkey.
                 Self::add_balance_to_coldkey_account(&coldkey, tao_unstaked);
@@ -185,6 +185,8 @@ impl<T: Config> Pallet<T> {
         origin: T::RuntimeOrigin,
         hotkey: T::AccountId,
     ) -> dispatch::DispatchResult {
+        let fee = DefaultMinStake::<T>::get();
+
         // 1. We check the transaction is signed by the caller and retrieve the T::AccountId coldkey information.
         let coldkey = ensure_signed(origin)?;
         log::info!("do_unstake_all( origin:{:?} hotkey:{:?} )", coldkey, hotkey);
@@ -210,7 +212,7 @@ impl<T: Config> Pallet<T> {
                 if alpha_unstaked > 0 {
                     // Swap the alpha to tao and update counters for this subnet.
                     let tao_unstaked: u64 =
-                        Self::unstake_from_subnet(&hotkey, &coldkey, *netuid, alpha_unstaked);
+                        Self::unstake_from_subnet(&hotkey, &coldkey, *netuid, alpha_unstaked, fee);
 
                     // Increment total
                     total_tao_unstaked = total_tao_unstaked.saturating_add(tao_unstaked);
@@ -227,6 +229,7 @@ impl<T: Config> Pallet<T> {
             &coldkey,
             Self::get_root_netuid(),
             total_tao_unstaked,
+            0, // no fee for restaking
         );
 
         // 5. Done and ok.

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -1,5 +1,7 @@
 use super::*;
+use crate::DefaultMinStake;
 use share_pool::{SharePool, SharePoolDataOperations};
+use sp_core::Get;
 use sp_std::ops::Neg;
 use substrate_fixed::types::{I64F64, I96F32, U64F64};
 
@@ -621,11 +623,19 @@ impl<T: Config> Pallet<T> {
         //     });
         // }
 
-        // Step 4. Deposit and log the unstaking event.
+        // Step 4. Reduce tao amount by staking fee and credit this fee to SubnetTAO
+        let fee = DefaultMinStake::<T>::get();
+        let tao_unstaked = tao.saturating_sub(fee);
+        let actual_fee = tao.saturating_sub(tao_unstaked);
+        SubnetTAO::<T>::mutate(netuid, |total| {
+            *total = total.saturating_add(actual_fee);
+        });
+
+        // Step 5. Deposit and log the unstaking event.
         Self::deposit_event(Event::StakeRemoved(
             coldkey.clone(),
             hotkey.clone(),
-            tao,
+            tao_unstaked,
             alpha,
             netuid,
         ));
@@ -633,13 +643,13 @@ impl<T: Config> Pallet<T> {
             "StakeRemoved( coldkey: {:?}, hotkey:{:?}, tao: {:?}, alpha:{:?}, netuid: {:?} )",
             coldkey.clone(),
             hotkey.clone(),
-            tao,
+            tao_unstaked,
             alpha,
             netuid
         );
 
-        // Step 5: Return the amount of TAO unstaked.
-        tao
+        // Step 6: Return the amount of TAO unstaked.
+        tao_unstaked
     }
 
     /// Stakes TAO into a subnet for a given hotkey and coldkey pair.
@@ -651,24 +661,37 @@ impl<T: Config> Pallet<T> {
         netuid: u16,
         tao: u64,
     ) -> u64 {
-        // Step 1. Swap the tao to alpha.
-        let alpha: u64 = Self::swap_tao_for_alpha(netuid, tao);
+        // Step 1. Reduce tao amount by staking fee and credit this fee to SubnetTAO
+        // At this point tao was already withdrawn from the user balance and is considered 
+        // available
+        let fee = DefaultMinStake::<T>::get();
+        let tao_staked = tao.saturating_sub(fee);
+        let actual_fee = tao.saturating_sub(tao_staked);
 
-        // Step 2: Increase the alpha on the hotkey account.
-        Self::increase_stake_for_hotkey_and_coldkey_on_subnet(hotkey, coldkey, netuid, alpha);
+        // Step 2. Swap the tao to alpha.
+        let alpha: u64 = Self::swap_tao_for_alpha(netuid, tao_staked);
+        if (tao_staked > 0) && (alpha > 0) {
+            // Step 3: Increase the alpha on the hotkey account.
+            Self::increase_stake_for_hotkey_and_coldkey_on_subnet(hotkey, coldkey, netuid, alpha);
 
-        // Step 4: Update the list of hotkeys staking for this coldkey
-        let mut staking_hotkeys = StakingHotkeys::<T>::get(coldkey);
-        if !staking_hotkeys.contains(hotkey) {
-            staking_hotkeys.push(hotkey.clone());
-            StakingHotkeys::<T>::insert(coldkey, staking_hotkeys.clone());
+            // Step 4: Update the list of hotkeys staking for this coldkey
+            let mut staking_hotkeys = StakingHotkeys::<T>::get(coldkey);
+            if !staking_hotkeys.contains(hotkey) {
+                staking_hotkeys.push(hotkey.clone());
+                StakingHotkeys::<T>::insert(coldkey, staking_hotkeys.clone());
+            }
         }
 
-        // Step 5. Deposit and log the staking event.
+        // Step 5. Increase Tao reserves by the fee amount.
+        SubnetTAO::<T>::mutate(netuid, |total| {
+            *total = total.saturating_add(actual_fee);
+        });
+
+        // Step 6. Deposit and log the staking event.
         Self::deposit_event(Event::StakeAdded(
             coldkey.clone(),
             hotkey.clone(),
-            tao,
+            tao_staked,
             alpha,
             netuid,
         ));
@@ -676,12 +699,12 @@ impl<T: Config> Pallet<T> {
             "StakeAdded( coldkey: {:?}, hotkey:{:?}, tao: {:?}, alpha:{:?}, netuid: {:?} )",
             coldkey.clone(),
             hotkey.clone(),
-            tao,
+            tao_staked,
             alpha,
             netuid
         );
 
-        // Step 6: Return the amount of alpha staked
+        // Step 7: Return the amount of alpha staked
         alpha
     }
 

--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -726,7 +726,8 @@ pub fn increase_stake_on_coldkey_hotkey_account(
     tao_staked: u64,
     netuid: u16,
 ) {
-    SubtensorModule::stake_into_subnet(hotkey, coldkey, netuid, tao_staked);
+    let fee = 0;
+    SubtensorModule::stake_into_subnet(hotkey, coldkey, netuid, tao_staked, fee);
 }
 
 /// Increases the stake on the hotkey account under its owning coldkey.

--- a/pallets/subtensor/src/tests/move_stake.rs
+++ b/pallets/subtensor/src/tests/move_stake.rs
@@ -17,11 +17,12 @@ fn test_do_move_success() {
         let origin_hotkey = U256::from(2);
         let destination_hotkey = U256::from(3);
         let stake_amount = DefaultMinStake::<Test>::get() * 10;
+        let fee = DefaultMinStake::<Test>::get();
 
         // Set up initial stake
         SubtensorModule::create_account_if_non_existent(&coldkey, &origin_hotkey);
         SubtensorModule::create_account_if_non_existent(&coldkey, &destination_hotkey);
-        SubtensorModule::stake_into_subnet(&origin_hotkey, &coldkey, netuid, stake_amount);
+        SubtensorModule::stake_into_subnet(&origin_hotkey, &coldkey, netuid, stake_amount, fee);
         let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
             &origin_hotkey,
             &coldkey,
@@ -53,7 +54,7 @@ fn test_do_move_success() {
                 &coldkey,
                 netuid
             ),
-            stake_amount,
+            stake_amount - 2 * fee,
             epsilon = stake_amount / 1000
         );
     });
@@ -73,11 +74,18 @@ fn test_do_move_different_subnets() {
         let origin_hotkey = U256::from(2);
         let destination_hotkey = U256::from(3);
         let stake_amount = DefaultMinStake::<Test>::get() * 10;
+        let fee = DefaultMinStake::<Test>::get();
 
         // Set up initial stake and subnets
         SubtensorModule::create_account_if_non_existent(&coldkey, &origin_hotkey);
         SubtensorModule::create_account_if_non_existent(&coldkey, &destination_hotkey);
-        SubtensorModule::stake_into_subnet(&origin_hotkey, &coldkey, origin_netuid, stake_amount);
+        SubtensorModule::stake_into_subnet(
+            &origin_hotkey,
+            &coldkey,
+            origin_netuid,
+            stake_amount,
+            fee,
+        );
         let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
             &origin_hotkey,
             &coldkey,
@@ -109,7 +117,7 @@ fn test_do_move_different_subnets() {
                 &coldkey,
                 destination_netuid
             ),
-            stake_amount,
+            stake_amount - 2 * fee,
             epsilon = stake_amount / 1000
         );
     });
@@ -129,9 +137,16 @@ fn test_do_move_nonexistent_subnet() {
         let destination_hotkey = U256::from(3);
         let nonexistent_netuid = 99; // Assuming this subnet doesn't exist
         let stake_amount = 1_000_000;
+        let fee = 0;
 
         // Set up initial stake
-        SubtensorModule::stake_into_subnet(&origin_hotkey, &coldkey, origin_netuid, stake_amount);
+        SubtensorModule::stake_into_subnet(
+            &origin_hotkey,
+            &coldkey,
+            origin_netuid,
+            stake_amount,
+            fee,
+        );
         let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
             &origin_hotkey,
             &coldkey,
@@ -221,9 +236,10 @@ fn test_do_move_nonexistent_destination_hotkey() {
         let nonexistent_destination_hotkey = U256::from(99); // Assuming this hotkey doesn't exist
         let netuid = 1;
         let stake_amount = 1_000_000;
+        let fee = 0;
 
         // Set up initial stake
-        SubtensorModule::stake_into_subnet(&origin_hotkey, &coldkey, netuid, stake_amount);
+        SubtensorModule::stake_into_subnet(&origin_hotkey, &coldkey, netuid, stake_amount, fee);
 
         // Attempt to move stake from a non-existent origin hotkey
         add_network(netuid, 0, 0);
@@ -272,9 +288,10 @@ fn test_do_move_all_stake() {
         let origin_hotkey = U256::from(2);
         let destination_hotkey = U256::from(3);
         let stake_amount = DefaultMinStake::<Test>::get() * 10;
+        let fee = DefaultMinStake::<Test>::get();
 
         // Set up initial stake
-        SubtensorModule::stake_into_subnet(&origin_hotkey, &coldkey, netuid, stake_amount);
+        SubtensorModule::stake_into_subnet(&origin_hotkey, &coldkey, netuid, stake_amount, fee);
         let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
             &origin_hotkey,
             &coldkey,
@@ -308,7 +325,7 @@ fn test_do_move_all_stake() {
                 &coldkey,
                 netuid
             ),
-            stake_amount,
+            stake_amount - 2 * fee,
             epsilon = stake_amount / 1000
         );
     });
@@ -324,9 +341,10 @@ fn test_do_move_half_stake() {
         let origin_hotkey = U256::from(2);
         let destination_hotkey = U256::from(3);
         let stake_amount = DefaultMinStake::<Test>::get() * 10;
+        let fee = DefaultMinStake::<Test>::get();
 
         // Set up initial stake
-        SubtensorModule::stake_into_subnet(&origin_hotkey, &coldkey, netuid, stake_amount);
+        SubtensorModule::stake_into_subnet(&origin_hotkey, &coldkey, netuid, stake_amount, fee);
         let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
             &origin_hotkey,
             &coldkey,
@@ -352,8 +370,8 @@ fn test_do_move_half_stake() {
                 &coldkey,
                 netuid
             ),
-            stake_amount / 2,
-            epsilon = stake_amount / 1000
+            alpha / 2,
+            epsilon = alpha / 1000
         );
         assert_abs_diff_eq!(
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
@@ -361,8 +379,8 @@ fn test_do_move_half_stake() {
                 &coldkey,
                 netuid
             ),
-            stake_amount / 2,
-            epsilon = stake_amount / 1000
+            alpha / 2 - fee,
+            epsilon = alpha / 1000
         );
     });
 }
@@ -380,9 +398,10 @@ fn test_do_move_partial_stake() {
         let origin_hotkey = U256::from(2);
         let destination_hotkey = U256::from(3);
         let total_stake = DefaultMinStake::<Test>::get() * 10;
+        let fee = DefaultMinStake::<Test>::get();
 
         // Set up initial stake
-        SubtensorModule::stake_into_subnet(&origin_hotkey, &coldkey, netuid, total_stake);
+        SubtensorModule::stake_into_subnet(&origin_hotkey, &coldkey, netuid, total_stake, fee);
         let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
             &origin_hotkey,
             &coldkey,
@@ -416,7 +435,7 @@ fn test_do_move_partial_stake() {
                 &coldkey,
                 netuid
             ),
-            total_stake,
+            total_stake - 2 * fee,
             epsilon = total_stake / 1000
         );
     });
@@ -435,11 +454,12 @@ fn test_do_move_multiple_times() {
         let hotkey1 = U256::from(2);
         let hotkey2 = U256::from(3);
         let initial_stake = DefaultMinStake::<Test>::get() * 10;
+        let fee = DefaultMinStake::<Test>::get();
 
         // Set up initial stake
         SubtensorModule::create_account_if_non_existent(&coldkey, &hotkey1);
         SubtensorModule::create_account_if_non_existent(&coldkey, &hotkey2);
-        SubtensorModule::stake_into_subnet(&hotkey1, &coldkey, netuid, initial_stake);
+        SubtensorModule::stake_into_subnet(&hotkey1, &coldkey, netuid, initial_stake, fee);
 
         // Move stake multiple times
         for _ in 0..3 {
@@ -470,7 +490,7 @@ fn test_do_move_multiple_times() {
         // Check final stake distribution
         assert_abs_diff_eq!(
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey1, &coldkey, netuid),
-            initial_stake,
+            initial_stake - 7 * fee,
             epsilon = initial_stake / 1000
         );
         assert_eq!(
@@ -492,9 +512,10 @@ fn test_do_move_wrong_origin() {
         let destination_hotkey = U256::from(3);
         let netuid = 1;
         let stake_amount = 1000;
+        let fee = 0;
 
         // Set up initial stake
-        SubtensorModule::stake_into_subnet(&origin_hotkey, &coldkey, netuid, stake_amount);
+        SubtensorModule::stake_into_subnet(&origin_hotkey, &coldkey, netuid, stake_amount, fee);
         let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
             &origin_hotkey,
             &coldkey,
@@ -549,10 +570,11 @@ fn test_do_move_same_hotkey() {
         let coldkey = U256::from(1);
         let hotkey = U256::from(2);
         let stake_amount = DefaultMinStake::<Test>::get() * 10;
+        let fee = DefaultMinStake::<Test>::get();
 
         // Set up initial stake
         SubtensorModule::create_account_if_non_existent(&coldkey, &hotkey);
-        SubtensorModule::stake_into_subnet(&hotkey, &coldkey, netuid, stake_amount);
+        SubtensorModule::stake_into_subnet(&hotkey, &coldkey, netuid, stake_amount, fee);
         let alpha =
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
 
@@ -569,8 +591,8 @@ fn test_do_move_same_hotkey() {
         // Check that stake remains unchanged
         assert_abs_diff_eq!(
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid),
-            alpha,
-            epsilon = 5
+            alpha - fee,
+            epsilon = alpha / 1000
         );
     });
 }
@@ -588,11 +610,12 @@ fn test_do_move_event_emission() {
         let origin_hotkey = U256::from(2);
         let destination_hotkey = U256::from(3);
         let stake_amount = DefaultMinStake::<Test>::get() * 10;
+        let fee = DefaultMinStake::<Test>::get();
 
         // Set up initial stake
         SubtensorModule::create_account_if_non_existent(&coldkey, &origin_hotkey);
         SubtensorModule::create_account_if_non_existent(&coldkey, &destination_hotkey);
-        SubtensorModule::stake_into_subnet(&origin_hotkey, &coldkey, netuid, stake_amount);
+        SubtensorModule::stake_into_subnet(&origin_hotkey, &coldkey, netuid, stake_amount, 0); // use 0 fee for precision
         let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
             &origin_hotkey,
             &coldkey,
@@ -618,7 +641,7 @@ fn test_do_move_event_emission() {
                 netuid,
                 destination_hotkey,
                 netuid,
-                19999999, // Should be TAO equivalent
+                stake_amount - fee - 1, // Should be TAO equivalent
             )
             .into(),
         );
@@ -639,9 +662,16 @@ fn test_do_move_storage_updates() {
         let origin_hotkey = U256::from(2);
         let destination_hotkey = U256::from(3);
         let stake_amount = DefaultMinStake::<Test>::get() * 10;
+        let fee = DefaultMinStake::<Test>::get();
 
         // Set up initial stake
-        SubtensorModule::stake_into_subnet(&origin_hotkey, &coldkey, origin_netuid, stake_amount);
+        SubtensorModule::stake_into_subnet(
+            &origin_hotkey,
+            &coldkey,
+            origin_netuid,
+            stake_amount,
+            fee,
+        );
 
         // Move stake
         SubtensorModule::create_account_if_non_existent(&coldkey, &origin_hotkey);
@@ -676,8 +706,8 @@ fn test_do_move_storage_updates() {
                 &coldkey,
                 destination_netuid
             ),
-            alpha,
-            epsilon = 5
+            alpha - fee,
+            epsilon = alpha / 1000
         );
     });
 }
@@ -695,11 +725,12 @@ fn test_do_move_max_values() {
         let destination_hotkey = U256::from(3);
         let max_stake = u64::MAX;
         let netuid: u16 = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
+        let fee = 0;
 
         // Set up initial stake with maximum value
         SubtensorModule::create_account_if_non_existent(&coldkey, &origin_hotkey);
         SubtensorModule::create_account_if_non_existent(&coldkey, &destination_hotkey);
-        SubtensorModule::stake_into_subnet(&origin_hotkey, &coldkey, netuid, max_stake);
+        SubtensorModule::stake_into_subnet(&origin_hotkey, &coldkey, netuid, max_stake, fee);
         let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
             &origin_hotkey,
             &coldkey,
@@ -744,19 +775,20 @@ fn test_moving_too_little_fails() {
         let hotkey_account_id = U256::from(533453);
         let coldkey_account_id = U256::from(55453);
         let amount = DefaultMinStake::<Test>::get();
+        let fee = DefaultMinStake::<Test>::get();
 
         //add network
         let netuid: u16 = add_dynamic_network(&hotkey_account_id, &coldkey_account_id);
         let netuid2: u16 = add_dynamic_network(&hotkey_account_id, &coldkey_account_id);
 
         // Give it some $$$ in his coldkey balance
-        SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, amount);
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, amount + fee);
 
         assert_ok!(SubtensorModule::add_stake(
             RuntimeOrigin::signed(coldkey_account_id),
             hotkey_account_id,
             netuid,
-            amount
+            amount + fee
         ));
 
         // Coldkey / hotkey 0 decreases take to 5%. This should fail as the minimum take is 9%

--- a/pallets/subtensor/src/tests/senate.rs
+++ b/pallets/subtensor/src/tests/senate.rs
@@ -67,6 +67,7 @@ fn test_senate_join_works() {
         let burn_cost = 1000;
         let coldkey_account_id = U256::from(667); // Neighbour of the beast, har har
         let stake = DefaultMinStake::<Test>::get() * 100;
+        let fee = DefaultMinStake::<Test>::get();
 
         //add network
         SubtensorModule::set_burn(netuid, burn_cost);
@@ -112,12 +113,12 @@ fn test_senate_join_works() {
                 &staker_coldkey,
                 netuid
             ),
-            stake,
+            stake - fee,
             epsilon = 10
         );
         assert_abs_diff_eq!(
             SubtensorModule::get_stake_for_hotkey_on_subnet(&hotkey_account_id, netuid),
-            stake,
+            stake - fee,
             epsilon = 10
         );
 
@@ -140,6 +141,7 @@ fn test_senate_vote_works() {
         let hotkey_account_id = U256::from(6);
         let burn_cost = 1000;
         let coldkey_account_id = U256::from(667); // Neighbour of the beast, har har
+        let fee = DefaultMinStake::<Test>::get();
 
         //add network
         SubtensorModule::set_burn(netuid, burn_cost);
@@ -185,12 +187,12 @@ fn test_senate_vote_works() {
                 &staker_coldkey,
                 netuid
             ),
-            stake,
+            stake - fee,
             epsilon = stake / 1000
         );
         assert_abs_diff_eq!(
             SubtensorModule::get_stake_for_hotkey_on_subnet(&hotkey_account_id, netuid),
-            stake,
+            stake - fee,
             epsilon = stake / 1000
         );
 
@@ -313,6 +315,7 @@ fn test_senate_leave_works() {
         let burn_cost = 1000;
         let coldkey_account_id = U256::from(667); // Neighbour of the beast, har har
         let stake = DefaultMinStake::<Test>::get() * 10;
+        let fee = DefaultMinStake::<Test>::get();
 
         //add network
         SubtensorModule::set_burn(netuid, burn_cost);
@@ -357,12 +360,12 @@ fn test_senate_leave_works() {
                 &staker_coldkey,
                 netuid
             ),
-            stake,
+            stake - fee,
             epsilon = stake / 1000
         );
         assert_abs_diff_eq!(
             SubtensorModule::get_stake_for_hotkey_on_subnet(&hotkey_account_id, netuid),
-            stake,
+            stake - fee,
             epsilon = stake / 1000
         );
 
@@ -387,6 +390,7 @@ fn test_senate_leave_vote_removal() {
         let coldkey_account_id = U256::from(667); // Neighbour of the beast, har har
         let coldkey_origin = <<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id);
         let stake = DefaultMinStake::<Test>::get() * 10;
+        let fee = DefaultMinStake::<Test>::get();
 
         //add network
         SubtensorModule::set_burn(netuid, burn_cost);
@@ -431,12 +435,12 @@ fn test_senate_leave_vote_removal() {
                 &staker_coldkey,
                 netuid
             ),
-            stake,
+            stake - fee,
             epsilon = 10
         );
         assert_abs_diff_eq!(
             SubtensorModule::get_stake_for_hotkey_on_subnet(&hotkey_account_id, netuid),
-            stake,
+            stake - fee,
             epsilon = 10
         );
 
@@ -528,6 +532,7 @@ fn test_senate_not_leave_when_stake_removed() {
         let hotkey_account_id = U256::from(6);
         let burn_cost = 1000;
         let coldkey_account_id = U256::from(667); // Neighbour of the beast, har har
+        let fee = DefaultMinStake::<Test>::get();
 
         //add network
         SubtensorModule::set_burn(netuid, burn_cost);
@@ -573,12 +578,12 @@ fn test_senate_not_leave_when_stake_removed() {
                 &staker_coldkey,
                 netuid
             ),
-            stake_amount,
+            stake_amount - fee,
             epsilon = stake_amount / 1000
         );
         assert_abs_diff_eq!(
             SubtensorModule::get_stake_for_hotkey_on_subnet(&hotkey_account_id, netuid),
-            stake_amount,
+            stake_amount - fee,
             epsilon = stake_amount / 1000
         );
 
@@ -686,6 +691,7 @@ fn test_adjust_senate_events() {
         let burn_cost = 1000;
         let coldkey_account_id = U256::from(667);
         let root_netuid = SubtensorModule::get_root_netuid();
+        let fee = DefaultMinStake::<Test>::get();
 
         let max_senate_size: u16 = SenateMaxMembers::get() as u16;
         let stake_threshold: u64 = DefaultMinStake::<Test>::get(); // Give this much to every senator
@@ -806,7 +812,7 @@ fn test_adjust_senate_events() {
                 &coldkey_account_id,
                 root_netuid
             ),
-            stake,
+            stake - fee,
             epsilon = stake / 1000
         );
         assert_abs_diff_eq!(
@@ -814,7 +820,7 @@ fn test_adjust_senate_events() {
                 &replacement_hotkey_account_id,
                 root_netuid
             ),
-            stake,
+            stake - fee,
             epsilon = stake / 1000
         );
 

--- a/pallets/subtensor/src/tests/staking.rs
+++ b/pallets/subtensor/src/tests/staking.rs
@@ -42,6 +42,7 @@ fn test_add_stake_ok_no_emission() {
         let hotkey_account_id = U256::from(533453);
         let coldkey_account_id = U256::from(55453);
         let amount = DefaultMinStake::<Test>::get() * 10;
+        let fee = DefaultMinStake::<Test>::get();
 
         //add network
         let netuid: u16 = add_dynamic_network(&hotkey_account_id, &coldkey_account_id);
@@ -69,7 +70,7 @@ fn test_add_stake_ok_no_emission() {
         // Check if stake has increased
         assert_abs_diff_eq!(
             SubtensorModule::get_total_stake_for_hotkey(&hotkey_account_id),
-            amount,
+            amount - fee,
             epsilon = amount / 1000,
         );
 
@@ -78,7 +79,6 @@ fn test_add_stake_ok_no_emission() {
 
         // Check if total stake has increased accordingly.
         assert_eq!(SubtensorModule::get_total_stake(), amount);
-        assert_abs_diff_eq!(SubtensorModule::get_total_stake(), amount, epsilon = 1,);
     });
 }
 
@@ -350,7 +350,8 @@ fn test_remove_stake_ok_no_emission() {
         let subnet_owner_hotkey = U256::from(2);
         let coldkey_account_id = U256::from(4343);
         let hotkey_account_id = U256::from(4968585);
-        let amount = 10000;
+        let amount = DefaultMinStake::<Test>::get() * 10;
+        let fee = DefaultMinStake::<Test>::get();
         let netuid: u16 = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
         register_ok_neuron(netuid, hotkey_account_id, coldkey_account_id, 192213123);
 
@@ -379,12 +380,12 @@ fn test_remove_stake_ok_no_emission() {
         ));
 
         // we do not expect the exact amount due to slippage
-        assert!(SubtensorModule::get_coldkey_balance(&coldkey_account_id) > amount / 10 * 9,);
+        assert!(SubtensorModule::get_coldkey_balance(&coldkey_account_id) > amount / 10 * 9 - fee);
         assert_eq!(
             SubtensorModule::get_total_stake_for_hotkey(&hotkey_account_id),
             0
         );
-        assert_eq!(SubtensorModule::get_total_stake(), 0);
+        assert_eq!(SubtensorModule::get_total_stake(), fee);
     });
 }
 
@@ -498,6 +499,7 @@ fn test_remove_stake_no_enough_stake() {
 #[test]
 fn test_remove_stake_total_balance_no_change() {
     // When we remove stake, the total balance of the coldkey account should not change
+    //    (except for staking fees)
     //    this is because the stake should be part of the coldkey account balance (reserved/locked)
     //    then the removed stake just becomes free balance
     new_test_ext(1).execute_with(|| {
@@ -505,7 +507,8 @@ fn test_remove_stake_total_balance_no_change() {
         let subnet_owner_hotkey = U256::from(2);
         let hotkey_account_id = U256::from(571337);
         let coldkey_account_id = U256::from(71337);
-        let amount = 10_000;
+        let amount = DefaultMinStake::<Test>::get() * 10;
+        let fee = DefaultMinStake::<Test>::get();
         let netuid: u16 = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
         register_ok_neuron(netuid, hotkey_account_id, coldkey_account_id, 192213123);
 
@@ -537,18 +540,18 @@ fn test_remove_stake_total_balance_no_change() {
 
         assert_abs_diff_eq!(
             SubtensorModule::get_coldkey_balance(&coldkey_account_id),
-            amount,
-            epsilon = 1,
+            amount - fee,
+            epsilon = amount / 1000,
         );
         assert_eq!(
             SubtensorModule::get_total_stake_for_hotkey(&hotkey_account_id),
             0
         );
-        assert_eq!(SubtensorModule::get_total_stake(), 0);
+        assert_eq!(SubtensorModule::get_total_stake(), fee);
 
         // Check total balance is equal to the added stake. Even after remove stake (no fee, includes reserved/locked balance)
         let total_balance = Balances::total_balance(&coldkey_account_id);
-        assert_abs_diff_eq!(total_balance, amount, epsilon = 1,);
+        assert_abs_diff_eq!(total_balance, amount - fee, epsilon = amount / 1000);
     });
 }
 
@@ -564,6 +567,7 @@ fn test_remove_stake_total_issuance_no_change() {
         let coldkey_account_id = U256::from(81337);
         let amount = DefaultMinStake::<Test>::get() * 10;
         let netuid: u16 = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
+        let fee = DefaultMinStake::<Test>::get();
         register_ok_neuron(netuid, hotkey_account_id, coldkey_account_id, 192213123);
 
         // Give it some $$$ in his coldkey balance
@@ -610,14 +614,18 @@ fn test_remove_stake_total_issuance_no_change() {
 
         assert_abs_diff_eq!(
             SubtensorModule::get_coldkey_balance(&coldkey_account_id),
-            amount,
-            epsilon = 1,
+            amount - fee * 2,
+            epsilon = amount / 1000,
         );
         assert_eq!(
             SubtensorModule::get_total_stake_for_hotkey(&hotkey_account_id),
             0
         );
-        assert_abs_diff_eq!(SubtensorModule::get_total_stake(), 0, epsilon = 1,);
+        assert_abs_diff_eq!(
+            SubtensorModule::get_total_stake(),
+            fee * 2,
+            epsilon = fee / 1000
+        );
 
         // Check if total issuance is equal to the added stake, even after remove stake (no fee, includes reserved/locked balance)
         assert_abs_diff_eq!(
@@ -625,10 +633,13 @@ fn test_remove_stake_total_issuance_no_change() {
             total_issuance_after_stake + amount,
             epsilon = 1,
         );
+
+        // After staking + unstaking the 2 * fee amount stays in SubnetTAO and TotalStake,
+        // so the total issuance should be lower by that amount
         assert_abs_diff_eq!(
             inital_total_issuance,
-            total_issuance_after_unstake,
-            epsilon = 1,
+            total_issuance_after_unstake + 2 * fee,
+            epsilon = inital_total_issuance / 10000,
         );
     });
 }
@@ -1108,6 +1119,8 @@ fn test_clear_small_nominations() {
         let cold2 = U256::from(4);
         let netuid: u16 = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
         let amount = DefaultMinStake::<Test>::get() * 10;
+        let fee: u64 = DefaultMinStake::<Test>::get();
+        let init_balance = amount + fee + ExistentialDeposit::get();
 
         // Register hot1.
         register_ok_neuron(netuid, hot1, cold1, 0);
@@ -1120,80 +1133,84 @@ fn test_clear_small_nominations() {
         assert_eq!(SubtensorModule::get_owning_coldkey_for_hotkey(&hot2), cold2);
 
         // Add stake cold1 --> hot1 (non delegation.)
-        SubtensorModule::add_balance_to_coldkey_account(&cold1, amount);
+        SubtensorModule::add_balance_to_coldkey_account(&cold1, init_balance);
         assert_ok!(SubtensorModule::add_stake(
             RuntimeOrigin::signed(cold1),
             hot1,
             netuid,
-            amount
+            amount + fee
         ));
         assert_ok!(SubtensorModule::remove_stake(
             RuntimeOrigin::signed(cold1),
             hot1,
             netuid,
-            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hot1, &cold1, netuid) - 1
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hot1, &cold1, netuid)
+                - 100
         ));
         assert_eq!(
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hot1, &cold1, netuid),
-            1
+            100
         );
 
         // Add stake cold2 --> hot1 (is delegation.)
-        SubtensorModule::add_balance_to_coldkey_account(&cold2, amount);
+        SubtensorModule::add_balance_to_coldkey_account(&cold2, init_balance);
         assert_ok!(SubtensorModule::add_stake(
             RuntimeOrigin::signed(cold2),
             hot1,
             netuid,
-            amount
+            amount + fee
         ));
         assert_ok!(SubtensorModule::remove_stake(
             RuntimeOrigin::signed(cold2),
             hot1,
             netuid,
-            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hot1, &cold2, netuid) - 1
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hot1, &cold2, netuid)
+                - 100
         ));
         assert_eq!(
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hot1, &cold2, netuid),
-            1
+            100
         );
 
         // Add stake cold1 --> hot2 (non delegation.)
-        SubtensorModule::add_balance_to_coldkey_account(&cold1, amount);
+        SubtensorModule::add_balance_to_coldkey_account(&cold1, init_balance);
         assert_ok!(SubtensorModule::add_stake(
             RuntimeOrigin::signed(cold1),
             hot2,
             netuid,
-            amount
+            amount + fee
         ));
         assert_ok!(SubtensorModule::remove_stake(
             RuntimeOrigin::signed(cold1),
             hot2,
             netuid,
-            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hot2, &cold1, netuid) - 1
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hot2, &cold1, netuid)
+                - 100
         ));
         assert_eq!(
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hot2, &cold1, netuid),
-            1
+            100
         );
         let balance1_before_cleaning = Balances::free_balance(cold1);
 
         // Add stake cold2 --> hot2 (is delegation.)
-        SubtensorModule::add_balance_to_coldkey_account(&cold2, amount);
+        SubtensorModule::add_balance_to_coldkey_account(&cold2, init_balance);
         assert_ok!(SubtensorModule::add_stake(
             RuntimeOrigin::signed(cold2),
             hot2,
             netuid,
-            amount
+            amount + fee
         ));
         assert_ok!(SubtensorModule::remove_stake(
             RuntimeOrigin::signed(cold2),
             hot2,
             netuid,
-            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hot2, &cold2, netuid) - 1
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hot2, &cold2, netuid)
+                - 100
         ));
         assert_eq!(
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hot2, &cold2, netuid),
-            1
+            100
         );
         let balance2_before_cleaning = Balances::free_balance(cold2);
 
@@ -1203,19 +1220,19 @@ fn test_clear_small_nominations() {
         SubtensorModule::clear_small_nominations();
         assert_eq!(
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hot1, &cold1, netuid),
-            1
+            100
         );
         assert_eq!(
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hot2, &cold1, netuid),
-            1
+            100
         );
         assert_eq!(
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hot1, &cold2, netuid),
-            1
+            100
         );
         assert_eq!(
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hot2, &cold2, netuid),
-            1
+            100
         );
 
         // Set min nomination to 10
@@ -1224,13 +1241,13 @@ fn test_clear_small_nominations() {
         let total_hot1_stake_before = TotalHotkeyAlpha::<Test>::get(hot1, netuid);
         let total_hot2_stake_before = TotalHotkeyAlpha::<Test>::get(hot2, netuid);
         let total_stake_before = TotalStake::<Test>::get();
-        SubtensorModule::set_nominator_min_required_stake(10);
+        SubtensorModule::set_nominator_min_required_stake(1000);
 
         // Run clear all small nominations (removes delegations under 10)
         SubtensorModule::clear_small_nominations();
         assert_eq!(
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hot1, &cold1, netuid),
-            1
+            100
         );
         assert_eq!(
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hot2, &cold1, netuid),
@@ -1242,24 +1259,26 @@ fn test_clear_small_nominations() {
         );
         assert_eq!(
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hot2, &cold2, netuid),
-            1
+            100
         );
 
         // Balances have been added back into accounts.
         let balance1_after_cleaning = Balances::free_balance(cold1);
         let balance2_after_cleaning = Balances::free_balance(cold2);
-        assert_eq!(balance1_before_cleaning + 1, balance1_after_cleaning);
-        assert_eq!(balance2_before_cleaning + 1, balance2_after_cleaning);
+        assert_eq!(balance1_before_cleaning + 100, balance1_after_cleaning);
+        assert_eq!(balance2_before_cleaning + 100, balance2_after_cleaning);
 
-        assert_eq!(
+        assert_abs_diff_eq!(
             TotalHotkeyAlpha::<Test>::get(hot2, netuid),
-            total_hot2_stake_before - 1
+            total_hot2_stake_before - 100,
+            epsilon = 1
         );
-        assert_eq!(
+        assert_abs_diff_eq!(
             TotalHotkeyAlpha::<Test>::get(hot1, netuid),
-            total_hot1_stake_before - 1
+            total_hot1_stake_before - 100,
+            epsilon = 1
         );
-        assert_eq!(TotalStake::<Test>::get(), total_stake_before - 2);
+        assert_eq!(TotalStake::<Test>::get(), total_stake_before - 200);
     });
 }
 
@@ -1590,6 +1609,7 @@ fn test_get_total_delegated_stake_after_unstaking() {
         let unstake_amount = DefaultMinStake::<Test>::get() * 5;
         let existential_deposit = ExistentialDeposit::get();
         let netuid = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
+        let fee = DefaultMinStake::<Test>::get();
 
         register_ok_neuron(netuid, delegate_hotkey, delegate_coldkey, 0);
 
@@ -1607,12 +1627,12 @@ fn test_get_total_delegated_stake_after_unstaking() {
         // Check initial delegated stake
         assert_abs_diff_eq!(
             SubtensorModule::get_total_stake_for_coldkey(&delegator),
-            initial_stake - existential_deposit,
+            initial_stake - existential_deposit - fee,
             epsilon = initial_stake / 1000,
         );
         assert_abs_diff_eq!(
             SubtensorModule::get_total_stake_for_hotkey(&delegate_hotkey),
-            initial_stake - existential_deposit,
+            initial_stake - existential_deposit - fee,
             epsilon = initial_stake / 1000,
         );
 
@@ -1625,7 +1645,7 @@ fn test_get_total_delegated_stake_after_unstaking() {
         ));
 
         // Calculate the expected delegated stake
-        let expected_delegated_stake = initial_stake - unstake_amount - existential_deposit;
+        let expected_delegated_stake = initial_stake - unstake_amount - existential_deposit - fee;
 
         // Debug prints
         log::debug!("Initial stake: {}", initial_stake);
@@ -1677,6 +1697,7 @@ fn test_get_total_delegated_stake_single_delegator() {
         let stake_amount = DefaultMinStake::<Test>::get() * 10 - 1;
         let existential_deposit = ExistentialDeposit::get();
         let netuid = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
+        let fee = DefaultMinStake::<Test>::get();
 
         register_ok_neuron(netuid, delegate_hotkey, delegate_coldkey, 0);
 
@@ -1705,7 +1726,7 @@ fn test_get_total_delegated_stake_single_delegator() {
         );
 
         // Calculate expected delegated stake
-        let expected_delegated_stake = stake_amount - existential_deposit;
+        let expected_delegated_stake = stake_amount - existential_deposit - fee;
         let actual_delegated_stake = SubtensorModule::get_total_stake_for_hotkey(&delegate_hotkey);
         let actual_delegator_stake = SubtensorModule::get_total_stake_for_coldkey(&delegator);
 
@@ -1734,6 +1755,7 @@ fn test_get_alpha_share_stake_multiple_delegators() {
         let existential_deposit = 2;
         let stake1 = DefaultMinStake::<Test>::get() * 10;
         let stake2 = DefaultMinStake::<Test>::get() * 10 - 1;
+        let fee = DefaultMinStake::<Test>::get();
 
         let netuid = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
         register_ok_neuron(netuid, hotkey1, coldkey1, 0);
@@ -1770,7 +1792,7 @@ fn test_get_alpha_share_stake_multiple_delegators() {
         );
 
         // Calculate expected total delegated stake
-        let expected_total_stake = stake1 + stake2 - existential_deposit * 2;
+        let expected_total_stake = stake1 + stake2 - existential_deposit * 2 - fee * 2;
         let actual_total_stake = SubtensorModule::get_alpha_share_pool(hotkey1, netuid)
             .get_value(&coldkey1)
             + SubtensorModule::get_alpha_share_pool(hotkey2, netuid).get_value(&coldkey2);
@@ -1792,6 +1814,7 @@ fn test_get_total_delegated_stake_exclude_owner_stake() {
         let delegator = U256::from(3);
         let owner_stake = DefaultMinStake::<Test>::get() * 10;
         let delegator_stake = DefaultMinStake::<Test>::get() * 10 - 1;
+        let fee = DefaultMinStake::<Test>::get();
 
         let netuid = add_dynamic_network(&delegate_hotkey, &delegate_coldkey);
 
@@ -1825,7 +1848,7 @@ fn test_get_total_delegated_stake_exclude_owner_stake() {
         );
 
         // Check the total delegated stake (should exclude owner's stake)
-        let expected_delegated_stake = delegator_stake;
+        let expected_delegated_stake = delegator_stake - fee;
         let actual_delegated_stake =
             SubtensorModule::get_total_stake_for_coldkey(&delegate_coldkey);
 
@@ -1969,7 +1992,8 @@ fn test_add_stake_fee_goes_to_subnet_tao() {
 
         // Calculate expected stake
         let expected_alpha = tao_to_stake - existential_deposit - fee;
-        let actual_alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
+        let actual_alpha =
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
         let subnet_tao_after = SubnetTAO::<Test>::get(netuid);
 
         // Total subnet stake should match the sum of delegators' stakes minus existential deposits.
@@ -2013,7 +2037,8 @@ fn test_remove_stake_fee_goes_to_subnet_tao() {
         ));
 
         // Remove all stake
-        let alpha_to_unstake = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
+        let alpha_to_unstake =
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
         assert_ok!(SubtensorModule::remove_stake(
             RuntimeOrigin::signed(coldkey),
             hotkey,
@@ -2036,5 +2061,69 @@ fn test_remove_stake_fee_goes_to_subnet_tao() {
             tao_to_stake,
             epsilon = tao_to_stake / 1000
         );
+    });
+}
+
+#[test]
+fn test_stake_below_min_validate() {
+    // Testing the signed extension validate function
+    // correctly filters the `add_stake` transaction.
+
+    new_test_ext(0).execute_with(|| {
+        let subnet_owner_coldkey = U256::from(1001);
+        let subnet_owner_hotkey = U256::from(1002);
+        let hotkey = U256::from(2);
+        let coldkey = U256::from(3);
+        let amount_staked = DefaultMinStake::<Test>::get() - 1;
+
+        let netuid = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
+        SubtensorModule::create_account_if_non_existent(&coldkey, &hotkey);
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey, amount_staked);
+
+        // Add stake call
+        let call = RuntimeCall::SubtensorModule(SubtensorCall::add_stake {
+            hotkey,
+            netuid,
+            amount_staked,
+        });
+
+        let info: crate::DispatchInfo =
+            crate::DispatchInfoOf::<<Test as frame_system::Config>::RuntimeCall>::default();
+
+        let extension = crate::SubtensorSignedExtension::<Test>::new();
+        // Submit to the signed extension validate function
+        let result_no_stake = extension.validate(&coldkey, &call.clone(), &info, 10);
+
+        // Should fail due to insufficient stake
+        assert_err!(
+            result_no_stake,
+            crate::TransactionValidityError::Invalid(crate::InvalidTransaction::Custom(1))
+        );
+
+        // Increase the stake to be equal to the minimum, but leave the balance low
+        let amount_staked = DefaultMinStake::<Test>::get();
+        let call_2 = RuntimeCall::SubtensorModule(SubtensorCall::add_stake {
+            hotkey,
+            netuid,
+            amount_staked,
+        });
+
+        // Submit to the signed extension validate function
+        let result_low_balance = extension.validate(&coldkey, &call_2.clone(), &info, 10);
+
+        // Still doesn't pass
+        assert_err!(
+            result_low_balance,
+            crate::TransactionValidityError::Invalid(crate::InvalidTransaction::Custom(1))
+        );
+
+        // Increase the coldkey balance to match the minimum
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey, 1);
+
+        // Submit to the signed extension validate function
+        let result_min_stake = extension.validate(&coldkey, &call_2.clone(), &info, 10);
+
+        // Now the call passes
+        assert_ok!(result_min_stake);
     });
 }

--- a/pallets/subtensor/src/tests/swap_hotkey.rs
+++ b/pallets/subtensor/src/tests/swap_hotkey.rs
@@ -66,6 +66,7 @@ fn test_swap_total_hotkey_stake() {
         let coldkey = U256::from(3);
         let amount = DefaultMinStake::<Test>::get() * 10;
         let mut weight = Weight::zero();
+        let fee = DefaultMinStake::<Test>::get();
 
         //add network
         let netuid: u16 = add_dynamic_network(&old_hotkey, &coldkey);
@@ -84,7 +85,7 @@ fn test_swap_total_hotkey_stake() {
         // Check if stake has increased
         assert_abs_diff_eq!(
             SubtensorModule::get_total_stake_for_hotkey(&old_hotkey),
-            amount,
+            amount - fee,
             epsilon = amount / 1000,
         );
         assert_abs_diff_eq!(
@@ -109,7 +110,7 @@ fn test_swap_total_hotkey_stake() {
         );
         assert_abs_diff_eq!(
             SubtensorModule::get_total_stake_for_hotkey(&new_hotkey),
-            amount,
+            amount - fee,
             epsilon = amount / 1000,
         );
     });

--- a/pallets/subtensor/src/tests/weights.rs
+++ b/pallets/subtensor/src/tests/weights.rs
@@ -69,6 +69,7 @@ fn test_set_rootweights_validate() {
         let coldkey = U256::from(0);
         let hotkey: U256 = U256::from(1); // Add the hotkey field
         assert_ne!(hotkey, coldkey); // Ensure hotkey is NOT the same as coldkey !!!
+        let fee = DefaultMinStake::<Test>::get();
 
         let who = coldkey; // The coldkey signs this transaction
 
@@ -112,7 +113,7 @@ fn test_set_rootweights_validate() {
             RuntimeOrigin::signed(hotkey),
             hotkey,
             netuid,
-            min_stake
+            min_stake + fee
         ));
 
         // Verify stake is equal to minimum
@@ -183,6 +184,7 @@ fn test_commit_weights_validate() {
         let coldkey = U256::from(0);
         let hotkey: U256 = U256::from(1); // Add the hotkey field
         assert_ne!(hotkey, coldkey); // Ensure hotkey is NOT the same as coldkey !!!
+        let fee = DefaultMinStake::<Test>::get();
 
         let who = hotkey; // The hotkey signs this transaction
 
@@ -226,7 +228,7 @@ fn test_commit_weights_validate() {
             RuntimeOrigin::signed(hotkey),
             hotkey,
             netuid,
-            min_stake
+            min_stake + fee
         ));
 
         // Verify stake is equal to minimum
@@ -292,6 +294,7 @@ fn test_set_weights_validate() {
         let coldkey = U256::from(0);
         let hotkey: U256 = U256::from(1);
         assert_ne!(hotkey, coldkey);
+        let fee = DefaultMinStake::<Test>::get();
 
         let who = hotkey; // The hotkey signs this transaction
 
@@ -333,7 +336,7 @@ fn test_set_weights_validate() {
             RuntimeOrigin::signed(hotkey),
             hotkey,
             netuid,
-            min_stake
+            min_stake + fee
         ));
 
         // Verify stake is equal to minimum
@@ -364,6 +367,7 @@ fn test_reveal_weights_validate() {
         let coldkey = U256::from(0);
         let hotkey: U256 = U256::from(1); // Add the hotkey field
         assert_ne!(hotkey, coldkey); // Ensure hotkey is NOT the same as coldkey !!!
+        let fee = DefaultMinStake::<Test>::get();
 
         let who = hotkey; // The hotkey signs this transaction
 
@@ -406,7 +410,7 @@ fn test_reveal_weights_validate() {
             RuntimeOrigin::signed(hotkey),
             hotkey,
             netuid,
-            min_stake
+            min_stake + fee
         ));
 
         // Verify stake is equal to minimum


### PR DESCRIPTION
## Description
`add_stake`, `remove_stake`, and `move_stake` will capture fees from the TAO being staked / unstaked. The fee amount will be 500k rao (using DefaultMinStake value).

Validation will be filtering out `add_stake` transactions if amount to be staked or account balance to fulfill the fee is insufficient.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

