### PR TITLE
Make commitment pallet rate limit configurable via sudo

### DIFF
--- a/pallets/commitments/src/tests.rs
+++ b/pallets/commitments/src/tests.rs
@@ -86,7 +86,7 @@ impl pallet_commitments::Config for Test {
     type CanCommit = ();
     type FieldDeposit = frame_support::traits::ConstU64<0>;
     type InitialDeposit = frame_support::traits::ConstU64<0>;
-    type RateLimit = frame_support::traits::ConstU64<0>;
+    type DefaultRateLimit = frame_support::traits::ConstU64<0>;
 }
 
 // // Build genesis storage according to the mock runtime.

--- a/pallets/commitments/src/weights.rs
+++ b/pallets/commitments/src/weights.rs
@@ -30,6 +30,7 @@ use core::marker::PhantomData;
 /// Weight functions needed for `pallet_commitments`.
 pub trait WeightInfo {
 	fn set_commitment() -> Weight;
+	fn set_rate_limit() -> Weight;
 }
 
 /// Weights for `pallet_commitments` using the Substrate node and recommended hardware.
@@ -48,6 +49,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
+	/// Sudo setting rate limit for commitments
+	fn set_rate_limit() -> Weight {
+		Weight::from_parts(10_000_000, 2000)
+			.saturating_add(RocksDbWeight::get().reads(1_u64))
+	}	
 }
 
 // For backwards compatibility and tests.
@@ -65,4 +71,10 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(2_u64))
 			.saturating_add(RocksDbWeight::get().writes(2_u64))
 	}
+
+	/// Sudo setting rate limit for commitments
+	fn set_rate_limit() -> Weight {
+		Weight::from_parts(10_000_000, 2000)
+			.saturating_add(RocksDbWeight::get().reads(1_u64))
+	}	
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -974,7 +974,7 @@ impl pallet_commitments::Config for Runtime {
     type MaxFields = MaxCommitFields;
     type InitialDeposit = CommitmentInitialDeposit;
     type FieldDeposit = CommitmentFieldDeposit;
-    type RateLimit = CommitmentRateLimit;
+    type DefaultRateLimit = CommitmentRateLimit;
 }
 
 #[cfg(not(feature = "fast-blocks"))]


### PR DESCRIPTION
## Description
Makes commitment pallet rate limit configurable (with sudo)

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

