### PR TITLE
change pool liq init

### DIFF
--- a/pallets/subtensor/src/migrations/migrate_rao.rs
+++ b/pallets/subtensor/src/migrations/migrate_rao.rs
@@ -71,17 +71,26 @@ pub fn migrate_rao<T: Config>() -> Weight {
         }
         let owner: T::AccountId = SubnetOwner::<T>::get(netuid);
         let lock: u64 = SubnetLocked::<T>::get(netuid);
-        let initial_liquidity: u64 = 100_000_000_000; // 100 TAO.
-        let remaining_lock: u64 = lock.saturating_sub(initial_liquidity);
+
+        // Put initial TAO from lock into subnet TAO and produce numerically equal amount of Alpha
+        // The initial TAO is the locked amount, with a minimum of 1 TAO and a cap of 100 TAO.
+        let pool_initial_tao = 100_000_000_000.min(lock.max(1));
+
+        let remaining_lock = lock.saturating_sub(pool_initial_tao);
+        // Refund the owner for the remaining lock.
         Pallet::<T>::add_balance_to_coldkey_account(&owner, remaining_lock);
-        SubnetTAO::<T>::insert(netuid, initial_liquidity); // Set TAO to the lock.
-        SubnetAlphaIn::<T>::insert(netuid, initial_liquidity); // Set AlphaIn to the initial alpha distribution.
+        SubnetTAO::<T>::insert(netuid, pool_initial_tao); // Set TAO to the lock.
+
+        SubnetAlphaIn::<T>::insert(
+            netuid,
+            pool_initial_tao.saturating_mul(netuids.len() as u64),
+        ); // Set AlphaIn to the initial alpha distribution.
+
         SubnetAlphaOut::<T>::insert(netuid, 0); // Set zero subnet alpha out.
         SubnetMechanism::<T>::insert(netuid, 1); // Convert to dynamic immediately with initialization.
         Tempo::<T>::insert(netuid, DefaultTempo::<T>::get());
         // Set the token symbol for this subnet using Self instead of Pallet::<T>
         TokenSymbol::<T>::insert(netuid, Pallet::<T>::get_symbol_for_subnet(*netuid));
-        SubnetTAO::<T>::insert(netuid, initial_liquidity); // Set TAO to the lock.
         TotalStakeAtDynamic::<T>::insert(netuid, 0);
 
         if let Ok(owner_coldkey) = SubnetOwner::<T>::try_get(netuid) {

--- a/pallets/subtensor/src/migrations/migrate_rao.rs
+++ b/pallets/subtensor/src/migrations/migrate_rao.rs
@@ -73,7 +73,7 @@ pub fn migrate_rao<T: Config>() -> Weight {
         let lock: u64 = SubnetLocked::<T>::get(netuid);
 
         // Put initial TAO from lock into subnet TAO and produce numerically equal amount of Alpha
-        // The initial TAO is the locked amount, with a minimum of 1 TAO and a cap of 100 TAO.
+        // The initial TAO is the locked amount, with a minimum of 1 RAO and a cap of 100 TAO.
         let pool_initial_tao = 100_000_000_000.min(lock.max(1));
 
         let remaining_lock = lock.saturating_sub(pool_initial_tao);

--- a/pallets/subtensor/src/subnets/subnet.rs
+++ b/pallets/subtensor/src/subnets/subnet.rs
@@ -233,18 +233,18 @@ impl<T: Config> Pallet<T> {
             Self::get_symbol_for_subnet(netuid_to_register),
         ); // Set subnet token symbol.
 
-        // Put 100 TAO from lock into subnet TAO and produce numerically equal amount of Alpha
-        let mut pool_initial_tao = 100_000_000_000;
-        if pool_initial_tao > actual_tao_lock_amount {
-            pool_initial_tao = actual_tao_lock_amount;
-        }
-        if pool_initial_tao < 1 {
-            pool_initial_tao = 1;
-        }
+        // Put initial TAO from lock into subnet TAO and produce numerically equal amount of Alpha
+        // The initial TAO is the locked amount, with a minimum of 1 TAO and a cap of 100 TAO.
+        let pool_initial_tao = 100_000_000_000.min(actual_tao_lock_amount.max(1));
+
         let actual_tao_lock_amount_less_pool_tao =
             actual_tao_lock_amount.saturating_sub(pool_initial_tao);
         SubnetTAO::<T>::insert(netuid_to_register, pool_initial_tao);
-        SubnetAlphaIn::<T>::insert(netuid_to_register, pool_initial_tao);
+        SubnetAlphaIn::<T>::insert(
+            netuid_to_register,
+            pool_initial_tao.saturating_mul(Self::get_all_subnet_netuids().len() as u64),
+        ); // Set AlphaIn to the initial alpha distribution.
+
         SubnetOwner::<T>::insert(netuid_to_register, coldkey.clone());
         SubnetOwnerHotkey::<T>::insert(netuid_to_register, hotkey.clone());
         TotalStakeAtDynamic::<T>::insert(netuid_to_register, TotalStake::<T>::get());

--- a/pallets/subtensor/src/subnets/subnet.rs
+++ b/pallets/subtensor/src/subnets/subnet.rs
@@ -234,7 +234,7 @@ impl<T: Config> Pallet<T> {
         ); // Set subnet token symbol.
 
         // Put initial TAO from lock into subnet TAO and produce numerically equal amount of Alpha
-        // The initial TAO is the locked amount, with a minimum of 1 TAO and a cap of 100 TAO.
+        // The initial TAO is the locked amount, with a minimum of 1 RAO and a cap of 100 TAO.
         let pool_initial_tao = 100_000_000_000.min(actual_tao_lock_amount.max(1));
 
         let actual_tao_lock_amount_less_pool_tao =

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -598,9 +598,9 @@ fn test_migrate_rao() {
 
         // Verify root subnet (netuid 0) state after migration
         assert_eq!(SubnetTAO::<Test>::get(netuid_0), 4 * stake_amount); // Root has everything
-        assert_eq!(SubnetTAO::<Test>::get(netuid_1), 100_000_000_000); // Initial Rao amount.
+        assert_eq!(SubnetTAO::<Test>::get(netuid_1), lock_amount); // Initial Rao amount.
         assert_eq!(SubnetAlphaIn::<Test>::get(netuid_0), 1); // No Alpha in pool on root.
-        assert_eq!(SubnetAlphaIn::<Test>::get(netuid_1), 100_000_000_000); // Initial Rao amount.
+        assert_eq!(SubnetAlphaIn::<Test>::get(netuid_1), 2 * lock_amount); // Initial Rao amount == num_subnets * lock_amount
         assert_eq!(SubnetAlphaOut::<Test>::get(netuid_0), 4 * stake_amount); // All stake is outstanding.
         assert_eq!(SubnetAlphaOut::<Test>::get(netuid_1), 0); // No stake outstanding.
 

--- a/pallets/subtensor/src/tests/move_stake.rs
+++ b/pallets/subtensor/src/tests/move_stake.rs
@@ -1401,15 +1401,18 @@ fn test_do_swap_storage_updates() {
         );
 
         let alpha_fee =
-            SubtensorModule::get_alpha_price(destination_netuid) * I96F32::from_num(fee);
+            I96F32::from_num(fee) / SubtensorModule::get_alpha_price(destination_netuid);
+        let expected_value = I96F32::from_num(alpha)
+            * SubtensorModule::get_alpha_price(origin_netuid)
+            / SubtensorModule::get_alpha_price(destination_netuid);
         assert_abs_diff_eq!(
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
                 &hotkey,
                 &coldkey,
                 destination_netuid
             ),
-            alpha - alpha_fee.to_num::<u64>(),
-            epsilon = 5
+            (expected_value - alpha_fee).to_num::<u64>(),
+            epsilon = (expected_value / 1000).to_num::<u64>()
         );
     });
 }

--- a/pallets/subtensor/src/tests/move_stake.rs
+++ b/pallets/subtensor/src/tests/move_stake.rs
@@ -3,6 +3,7 @@ use crate::*;
 use approx::assert_abs_diff_eq;
 use frame_support::{assert_err, assert_noop, assert_ok};
 use sp_core::{Get, U256};
+use substrate_fixed::types::I96F32;
 
 // 1. test_do_move_success
 // Description: Test a successful move of stake between two hotkeys in the same subnet
@@ -111,14 +112,19 @@ fn test_do_move_different_subnets() {
             ),
             0
         );
+        let alpha_fee: I96F32 =
+            I96F32::from_num(fee) / SubtensorModule::get_alpha_price(destination_netuid);
+        let expected_value = I96F32::from_num(alpha)
+            * SubtensorModule::get_alpha_price(origin_netuid)
+            / SubtensorModule::get_alpha_price(destination_netuid);
         assert_abs_diff_eq!(
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
                 &destination_hotkey,
                 &coldkey,
                 destination_netuid
             ),
-            stake_amount - 2 * fee,
-            epsilon = stake_amount / 1000
+            (expected_value - alpha_fee).to_num::<u64>(),
+            epsilon = (expected_value / 1000).to_num::<u64>()
         );
     });
 }
@@ -700,13 +706,17 @@ fn test_do_move_storage_updates() {
             ),
             0
         );
+        let alpha_fee =
+            I96F32::from_num(fee) / SubtensorModule::get_alpha_price(destination_netuid);
+        let alpha2 = I96F32::from_num(alpha) * SubtensorModule::get_alpha_price(origin_netuid)
+            / SubtensorModule::get_alpha_price(destination_netuid);
         assert_abs_diff_eq!(
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
                 &destination_hotkey,
                 &coldkey,
                 destination_netuid
             ),
-            alpha - fee,
+            (alpha2 - alpha_fee).to_num::<u64>(),
             epsilon = alpha / 1000
         );
     });
@@ -1063,10 +1073,12 @@ fn test_do_transfer_different_subnets() {
             &destination_coldkey,
             destination_netuid,
         );
+        let expected_value = I96F32::from_num(stake_amount - fee)
+            / SubtensorModule::get_alpha_price(destination_netuid);
         assert_abs_diff_eq!(
             dest_stake,
-            stake_amount - fee,
-            epsilon = stake_amount / 1000
+            expected_value.to_num::<u64>(),
+            epsilon = (expected_value / 1000).to_num::<u64>()
         );
     });
 }
@@ -1114,10 +1126,15 @@ fn test_do_swap_success() {
             &coldkey,
             destination_netuid,
         );
+        let alpha_fee =
+            I96F32::from_num(fee) / SubtensorModule::get_alpha_price(destination_netuid);
+        let expected_value = I96F32::from_num(alpha_before)
+            * SubtensorModule::get_alpha_price(origin_netuid)
+            / SubtensorModule::get_alpha_price(destination_netuid);
         assert_abs_diff_eq!(
             alpha_after,
-            stake_amount - fee,
-            epsilon = stake_amount / 1000
+            (expected_value - alpha_fee).to_num::<u64>(),
+            epsilon = (expected_value / 1000).to_num::<u64>()
         );
     });
 }
@@ -1309,7 +1326,6 @@ fn test_do_swap_partial_stake() {
         SubtensorModule::create_account_if_non_existent(&coldkey, &hotkey);
         SubtensorModule::stake_into_subnet(&hotkey, &coldkey, origin_netuid, total_stake, 0);
 
-        let fee_as_alpha2 = SubtensorModule::swap_tao_for_alpha(destination_netuid, fee);
         let swap_amount = total_stake / 2;
         assert_ok!(SubtensorModule::do_swap_stake(
             RuntimeOrigin::signed(coldkey),
@@ -1328,14 +1344,20 @@ fn test_do_swap_partial_stake() {
             total_stake - swap_amount,
             epsilon = total_stake / 1000
         );
+
+        let alpha_fee =
+            I96F32::from_num(fee) / SubtensorModule::get_alpha_price(destination_netuid);
+        let expected_value = I96F32::from_num(swap_amount)
+            * SubtensorModule::get_alpha_price(origin_netuid)
+            / SubtensorModule::get_alpha_price(destination_netuid);
         assert_abs_diff_eq!(
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
                 &hotkey,
                 &coldkey,
                 destination_netuid
             ),
-            swap_amount - fee_as_alpha2,
-            epsilon = total_stake / 1000
+            (expected_value - alpha_fee).to_num::<u64>(),
+            epsilon = (expected_value / 1000).to_num::<u64>()
         );
     });
 }
@@ -1378,15 +1400,15 @@ fn test_do_swap_storage_updates() {
             0
         );
 
-        let fee_as_alpha = SubtensorModule::swap_tao_for_alpha(destination_netuid, fee);
-
+        let alpha_fee =
+            SubtensorModule::get_alpha_price(destination_netuid) * I96F32::from_num(fee);
         assert_abs_diff_eq!(
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
                 &hotkey,
                 &coldkey,
                 destination_netuid
             ),
-            alpha - fee_as_alpha,
+            alpha - alpha_fee.to_num::<u64>(),
             epsilon = 5
         );
     });


### PR DESCRIPTION
This changes the RAO pool initialization to use an initial subnetTAO of `init_liq = min(100e9, max(1, lock))` and an initial subnetAlpha of `init_liq * num_subnets`