### PR TITLE
[RAO] add alpha transfer toggle

### DIFF
--- a/pallets/admin-utils/src/benchmarking.rs
+++ b/pallets/admin-utils/src/benchmarking.rs
@@ -287,7 +287,7 @@ mod benchmarks {
             1u16, /*sudo_tempo*/
         );
         let owner: T::AccountId = account("Alice", 0, 1);
-        SubnetOwner::<T>::insert(1u16, owner.clone());
+        pallet_subtensor::SubnetOwner::<T>::insert(1u16, owner.clone());
 
         #[extrinsic_call]
 		_(RawOrigin::Signed(owner.clone()), 1u16/*netuid*/)/*sudo_enable_alpha_transfer*/;

--- a/pallets/admin-utils/src/benchmarking.rs
+++ b/pallets/admin-utils/src/benchmarking.rs
@@ -280,5 +280,18 @@ mod benchmarks {
         _(RawOrigin::Root, 1u16/*netuid*/, 1_000_000_000_000_000u64/*max_stake*/)/*sudo_set_network_max_stake*/;
     }
 
+    #[benchmark]
+    fn sudo_enable_alpha_transfer() {
+        pallet_subtensor::Pallet::<T>::init_new_network(
+            1u16, /*netuid*/
+            1u16, /*sudo_tempo*/
+        );
+        let owner: T::AccountId = account("Alice", 0, 1);
+        SubnetOwner::<T>::insert(1u16, owner.clone());
+
+        #[extrinsic_call]
+		_(RawOrigin::Signed(owner.clone()), 1u16/*netuid*/)/*sudo_enable_alpha_transfer*/;
+    }
+
     //impl_benchmark_test_suite!(AdminUtils, crate::mock::new_test_ext(), crate::mock::Test);
 }

--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -69,6 +69,7 @@ pub mod pallet {
     }
 
     #[pallet::event]
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
     pub enum Event<T: Config> {
         /// Alpha transfer was enabled on a subnet.
         AlphaTransferEnabled(u16, bool),

--- a/pallets/admin-utils/src/weights.rs
+++ b/pallets/admin-utils/src/weights.rs
@@ -65,6 +65,7 @@ pub trait WeightInfo {
 	fn sudo_set_commit_reveal_weights_enabled() -> Weight;
 	fn sudo_set_evm_chain_id() -> Weight;
 	fn schedule_grandpa_change(a: u32) -> Weight;
+	fn sudo_set_alpha_transfer_enabled() -> Weight;
 }
 
 /// Weights for `pallet_admin_utils` using the Substrate node and recommended hardware.
@@ -455,6 +456,14 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	fn schedule_grandpa_change(_a: u32) -> Weight {
 		// TODO should be replaced by benchmarked weights
 		Weight::default()
+	}
+
+	fn sudo_set_alpha_transfer_enabled() -> Weight {
+		// TODO benchmark
+		// 1 read for check subnet owner
+		// 1 read for check alpha transfer enabled
+		// 1 write for set alpha transfer enabled
+		Weight::default().saturating_add(RocksDbWeight::get().reads_writes(2_u64, 1_u64))
 	}
 }
 
@@ -850,5 +859,12 @@ impl WeightInfo for () {
 	fn schedule_grandpa_change(_a: u32) -> Weight {
 		// TODO should be replaced by benchmarked weights
 		Weight::default()
+	}
+	fn sudo_set_alpha_transfer_enabled() -> Weight {
+		// TODO benchmark
+		// 1 read for check subnet owner
+		// 1 read for check alpha transfer enabled
+		// 1 write for set alpha transfer enabled
+		Weight::default().saturating_add(RocksDbWeight::get().reads_writes(2_u64, 1_u64))
 	}
 }

--- a/pallets/admin-utils/src/weights.rs
+++ b/pallets/admin-utils/src/weights.rs
@@ -65,7 +65,7 @@ pub trait WeightInfo {
 	fn sudo_set_commit_reveal_weights_enabled() -> Weight;
 	fn sudo_set_evm_chain_id() -> Weight;
 	fn schedule_grandpa_change(a: u32) -> Weight;
-	fn sudo_set_alpha_transfer_enabled() -> Weight;
+	fn sudo_enable_alpha_transfer() -> Weight;
 }
 
 /// Weights for `pallet_admin_utils` using the Substrate node and recommended hardware.
@@ -458,7 +458,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		Weight::default()
 	}
 
-	fn sudo_set_alpha_transfer_enabled() -> Weight {
+	fn sudo_enable_alpha_transfer() -> Weight {
 		// TODO benchmark
 		// 1 read for check subnet owner
 		// 1 read for check alpha transfer enabled
@@ -860,7 +860,7 @@ impl WeightInfo for () {
 		// TODO should be replaced by benchmarked weights
 		Weight::default()
 	}
-	fn sudo_set_alpha_transfer_enabled() -> Weight {
+	fn sudo_enable_alpha_transfer() -> Weight {
 		// TODO benchmark
 		// 1 read for check subnet owner
 		// 1 read for check alpha transfer enabled

--- a/pallets/subtensor/src/macros/errors.rs
+++ b/pallets/subtensor/src/macros/errors.rs
@@ -185,5 +185,7 @@ mod errors {
         CommittingWeightsTooFast,
         /// Stake amount is too low.
         AmountTooLow,
+        /// Alpha transfer is not enabled on this subnet.
+        AlphaTransferNotEnabled,
     }
 }

--- a/pallets/subtensor/src/staking/move_stake.rs
+++ b/pallets/subtensor/src/staking/move_stake.rs
@@ -114,6 +114,12 @@ impl<T: Config> Pallet<T> {
             alpha_amount,
         )?;
 
+        // Ensure alpha transfer is enabled on the origin subnet
+        ensure!(
+            Pallet::<T>::get_alpha_transfer_enabled(origin_netuid),
+            Error::<T>::AlphaTransferNotEnabled
+        );
+
         // 9. Emit an event for logging/monitoring.
         log::info!(
             "StakeTransferred(origin_coldkey: {:?}, destination_coldkey: {:?}, hotkey: {:?}, origin_netuid: {:?}, destination_netuid: {:?}, amount: {:?})",

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -841,6 +841,31 @@ impl<T: Config> Pallet<T> {
 
         Ok(())
     }
+
+    pub fn validate_alpha_transfer(
+        origin_coldkey: &T::AccountId,
+        destination_coldkey: &T::AccountId,
+        origin_hotkey: &T::AccountId,
+        destination_hotkey: &T::AccountId,
+        origin_netuid: u16,
+        destination_netuid: u16,
+        alpha_amount: u64,
+    ) -> Result<(), Error<T>> {
+        ensure!(
+            Self::get_alpha_transfer_enabled(origin_netuid),
+            Error::<T>::AlphaTransferNotEnabled
+        );
+
+        Self::validate_stake_transition(
+            origin_coldkey,
+            destination_coldkey,
+            origin_hotkey,
+            destination_hotkey,
+            origin_netuid,
+            destination_netuid,
+            alpha_amount,
+        )
+    }
 }
 
 ///////////////////////////////////////////

--- a/pallets/subtensor/src/utils/misc.rs
+++ b/pallets/subtensor/src/utils/misc.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    system::{ensure_root, ensure_signed_or_root, pallet_prelude::BlockNumberFor},
+    system::{ensure_root, ensure_signed, ensure_signed_or_root, pallet_prelude::BlockNumberFor},
     Error,
 };
 use sp_core::Get;
@@ -18,6 +18,17 @@ impl<T: Config> Pallet<T> {
             Ok(Some(who)) if SubnetOwner::<T>::get(netuid) == who => Ok(()),
             Ok(Some(_)) => Err(DispatchError::BadOrigin),
             Ok(None) => Ok(()),
+            Err(x) => Err(x.into()),
+        }
+    }
+
+    /// Ensure that the caller is the owner of the subnet.
+    /// Note: this is *not* true for the root account.
+    pub fn ensure_subnet_owner(o: T::RuntimeOrigin, netuid: u16) -> Result<(), DispatchError> {
+        let coldkey = ensure_signed(o);
+        match coldkey {
+            Ok(who) if SubnetOwner::<T>::get(netuid) == who => Ok(()),
+            Ok(_) => Err(DispatchError::BadOrigin),
             Err(x) => Err(x.into()),
         }
     }
@@ -468,6 +479,13 @@ impl<T: Config> Pallet<T> {
     }
     pub fn set_commit_reveal_weights_enabled(netuid: u16, enabled: bool) {
         CommitRevealWeightsEnabled::<T>::set(netuid, enabled);
+    }
+
+    pub fn get_alpha_transfer_enabled(netuid: u16) -> bool {
+        AlphaTransferEnabled::<T>::get(netuid)
+    }
+    pub fn set_alpha_transfer_enabled(netuid: u16, enabled: bool) {
+        AlphaTransferEnabled::<T>::set(netuid, enabled);
     }
 
     pub fn get_rho(netuid: u16) -> u16 {


### PR DESCRIPTION
Adds functionality to enable and a check for Alpha-transferability to be set by subnet owner *only*.  

Currently, it defaults to `false` and only allows enabling by SubnetOwner, i.e., not by Root.