### PR TITLE
[RAO] alpha out emission equal to alpha block

### DIFF
--- a/pallets/subtensor/src/coinbase/block_emission.rs
+++ b/pallets/subtensor/src/coinbase/block_emission.rs
@@ -65,9 +65,7 @@ impl<T: Config> Pallet<T> {
         }
 
         // Set Alpha in emission.
-        let alpha_out_emission = I96F32::from_num(2)
-            .saturating_mul(float_alpha_block_emission)
-            .saturating_sub(alpha_in_emission);
+        let alpha_out_emission = float_alpha_block_emission;
 
         // Log results.
         log::debug!("{:?} - tao_in_emission: {:?}", netuid, tao_in_emission);


### PR DESCRIPTION
Changes `alpha_out = alpha_block_emission` rather than `2 * alpha_block_emission - alpha_in`