### PR TITLE
[RAO] [Fix] make sure to ensure burn reg before writing

### DIFF
--- a/pallets/subtensor/src/subnets/registration.rs
+++ b/pallets/subtensor/src/subnets/registration.rs
@@ -119,6 +119,9 @@ impl<T: Config> Pallet<T> {
             Error::<T>::NotEnoughBalanceToStake
         );
 
+        // If the network account does not exist we will create it here.
+        Self::create_account_if_non_existent(&coldkey, &hotkey);
+
         // --- 8. Ensure that the pairing is correct.
         ensure!(
             Self::coldkey_owns_hotkey(&coldkey, &hotkey),
@@ -138,9 +141,6 @@ impl<T: Config> Pallet<T> {
         // Tokens are swapped and then burned.
         let burned_alpha: u64 = Self::swap_tao_for_alpha(netuid, actual_burn_amount);
         SubnetAlphaOut::<T>::mutate(netuid, |total| *total = total.saturating_sub(burned_alpha));
-
-        // --- 11. If the network account does not exist we will create it here.
-        Self::create_account_if_non_existent(&coldkey, &hotkey);
 
         // Actually perform the registration.
         let neuron_uid: u16 = Self::register_neuron(netuid, &hotkey);

--- a/pallets/subtensor/src/tests/registration.rs
+++ b/pallets/subtensor/src/tests/registration.rs
@@ -526,10 +526,7 @@ fn test_burn_registration_doesnt_write_on_failure() {
         // Make sure the neuron is not registered.
         assert_eq!(SubtensorModule::get_subnetwork_n(netuid), 0);
         // Make sure the hotkey is not registered.
-        assert_eq!(
-            SubtensorModule::get_uid_for_net_and_hotkey(netuid, &hotkey_account_id).is_err(),
-            true
-        );
+        assert!(SubtensorModule::get_uid_for_net_and_hotkey(netuid, &hotkey_account_id).is_err());
     });
 }
 

--- a/pallets/subtensor/src/tests/registration.rs
+++ b/pallets/subtensor/src/tests/registration.rs
@@ -491,6 +491,49 @@ fn test_burn_registration_without_neuron_slot() {
 }
 
 #[test]
+fn test_burn_registration_doesnt_write_on_failure() {
+    new_test_ext(1).execute_with(|| {
+        let netuid: u16 = 1;
+        let tempo: u16 = 13;
+        let hotkey_account_id = U256::from(1);
+        let burn_cost = 1000;
+        let initial_balance = burn_cost * 10;
+        let coldkey_account_id = U256::from(987);
+
+        // Add network and set burn cost
+        add_network(netuid, tempo, 0);
+        SubtensorModule::set_burn(netuid, burn_cost);
+        // Give coldkey balance to pay for registration
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, initial_balance);
+        // Set max allowed uids to 0 so registration will fail, but only on last check.
+        SubtensorModule::set_max_allowed_uids(netuid, 0);
+
+        // We expect this to fail at the last ensure check.
+        assert_err!(
+            SubtensorModule::burned_register(
+                <<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id),
+                netuid,
+                hotkey_account_id
+            ),
+            Error::<Test>::NoNeuronIdAvailable
+        );
+
+        // Make sure the coldkey balance is unchanged.
+        assert_eq!(
+            SubtensorModule::get_coldkey_balance(&coldkey_account_id),
+            initial_balance
+        );
+        // Make sure the neuron is not registered.
+        assert_eq!(SubtensorModule::get_subnetwork_n(netuid), 0);
+        // Make sure the hotkey is not registered.
+        assert_eq!(
+            SubtensorModule::get_uid_for_net_and_hotkey(netuid, &hotkey_account_id).is_err(),
+            true
+        );
+    });
+}
+
+#[test]
 fn test_burn_adjustment() {
     new_test_ext(1).execute_with(|| {
         let netuid: u16 = 1;


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
This PR fixes an issue with burned reg where we swapped TAO (made a write) before ensuring everything was correct with the transaction. This would've taken TAO and burned it without giving the user a registration if something else failed.


## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
