### PR TITLE
Fix/swap pending childkeys on hk swap

### DIFF
--- a/pallets/subtensor/src/swap/swap_hotkey.rs
+++ b/pallets/subtensor/src/swap/swap_hotkey.rs
@@ -403,8 +403,15 @@ impl<T: Config> Pallet<T> {
             }
         }
 
-        // 14. Swap Stake Delta for all coldkeys.
-        // DEPRECATED
+        // 14. Swap PendingChildKeys.
+        // PendingChildKeys( netuid, parent ) --> Vec<(proportion,child), cool_down_block>
+        for netuid in Self::get_all_subnet_netuids() {
+            if PendingChildKeys::<T>::contains_key(netuid, old_hotkey) {
+                let (children, cool_down_block) = PendingChildKeys::<T>::get(netuid, old_hotkey);
+                PendingChildKeys::<T>::remove(netuid, old_hotkey);
+                PendingChildKeys::<T>::insert(netuid, new_hotkey, (children, cool_down_block));
+            }
+        }
 
         // Return successful after swapping all the relevant terms.
         Ok(())

--- a/pallets/subtensor/src/tests/swap_hotkey.rs
+++ b/pallets/subtensor/src/tests/swap_hotkey.rs
@@ -1264,6 +1264,8 @@ fn test_swap_parent_hotkey_childkey_maps() {
 
         // Set child and verify state maps
         mock_set_children(&coldkey, &parent_old, netuid, &[(u64::MAX, child)]);
+        // Wait rate limit
+        step_rate_limit(&TransactionType::SetChildren, netuid);
         // Schedule some pending child keys.
         mock_schedule_children(&coldkey, &parent_old, netuid, &[(u64::MAX, child_other)]);
 
@@ -1317,6 +1319,8 @@ fn test_swap_child_hotkey_childkey_maps() {
 
         // Set child and verify state maps
         mock_set_children(&coldkey, &parent, netuid, &[(u64::MAX, child_old)]);
+        // Wait rate limit
+        step_rate_limit(&TransactionType::SetChildren, netuid);
         // Schedule some pending child keys.
         mock_schedule_children(&coldkey, &parent, netuid, &[(u64::MAX, child_old)]);
 


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
This PR adds the `PendingChildKeys` map to the swap hotkey function and adds some tests.

## Related Issue(s)

- Closes #1125 

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
