### PR TITLE
Ban saturating_div, to_num, and from_num

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6456,6 +6456,7 @@ dependencies = [
  "parity-util-mem",
  "rand",
  "rand_chacha",
+ "safe-math",
  "scale-info",
  "serde",
  "serde-tuple-vec-map",
@@ -8033,6 +8034,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "safe-math"
+version = "0.1.0"
+dependencies = [
+ "num-traits",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2409)",
+ "substrate-fixed",
+]
+
+[[package]]
 name = "safe-mix"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9568,6 +9578,7 @@ dependencies = [
 name = "share-pool"
 version = "0.1.0"
 dependencies = [
+ "safe-math",
  "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2409)",
  "substrate-fixed",
 ]

--- a/pallets/collective/src/lib.rs
+++ b/pallets/collective/src/lib.rs
@@ -549,7 +549,8 @@ pub mod pallet {
             );
 
             let threshold = T::GetVotingMembers::get_count()
-                .saturating_div(2)
+                .checked_div(2)
+                .unwrap_or(0)
                 .saturating_add(1);
 
             let members = Self::members();

--- a/pallets/subtensor/Cargo.toml
+++ b/pallets/subtensor/Cargo.toml
@@ -41,6 +41,7 @@ pallet-utility = { workspace = true }
 ndarray = { workspace = true }
 hex = { workspace = true }
 share-pool = { default-features = false, path = "../../primitives/share-pool" }
+safe-math = { default-features = false, path = "../../primitives/safe-math" }
 approx = { workspace = true }
 
 pallet-collective = { version = "4.0.0-dev", default-features = false, path = "../collective" }

--- a/pallets/subtensor/Cargo.toml
+++ b/pallets/subtensor/Cargo.toml
@@ -105,6 +105,7 @@ std = [
 	"ark-serialize/std",
 	"w3f-bls/std",
 	"rand_chacha/std",
+	"safe-math/std",
 	"sha2/std",
 	"share-pool/std"
 ]

--- a/pallets/subtensor/src/coinbase/block_emission.rs
+++ b/pallets/subtensor/src/coinbase/block_emission.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::epoch::math::*;
 use frame_support::traits::Get;
 use substrate_fixed::{transcendental::log2, types::I96F32};
 
@@ -139,7 +140,7 @@ impl<T: Config> Pallet<T> {
         for _ in 0..floored_residual_int {
             multiplier = multiplier.saturating_mul(I96F32::from_num(2.0));
         }
-        let block_emission_percentage: I96F32 = I96F32::from_num(1.0).saturating_div(multiplier);
+        let block_emission_percentage: I96F32 = I96F32::from_num(1.0).safe_div(multiplier);
         // Calculate the actual emission based on the emission rate
         let block_emission: I96F32 = block_emission_percentage
             .saturating_mul(I96F32::from_num(DefaultBlockEmission::<T>::get()));

--- a/pallets/subtensor/src/coinbase/block_emission.rs
+++ b/pallets/subtensor/src/coinbase/block_emission.rs
@@ -1,6 +1,6 @@
 use super::*;
-use crate::epoch::math::*;
 use frame_support::traits::Get;
+use safe_math::*;
 use substrate_fixed::{transcendental::log2, types::I96F32};
 
 impl<T: Config> Pallet<T> {
@@ -81,9 +81,9 @@ impl<T: Config> Pallet<T> {
 
         // Return result.
         (
-            tao_in_emission.to_num::<u64>(),
-            alpha_in_emission.to_num::<u64>(),
-            alpha_out_emission.to_num::<u64>(),
+            tao_in_emission.saturating_to_num::<u64>(),
+            alpha_in_emission.saturating_to_num::<u64>(),
+            alpha_out_emission.saturating_to_num::<u64>(),
         )
     }
 
@@ -134,7 +134,7 @@ impl<T: Config> Pallet<T> {
         let floored_residual: I96F32 = residual.floor();
         // Calculate the final emission rate using the floored residual.
         // Convert floored_residual to an integer
-        let floored_residual_int: u64 = floored_residual.to_num::<u64>();
+        let floored_residual_int: u64 = floored_residual.saturating_to_num::<u64>();
         // Multiply 2.0 by itself floored_residual times to calculate the power of 2.
         let mut multiplier: I96F32 = I96F32::from_num(1.0);
         for _ in 0..floored_residual_int {
@@ -145,7 +145,7 @@ impl<T: Config> Pallet<T> {
         let block_emission: I96F32 = block_emission_percentage
             .saturating_mul(I96F32::from_num(DefaultBlockEmission::<T>::get()));
         // Convert to u64
-        let block_emission_u64: u64 = block_emission.to_num::<u64>();
+        let block_emission_u64: u64 = block_emission.saturating_to_num::<u64>();
         if BlockEmission::<T>::get() != block_emission_u64 {
             BlockEmission::<T>::put(block_emission_u64);
         }

--- a/pallets/subtensor/src/coinbase/block_step.rs
+++ b/pallets/subtensor/src/coinbase/block_step.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::epoch::math::*;
 use frame_support::storage::IterableStorageMap;
 use substrate_fixed::types::{I110F18, I96F32};
 
@@ -202,11 +203,11 @@ impl<T: Config + pallet_drand::Config> Pallet<T> {
             .saturating_mul(I110F18::from_num(
                 registrations_this_interval.saturating_add(target_registrations_per_interval),
             ))
-            .saturating_div(I110F18::from_num(
+            .safe_div(I110F18::from_num(
                 target_registrations_per_interval.saturating_add(target_registrations_per_interval),
             ));
         let alpha: I110F18 = I110F18::from_num(Self::get_adjustment_alpha(netuid))
-            .saturating_div(I110F18::from_num(u64::MAX));
+            .safe_div(I110F18::from_num(u64::MAX));
         let next_value: I110F18 = alpha
             .saturating_mul(I110F18::from_num(current_difficulty))
             .saturating_add(
@@ -236,11 +237,11 @@ impl<T: Config + pallet_drand::Config> Pallet<T> {
             .saturating_mul(I110F18::from_num(
                 registrations_this_interval.saturating_add(target_registrations_per_interval),
             ))
-            .saturating_div(I110F18::from_num(
+            .safe_div(I110F18::from_num(
                 target_registrations_per_interval.saturating_add(target_registrations_per_interval),
             ));
         let alpha: I110F18 = I110F18::from_num(Self::get_adjustment_alpha(netuid))
-            .saturating_div(I110F18::from_num(u64::MAX));
+            .safe_div(I110F18::from_num(u64::MAX));
         let next_value: I110F18 = alpha
             .saturating_mul(I110F18::from_num(current_burn))
             .saturating_add(

--- a/pallets/subtensor/src/coinbase/block_step.rs
+++ b/pallets/subtensor/src/coinbase/block_step.rs
@@ -11,7 +11,8 @@ impl<T: Config + pallet_drand::Config> Pallet<T> {
         // --- 1. Adjust difficulties.
         Self::adjust_registration_terms_for_networks();
         // --- 2. Get the current coinbase emission.
-        let block_emission: I96F32 = I96F32::from_num(Self::get_block_emission().unwrap_or(0));
+        let block_emission: I96F32 =
+            I96F32::saturating_from_num(Self::get_block_emission().unwrap_or(0));
         log::debug!("Block emission: {:?}", block_emission);
         // --- 3. Run emission through network.
         Self::run_coinbase(block_emission);
@@ -199,25 +200,25 @@ impl<T: Config + pallet_drand::Config> Pallet<T> {
         registrations_this_interval: u16,
         target_registrations_per_interval: u16,
     ) -> u64 {
-        let updated_difficulty: I110F18 = I110F18::from_num(current_difficulty)
-            .saturating_mul(I110F18::from_num(
+        let updated_difficulty: I110F18 = I110F18::saturating_from_num(current_difficulty)
+            .saturating_mul(I110F18::saturating_from_num(
                 registrations_this_interval.saturating_add(target_registrations_per_interval),
             ))
-            .safe_div(I110F18::from_num(
+            .safe_div(I110F18::saturating_from_num(
                 target_registrations_per_interval.saturating_add(target_registrations_per_interval),
             ));
-        let alpha: I110F18 = I110F18::from_num(Self::get_adjustment_alpha(netuid))
-            .safe_div(I110F18::from_num(u64::MAX));
+        let alpha: I110F18 = I110F18::saturating_from_num(Self::get_adjustment_alpha(netuid))
+            .safe_div(I110F18::saturating_from_num(u64::MAX));
         let next_value: I110F18 = alpha
-            .saturating_mul(I110F18::from_num(current_difficulty))
+            .saturating_mul(I110F18::saturating_from_num(current_difficulty))
             .saturating_add(
-                I110F18::from_num(1.0)
+                I110F18::saturating_from_num(1.0)
                     .saturating_sub(alpha)
                     .saturating_mul(updated_difficulty),
             );
-        if next_value >= I110F18::from_num(Self::get_max_difficulty(netuid)) {
+        if next_value >= I110F18::saturating_from_num(Self::get_max_difficulty(netuid)) {
             Self::get_max_difficulty(netuid)
-        } else if next_value <= I110F18::from_num(Self::get_min_difficulty(netuid)) {
+        } else if next_value <= I110F18::saturating_from_num(Self::get_min_difficulty(netuid)) {
             return Self::get_min_difficulty(netuid);
         } else {
             return next_value.saturating_to_num::<u64>();
@@ -233,25 +234,25 @@ impl<T: Config + pallet_drand::Config> Pallet<T> {
         registrations_this_interval: u16,
         target_registrations_per_interval: u16,
     ) -> u64 {
-        let updated_burn: I110F18 = I110F18::from_num(current_burn)
-            .saturating_mul(I110F18::from_num(
+        let updated_burn: I110F18 = I110F18::saturating_from_num(current_burn)
+            .saturating_mul(I110F18::saturating_from_num(
                 registrations_this_interval.saturating_add(target_registrations_per_interval),
             ))
-            .safe_div(I110F18::from_num(
+            .safe_div(I110F18::saturating_from_num(
                 target_registrations_per_interval.saturating_add(target_registrations_per_interval),
             ));
-        let alpha: I110F18 = I110F18::from_num(Self::get_adjustment_alpha(netuid))
-            .safe_div(I110F18::from_num(u64::MAX));
+        let alpha: I110F18 = I110F18::saturating_from_num(Self::get_adjustment_alpha(netuid))
+            .safe_div(I110F18::saturating_from_num(u64::MAX));
         let next_value: I110F18 = alpha
-            .saturating_mul(I110F18::from_num(current_burn))
+            .saturating_mul(I110F18::saturating_from_num(current_burn))
             .saturating_add(
-                I110F18::from_num(1.0)
+                I110F18::saturating_from_num(1.0)
                     .saturating_sub(alpha)
                     .saturating_mul(updated_burn),
             );
-        if next_value >= I110F18::from_num(Self::get_max_burn_as_u64(netuid)) {
+        if next_value >= I110F18::saturating_from_num(Self::get_max_burn_as_u64(netuid)) {
             Self::get_max_burn_as_u64(netuid)
-        } else if next_value <= I110F18::from_num(Self::get_min_burn_as_u64(netuid)) {
+        } else if next_value <= I110F18::saturating_from_num(Self::get_min_burn_as_u64(netuid)) {
             return Self::get_min_burn_as_u64(netuid);
         } else {
             return next_value.saturating_to_num::<u64>();

--- a/pallets/subtensor/src/coinbase/block_step.rs
+++ b/pallets/subtensor/src/coinbase/block_step.rs
@@ -1,6 +1,6 @@
 use super::*;
-use crate::epoch::math::*;
 use frame_support::storage::IterableStorageMap;
+use safe_math::*;
 use substrate_fixed::types::{I110F18, I96F32};
 
 impl<T: Config + pallet_drand::Config> Pallet<T> {
@@ -220,7 +220,7 @@ impl<T: Config + pallet_drand::Config> Pallet<T> {
         } else if next_value <= I110F18::from_num(Self::get_min_difficulty(netuid)) {
             return Self::get_min_difficulty(netuid);
         } else {
-            return next_value.to_num::<u64>();
+            return next_value.saturating_to_num::<u64>();
         }
     }
 
@@ -254,7 +254,7 @@ impl<T: Config + pallet_drand::Config> Pallet<T> {
         } else if next_value <= I110F18::from_num(Self::get_min_burn_as_u64(netuid)) {
             return Self::get_min_burn_as_u64(netuid);
         } else {
-            return next_value.to_num::<u64>();
+            return next_value.saturating_to_num::<u64>();
         }
     }
 }

--- a/pallets/subtensor/src/coinbase/root.rs
+++ b/pallets/subtensor/src/coinbase/root.rs
@@ -113,7 +113,7 @@ impl<T: Config> Pallet<T> {
 
         // --- 2. Initialize a 2D vector with zeros to store the weights. The dimensions are determined
         // by `n` (number of validators) and `k` (total number of subnets).
-        let mut weights: Vec<Vec<I64F64>> = vec![vec![I64F64::from_num(0.0); k]; n];
+        let mut weights: Vec<Vec<I64F64>> = vec![vec![I64F64::saturating_from_num(0.0); k]; n];
         log::debug!("weights:\n{:?}\n", weights);
 
         let subnet_list = Self::get_all_subnet_netuids();
@@ -135,7 +135,7 @@ impl<T: Config> Pallet<T> {
                         .zip(&subnet_list)
                         .find(|(_, subnet)| *subnet == netuid)
                     {
-                        *w = I64F64::from_num(*weight_ij);
+                        *w = I64F64::saturating_from_num(*weight_ij);
                     }
                 }
             }

--- a/pallets/subtensor/src/coinbase/root.rs
+++ b/pallets/subtensor/src/coinbase/root.rs
@@ -16,10 +16,10 @@
 // DEALINGS IN THE SOFTWARE.
 
 use super::*;
-use crate::epoch::math::*;
 use frame_support::dispatch::Pays;
 use frame_support::storage::IterableStorageDoubleMap;
 use frame_support::weights::Weight;
+use safe_math::*;
 use sp_core::Get;
 use sp_std::vec;
 use substrate_fixed::types::I64F64;

--- a/pallets/subtensor/src/coinbase/root.rs
+++ b/pallets/subtensor/src/coinbase/root.rs
@@ -16,6 +16,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use super::*;
+use crate::epoch::math::*;
 use frame_support::dispatch::Pays;
 use frame_support::storage::IterableStorageDoubleMap;
 use frame_support::weights::Weight;
@@ -624,7 +625,7 @@ impl<T: Config> Pallet<T> {
 
         let mut lock_cost = last_lock.saturating_mul(mult).saturating_sub(
             last_lock
-                .saturating_div(lock_reduction_interval)
+                .safe_div(lock_reduction_interval)
                 .saturating_mul(current_block.saturating_sub(last_lock_block)),
         );
 

--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::epoch::math::*;
 use alloc::collections::BTreeMap;
 use substrate_fixed::types::I96F32;
 use tle::stream_ciphers::AESGCMStreamCipherProvider;
@@ -557,7 +558,7 @@ impl<T: Config> Pallet<T> {
         for (proportion, _) in childkeys {
             remaining_proportion = remaining_proportion.saturating_sub(
                 I96F32::from_num(proportion) // Normalize
-                    .saturating_div(I96F32::from_num(u64::MAX)),
+                    .safe_div(I96F32::from_num(u64::MAX)),
             );
         }
 
@@ -608,7 +609,7 @@ impl<T: Config> Pallet<T> {
         let validating_emission: I96F32 = I96F32::from_num(dividends);
         let childkey_take_proportion: I96F32 =
             I96F32::from_num(Self::get_childkey_take(hotkey, netuid))
-                .saturating_div(I96F32::from_num(u16::MAX));
+                .safe_div(I96F32::from_num(u16::MAX));
         log::debug!(
             "Childkey take proportion: {:?} for hotkey {:?}",
             childkey_take_proportion,
@@ -656,7 +657,7 @@ impl<T: Config> Pallet<T> {
         for (proportion, parent) in Self::get_parents(hotkey, netuid) {
             // Convert the parent's stake proportion to a fractional value
             let parent_proportion: I96F32 =
-                I96F32::from_num(proportion).saturating_div(I96F32::from_num(u64::MAX));
+                I96F32::from_num(proportion).safe_div(I96F32::from_num(u64::MAX));
 
             // Get the parent's root and subnet-specific (alpha) stakes
             let parent_root: I96F32 = I96F32::from_num(Self::get_stake_for_hotkey_on_subnet(

--- a/pallets/subtensor/src/epoch/math.rs
+++ b/pallets/subtensor/src/epoch/math.rs
@@ -17,7 +17,7 @@ use sp_std::vec::Vec;
 
 #[allow(dead_code)]
 pub fn fixed(val: f32) -> I32F32 {
-    I32F32::from_num(val)
+    I32F32::saturating_from_num(val)
 }
 
 #[allow(dead_code)]
@@ -37,27 +37,27 @@ pub fn fixed64_to_u64(x: I64F64) -> u64 {
 
 #[allow(dead_code)]
 pub fn fixed64_to_fixed32(x: I64F64) -> I32F32 {
-    I32F32::from_num(x)
+    I32F32::saturating_from_num(x)
 }
 
 #[allow(dead_code)]
 pub fn fixed32_to_fixed64(x: I32F32) -> I64F64 {
-    I64F64::from_num(x)
+    I64F64::saturating_from_num(x)
 }
 
 #[allow(dead_code)]
 pub fn u16_to_fixed(x: u16) -> I32F32 {
-    I32F32::from_num(x)
+    I32F32::saturating_from_num(x)
 }
 
 #[allow(dead_code)]
 pub fn u16_proportion_to_fixed(x: u16) -> I32F32 {
-    I32F32::from_num(x).safe_div(I32F32::from_num(u16::MAX))
+    I32F32::saturating_from_num(x).safe_div(I32F32::saturating_from_num(u16::MAX))
 }
 
 #[allow(dead_code)]
 pub fn fixed_proportion_to_u16(x: I32F32) -> u16 {
-    fixed_to_u16(x.saturating_mul(I32F32::from_num(u16::MAX)))
+    fixed_to_u16(x.saturating_mul(I32F32::saturating_from_num(u16::MAX)))
 }
 
 #[allow(dead_code)]
@@ -93,12 +93,12 @@ pub fn vec_fixed_proportions_to_u16(vec: Vec<I32F32>) -> Vec<u16> {
 #[allow(dead_code)]
 // Max-upscale vector and convert to u16 so max_value = u16::MAX. Assumes non-negative normalized input.
 pub fn vec_max_upscale_to_u16(vec: &[I32F32]) -> Vec<u16> {
-    let u16_max: I32F32 = I32F32::from_num(u16::MAX);
-    let threshold: I32F32 = I32F32::from_num(32768);
+    let u16_max: I32F32 = I32F32::saturating_from_num(u16::MAX);
+    let threshold: I32F32 = I32F32::saturating_from_num(32768);
     let max_value: Option<&I32F32> = vec.iter().max();
     match max_value {
         Some(val) => {
-            if *val == I32F32::from_num(0) {
+            if *val == I32F32::saturating_from_num(0) {
                 return vec
                     .iter()
                     .map(|e: &I32F32| e.saturating_mul(u16_max).saturating_to_num::<u16>())
@@ -139,15 +139,22 @@ pub fn vec_max_upscale_to_u16(vec: &[I32F32]) -> Vec<u16> {
 #[allow(dead_code)]
 // Max-upscale u16 vector and convert to u16 so max_value = u16::MAX. Assumes u16 vector input.
 pub fn vec_u16_max_upscale_to_u16(vec: &[u16]) -> Vec<u16> {
-    let vec_fixed: Vec<I32F32> = vec.iter().map(|e: &u16| I32F32::from_num(*e)).collect();
+    let vec_fixed: Vec<I32F32> = vec
+        .iter()
+        .map(|e: &u16| I32F32::saturating_from_num(*e))
+        .collect();
     vec_max_upscale_to_u16(&vec_fixed)
 }
 
 #[allow(dead_code)]
 // Checks if u16 vector, when normalized, has a max value not greater than a u16 ratio max_limit.
 pub fn check_vec_max_limited(vec: &[u16], max_limit: u16) -> bool {
-    let max_limit_fixed: I32F32 = I32F32::from_num(max_limit).safe_div(I32F32::from_num(u16::MAX));
-    let mut vec_fixed: Vec<I32F32> = vec.iter().map(|e: &u16| I32F32::from_num(*e)).collect();
+    let max_limit_fixed: I32F32 =
+        I32F32::saturating_from_num(max_limit).safe_div(I32F32::saturating_from_num(u16::MAX));
+    let mut vec_fixed: Vec<I32F32> = vec
+        .iter()
+        .map(|e: &u16| I32F32::saturating_from_num(*e))
+        .collect();
     inplace_normalize(&mut vec_fixed);
     let max_value: Option<&I32F32> = vec_fixed.iter().max();
     max_value.is_none_or(|v| *v <= max_limit_fixed)
@@ -180,14 +187,14 @@ where
 #[allow(dead_code)]
 pub fn is_zero(vector: &[I32F32]) -> bool {
     let vector_sum: I32F32 = sum(vector);
-    vector_sum == I32F32::from_num(0)
+    vector_sum == I32F32::saturating_from_num(0)
 }
 
 // Exp safe function with I32F32 output of I32F32 input.
 #[allow(dead_code)]
 pub fn exp_safe(input: I32F32) -> I32F32 {
-    let min_input: I32F32 = I32F32::from_num(-20); // <= 1/exp(-20) = 485 165 195,4097903
-    let max_input: I32F32 = I32F32::from_num(20); // <= exp(20) = 485 165 195,4097903
+    let min_input: I32F32 = I32F32::saturating_from_num(-20); // <= 1/exp(-20) = 485 165 195,4097903
+    let max_input: I32F32 = I32F32::saturating_from_num(20); // <= exp(20) = 485 165 195,4097903
     let mut safe_input: I32F32 = input;
     if input < min_input {
         safe_input = min_input;
@@ -201,7 +208,7 @@ pub fn exp_safe(input: I32F32) -> I32F32 {
         }
         Err(_err) => {
             if safe_input <= 0 {
-                output = I32F32::from_num(0);
+                output = I32F32::saturating_from_num(0);
             } else {
                 output = I32F32::max_value();
             }
@@ -213,7 +220,7 @@ pub fn exp_safe(input: I32F32) -> I32F32 {
 // Sigmoid safe function with I32F32 output of I32F32 input with offset kappa and (recommended) scaling 0 < rho <= 40.
 #[allow(dead_code)]
 pub fn sigmoid_safe(input: I32F32, rho: I32F32, kappa: I32F32) -> I32F32 {
-    let one: I32F32 = I32F32::from_num(1);
+    let one: I32F32 = I32F32::saturating_from_num(1);
     let offset: I32F32 = input.saturating_sub(kappa); // (input - kappa)
     let neg_rho: I32F32 = rho.saturating_mul(one.saturating_neg()); // -rho
     let exp_input: I32F32 = neg_rho.saturating_mul(offset); // -rho*(input-kappa)
@@ -243,7 +250,7 @@ pub fn is_topk(vector: &[I32F32], k: usize) -> Vec<bool> {
 #[allow(dead_code)]
 pub fn normalize(x: &[I32F32]) -> Vec<I32F32> {
     let x_sum: I32F32 = sum(x);
-    if x_sum != I32F32::from_num(0.0_f32) {
+    if x_sum != I32F32::saturating_from_num(0.0_f32) {
         x.iter().map(|xi| xi.safe_div(x_sum)).collect()
     } else {
         x.to_vec()
@@ -254,7 +261,7 @@ pub fn normalize(x: &[I32F32]) -> Vec<I32F32> {
 #[allow(dead_code)]
 pub fn inplace_normalize(x: &mut [I32F32]) {
     let x_sum: I32F32 = x.iter().sum();
-    if x_sum == I32F32::from_num(0.0_f32) {
+    if x_sum == I32F32::saturating_from_num(0.0_f32) {
         return;
     }
     x.iter_mut()
@@ -264,7 +271,7 @@ pub fn inplace_normalize(x: &mut [I32F32]) {
 // Normalizes (sum to 1 except 0) the input vector directly in-place, using the sum arg.
 #[allow(dead_code)]
 pub fn inplace_normalize_using_sum(x: &mut [I32F32], x_sum: I32F32) {
-    if x_sum == I32F32::from_num(0.0_f32) {
+    if x_sum == I32F32::saturating_from_num(0.0_f32) {
         return;
     }
     x.iter_mut()
@@ -275,7 +282,7 @@ pub fn inplace_normalize_using_sum(x: &mut [I32F32], x_sum: I32F32) {
 #[allow(dead_code)]
 pub fn inplace_normalize_64(x: &mut [I64F64]) {
     let x_sum: I64F64 = x.iter().sum();
-    if x_sum == I64F64::from_num(0) {
+    if x_sum == I64F64::saturating_from_num(0) {
         return;
     }
     x.iter_mut()
@@ -287,7 +294,7 @@ pub fn inplace_normalize_64(x: &mut [I64F64]) {
 pub fn inplace_row_normalize_64(x: &mut [Vec<I64F64>]) {
     for row in x {
         let row_sum: I64F64 = row.iter().sum();
-        if row_sum > I64F64::from_num(0.0_f64) {
+        if row_sum > I64F64::saturating_from_num(0.0_f64) {
             row.iter_mut()
                 .for_each(|x_ij: &mut I64F64| *x_ij = x_ij.safe_div(row_sum));
         }
@@ -304,7 +311,7 @@ pub fn vecdiv(x: &[I32F32], y: &[I32F32]) -> Vec<I32F32> {
             if *y_i != 0 {
                 x_i.safe_div(*y_i)
             } else {
-                I32F32::from_num(0)
+                I32F32::saturating_from_num(0)
             }
         })
         .collect()
@@ -315,7 +322,7 @@ pub fn vecdiv(x: &[I32F32], y: &[I32F32]) -> Vec<I32F32> {
 pub fn inplace_row_normalize(x: &mut [Vec<I32F32>]) {
     for row in x {
         let row_sum: I32F32 = row.iter().sum();
-        if row_sum > I32F32::from_num(0.0_f32) {
+        if row_sum > I32F32::saturating_from_num(0.0_f32) {
             row.iter_mut()
                 .for_each(|x_ij: &mut I32F32| *x_ij = x_ij.safe_div(row_sum));
         }
@@ -327,7 +334,7 @@ pub fn inplace_row_normalize(x: &mut [Vec<I32F32>]) {
 pub fn inplace_row_normalize_sparse(sparse_matrix: &mut [Vec<(u16, I32F32)>]) {
     for sparse_row in sparse_matrix.iter_mut() {
         let row_sum: I32F32 = sparse_row.iter().map(|(_j, value)| *value).sum();
-        if row_sum > I32F32::from_num(0.0) {
+        if row_sum > I32F32::saturating_from_num(0.0) {
             sparse_row
                 .iter_mut()
                 .for_each(|(_j, value)| *value = value.safe_div(row_sum));
@@ -365,19 +372,21 @@ pub fn col_sum(x: &[Vec<I32F32>]) -> Vec<I32F32> {
     if cols == 0 {
         return vec![];
     }
-    x.iter()
-        .fold(vec![I32F32::from_num(0); cols], |acc, next_row| {
+    x.iter().fold(
+        vec![I32F32::saturating_from_num(0); cols],
+        |acc, next_row| {
             acc.into_iter()
                 .zip(next_row)
                 .map(|(acc_elem, next_elem)| acc_elem.saturating_add(*next_elem))
                 .collect()
-        })
+        },
+    )
 }
 
 // Sum across each column (dim=1) of a sparse matrix.
 #[allow(dead_code, clippy::indexing_slicing)]
 pub fn col_sum_sparse(sparse_matrix: &[Vec<(u16, I32F32)>], columns: u16) -> Vec<I32F32> {
-    let mut result: Vec<I32F32> = vec![I32F32::from_num(0); columns as usize];
+    let mut result: Vec<I32F32> = vec![I32F32::saturating_from_num(0); columns as usize];
     for sparse_row in sparse_matrix {
         for (j, value) in sparse_row {
             result[*j as usize] = result[*j as usize].saturating_add(*value);
@@ -389,7 +398,7 @@ pub fn col_sum_sparse(sparse_matrix: &[Vec<(u16, I32F32)>], columns: u16) -> Vec
 // Normalizes (sum to 1 except 0) each column (dim=1) of a sparse matrix in-place.
 #[allow(dead_code, clippy::indexing_slicing)]
 pub fn inplace_col_normalize_sparse(sparse_matrix: &mut [Vec<(u16, I32F32)>], columns: u16) {
-    let mut col_sum: Vec<I32F32> = vec![I32F32::from_num(0.0); columns as usize]; // assume square matrix, rows=cols
+    let mut col_sum: Vec<I32F32> = vec![I32F32::saturating_from_num(0.0); columns as usize]; // assume square matrix, rows=cols
     for sparse_row in sparse_matrix.iter() {
         for (j, value) in sparse_row.iter() {
             col_sum[*j as usize] = col_sum[*j as usize].saturating_add(*value);
@@ -397,7 +406,7 @@ pub fn inplace_col_normalize_sparse(sparse_matrix: &mut [Vec<(u16, I32F32)>], co
     }
     for sparse_row in sparse_matrix {
         for (j, value) in sparse_row {
-            if col_sum[*j as usize] == I32F32::from_num(0.0_f32) {
+            if col_sum[*j as usize] == I32F32::saturating_from_num(0.0_f32) {
                 continue;
             }
             *value = value.safe_div(col_sum[*j as usize]);
@@ -417,7 +426,7 @@ pub fn inplace_col_normalize(x: &mut [Vec<I32F32>]) {
     let cols = first_row.len();
     let col_sums = x
         .iter_mut()
-        .fold(vec![I32F32::from_num(0.0); cols], |acc, row| {
+        .fold(vec![I32F32::saturating_from_num(0.0); cols], |acc, row| {
             row.iter_mut()
                 .zip(acc)
                 .map(|(&mut m_val, acc_val)| acc_val.saturating_add(m_val))
@@ -426,7 +435,7 @@ pub fn inplace_col_normalize(x: &mut [Vec<I32F32>]) {
     x.iter_mut().for_each(|row| {
         row.iter_mut()
             .zip(&col_sums)
-            .filter(|(_, col_sum)| **col_sum != I32F32::from_num(0_f32))
+            .filter(|(_, col_sum)| **col_sum != I32F32::saturating_from_num(0_f32))
             .for_each(|(m_val, col_sum)| {
                 *m_val = m_val.safe_div(*col_sum);
             });
@@ -436,7 +445,7 @@ pub fn inplace_col_normalize(x: &mut [Vec<I32F32>]) {
 // Max-upscale each column (dim=1) of a sparse matrix in-place.
 #[allow(dead_code, clippy::indexing_slicing)]
 pub fn inplace_col_max_upscale_sparse(sparse_matrix: &mut [Vec<(u16, I32F32)>], columns: u16) {
-    let mut col_max: Vec<I32F32> = vec![I32F32::from_num(0.0); columns as usize]; // assume square matrix, rows=cols
+    let mut col_max: Vec<I32F32> = vec![I32F32::saturating_from_num(0.0); columns as usize]; // assume square matrix, rows=cols
     for sparse_row in sparse_matrix.iter() {
         for (j, value) in sparse_row.iter() {
             if col_max[*j as usize] < *value {
@@ -446,7 +455,7 @@ pub fn inplace_col_max_upscale_sparse(sparse_matrix: &mut [Vec<(u16, I32F32)>], 
     }
     for sparse_row in sparse_matrix {
         for (j, value) in sparse_row {
-            if col_max[*j as usize] == I32F32::from_num(0.0_f32) {
+            if col_max[*j as usize] == I32F32::saturating_from_num(0.0_f32) {
                 continue;
             }
             *value = value.safe_div(col_max[*j as usize]);
@@ -464,18 +473,19 @@ pub fn inplace_col_max_upscale(x: &mut [Vec<I32F32>]) {
         return;
     }
     let cols = first_row.len();
-    let col_maxes = x
-        .iter_mut()
-        .fold(vec![I32F32::from_num(0_f32); cols], |acc, row| {
+    let col_maxes = x.iter_mut().fold(
+        vec![I32F32::saturating_from_num(0_f32); cols],
+        |acc, row| {
             row.iter_mut()
                 .zip(acc)
                 .map(|(m_val, acc_val)| acc_val.max(*m_val))
                 .collect()
-        });
+        },
+    );
     x.iter_mut().for_each(|row| {
         row.iter_mut()
             .zip(&col_maxes)
-            .filter(|(_, col_max)| **col_max != I32F32::from_num(0))
+            .filter(|(_, col_max)| **col_max != I32F32::saturating_from_num(0))
             .for_each(|(m_val, col_max)| {
                 *m_val = m_val.safe_div(*col_max);
             });
@@ -489,7 +499,7 @@ pub fn inplace_mask_vector(mask: &[bool], vector: &mut [I32F32]) {
         return;
     }
     assert_eq!(mask.len(), vector.len());
-    let zero: I32F32 = I32F32::from_num(0.0);
+    let zero: I32F32 = I32F32::saturating_from_num(0.0);
     mask.iter()
         .zip(vector)
         .filter(|(m, _)| **m)
@@ -508,7 +518,7 @@ pub fn inplace_mask_matrix(mask: &[Vec<bool>], matrix: &mut Vec<Vec<I32F32>>) {
         return;
     }
     assert_eq!(mask.len(), matrix.len());
-    let zero: I32F32 = I32F32::from_num(0.0);
+    let zero: I32F32 = I32F32::saturating_from_num(0.0);
     mask.iter().zip(matrix).for_each(|(mask_row, matrix_row)| {
         mask_row
             .iter()
@@ -528,7 +538,7 @@ pub fn inplace_mask_rows(mask: &[bool], matrix: &mut [Vec<I32F32>]) {
     };
     let cols = first_row.len();
     assert_eq!(mask.len(), matrix.len());
-    let zero: I32F32 = I32F32::from_num(0);
+    let zero: I32F32 = I32F32::saturating_from_num(0);
     matrix
         .iter_mut()
         .zip(mask)
@@ -549,7 +559,7 @@ pub fn inplace_mask_diag(matrix: &mut [Vec<I32F32>]) {
         return;
     }
     assert_eq!(matrix.len(), first_row.len());
-    let zero: I32F32 = I32F32::from_num(0.0);
+    let zero: I32F32 = I32F32::saturating_from_num(0.0);
     matrix.iter_mut().enumerate().for_each(|(idx, row)| {
         let Some(elem) = row.get_mut(idx) else {
             // Should not happen since matrix is square
@@ -664,7 +674,7 @@ pub fn matmul(matrix: &[Vec<I32F32>], vector: &[I32F32]) -> Vec<I32F32> {
     }
     assert!(matrix.len() == vector.len());
     matrix.iter().zip(vector).fold(
-        vec![I32F32::from_num(0_f32); cols],
+        vec![I32F32::saturating_from_num(0_f32); cols],
         |acc, (row, vec_val)| {
             row.iter()
                 .zip(acc)
@@ -690,10 +700,9 @@ pub fn matmul_64(matrix: &[Vec<I64F64>], vector: &[I64F64]) -> Vec<I64F64> {
         return vec![];
     }
     assert!(matrix.len() == vector.len());
-    matrix
-        .iter()
-        .zip(vector)
-        .fold(vec![I64F64::from_num(0.0); cols], |acc, (row, vec_val)| {
+    matrix.iter().zip(vector).fold(
+        vec![I64F64::saturating_from_num(0.0); cols],
+        |acc, (row, vec_val)| {
             row.iter()
                 .zip(acc)
                 .map(|(m_val, acc_val)| {
@@ -703,7 +712,8 @@ pub fn matmul_64(matrix: &[Vec<I64F64>], vector: &[I64F64]) -> Vec<I64F64> {
                     acc_val.saturating_add(vec_val.saturating_mul(*m_val))
                 })
                 .collect()
-        })
+        },
+    )
 }
 
 // Column-wise matrix-vector product, row-wise sum: result_i = SUM(j) vector_j * matrix_ij.
@@ -721,7 +731,7 @@ pub fn matmul_transpose(matrix: &[Vec<I32F32>], vector: &[I32F32]) -> Vec<I32F32
         .map(|row| {
             row.iter()
                 .zip(vector)
-                .fold(I32F32::from_num(0.0), |acc, (velem, melem)| {
+                .fold(I32F32::saturating_from_num(0.0), |acc, (velem, melem)| {
                     // Compute dividends: d_j = SUM(i) b_ji * inc_i
                     // result_j = SUM(i) vector_i * matrix_ji
                     // result_i = SUM(j) vector_j * matrix_ij
@@ -738,7 +748,7 @@ pub fn matmul_sparse(
     vector: &[I32F32],
     columns: u16,
 ) -> Vec<I32F32> {
-    let mut result: Vec<I32F32> = vec![I32F32::from_num(0.0); columns as usize];
+    let mut result: Vec<I32F32> = vec![I32F32::saturating_from_num(0.0); columns as usize];
     for (i, sparse_row) in sparse_matrix.iter().enumerate() {
         for (j, value) in sparse_row.iter() {
             // Compute ranks: r_j = SUM(i) w_ij * s_i
@@ -757,7 +767,7 @@ pub fn matmul_transpose_sparse(
     sparse_matrix: &[Vec<(u16, I32F32)>],
     vector: &[I32F32],
 ) -> Vec<I32F32> {
-    let mut result: Vec<I32F32> = vec![I32F32::from_num(0.0); sparse_matrix.len()];
+    let mut result: Vec<I32F32> = vec![I32F32::saturating_from_num(0.0); sparse_matrix.len()];
     for (i, sparse_row) in sparse_matrix.iter().enumerate() {
         for (j, value) in sparse_row.iter() {
             // Compute dividends: d_j = SUM(i) b_ji * inc_i
@@ -892,7 +902,7 @@ pub fn weighted_median(
 ) -> I32F32 {
     let n = partition_idx.len();
     if n == 0 {
-        return I32F32::from_num(0);
+        return I32F32::saturating_from_num(0);
     }
     if n == 1 {
         return score[partition_idx[0]];
@@ -900,8 +910,8 @@ pub fn weighted_median(
     assert!(stake.len() == score.len());
     let mid_idx: usize = n.safe_div(2);
     let pivot: I32F32 = score[partition_idx[mid_idx]];
-    let mut lo_stake: I32F32 = I32F32::from_num(0);
-    let mut hi_stake: I32F32 = I32F32::from_num(0);
+    let mut lo_stake: I32F32 = I32F32::saturating_from_num(0);
+    let mut hi_stake: I32F32 = I32F32::saturating_from_num(0);
     let mut lower: Vec<usize> = vec![];
     let mut upper: Vec<usize> = vec![];
     for &idx in partition_idx {
@@ -951,7 +961,7 @@ pub fn weighted_median_col(
 ) -> Vec<I32F32> {
     let rows = stake.len();
     let columns = score[0].len();
-    let zero: I32F32 = I32F32::from_num(0);
+    let zero: I32F32 = I32F32::saturating_from_num(0);
     let mut median: Vec<I32F32> = vec![zero; columns];
 
     #[allow(clippy::needless_range_loop)]
@@ -991,7 +1001,7 @@ pub fn weighted_median_col_sparse(
     majority: I32F32,
 ) -> Vec<I32F32> {
     let rows = stake.len();
-    let zero: I32F32 = I32F32::from_num(0);
+    let zero: I32F32 = I32F32::saturating_from_num(0);
     let mut use_stake: Vec<I32F32> = stake.iter().copied().filter(|&s| s > zero).collect();
     inplace_normalize(&mut use_stake);
     let stake_sum: I32F32 = use_stake.iter().sum();
@@ -1028,10 +1038,10 @@ pub fn weighted_median_col_sparse(
 // ratio=1: Result = B
 #[allow(dead_code)]
 pub fn interpolate(mat1: &[Vec<I32F32>], mat2: &[Vec<I32F32>], ratio: I32F32) -> Vec<Vec<I32F32>> {
-    if ratio == I32F32::from_num(0) {
+    if ratio == I32F32::saturating_from_num(0) {
         return mat1.to_owned();
     }
-    if ratio == I32F32::from_num(1) {
+    if ratio == I32F32::saturating_from_num(1) {
         return mat2.to_owned();
     }
     assert!(mat1.len() == mat2.len());
@@ -1042,7 +1052,10 @@ pub fn interpolate(mat1: &[Vec<I32F32>], mat2: &[Vec<I32F32>], ratio: I32F32) ->
         return vec![vec![]; 1];
     }
     let mut result: Vec<Vec<I32F32>> =
-        vec![vec![I32F32::from_num(0); mat1.first().unwrap_or(&vec![]).len()]; mat1.len()];
+        vec![
+            vec![I32F32::saturating_from_num(0); mat1.first().unwrap_or(&vec![]).len()];
+            mat1.len()
+        ];
     for (i, (row1, row2)) in mat1.iter().zip(mat2.iter()).enumerate() {
         assert!(row1.len() == row2.len());
         for (j, (&v1, &v2)) in row1.iter().zip(row2.iter()).enumerate() {
@@ -1065,15 +1078,15 @@ pub fn interpolate_sparse(
     columns: u16,
     ratio: I32F32,
 ) -> Vec<Vec<(u16, I32F32)>> {
-    if ratio == I32F32::from_num(0) {
+    if ratio == I32F32::saturating_from_num(0) {
         return mat1.to_owned();
     }
-    if ratio == I32F32::from_num(1) {
+    if ratio == I32F32::saturating_from_num(1) {
         return mat2.to_owned();
     }
     assert!(mat1.len() == mat2.len());
     let rows = mat1.len();
-    let zero: I32F32 = I32F32::from_num(0);
+    let zero: I32F32 = I32F32::saturating_from_num(0);
     let mut result: Vec<Vec<(u16, I32F32)>> = vec![vec![]; rows];
     for i in 0..rows {
         let mut row1: Vec<I32F32> = vec![zero; columns as usize];
@@ -1137,7 +1150,7 @@ pub fn hadamard_sparse(
 ) -> Vec<Vec<(u16, I32F32)>> {
     assert!(mat1.len() == mat2.len());
     let rows = mat1.len();
-    let zero: I32F32 = I32F32::from_num(0);
+    let zero: I32F32 = I32F32::saturating_from_num(0);
     let mut result: Vec<Vec<(u16, I32F32)>> = vec![vec![]; rows];
     for i in 0..rows {
         let mut row1: Vec<I32F32> = vec![zero; columns as usize];
@@ -1169,7 +1182,7 @@ pub fn mat_ema(new: &[Vec<I32F32>], old: &[Vec<I32F32>], alpha: I32F32) -> Vec<V
     if first_row.is_empty() {
         return vec![vec![]; 1];
     }
-    let one_minus_alpha: I32F32 = I32F32::from_num(1.0).saturating_sub(alpha);
+    let one_minus_alpha: I32F32 = I32F32::saturating_from_num(1.0).saturating_sub(alpha);
     new.iter()
         .zip(old)
         .map(|(new_row, old_row)| {
@@ -1197,8 +1210,8 @@ pub fn mat_ema_sparse(
 ) -> Vec<Vec<(u16, I32F32)>> {
     assert!(new.len() == old.len());
     let n = new.len(); // assume square matrix, rows=cols
-    let zero: I32F32 = I32F32::from_num(0.0);
-    let one_minus_alpha: I32F32 = I32F32::from_num(1.0).saturating_sub(alpha);
+    let zero: I32F32 = I32F32::saturating_from_num(0.0);
+    let one_minus_alpha: I32F32 = I32F32::saturating_from_num(1.0).saturating_sub(alpha);
     let mut result: Vec<Vec<(u16, I32F32)>> = vec![vec![]; n];
     for i in 0..new.len() {
         let mut row: Vec<I32F32> = vec![zero; n];
@@ -1241,7 +1254,7 @@ pub fn mat_ema_alpha_vec_sparse(
     // Ensure the new and old matrices have the same number of rows.
     assert!(new.len() == old.len());
     let n = new.len(); // Assume square matrix, rows=cols
-    let zero: I32F32 = I32F32::from_num(0.0);
+    let zero: I32F32 = I32F32::saturating_from_num(0.0);
     let mut result: Vec<Vec<(u16, I32F32)>> = vec![vec![]; n];
 
     // Iterate over each row of the matrices.
@@ -1273,7 +1286,8 @@ pub fn mat_ema_alpha_vec_sparse(
             // Retrieve the alpha value for the current column.
             let alpha_val: I32F32 = alpha.get(*j as usize).copied().unwrap_or(zero);
             // Calculate the complement of the alpha value using saturating subtraction.
-            let one_minus_alpha: I32F32 = I32F32::from_num(1.0).saturating_sub(alpha_val);
+            let one_minus_alpha: I32F32 =
+                I32F32::saturating_from_num(1.0).saturating_sub(alpha_val);
             // Compute the EMA component for the old value and add it to the row using saturating operations.
             if let Some(row_val) = row.get_mut(*j as usize) {
                 *row_val = row_val.saturating_add(one_minus_alpha.saturating_mul(*value));
@@ -1323,7 +1337,10 @@ pub fn mat_ema_alpha_vec(
 
     // Initialize the result matrix with zeros, having the same dimensions as the new matrix.
     let mut result: Vec<Vec<I32F32>> =
-        vec![vec![I32F32::from_num(0.0); new.first().map_or(0, |row| row.len())]; new.len()];
+        vec![
+            vec![I32F32::saturating_from_num(0.0); new.first().map_or(0, |row| row.len())];
+            new.len()
+        ];
 
     // Iterate over each row of the matrices.
     for (i, (new_row, old_row)) in new.iter().zip(old).enumerate() {
@@ -1333,7 +1350,7 @@ pub fn mat_ema_alpha_vec(
         // Iterate over each column of the current row.
         for (j, &alpha_val) in alpha.iter().enumerate().take(new_row.len()) {
             // Calculate the complement of the alpha value using saturating subtraction.
-            let one_minus_alpha = I32F32::from_num(1.0).saturating_sub(alpha_val);
+            let one_minus_alpha = I32F32::saturating_from_num(1.0).saturating_sub(alpha_val);
 
             // Compute the EMA for the current element using saturating operations.
             if let (Some(new_val), Some(old_val), Some(result_val)) = (
@@ -1365,7 +1382,7 @@ pub fn quantile(data: &[I32F32], quantile: f64) -> I32F32 {
 
     // If the data is empty, return 0 as the quantile value.
     if len == 0 {
-        return I32F32::from_num(0);
+        return I32F32::saturating_from_num(0);
     }
 
     // Calculate the position in the sorted array corresponding to the quantile.
@@ -1382,20 +1399,20 @@ pub fn quantile(data: &[I32F32], quantile: f64) -> I32F32 {
         sorted_data
             .get(low)
             .copied()
-            .unwrap_or_else(|| I32F32::from_num(0))
+            .unwrap_or_else(|| I32F32::saturating_from_num(0))
     } else {
         // Otherwise, perform linear interpolation between the low and high values.
         let low_value = sorted_data
             .get(low)
             .copied()
-            .unwrap_or_else(|| I32F32::from_num(0));
+            .unwrap_or_else(|| I32F32::saturating_from_num(0));
         let high_value = sorted_data
             .get(high)
             .copied()
-            .unwrap_or_else(|| I32F32::from_num(0));
+            .unwrap_or_else(|| I32F32::saturating_from_num(0));
 
         // Calculate the weight for interpolation.
-        let weight = I32F32::from_num(pos - low as f64);
+        let weight = I32F32::saturating_from_num(pos - low as f64);
 
         // Return the interpolated value using saturating operations.
         low_value.saturating_add((high_value.saturating_sub(low_value)).saturating_mul(weight))
@@ -1404,10 +1421,10 @@ pub fn quantile(data: &[I32F32], quantile: f64) -> I32F32 {
 
 /// Safe ln function, returns 0 if value is 0.
 pub fn safe_ln(value: I32F32) -> I32F32 {
-    ln(value).unwrap_or(I32F32::from_num(0.0))
+    ln(value).unwrap_or(I32F32::saturating_from_num(0.0))
 }
 
 /// Safe exp function, returns 0 if value is 0.
 pub fn safe_exp(value: I32F32) -> I32F32 {
-    exp(value).unwrap_or(I32F32::from_num(0.0))
+    exp(value).unwrap_or(I32F32::saturating_from_num(0.0))
 }

--- a/pallets/subtensor/src/epoch/run_epoch.rs
+++ b/pallets/subtensor/src/epoch/run_epoch.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::epoch::math::*;
 use frame_support::IterableStorageDoubleMap;
+use safe_math::*;
 use sp_std::vec;
 use substrate_fixed::types::{I32F32, I64F64, I96F32};
 
@@ -238,7 +239,7 @@ impl<T: Config> Pallet<T> {
             .collect();
         let server_emission: Vec<u64> = server_emission
             .iter()
-            .map(|e: &I96F32| e.to_num::<u64>())
+            .map(|e: &I96F32| e.saturating_to_num::<u64>())
             .collect();
 
         let validator_emission: Vec<I96F32> = normalized_validator_emission
@@ -247,7 +248,7 @@ impl<T: Config> Pallet<T> {
             .collect();
         let validator_emission: Vec<u64> = validator_emission
             .iter()
-            .map(|e: &I96F32| e.to_num::<u64>())
+            .map(|e: &I96F32| e.saturating_to_num::<u64>())
             .collect();
 
         // Used only to track combined emission in the storage.
@@ -257,7 +258,7 @@ impl<T: Config> Pallet<T> {
             .collect();
         let combined_emission: Vec<u64> = combined_emission
             .iter()
-            .map(|e: &I96F32| e.to_num::<u64>())
+            .map(|e: &I96F32| e.saturating_to_num::<u64>())
             .collect();
 
         log::trace!("nSE: {:?}", &normalized_server_emission);
@@ -609,7 +610,7 @@ impl<T: Config> Pallet<T> {
             .collect();
         let server_emission: Vec<u64> = server_emission
             .iter()
-            .map(|e: &I96F32| e.to_num::<u64>())
+            .map(|e: &I96F32| e.saturating_to_num::<u64>())
             .collect();
 
         let validator_emission: Vec<I96F32> = normalized_validator_emission
@@ -618,7 +619,7 @@ impl<T: Config> Pallet<T> {
             .collect();
         let validator_emission: Vec<u64> = validator_emission
             .iter()
-            .map(|e: &I96F32| e.to_num::<u64>())
+            .map(|e: &I96F32| e.saturating_to_num::<u64>())
             .collect();
 
         // Only used to track emission in storage.
@@ -628,7 +629,7 @@ impl<T: Config> Pallet<T> {
             .collect();
         let combined_emission: Vec<u64> = combined_emission
             .iter()
-            .map(|e: &I96F32| e.to_num::<u64>())
+            .map(|e: &I96F32| e.saturating_to_num::<u64>())
             .collect();
 
         log::trace!(

--- a/pallets/subtensor/src/epoch/run_epoch.rs
+++ b/pallets/subtensor/src/epoch/run_epoch.rs
@@ -231,11 +231,11 @@ impl<T: Config> Pallet<T> {
         }
 
         // Compute rao based emission scores. range: I96F32(0, rao_emission)
-        let float_rao_emission: I96F32 = I96F32::from_num(rao_emission);
+        let float_rao_emission: I96F32 = I96F32::saturating_from_num(rao_emission);
 
         let server_emission: Vec<I96F32> = normalized_server_emission
             .iter()
-            .map(|se: &I32F32| I96F32::from_num(*se).saturating_mul(float_rao_emission))
+            .map(|se: &I32F32| I96F32::saturating_from_num(*se).saturating_mul(float_rao_emission))
             .collect();
         let server_emission: Vec<u64> = server_emission
             .iter()
@@ -244,7 +244,7 @@ impl<T: Config> Pallet<T> {
 
         let validator_emission: Vec<I96F32> = normalized_validator_emission
             .iter()
-            .map(|ve: &I32F32| I96F32::from_num(*ve).saturating_mul(float_rao_emission))
+            .map(|ve: &I32F32| I96F32::saturating_from_num(*ve).saturating_mul(float_rao_emission))
             .collect();
         let validator_emission: Vec<u64> = validator_emission
             .iter()
@@ -254,7 +254,7 @@ impl<T: Config> Pallet<T> {
         // Used only to track combined emission in the storage.
         let combined_emission: Vec<I96F32> = normalized_combined_emission
             .iter()
-            .map(|ce: &I32F32| I96F32::from_num(*ce).saturating_mul(float_rao_emission))
+            .map(|ce: &I32F32| I96F32::saturating_from_num(*ce).saturating_mul(float_rao_emission))
             .collect();
         let combined_emission: Vec<u64> = combined_emission
             .iter()
@@ -602,11 +602,11 @@ impl<T: Config> Pallet<T> {
         }
 
         // Compute rao based emission scores. range: I96F32(0, rao_emission)
-        let float_rao_emission: I96F32 = I96F32::from_num(rao_emission);
+        let float_rao_emission: I96F32 = I96F32::saturating_from_num(rao_emission);
 
         let server_emission: Vec<I96F32> = normalized_server_emission
             .iter()
-            .map(|se: &I32F32| I96F32::from_num(*se).saturating_mul(float_rao_emission))
+            .map(|se: &I32F32| I96F32::saturating_from_num(*se).saturating_mul(float_rao_emission))
             .collect();
         let server_emission: Vec<u64> = server_emission
             .iter()
@@ -615,7 +615,7 @@ impl<T: Config> Pallet<T> {
 
         let validator_emission: Vec<I96F32> = normalized_validator_emission
             .iter()
-            .map(|ve: &I32F32| I96F32::from_num(*ve).saturating_mul(float_rao_emission))
+            .map(|ve: &I32F32| I96F32::saturating_from_num(*ve).saturating_mul(float_rao_emission))
             .collect();
         let validator_emission: Vec<u64> = validator_emission
             .iter()
@@ -625,7 +625,7 @@ impl<T: Config> Pallet<T> {
         // Only used to track emission in storage.
         let combined_emission: Vec<I96F32> = normalized_combined_emission
             .iter()
-            .map(|ce: &I32F32| I96F32::from_num(*ce).saturating_mul(float_rao_emission))
+            .map(|ce: &I32F32| I96F32::saturating_from_num(*ce).saturating_mul(float_rao_emission))
             .collect();
         let combined_emission: Vec<u64> = combined_emission
             .iter()
@@ -733,13 +733,15 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn get_float_rho(netuid: u16) -> I32F32 {
-        I32F32::from_num(Self::get_rho(netuid))
+        I32F32::saturating_from_num(Self::get_rho(netuid))
     }
     pub fn get_float_kappa(netuid: u16) -> I32F32 {
-        I32F32::from_num(Self::get_kappa(netuid)).safe_div(I32F32::from_num(u16::MAX))
+        I32F32::saturating_from_num(Self::get_kappa(netuid))
+            .safe_div(I32F32::saturating_from_num(u16::MAX))
     }
     pub fn get_float_bonds_penalty(netuid: u16) -> I32F32 {
-        I32F32::from_num(Self::get_bonds_penalty(netuid)).safe_div(I32F32::from_num(u16::MAX))
+        I32F32::saturating_from_num(Self::get_bonds_penalty(netuid))
+            .safe_div(I32F32::saturating_from_num(u16::MAX))
     }
 
     pub fn get_block_at_registration(netuid: u16) -> Vec<u64> {
@@ -768,7 +770,7 @@ impl<T: Config> Pallet<T> {
                 weights
                     .get_mut(uid_i as usize)
                     .expect("uid_i is filtered to be less than n; qed")
-                    .push((*uid_j, I32F32::from_num(*weight_ij)));
+                    .push((*uid_j, I32F32::saturating_from_num(*weight_ij)));
             }
         }
         weights
@@ -777,7 +779,7 @@ impl<T: Config> Pallet<T> {
     /// Output unnormalized weights in [n, n] matrix, input weights are assumed to be row max-upscaled in u16.
     pub fn get_weights(netuid: u16) -> Vec<Vec<I32F32>> {
         let n: usize = Self::get_subnetwork_n(netuid) as usize;
-        let mut weights: Vec<Vec<I32F32>> = vec![vec![I32F32::from_num(0.0); n]; n];
+        let mut weights: Vec<Vec<I32F32>> = vec![vec![I32F32::saturating_from_num(0.0); n]; n];
         for (uid_i, weights_vec) in
             <Weights<T> as IterableStorageDoubleMap<u16, u16, Vec<(u16, u16)>>>::iter_prefix(netuid)
                 .filter(|(uid_i, _)| *uid_i < n as u16)
@@ -791,7 +793,7 @@ impl<T: Config> Pallet<T> {
                     .expect("uid_i is filtered to be less than n; qed")
                     .get_mut(uid_j as usize)
                     .expect("uid_j is filtered to be less than n; qed") =
-                    I32F32::from_num(weight_ij);
+                    I32F32::saturating_from_num(weight_ij);
             }
         }
         weights
@@ -809,7 +811,7 @@ impl<T: Config> Pallet<T> {
                 bonds
                     .get_mut(uid_i as usize)
                     .expect("uid_i is filtered to be less than n; qed")
-                    .push((uid_j, I32F32::from_num(bonds_ij)));
+                    .push((uid_j, I32F32::saturating_from_num(bonds_ij)));
             }
         }
         bonds
@@ -818,7 +820,7 @@ impl<T: Config> Pallet<T> {
     /// Output unnormalized bonds in [n, n] matrix, input bonds are assumed to be column max-upscaled in u16.
     pub fn get_bonds(netuid: u16) -> Vec<Vec<I32F32>> {
         let n: usize = Self::get_subnetwork_n(netuid) as usize;
-        let mut bonds: Vec<Vec<I32F32>> = vec![vec![I32F32::from_num(0.0); n]; n];
+        let mut bonds: Vec<Vec<I32F32>> = vec![vec![I32F32::saturating_from_num(0.0); n]; n];
         for (uid_i, bonds_vec) in
             <Bonds<T> as IterableStorageDoubleMap<u16, u16, Vec<(u16, u16)>>>::iter_prefix(netuid)
                 .filter(|(uid_i, _)| *uid_i < n as u16)
@@ -829,7 +831,7 @@ impl<T: Config> Pallet<T> {
                     .expect("uid_i has been filtered to be less than n; qed")
                     .get_mut(uid_j as usize)
                     .expect("uid_j has been filtered to be less than n; qed") =
-                    I32F32::from_num(bonds_ij);
+                    I32F32::saturating_from_num(bonds_ij);
             }
         }
         bonds
@@ -859,16 +861,21 @@ impl<T: Config> Pallet<T> {
         // extra caution to ensure we never divide by zero
         if consensus_high <= consensus_low || alpha_low == 0 || alpha_high == 0 {
             // Return 0 for both 'a' and 'b' when consensus values are equal
-            return (I32F32::from_num(0.0), I32F32::from_num(0.0));
+            return (
+                I32F32::saturating_from_num(0.0),
+                I32F32::saturating_from_num(0.0),
+            );
         }
 
         // Calculate the slope 'a' of the logistic function.
         // a = (ln((1 / alpha_high - 1)) - ln((1 / alpha_low - 1))) / (consensus_low - consensus_high)
         let a = (safe_ln(
-            (I32F32::from_num(1.0).safe_div(alpha_high)).saturating_sub(I32F32::from_num(1.0)),
+            (I32F32::saturating_from_num(1.0).safe_div(alpha_high))
+                .saturating_sub(I32F32::saturating_from_num(1.0)),
         )
         .saturating_sub(safe_ln(
-            (I32F32::from_num(1.0).safe_div(alpha_low)).saturating_sub(I32F32::from_num(1.0)),
+            (I32F32::saturating_from_num(1.0).safe_div(alpha_low))
+                .saturating_sub(I32F32::saturating_from_num(1.0)),
         )))
         .safe_div(consensus_low.saturating_sub(consensus_high));
         log::trace!("a: {:?}", a);
@@ -876,7 +883,8 @@ impl<T: Config> Pallet<T> {
         // Calculate the intercept 'b' of the logistic function.
         // b = ln((1 / alpha_low - 1)) + a * consensus_low
         let b = safe_ln(
-            (I32F32::from_num(1.0).safe_div(alpha_low)).saturating_sub(I32F32::from_num(1.0)),
+            (I32F32::saturating_from_num(1.0).safe_div(alpha_low))
+                .saturating_sub(I32F32::saturating_from_num(1.0)),
         )
         .saturating_add(a.saturating_mul(consensus_low));
         log::trace!("b: {:?}", b);
@@ -905,7 +913,8 @@ impl<T: Config> Pallet<T> {
 
                 // Compute the alpha value using the logistic function formula.
                 // alpha = 1 / (1 + exp_val)
-                I32F32::from_num(1.0).safe_div(I32F32::from_num(1.0).saturating_add(exp_val))
+                I32F32::saturating_from_num(1.0)
+                    .safe_div(I32F32::saturating_from_num(1.0).saturating_add(exp_val))
             })
             .collect();
 
@@ -1019,13 +1028,14 @@ impl<T: Config> Pallet<T> {
         netuid: u16,
     ) -> Vec<Vec<(u16, I32F32)>> {
         // Retrieve the bonds moving average for the given network ID and scale it down.
-        let bonds_moving_average: I64F64 = I64F64::from_num(Self::get_bonds_moving_average(netuid))
-            .safe_div(I64F64::from_num(1_000_000));
+        let bonds_moving_average: I64F64 =
+            I64F64::saturating_from_num(Self::get_bonds_moving_average(netuid))
+                .safe_div(I64F64::saturating_from_num(1_000_000));
 
         // Calculate the alpha value for the EMA calculation.
         // Alpha is derived by subtracting the scaled bonds moving average from 1.
-        let alpha: I32F32 =
-            I32F32::from_num(1).saturating_sub(I32F32::from_num(bonds_moving_average));
+        let alpha: I32F32 = I32F32::saturating_from_num(1)
+            .saturating_sub(I32F32::saturating_from_num(bonds_moving_average));
 
         // Compute the Exponential Moving Average (EMA) of bonds using the calculated alpha value.
         let ema_bonds = mat_ema_sparse(bonds_delta, bonds, alpha);
@@ -1052,13 +1062,14 @@ impl<T: Config> Pallet<T> {
         netuid: u16,
     ) -> Vec<Vec<I32F32>> {
         // Retrieve the bonds moving average for the given network ID and scale it down.
-        let bonds_moving_average: I64F64 = I64F64::from_num(Self::get_bonds_moving_average(netuid))
-            .safe_div(I64F64::from_num(1_000_000));
+        let bonds_moving_average: I64F64 =
+            I64F64::saturating_from_num(Self::get_bonds_moving_average(netuid))
+                .safe_div(I64F64::saturating_from_num(1_000_000));
 
         // Calculate the alpha value for the EMA calculation.
         // Alpha is derived by subtracting the scaled bonds moving average from 1.
-        let alpha: I32F32 =
-            I32F32::from_num(1).saturating_sub(I32F32::from_num(bonds_moving_average));
+        let alpha: I32F32 = I32F32::saturating_from_num(1)
+            .saturating_sub(I32F32::saturating_from_num(bonds_moving_average));
 
         // Compute the Exponential Moving Average (EMA) of bonds using the calculated alpha value.
         let ema_bonds = mat_ema(bonds_delta, bonds, alpha);
@@ -1090,7 +1101,9 @@ impl<T: Config> Pallet<T> {
         // This way we avoid the quantil function panic.
         if LiquidAlphaOn::<T>::get(netuid)
             && !consensus.is_empty()
-            && consensus.iter().any(|&c| c != I32F32::from_num(0))
+            && consensus
+                .iter()
+                .any(|&c| c != I32F32::saturating_from_num(0))
         {
             // Calculate the 75th percentile (high) and 25th percentile (low) of the consensus values.
             let consensus_high = quantile(&consensus, 0.75);
@@ -1158,7 +1171,9 @@ impl<T: Config> Pallet<T> {
         // Check if Liquid Alpha is enabled, consensus is not empty, and contains non-zero values.
         if LiquidAlphaOn::<T>::get(netuid)
             && !consensus.is_empty()
-            && consensus.iter().any(|&c| c != I32F32::from_num(0))
+            && consensus
+                .iter()
+                .any(|&c| c != I32F32::saturating_from_num(0))
         {
             // Calculate the 75th percentile (high) and 25th percentile (low) of the consensus values.
             let consensus_high = quantile(&consensus, 0.75);

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -730,7 +730,7 @@ pub mod pallet {
     #[pallet::type_value]
     /// Default value for Share Pool variables
     pub fn DefaultSharePoolZero<T: Config>() -> U64F64 {
-        U64F64::from_num(0)
+        U64F64::saturating_from_num(0)
     }
 
     #[pallet::storage]

--- a/pallets/subtensor/src/macros/genesis.rs
+++ b/pallets/subtensor/src/macros/genesis.rs
@@ -66,13 +66,13 @@ mod genesis {
                 Alpha::<T>::insert(
                     // Lock the initial funds making this key the owner.
                     (hotkey.clone(), hotkey.clone(), netuid),
-                    U64F64::from_num(1_000_000_000),
+                    U64F64::saturating_from_num(1_000_000_000),
                 );
                 TotalHotkeyAlpha::<T>::insert(hotkey.clone(), netuid, 1_000_000_000);
                 TotalHotkeyShares::<T>::insert(
                     hotkey.clone(),
                     netuid,
-                    U64F64::from_num(1_000_000_000),
+                    U64F64::saturating_from_num(1_000_000_000),
                 );
                 // TotalColdkeyAlpha::<T>::insert(hotkey.clone(), netuid, 1_000_000_000);
                 SubnetAlphaOut::<T>::insert(netuid, 1_000_000_000);

--- a/pallets/subtensor/src/migrations/migrate_rao.rs
+++ b/pallets/subtensor/src/migrations/migrate_rao.rs
@@ -45,10 +45,10 @@ pub fn migrate_rao<T: Config>() -> Weight {
         });
         // Set all the stake on root 0 subnet.
         Alpha::<T>::mutate((hotkey.clone(), coldkey.clone(), 0), |total| {
-            *total = total.saturating_add(U64F64::from_num(stake))
+            *total = total.saturating_add(U64F64::saturating_from_num(stake))
         });
         TotalHotkeyShares::<T>::mutate(hotkey.clone(), 0, |total| {
-            *total = total.saturating_add(U64F64::from_num(stake))
+            *total = total.saturating_add(U64F64::saturating_from_num(stake))
         });
         // Set the total stake on the hotkey
         TotalHotkeyAlpha::<T>::mutate(hotkey.clone(), 0, |total| {

--- a/pallets/subtensor/src/rpc_info/delegate_info.rs
+++ b/pallets/subtensor/src/rpc_info/delegate_info.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::epoch::math::*;
 use frame_support::pallet_prelude::{Decode, Encode};
 use frame_support::storage::IterableStorageMap;
 use frame_support::IterableStorageDoubleMap;
@@ -27,14 +28,14 @@ impl<T: Config> Pallet<T> {
         emissions_per_day: U64F64,
     ) -> U64F64 {
         // Get the take as a percentage and subtract it from 1 for remainder.
-        let without_take: U64F64 = U64F64::from_num(1)
-            .saturating_sub(U64F64::from_num(take.0).saturating_div(u16::MAX.into()));
+        let without_take: U64F64 =
+            U64F64::from_num(1).saturating_sub(U64F64::from_num(take.0).safe_div(u16::MAX.into()));
 
         if total_stake > U64F64::from_num(0) {
             emissions_per_day
                 .saturating_mul(without_take)
                 // Divide by 1000 TAO for return per 1k
-                .saturating_div(total_stake.saturating_div(U64F64::from_num(1000.0 * 1e9)))
+                .safe_div(total_stake.safe_div(U64F64::from_num(1000.0 * 1e9)))
         } else {
             U64F64::from_num(0)
         }
@@ -78,7 +79,7 @@ impl<T: Config> Pallet<T> {
                 let emission: U64F64 = Self::get_emission_for_uid(*netuid, uid).into();
                 let tempo: U64F64 = Self::get_tempo(*netuid).into();
                 if tempo > U64F64::from_num(0) {
-                    let epochs_per_day: U64F64 = U64F64::from_num(7200).saturating_div(tempo);
+                    let epochs_per_day: U64F64 = U64F64::from_num(7200).safe_div(tempo);
                     emissions_per_day =
                         emissions_per_day.saturating_add(emission.saturating_mul(epochs_per_day));
                 }

--- a/pallets/subtensor/src/rpc_info/delegate_info.rs
+++ b/pallets/subtensor/src/rpc_info/delegate_info.rs
@@ -28,16 +28,16 @@ impl<T: Config> Pallet<T> {
         emissions_per_day: U64F64,
     ) -> U64F64 {
         // Get the take as a percentage and subtract it from 1 for remainder.
-        let without_take: U64F64 =
-            U64F64::from_num(1).saturating_sub(U64F64::from_num(take.0).safe_div(u16::MAX.into()));
+        let without_take: U64F64 = U64F64::saturating_from_num(1)
+            .saturating_sub(U64F64::saturating_from_num(take.0).safe_div(u16::MAX.into()));
 
-        if total_stake > U64F64::from_num(0) {
+        if total_stake > U64F64::saturating_from_num(0) {
             emissions_per_day
                 .saturating_mul(without_take)
                 // Divide by 1000 TAO for return per 1k
-                .safe_div(total_stake.safe_div(U64F64::from_num(1000.0 * 1e9)))
+                .safe_div(total_stake.safe_div(U64F64::saturating_from_num(1000.0 * 1e9)))
         } else {
-            U64F64::from_num(0)
+            U64F64::saturating_from_num(0)
         }
     }
 
@@ -67,7 +67,7 @@ impl<T: Config> Pallet<T> {
 
         let registrations = Self::get_registered_networks_for_hotkey(&delegate.clone());
         let mut validator_permits = Vec::<Compact<u16>>::new();
-        let mut emissions_per_day: U64F64 = U64F64::from_num(0);
+        let mut emissions_per_day: U64F64 = U64F64::saturating_from_num(0);
 
         for netuid in registrations.iter() {
             if let Ok(uid) = Self::get_uid_for_net_and_hotkey(*netuid, &delegate.clone()) {
@@ -78,8 +78,8 @@ impl<T: Config> Pallet<T> {
 
                 let emission: U64F64 = Self::get_emission_for_uid(*netuid, uid).into();
                 let tempo: U64F64 = Self::get_tempo(*netuid).into();
-                if tempo > U64F64::from_num(0) {
-                    let epochs_per_day: U64F64 = U64F64::from_num(7200).safe_div(tempo);
+                if tempo > U64F64::saturating_from_num(0) {
+                    let epochs_per_day: U64F64 = U64F64::saturating_from_num(7200).safe_div(tempo);
                     emissions_per_day =
                         emissions_per_day.saturating_add(emission.saturating_mul(epochs_per_day));
                 }

--- a/pallets/subtensor/src/rpc_info/delegate_info.rs
+++ b/pallets/subtensor/src/rpc_info/delegate_info.rs
@@ -1,8 +1,8 @@
 use super::*;
-use crate::epoch::math::*;
 use frame_support::pallet_prelude::{Decode, Encode};
 use frame_support::storage::IterableStorageMap;
 use frame_support::IterableStorageDoubleMap;
+use safe_math::*;
 use substrate_fixed::types::U64F64;
 extern crate alloc;
 use codec::Compact;
@@ -102,8 +102,8 @@ impl<T: Config> Pallet<T> {
             owner_ss58: owner.clone(),
             registrations: registrations.iter().map(|x| x.into()).collect(),
             validator_permits,
-            return_per_1000: U64F64::to_num::<u64>(return_per_1000).into(),
-            total_daily_return: U64F64::to_num::<u64>(emissions_per_day).into(),
+            return_per_1000: return_per_1000.saturating_to_num::<u64>().into(),
+            total_daily_return: emissions_per_day.saturating_to_num::<u64>().into(),
         }
     }
 

--- a/pallets/subtensor/src/staking/helpers.rs
+++ b/pallets/subtensor/src/staking/helpers.rs
@@ -49,7 +49,7 @@ impl<T: Config> Pallet<T> {
                 let alpha: I96F32 =
                     I96F32::from_num(Self::get_stake_for_hotkey_on_subnet(hotkey, *netuid));
                 let tao_price: I96F32 = Self::get_alpha_price(*netuid);
-                alpha.saturating_mul(tao_price).to_num::<u64>()
+                alpha.saturating_mul(tao_price).saturating_to_num::<u64>()
             })
             .sum()
     }
@@ -67,7 +67,7 @@ impl<T: Config> Pallet<T> {
                     total_stake = total_stake.saturating_add(
                         I96F32::from_num(alpha)
                             .saturating_mul(tao_price)
-                            .to_num::<u64>(),
+                            .saturating_to_num::<u64>(),
                     );
                 }
                 total_stake

--- a/pallets/subtensor/src/staking/helpers.rs
+++ b/pallets/subtensor/src/staking/helpers.rs
@@ -46,8 +46,9 @@ impl<T: Config> Pallet<T> {
         Self::get_all_subnet_netuids()
             .iter()
             .map(|netuid| {
-                let alpha: I96F32 =
-                    I96F32::from_num(Self::get_stake_for_hotkey_on_subnet(hotkey, *netuid));
+                let alpha: I96F32 = I96F32::saturating_from_num(
+                    Self::get_stake_for_hotkey_on_subnet(hotkey, *netuid),
+                );
                 let tao_price: I96F32 = Self::get_alpha_price(*netuid);
                 alpha.saturating_mul(tao_price).saturating_to_num::<u64>()
             })
@@ -65,7 +66,7 @@ impl<T: Config> Pallet<T> {
                 for (netuid, alpha) in Alpha::<T>::iter_prefix((hotkey, coldkey)) {
                     let tao_price: I96F32 = Self::get_alpha_price(netuid);
                     total_stake = total_stake.saturating_add(
-                        I96F32::from_num(alpha)
+                        I96F32::saturating_from_num(alpha)
                             .saturating_mul(tao_price)
                             .saturating_to_num::<u64>(),
                     );

--- a/pallets/subtensor/src/staking/move_stake.rs
+++ b/pallets/subtensor/src/staking/move_stake.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::epoch::math::*;
 use sp_core::Get;
 
 impl<T: Config> Pallet<T> {
@@ -223,7 +224,7 @@ impl<T: Config> Pallet<T> {
         )?;
 
         // Unstake from the origin subnet, returning TAO (or a 1:1 equivalent).
-        let fee = DefaultStakingFee::<T>::get().saturating_div(2);
+        let fee = DefaultStakingFee::<T>::get().safe_div(2);
         let tao_unstaked = Self::unstake_from_subnet(
             origin_hotkey,
             origin_coldkey,

--- a/pallets/subtensor/src/staking/move_stake.rs
+++ b/pallets/subtensor/src/staking/move_stake.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::epoch::math::*;
+use safe_math::*;
 use sp_core::Get;
 
 impl<T: Config> Pallet<T> {

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::epoch::math::*;
+use safe_math::*;
 use share_pool::{SharePool, SharePoolDataOperations};
 use sp_std::ops::Neg;
 use substrate_fixed::types::{I64F64, I96F32, U64F64};
@@ -208,7 +208,7 @@ impl<T: Config> Pallet<T> {
             initial_alpha
         );
         if netuid == 0 {
-            return initial_alpha.to_num::<u64>();
+            return initial_alpha.saturating_to_num::<u64>();
         }
 
         // Initialize variables to track alpha allocated to children and inherited from parents.
@@ -299,7 +299,7 @@ impl<T: Config> Pallet<T> {
         );
 
         // Step 6: Return the final inherited alpha value.
-        finalized_alpha.to_num::<u64>()
+        finalized_alpha.saturating_to_num::<u64>()
     }
 
     /// Checks if a specific hotkey-coldkey pair has enough stake on a subnet to fulfill a given decrement.
@@ -476,7 +476,7 @@ impl<T: Config> Pallet<T> {
             I96F32::from_num(tao)
         };
         // Return simulated amount.
-        alpha.to_num::<u64>()
+        alpha.saturating_to_num::<u64>()
     }
 
     /// Swaps a subnet's Alpba token for TAO.
@@ -502,7 +502,7 @@ impl<T: Config> Pallet<T> {
             // Step 3.b.1: Stable mechanism, just return the value 1:1
             I96F32::from_num(alpha)
         };
-        tao.to_num::<u64>()
+        tao.saturating_to_num::<u64>()
     }
 
     /// Swaps TAO for the alpha token on the subnet.
@@ -530,11 +530,11 @@ impl<T: Config> Pallet<T> {
         };
         // Step 4. Decrease Alpha reserves.
         SubnetAlphaIn::<T>::mutate(netuid, |total| {
-            *total = total.saturating_sub(alpha.to_num::<u64>());
+            *total = total.saturating_sub(alpha.saturating_to_num::<u64>());
         });
         // Step 5: Increase Alpha outstanding.
         SubnetAlphaOut::<T>::mutate(netuid, |total| {
-            *total = total.saturating_add(alpha.to_num::<u64>());
+            *total = total.saturating_add(alpha.saturating_to_num::<u64>());
         });
         // Step 6: Increase Tao reserves.
         SubnetTAO::<T>::mutate(netuid, |total| {
@@ -549,7 +549,7 @@ impl<T: Config> Pallet<T> {
             *total = total.saturating_sub(tao);
         });
         // Step 9. Return the alpha received.
-        alpha.to_num::<u64>()
+        alpha.saturating_to_num::<u64>()
     }
 
     /// Swaps a subnet's Alpba token for TAO.
@@ -585,18 +585,18 @@ impl<T: Config> Pallet<T> {
         });
         // Step 6: Decrease tao reserves.
         SubnetTAO::<T>::mutate(netuid, |total| {
-            *total = total.saturating_sub(tao.to_num::<u64>());
+            *total = total.saturating_sub(tao.saturating_to_num::<u64>());
         });
         // Step 7: Reduce total TAO reserves.
         TotalStake::<T>::mutate(|total| {
-            *total = total.saturating_sub(tao.to_num::<u64>());
+            *total = total.saturating_sub(tao.saturating_to_num::<u64>());
         });
         // Step 8. Decrease Alpha reserves.
         SubnetVolume::<T>::mutate(netuid, |total| {
-            *total = total.saturating_sub(tao.to_num::<u64>());
+            *total = total.saturating_sub(tao.saturating_to_num::<u64>());
         });
         // Step 9. Return the tao received.
-        tao.to_num::<u64>()
+        tao.saturating_to_num::<u64>()
     }
 
     /// Unstakes alpha from a subnet for a given hotkey and coldkey pair.
@@ -891,7 +891,7 @@ impl<T: Config> SharePoolDataOperations<AlphaShareKey<T>>
             crate::TotalHotkeyAlpha::<T>::insert(
                 &(self.hotkey),
                 self.netuid,
-                value.to_num::<u64>(),
+                value.saturating_to_num::<u64>(),
             );
         } else {
             crate::TotalHotkeyAlpha::<T>::remove(&(self.hotkey), self.netuid);

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::epoch::math::*;
 use share_pool::{SharePool, SharePoolDataOperations};
 use sp_std::ops::Neg;
 use substrate_fixed::types::{I64F64, I96F32, U64F64};
@@ -70,7 +71,7 @@ impl<T: Config> Pallet<T> {
 
         // Step 3: Normalize the weight by dividing by u64::MAX
         // This ensures the result is always between 0 and 1
-        weight_fixed.saturating_div(I96F32::from_num(u64::MAX))
+        weight_fixed.safe_div(I96F32::from_num(u64::MAX))
     }
 
     /// Sets the global global weight in storage.
@@ -234,7 +235,7 @@ impl<T: Config> Pallet<T> {
         for (proportion, _) in children {
             // Convert the proportion to a normalized value between 0 and 1.
             let normalized_proportion: I96F32 =
-                I96F32::from_num(proportion).saturating_div(I96F32::from_num(u64::MAX));
+                I96F32::from_num(proportion).safe_div(I96F32::from_num(u64::MAX));
             log::trace!(
                 "Normalized proportion for child: {:?}",
                 normalized_proportion
@@ -264,7 +265,7 @@ impl<T: Config> Pallet<T> {
 
             // Convert the proportion to a normalized value between 0 and 1.
             let normalized_proportion: I96F32 =
-                I96F32::from_num(proportion).saturating_div(I96F32::from_num(u64::MAX));
+                I96F32::from_num(proportion).safe_div(I96F32::from_num(u64::MAX));
             log::trace!(
                 "Normalized proportion from parent: {:?}",
                 normalized_proportion

--- a/pallets/subtensor/src/subnets/weights.rs
+++ b/pallets/subtensor/src/subnets/weights.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::epoch::math::*;
 use codec::Compact;
+use safe_math::*;
 use sp_core::{ConstU32, H256};
 use sp_runtime::{
     traits::{BlakeTwo256, Hash},

--- a/pallets/subtensor/src/subnets/weights.rs
+++ b/pallets/subtensor/src/subnets/weights.rs
@@ -1001,9 +1001,7 @@ impl<T: Config> Pallet<T> {
             return weights;
         }
         weights.iter_mut().for_each(|x| {
-            *x = (*x as u64)
-                .saturating_mul(u16::MAX as u64)
-                .saturating_div(sum) as u16;
+            *x = (*x as u64).saturating_mul(u16::MAX as u64).safe_div(sum) as u16;
         });
         weights
     }

--- a/pallets/subtensor/src/tests/children.rs
+++ b/pallets/subtensor/src/tests/children.rs
@@ -3357,7 +3357,7 @@ fn test_parent_child_chain_emission() {
         let total_tao: I96F32 = I96F32::from_num(300_000 + 100_000 + 50_000);
         let total_alpha: I96F32 = I96F32::from_num(SubtensorModule::swap_tao_for_alpha(
             netuid,
-            total_tao.saturating_to_num::<u64>(),
+            total_tao.to_num::<u64>(),
         ));
 
         // Set the stakes directly

--- a/pallets/subtensor/src/tests/children.rs
+++ b/pallets/subtensor/src/tests/children.rs
@@ -3702,7 +3702,7 @@ fn test_dynamic_parent_child_relationships() {
         let expected_parent_stake = ((I96F32::from_num(stake_parent_0)
             + total_emission * rel_stake_parent_0)
             * I96F32::from_num(5))
-        .saturating_div(I96F32::from_num(12));
+            / I96F32::from_num(12);
         assert!(
             (I96F32::from_num(stake_parent_2) - expected_parent_stake).abs()
                 / expected_parent_stake

--- a/pallets/subtensor/src/tests/delegate_info.rs
+++ b/pallets/subtensor/src/tests/delegate_info.rs
@@ -6,7 +6,7 @@ use super::mock::*;
 #[test]
 fn test_return_per_1000_tao() {
     let take = // 18% take to the Validator
-        Compact::<u16>::from((U64F64::from_num(0.18 * u16::MAX as f64)).saturating_to_num::<u16>());
+        Compact::<u16>::from((U64F64::from_num(0.18 * u16::MAX as f64)).to_num::<u16>());
 
     // 10_000 TAO total validator stake
     let total_stake = U64F64::from_num(10_000.0 * 1e9);

--- a/pallets/subtensor/src/tests/epoch.rs
+++ b/pallets/subtensor/src/tests/epoch.rs
@@ -2285,22 +2285,19 @@ fn test_compute_alpha_values() {
     // exp_val = exp(0.0 - 1.0 * 0.1) = exp(-0.1)
     // alpha[0] = 1 / (1 + exp(-0.1)) ~ 0.9048374180359595
     let exp_val_0 = I32F32::from_num(0.9048374180359595);
-    let expected_alpha_0 =
-        I32F32::from_num(1.0).saturating_div(I32F32::from_num(1.0).saturating_add(exp_val_0));
+    let expected_alpha_0 = I32F32::from_num(1.0) / I32F32::from_num(1.0).saturating_add(exp_val_0);
 
     // For consensus[1] = 0.5:
     // exp_val = exp(0.0 - 1.0 * 0.5) = exp(-0.5)
     // alpha[1] = 1 / (1 + exp(-0.5)) ~ 0.6065306597126334
     let exp_val_1 = I32F32::from_num(0.6065306597126334);
-    let expected_alpha_1 =
-        I32F32::from_num(1.0).saturating_div(I32F32::from_num(1.0).saturating_add(exp_val_1));
+    let expected_alpha_1 = I32F32::from_num(1.0) / I32F32::from_num(1.0).saturating_add(exp_val_1);
 
     // For consensus[2] = 0.9:
     // exp_val = exp(0.0 - 1.0 * 0.9) = exp(-0.9)
     // alpha[2] = 1 / (1 + exp(-0.9)) ~ 0.4065696597405991
     let exp_val_2 = I32F32::from_num(0.4065696597405991);
-    let expected_alpha_2 =
-        I32F32::from_num(1.0).saturating_div(I32F32::from_num(1.0).saturating_add(exp_val_2));
+    let expected_alpha_2 = I32F32::from_num(1.0) / I32F32::from_num(1.0).saturating_add(exp_val_2);
 
     // Define an epsilon for approximate equality checks.
     let epsilon = I32F32::from_num(1e-6);
@@ -2338,8 +2335,7 @@ fn test_compute_alpha_values_256_miners() {
         let exp_val = safe_exp(exponent);
 
         // Use saturating addition and division
-        let expected_alpha =
-            I32F32::from_num(1.0).saturating_div(I32F32::from_num(1.0).saturating_add(exp_val));
+        let expected_alpha = I32F32::from_num(1.0) / I32F32::from_num(1.0).saturating_add(exp_val);
 
         // Assert that the computed alpha values match the expected values within the epsilon.
         assert_approx_eq(alpha[i], expected_alpha, epsilon);

--- a/pallets/subtensor/src/tests/math.rs
+++ b/pallets/subtensor/src/tests/math.rs
@@ -2264,16 +2264,17 @@ fn test_math_fixed_to_u64() {
 }
 
 #[test]
-#[should_panic(expected = "-1 overflows")]
-fn test_math_fixed_to_u64_panics() {
+fn test_math_fixed_to_u64_saturates() {
     let bad_input = I32F32::from_num(-1);
-    fixed_to_u64(bad_input);
+    let expected = 0;
+    assert_eq!(fixed_to_u64(bad_input), expected);
 }
 
 #[test]
 fn test_math_fixed64_to_u64() {
     let expected = u64::MIN;
-    assert_eq!(fixed64_to_u64(I64F64::from_num(expected)), expected);
+    let input = I64F64::from_num(expected);
+    assert_eq!(fixed64_to_u64(input), expected);
 
     let input = i64::MAX / 2;
     let expected = u64::try_from(input).unwrap();
@@ -2285,10 +2286,10 @@ fn test_math_fixed64_to_u64() {
 }
 
 #[test]
-#[should_panic(expected = "-1 overflows")]
-fn test_math_fixed64_to_u64_panics() {
+fn test_math_fixed64_to_u64_saturates() {
     let bad_input = I64F64::from_num(-1);
-    fixed64_to_u64(bad_input);
+    let expected = 0;
+    assert_eq!(fixed64_to_u64(bad_input), expected);
 }
 
 /* @TODO: find the _true_ max, and half, input values */
@@ -2340,14 +2341,15 @@ fn test_fixed_proportion_to_u16() {
 }
 
 #[test]
-#[should_panic(expected = "overflow")]
-fn test_fixed_proportion_to_u16_panics() {
+fn test_fixed_proportion_to_u16_saturates() {
     let expected = u16::MAX;
     let input = I32F32::from_num(expected);
     log::trace!("Testing with input: {:?}", input); // Debug output
     let result = fixed_proportion_to_u16(input);
     log::trace!("Testing with result: {:?}", result); // Debug output
+    assert_eq!(result, expected);
 }
+
 #[test]
 fn test_vec_fixed64_to_fixed32() {
     let input = vec![I64F64::from_num(i32::MIN)];

--- a/pallets/subtensor/src/tests/math.rs
+++ b/pallets/subtensor/src/tests/math.rs
@@ -2305,10 +2305,9 @@ fn test_math_fixed64_to_fixed32() {
 }
 
 #[test]
-#[should_panic(expected = "overflow")]
-fn test_math_fixed64_to_fixed32_panics() {
+fn test_math_fixed64_to_fixed32_saturates() {
     let bad_input = I64F64::from_num(u32::MAX);
-    fixed64_to_fixed32(bad_input);
+    assert_eq!(fixed64_to_fixed32(bad_input), I32F32::max_value());
 }
 
 #[test]
@@ -2362,10 +2361,9 @@ fn test_vec_fixed64_to_fixed32() {
 }
 
 #[test]
-#[should_panic(expected = "overflow")]
-fn test_vec_fixed64_to_fixed32_panics() {
+fn test_vec_fixed64_to_fixed32_saturates() {
     let bad_input = vec![I64F64::from_num(i64::MAX)];
-    vec_fixed64_to_fixed32(bad_input);
+    assert_eq!(vec_fixed64_to_fixed32(bad_input), [I32F32::max_value()]);
 }
 
 #[test]

--- a/pallets/subtensor/src/utils/misc.rs
+++ b/pallets/subtensor/src/utils/misc.rs
@@ -1,9 +1,9 @@
 use super::*;
 use crate::{
-    epoch::math::*,
     system::{ensure_root, ensure_signed_or_root, pallet_prelude::BlockNumberFor},
     Error,
 };
+use safe_math::*;
 use sp_core::Get;
 use sp_core::U256;
 use sp_runtime::Saturating;

--- a/pallets/subtensor/src/utils/misc.rs
+++ b/pallets/subtensor/src/utils/misc.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::{
+    epoch::math::*,
     system::{ensure_root, ensure_signed_or_root, pallet_prelude::BlockNumberFor},
     Error,
 };
@@ -592,7 +593,7 @@ impl<T: Config> Pallet<T> {
         SubnetOwnerCut::<T>::get()
     }
     pub fn get_float_subnet_owner_cut() -> I96F32 {
-        I96F32::from_num(SubnetOwnerCut::<T>::get()).saturating_div(I96F32::from_num(u16::MAX))
+        I96F32::from_num(SubnetOwnerCut::<T>::get()).safe_div(I96F32::from_num(u16::MAX))
     }
     pub fn set_subnet_owner_cut(subnet_owner_cut: u16) {
         SubnetOwnerCut::<T>::set(subnet_owner_cut);
@@ -664,9 +665,8 @@ impl<T: Config> Pallet<T> {
 
     pub fn get_alpha_values_32(netuid: u16) -> (I32F32, I32F32) {
         let (alpha_low, alpha_high): (u16, u16) = AlphaValues::<T>::get(netuid);
-        let converted_low = I32F32::from_num(alpha_low).saturating_div(I32F32::from_num(u16::MAX));
-        let converted_high =
-            I32F32::from_num(alpha_high).saturating_div(I32F32::from_num(u16::MAX));
+        let converted_low = I32F32::from_num(alpha_low).safe_div(I32F32::from_num(u16::MAX));
+        let converted_high = I32F32::from_num(alpha_high).safe_div(I32F32::from_num(u16::MAX));
 
         (converted_low, converted_high)
     }

--- a/pallets/subtensor/src/utils/misc.rs
+++ b/pallets/subtensor/src/utils/misc.rs
@@ -593,7 +593,8 @@ impl<T: Config> Pallet<T> {
         SubnetOwnerCut::<T>::get()
     }
     pub fn get_float_subnet_owner_cut() -> I96F32 {
-        I96F32::from_num(SubnetOwnerCut::<T>::get()).safe_div(I96F32::from_num(u16::MAX))
+        I96F32::saturating_from_num(SubnetOwnerCut::<T>::get())
+            .safe_div(I96F32::saturating_from_num(u16::MAX))
     }
     pub fn set_subnet_owner_cut(subnet_owner_cut: u16) {
         SubnetOwnerCut::<T>::set(subnet_owner_cut);
@@ -665,8 +666,10 @@ impl<T: Config> Pallet<T> {
 
     pub fn get_alpha_values_32(netuid: u16) -> (I32F32, I32F32) {
         let (alpha_low, alpha_high): (u16, u16) = AlphaValues::<T>::get(netuid);
-        let converted_low = I32F32::from_num(alpha_low).safe_div(I32F32::from_num(u16::MAX));
-        let converted_high = I32F32::from_num(alpha_high).safe_div(I32F32::from_num(u16::MAX));
+        let converted_low =
+            I32F32::saturating_from_num(alpha_low).safe_div(I32F32::saturating_from_num(u16::MAX));
+        let converted_high =
+            I32F32::saturating_from_num(alpha_high).safe_div(I32F32::saturating_from_num(u16::MAX));
 
         (converted_low, converted_high)
     }

--- a/primitives/safe-math/Cargo.toml
+++ b/primitives/safe-math/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "share-pool"
+name = "safe-math"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
 substrate-fixed = { workspace = true }
 sp-std = { workspace = true }
-safe-math = { default-features = false, path = "../safe-math" }
+num-traits = { version = "0.2.19", default-features = false, features = ["libm"] }
 
 [lints]
 workspace = true

--- a/primitives/safe-math/Cargo.toml
+++ b/primitives/safe-math/Cargo.toml
@@ -16,4 +16,5 @@ default = ["std"]
 std = [
 	"substrate-fixed/std",
 	"sp-std/std",
+	"num-traits/std",
 ]

--- a/primitives/safe-math/src/lib.rs
+++ b/primitives/safe-math/src/lib.rs
@@ -1,0 +1,71 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![allow(clippy::result_unit_err)]
+
+use substrate_fixed::types::{I110F18, I32F32, I64F64, I96F32, U64F64};
+
+/// Safe division trait
+pub trait SafeDiv {
+    /// Safe division that returns supplied default value for division by zero
+    fn safe_div_or(self, rhs: Self, def: Self) -> Self;
+    /// Safe division that returns default value for division by zero
+    fn safe_div(self, rhs: Self) -> Self;
+}
+
+/// Implementation of safe division trait for primitive types
+macro_rules! impl_safe_div_for_primitive {
+    ($($t:ty),*) => {
+        $(
+            impl SafeDiv for $t {
+                fn safe_div_or(self, rhs: Self, def: Self) -> Self {
+                    self.checked_div(rhs).unwrap_or(def)
+                }
+
+                fn safe_div(self, rhs: Self) -> Self {
+                    self.checked_div(rhs).unwrap_or_default()
+                }
+            }
+        )*
+    };
+}
+impl_safe_div_for_primitive!(u8, u16, u32, u64, i8, i16, i32, i64, usize);
+
+/// Implementation of safe division trait for substrate fixed types
+macro_rules! impl_safe_div_for_fixed {
+    ($($t:ty),*) => {
+        $(
+            impl SafeDiv for $t {
+                fn safe_div_or(self, rhs: Self, def: Self) -> Self {
+                    self.checked_div(rhs).unwrap_or(def)
+                }
+
+                fn safe_div(self, rhs: Self) -> Self {
+                    self.checked_div(rhs).unwrap_or_default()
+                }
+            }
+        )*
+    };
+}
+impl_safe_div_for_fixed!(I96F32, I32F32, I64F64, I110F18, U64F64);
+
+// /// Trait for safe conversion to primitive type P
+// pub trait SafeToNum<T> {
+//     /// Safe conversion to primitive type P
+//     fn safe_to_num<P>(self) -> P
+//     where
+//         P: num_traits::Bounded + substrate_fixed::prelude::ToFixed + substrate_fixed::prelude::FromFixed;
+// }
+
+// impl<T> SafeToNum<T> for T
+// where
+//     T: substrate_fixed::traits::Fixed,
+// {
+//     fn safe_to_num<P>(self) -> P
+//     where
+//         P: num_traits::Bounded + substrate_fixed::prelude::ToFixed + substrate_fixed::prelude::FromFixed
+//     {
+//         match self.try_into() {
+//             Ok(value) => value,
+//             Err(_) => P::max_value(),
+//         }
+//     }
+// }

--- a/primitives/share-pool/Cargo.toml
+++ b/primitives/share-pool/Cargo.toml
@@ -16,4 +16,5 @@ default = ["std"]
 std = [
 	"substrate-fixed/std",
 	"sp-std/std",
+	"safe-math/std",
 ]

--- a/primitives/share-pool/src/lib.rs
+++ b/primitives/share-pool/src/lib.rs
@@ -54,7 +54,7 @@ where
             .checked_div(denominator)
             .unwrap_or(U64F64::from_num(0))
             .saturating_mul(current_share)
-            .to_num::<u64>()
+            .saturating_to_num::<u64>()
     }
 
     pub fn try_get_value(&self, key: &K) -> Result<u64, ()> {

--- a/primitives/share-pool/src/lib.rs
+++ b/primitives/share-pool/src/lib.rs
@@ -52,7 +52,7 @@ where
 
         shared_value
             .checked_div(denominator)
-            .unwrap_or(U64F64::from_num(0))
+            .unwrap_or(U64F64::saturating_from_num(0))
             .saturating_mul(current_share)
             .saturating_to_num::<u64>()
     }
@@ -69,9 +69,9 @@ where
     pub fn update_value_for_all(&mut self, update: i64) {
         let shared_value: U64F64 = self.state_ops.get_shared_value();
         self.state_ops.set_shared_value(if update >= 0 {
-            shared_value.saturating_add(U64F64::from_num(update))
+            shared_value.saturating_add(U64F64::saturating_from_num(update))
         } else {
-            shared_value.saturating_sub(U64F64::from_num(update.neg()))
+            shared_value.saturating_sub(U64F64::saturating_from_num(update.neg()))
         });
     }
 
@@ -92,31 +92,33 @@ where
             self.state_ops.set_share(key, new_shared_value);
         } else {
             // There are already keys in the pool, set or update this key
-            let value_per_share: I64F64 = I64F64::from_num(
+            let value_per_share: I64F64 = I64F64::saturating_from_num(
                 shared_value
                     .checked_div(denominator) // denominator is never 0 here
-                    .unwrap_or(U64F64::from_num(0)),
+                    .unwrap_or(U64F64::saturating_from_num(0)),
             );
 
-            let shares_per_update: I64F64 = I64F64::from_num(update)
+            let shares_per_update: I64F64 = I64F64::saturating_from_num(update)
                 .checked_div(value_per_share)
-                .unwrap_or(I64F64::from_num(0));
+                .unwrap_or(I64F64::saturating_from_num(0));
 
             if shares_per_update >= 0 {
                 self.state_ops.set_denominator(
-                    denominator.saturating_add(U64F64::from_num(shares_per_update)),
+                    denominator.saturating_add(U64F64::saturating_from_num(shares_per_update)),
                 );
                 self.state_ops.set_share(
                     key,
-                    current_share.saturating_add(U64F64::from_num(shares_per_update)),
+                    current_share.saturating_add(U64F64::saturating_from_num(shares_per_update)),
                 );
             } else {
                 self.state_ops.set_denominator(
-                    denominator.saturating_sub(U64F64::from_num(shares_per_update.neg())),
+                    denominator
+                        .saturating_sub(U64F64::saturating_from_num(shares_per_update.neg())),
                 );
                 self.state_ops.set_share(
                     key,
-                    current_share.saturating_sub(U64F64::from_num(shares_per_update.neg())),
+                    current_share
+                        .saturating_sub(U64F64::saturating_from_num(shares_per_update.neg())),
                 );
             }
         }
@@ -137,9 +139,9 @@ mod tests {
     impl MockSharePoolDataOperations {
         fn new() -> Self {
             MockSharePoolDataOperations {
-                shared_value: U64F64::from_num(0),
+                shared_value: U64F64::saturating_from_num(0),
                 share: BTreeMap::new(),
-                denominator: U64F64::from_num(0),
+                denominator: U64F64::saturating_from_num(0),
             }
         }
     }
@@ -150,7 +152,10 @@ mod tests {
         }
 
         fn get_share(&self, key: &u16) -> U64F64 {
-            *self.share.get(key).unwrap_or(&U64F64::from_num(0))
+            *self
+                .share
+                .get(key)
+                .unwrap_or(&U64F64::saturating_from_num(0))
         }
 
         fn try_get_share(&self, key: &u16) -> Result<U64F64, ()> {
@@ -180,10 +185,10 @@ mod tests {
     #[test]
     fn test_get_value() {
         let mut mock_ops = MockSharePoolDataOperations::new();
-        mock_ops.set_denominator(U64F64::from_num(10));
-        mock_ops.set_share(&1_u16, U64F64::from_num(3));
-        mock_ops.set_share(&2_u16, U64F64::from_num(7));
-        mock_ops.set_shared_value(U64F64::from_num(100));
+        mock_ops.set_denominator(U64F64::saturating_from_num(10));
+        mock_ops.set_share(&1_u16, U64F64::saturating_from_num(3));
+        mock_ops.set_share(&2_u16, U64F64::saturating_from_num(7));
+        mock_ops.set_shared_value(U64F64::saturating_from_num(100));
         let share_pool = SharePool::new(mock_ops);
         let result1 = share_pool.get_value(&1);
         let result2 = share_pool.get_value(&2);
@@ -194,7 +199,7 @@ mod tests {
     #[test]
     fn test_division_by_zero() {
         let mut mock_ops = MockSharePoolDataOperations::new();
-        mock_ops.set_denominator(U64F64::from_num(0)); // Zero denominator
+        mock_ops.set_denominator(U64F64::saturating_from_num(0)); // Zero denominator
         let pool = SharePool::<u16, MockSharePoolDataOperations>::new(mock_ops);
 
         let value = pool.get_value(&1);
@@ -204,10 +209,10 @@ mod tests {
     #[test]
     fn test_max_shared_value() {
         let mut mock_ops = MockSharePoolDataOperations::new();
-        mock_ops.set_shared_value(U64F64::from_num(u64::MAX));
-        mock_ops.set_share(&1, U64F64::from_num(3)); // Use a neutral value for share
-        mock_ops.set_share(&2, U64F64::from_num(7)); // Use a neutral value for share
-        mock_ops.set_denominator(U64F64::from_num(10)); // Neutral value to see max effect
+        mock_ops.set_shared_value(U64F64::saturating_from_num(u64::MAX));
+        mock_ops.set_share(&1, U64F64::saturating_from_num(3)); // Use a neutral value for share
+        mock_ops.set_share(&2, U64F64::saturating_from_num(7)); // Use a neutral value for share
+        mock_ops.set_denominator(U64F64::saturating_from_num(10)); // Neutral value to see max effect
         let pool = SharePool::<u16, MockSharePoolDataOperations>::new(mock_ops);
 
         let max_value = pool.get_value(&1) + pool.get_value(&2);
@@ -217,10 +222,10 @@ mod tests {
     #[test]
     fn test_max_share_value() {
         let mut mock_ops = MockSharePoolDataOperations::new();
-        mock_ops.set_shared_value(U64F64::from_num(1_000_000_000)); // Use a neutral value for shared value
-        mock_ops.set_share(&1, U64F64::from_num(u64::MAX / 2));
-        mock_ops.set_share(&2, U64F64::from_num(u64::MAX / 2));
-        mock_ops.set_denominator(U64F64::from_num(u64::MAX));
+        mock_ops.set_shared_value(U64F64::saturating_from_num(1_000_000_000)); // Use a neutral value for shared value
+        mock_ops.set_share(&1, U64F64::saturating_from_num(u64::MAX / 2));
+        mock_ops.set_share(&2, U64F64::saturating_from_num(u64::MAX / 2));
+        mock_ops.set_denominator(U64F64::saturating_from_num(u64::MAX));
         let pool = SharePool::<u16, MockSharePoolDataOperations>::new(mock_ops);
 
         let value1 = pool.get_value(&1) as i128;
@@ -268,6 +273,9 @@ mod tests {
         let mut pool = SharePool::<u16, MockSharePoolDataOperations>::new(mock_ops);
 
         pool.update_value_for_all(1000);
-        assert_eq!(pool.state_ops.shared_value, U64F64::from_num(1000));
+        assert_eq!(
+            pool.state_ops.shared_value,
+            U64F64::saturating_from_num(1000)
+        );
     }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1179,7 +1179,9 @@ const BLOCK_GAS_LIMIT: u64 = 75_000_000;
 /// `WeightPerGas` is an approximate ratio of the amount of Weight per Gas.
 ///
 fn weight_per_gas() -> Weight {
-    (NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT).saturating_div(BLOCK_GAS_LIMIT)
+    (NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT)
+        .checked_div(BLOCK_GAS_LIMIT)
+        .unwrap_or_default()
 }
 
 parameter_types! {


### PR DESCRIPTION
## Description

Remove use of `saturating_div`, `to_num`, and `from_num` and replace with their safe (custom) versions: `SafeDiv` trait, `saturating_to_num`, and `saturating_from_num` respectively.

Note for CI: `saturating_div`, `to_num`, and `from_num` should be forbidden (except in tests, tests should be able to panic).

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please describe): Security update

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
