### PR TITLE
[RAO] add subnet volume to runtimeAPIs

### DIFF
--- a/pallets/subtensor/src/rpc_info/dynamic_info.rs
+++ b/pallets/subtensor/src/rpc_info/dynamic_info.rs
@@ -4,7 +4,7 @@ use codec::Compact;
 use frame_support::pallet_prelude::{Decode, Encode};
 use subtensor_macros::freeze_struct;
 
-#[freeze_struct("44fd17b240416875")]
+#[freeze_struct("1be5a1e26a82082f")]
 #[derive(Decode, Encode, PartialEq, Eq, Clone, Debug)]
 pub struct DynamicInfo<T: Config> {
     netuid: Compact<u16>,
@@ -24,6 +24,7 @@ pub struct DynamicInfo<T: Config> {
     tao_in_emission: Compact<u64>,
     pending_alpha_emission: Compact<u64>,
     pending_root_emission: Compact<u64>,
+    subnet_volume: Compact<u64>,
     network_registered_at: Compact<u64>,
     subnet_identity: Option<SubnetIdentity>,
 }
@@ -60,6 +61,7 @@ impl<T: Config> Pallet<T> {
             tao_in_emission: SubnetTaoInEmission::<T>::get(netuid).into(),
             pending_alpha_emission: PendingEmission::<T>::get(netuid).into(),
             pending_root_emission: PendingRootDivs::<T>::get(netuid).into(),
+            subnet_volume: SubnetVolume::<T>::get(netuid).into(),
             network_registered_at: NetworkRegisteredAt::<T>::get(netuid).into(),
             subnet_identity: SubnetIdentities::<T>::get(netuid),
         })

--- a/pallets/subtensor/src/rpc_info/metagraph.rs
+++ b/pallets/subtensor/src/rpc_info/metagraph.rs
@@ -6,7 +6,7 @@ use frame_support::pallet_prelude::{Decode, Encode};
 use substrate_fixed::types::I64F64;
 use subtensor_macros::freeze_struct;
 
-#[freeze_struct("bce2310daa502e48")]
+#[freeze_struct("fa24d156067e5eb9")]
 #[derive(Decode, Encode, PartialEq, Eq, Clone, Debug)]
 pub struct Metagraph<T: Config> {
     // Subnet index
@@ -38,6 +38,7 @@ pub struct Metagraph<T: Config> {
     tao_in_emission: Compact<u64>,        // amount of tao injected per block
     pending_alpha_emission: Compact<u64>, // pending alpha to be distributed
     pending_root_emission: Compact<u64>,  // panding tao for root divs to be distributed
+    subnet_volume: Compact<u64>,          // volume of the subnet in TAO
 
     // Hparams for epoch
     rho: Compact<u16>,   // subnet rho param
@@ -141,6 +142,8 @@ impl<T: Config> Pallet<T> {
             Vec<I64F64>,
             Vec<I64F64>,
         ) = Self::get_stake_weights_for_network(netuid);
+
+        let subnet_volume = SubnetVolume::<T>::get(netuid);
         Some(Metagraph {
             // Subnet index
             netuid: netuid.into(), // subnet index.
@@ -177,6 +180,7 @@ impl<T: Config> Pallet<T> {
             tao_in_emission: SubnetTaoInEmission::<T>::get(netuid).into(), // amount of tao injected per block
             pending_alpha_emission: PendingEmission::<T>::get(netuid).into(), // pending alpha to be distributed
             pending_root_emission: PendingRootDivs::<T>::get(netuid).into(), // panding tao for root divs to be distributed
+            subnet_volume: subnet_volume.into(),
 
             // Hparams for epoch
             rho: Self::get_rho(netuid).into(), // subnet rho param


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
This PR adds the `SubnetVolume` to the runtimeAPIs `DynamicInfo` and `Metagraph` (info).  

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):


## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
