### PR TITLE
Raise minimum pool liquidity to 1 TAO

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -736,7 +736,7 @@ pub mod pallet {
     #[pallet::type_value]
     /// Default value for minimum liquidity in pool
     pub fn DefaultMinimumPoolLiquidity<T: Config>() -> I96F32 {
-        I96F32::saturating_from_num(1_000_000)
+        I96F32::saturating_from_num(1_000_000_000)
     }
 
     #[pallet::storage]

--- a/pallets/subtensor/src/tests/staking2.rs
+++ b/pallets/subtensor/src/tests/staking2.rs
@@ -15,7 +15,7 @@ fn test_stake_base_case() {
 
         // Initialize subnet with some existing TAO and Alpha
         let initial_subnet_tao = 10_000_000_000; // 10 TAO
-        let initial_subnet_alpha = 5_000_000; // 5 Alpha
+        let initial_subnet_alpha = 5_000_000_000; // 5 Alpha
         SubnetTAO::<Test>::insert(netuid, initial_subnet_tao);
         SubnetAlphaIn::<Test>::insert(netuid, initial_subnet_alpha);
         SubnetAlphaOut::<Test>::insert(netuid, initial_subnet_alpha);


### PR DESCRIPTION
## Description

Make minimum pool liquidity 1 TAO and 1 ALPHA (10^9) on both ends.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please describe): Parameter update

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
