### PR TITLE
Add allow_partial parameter for add_stake_limit and remove_stake_limit

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1569,6 +1569,7 @@ pub enum CustomTransactionError {
     NotEnoughStakeToWithdraw,
     RateLimitExceeded,
     InsufficientLiquidity,
+    SlippageTooHigh,
     BadRequest,
 }
 
@@ -1583,6 +1584,7 @@ impl From<CustomTransactionError> for u8 {
             CustomTransactionError::NotEnoughStakeToWithdraw => 5,
             CustomTransactionError::RateLimitExceeded => 6,
             CustomTransactionError::InsufficientLiquidity => 7,
+            CustomTransactionError::SlippageTooHigh => 8,
             CustomTransactionError::BadRequest => 255,
         }
     }
@@ -1652,6 +1654,10 @@ where
                 .into()),
                 Error::<T>::InsufficientLiquidity => Err(InvalidTransaction::Custom(
                     CustomTransactionError::InsufficientLiquidity.into(),
+                )
+                .into()),
+                Error::<T>::SlippageTooHigh => Err(InvalidTransaction::Custom(
+                    CustomTransactionError::SlippageTooHigh.into(),
                 )
                 .into()),
                 _ => Err(
@@ -1801,6 +1807,8 @@ where
                     hotkey,
                     *netuid,
                     *amount_staked,
+                    *amount_staked,
+                    false,
                 ))
             }
             Some(Call::remove_stake {
@@ -1814,6 +1822,8 @@ where
                     hotkey,
                     *netuid,
                     *amount_unstaked,
+                    *amount_unstaked,
+                    false,
                 ))
             }
             Some(Call::move_stake {

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -1710,6 +1710,10 @@ mod dispatches {
         ///  * 'limit_price' (u64):
         /// 	- The limit price expressed in units of RAO per one Alpha.
         ///
+        ///  * 'allow_partial' (bool):
+        /// 	- Allows partial execution of the amount. If set to false, this becomes
+        ///       fill or kill type or order.
+        ///
         /// # Event:
         ///  * StakeAdded;
         /// 	- On the successfully adding stake to a global account.
@@ -1734,8 +1738,16 @@ mod dispatches {
             netuid: u16,
             amount_staked: u64,
             limit_price: u64,
+            allow_partial: bool,
         ) -> DispatchResult {
-            Self::do_add_stake_limit(origin, hotkey, netuid, amount_staked, limit_price)
+            Self::do_add_stake_limit(
+                origin,
+                hotkey,
+                netuid,
+                amount_staked,
+                limit_price,
+                allow_partial,
+            )
         }
 
         /// --- Removes stake from a hotkey on a subnet with a price limit.
@@ -1758,6 +1770,10 @@ mod dispatches {
         ///
         ///  * 'limit_price' (u64):
         /// 	- The limit price expressed in units of RAO per one Alpha.
+        ///
+        ///  * 'allow_partial' (bool):
+        /// 	- Allows partial execution of the amount. If set to false, this becomes
+        ///       fill or kill type or order.
         ///
         /// # Event:
         /// * StakeRemoved;
@@ -1784,8 +1800,16 @@ mod dispatches {
             netuid: u16,
             amount_unstaked: u64,
             limit_price: u64,
+            allow_partial: bool,
         ) -> DispatchResult {
-            Self::do_remove_stake_limit(origin, hotkey, netuid, amount_unstaked, limit_price)
+            Self::do_remove_stake_limit(
+                origin,
+                hotkey,
+                netuid,
+                amount_unstaked,
+                limit_price,
+                allow_partial,
+            )
         }
     }
 }

--- a/pallets/subtensor/src/macros/errors.rs
+++ b/pallets/subtensor/src/macros/errors.rs
@@ -187,5 +187,7 @@ mod errors {
         AmountTooLow,
         /// Not enough liquidity.
         InsufficientLiquidity,
+        /// Slippage is too high for the transaction.
+        SlippageTooHigh,
     }
 }

--- a/pallets/subtensor/src/staking/remove_stake.rs
+++ b/pallets/subtensor/src/staking/remove_stake.rs
@@ -303,7 +303,7 @@ impl<T: Config> Pallet<T> {
             allow_partial,
         )?;
 
-        // 4. Swap the alpba to tao and update counters for this subnet.
+        // 4. Swap the alpha to tao and update counters for this subnet.
         let fee = DefaultStakingFee::<T>::get();
         let tao_unstaked: u64 =
             Self::unstake_from_subnet(&hotkey, &coldkey, netuid, possible_alpha, fee);

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -729,6 +729,8 @@ impl<T: Config> Pallet<T> {
         hotkey: &T::AccountId,
         netuid: u16,
         stake_to_be_added: u64,
+        max_amount: u64,
+        allow_partial: bool,
     ) -> Result<(), Error<T>> {
         // Ensure that the subnet exists.
         ensure!(Self::if_subnet_exist(netuid), Error::<T>::SubnetNotExists);
@@ -738,6 +740,12 @@ impl<T: Config> Pallet<T> {
 
         // Ensure that the stake_to_be_added is at least the min_amount
         ensure!(stake_to_be_added >= min_amount, Error::<T>::AmountTooLow);
+
+        // Ensure that if partial execution is not allowed, the amount will not cause
+        // slippage over desired
+        if !allow_partial {
+            ensure!(stake_to_be_added <= max_amount, Error::<T>::SlippageTooHigh);
+        }
 
         // Ensure the callers coldkey has enough stake to perform the transaction.
         ensure!(
@@ -767,6 +775,8 @@ impl<T: Config> Pallet<T> {
         hotkey: &T::AccountId,
         netuid: u16,
         alpha_unstaked: u64,
+        max_amount: u64,
+        allow_partial: bool,
     ) -> Result<(), Error<T>> {
         // Ensure that the subnet exists.
         ensure!(Self::if_subnet_exist(netuid), Error::<T>::SubnetNotExists);
@@ -780,6 +790,12 @@ impl<T: Config> Pallet<T> {
         } else {
             return Err(Error::<T>::InsufficientLiquidity);
         };
+
+        // Ensure that if partial execution is not allowed, the amount will not cause
+        // slippage over desired
+        if !allow_partial {
+            ensure!(alpha_unstaked <= max_amount, Error::<T>::SlippageTooHigh);
+        }
 
         // Ensure that the hotkey account exists this is only possible through registration.
         ensure!(

--- a/pallets/subtensor/src/tests/staking.rs
+++ b/pallets/subtensor/src/tests/staking.rs
@@ -2660,7 +2660,7 @@ fn test_add_stake_limit_fill_or_kill() {
         // add network
         let netuid: u16 = add_dynamic_network(&hotkey_account_id, &coldkey_account_id);
 
-        // Forse-set alpha in and tao reserve to make price equal 1.5
+        // Force-set alpha in and tao reserve to make price equal 1.5
         let tao_reserve: U96F32 = U96F32::from_num(150_000_000_000_u64);
         let alpha_in: U96F32 = U96F32::from_num(100_000_000_000_u64);
         SubnetTAO::<Test>::insert(netuid, tao_reserve.to_num::<u64>());

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -220,7 +220,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 224,
+    spec_version: 225,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description

Enable fill or kill type of orders for `add_stake_limit` and `remove_stake_limit` extrinsics.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
