### PR TITLE
Double-size SubnetVolume to u128

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -234,6 +234,11 @@ pub mod pallet {
     }
     #[pallet::type_value]
     /// Default value for zero.
+    pub fn DefaultZeroU128<T: Config>() -> u128 {
+        0
+    }
+    #[pallet::type_value]
+    /// Default value for zero.
     pub fn DefaultZeroU16<T: Config>() -> u16 {
         0
     }
@@ -907,7 +912,7 @@ pub mod pallet {
     pub type DynamicBlock<T> = StorageValue<_, u64, ValueQuery>;
     #[pallet::storage] // --- MAP ( netuid ) --> total_volume | The total amount of TAO bought and sold since the start of the network.
     pub type SubnetVolume<T: Config> =
-        StorageMap<_, Identity, u16, u64, ValueQuery, DefaultZeroU64<T>>;
+        StorageMap<_, Identity, u16, u128, ValueQuery, DefaultZeroU128<T>>;
     #[pallet::storage] // --- MAP ( netuid ) --> tao_in_subnet | Returns the amount of TAO in the subnet.
     pub type SubnetTAO<T: Config> =
         StorageMap<_, Identity, u16, u64, ValueQuery, DefaultZeroU64<T>>;

--- a/pallets/subtensor/src/rpc_info/dynamic_info.rs
+++ b/pallets/subtensor/src/rpc_info/dynamic_info.rs
@@ -4,7 +4,7 @@ use codec::Compact;
 use frame_support::pallet_prelude::{Decode, Encode};
 use subtensor_macros::freeze_struct;
 
-#[freeze_struct("1be5a1e26a82082f")]
+#[freeze_struct("a5cdc80d655398e9")]
 #[derive(Decode, Encode, PartialEq, Eq, Clone, Debug)]
 pub struct DynamicInfo<T: Config> {
     netuid: Compact<u16>,
@@ -24,7 +24,7 @@ pub struct DynamicInfo<T: Config> {
     tao_in_emission: Compact<u64>,
     pending_alpha_emission: Compact<u64>,
     pending_root_emission: Compact<u64>,
-    subnet_volume: Compact<u64>,
+    subnet_volume: Compact<u128>,
     network_registered_at: Compact<u64>,
     subnet_identity: Option<SubnetIdentity>,
 }

--- a/pallets/subtensor/src/rpc_info/metagraph.rs
+++ b/pallets/subtensor/src/rpc_info/metagraph.rs
@@ -6,7 +6,7 @@ use frame_support::pallet_prelude::{Decode, Encode};
 use substrate_fixed::types::I64F64;
 use subtensor_macros::freeze_struct;
 
-#[freeze_struct("fa24d156067e5eb9")]
+#[freeze_struct("7c5fe907490c5d5e")]
 #[derive(Decode, Encode, PartialEq, Eq, Clone, Debug)]
 pub struct Metagraph<T: Config> {
     // Subnet index
@@ -38,7 +38,7 @@ pub struct Metagraph<T: Config> {
     tao_in_emission: Compact<u64>,        // amount of tao injected per block
     pending_alpha_emission: Compact<u64>, // pending alpha to be distributed
     pending_root_emission: Compact<u64>,  // panding tao for root divs to be distributed
-    subnet_volume: Compact<u64>,          // volume of the subnet in TAO
+    subnet_volume: Compact<u128>,         // volume of the subnet in TAO
 
     // Hparams for epoch
     rho: Compact<u16>,   // subnet rho param

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -557,9 +557,9 @@ impl<T: Config> Pallet<T> {
             TotalStake::<T>::mutate(|total| {
                 *total = total.saturating_add(tao);
             });
-            // Step 8. Decrease Alpha reserves.
+            // Step 8. Increase total subnet TAO volume.
             SubnetVolume::<T>::mutate(netuid, |total| {
-                *total = total.saturating_add(tao);
+                *total = total.saturating_add(tao.into());
             });
             // Step 9. Return the alpha received.
             alpha
@@ -589,9 +589,9 @@ impl<T: Config> Pallet<T> {
             TotalStake::<T>::mutate(|total| {
                 *total = total.saturating_sub(tao);
             });
-            // Step 8. Decrease Alpha reserves.
+            // Step 8. Increase total subnet TAO volume.
             SubnetVolume::<T>::mutate(netuid, |total| {
-                *total = total.saturating_add(tao);
+                *total = total.saturating_add(tao.into());
             });
             // Step 9. Return the tao received.
             tao


### PR DESCRIPTION
## Description

SubnetVolume may overflow u64, so updated it to u128.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.