### PR TITLE
Remove dynamic fee pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2755,16 +2755,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fp-dynamic-fee"
-version = "1.0.0"
-source = "git+https://github.com/opentensor/frontier?rev=635bdac882#635bdac882333afed827053f31ef56ab739f7a2e"
-dependencies = [
- "async-trait",
- "sp-core",
- "sp-inherents",
-]
-
-[[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
 source = "git+https://github.com/opentensor/frontier?rev=635bdac882#635bdac882333afed827053f31ef56ab739f7a2e"
@@ -5745,7 +5735,6 @@ dependencies = [
  "fc-rpc-core",
  "fc-storage",
  "fp-consensus",
- "fp-dynamic-fee",
  "fp-rpc",
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -5842,7 +5831,6 @@ dependencies = [
  "pallet-collective",
  "pallet-commitments",
  "pallet-drand",
- "pallet-dynamic-fee",
  "pallet-ethereum",
  "pallet-evm",
  "pallet-evm-chain-id",
@@ -6342,21 +6330,6 @@ dependencies = [
  "subtensor-macros",
  "tle",
  "w3f-bls",
-]
-
-[[package]]
-name = "pallet-dynamic-fee"
-version = "4.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=635bdac882#635bdac882333afed827053f31ef56ab739f7a2e"
-dependencies = [
- "fp-dynamic-fee",
- "fp-evm",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-inherents",
 ]
 
 [[package]]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -95,7 +95,6 @@ substrate-prometheus-endpoint = { workspace = true }
 fc-storage = { workspace = true }
 fc-db = { workspace = true }
 fc-consensus = { workspace = true }
-fp-dynamic-fee = { workspace = true }
 fc-api = { workspace = true }
 fc-rpc = { workspace = true }
 fc-rpc-core = { workspace = true }

--- a/node/src/ethereum.rs
+++ b/node/src/ethereum.rs
@@ -56,10 +56,6 @@ pub struct EthConfiguration {
     #[arg(long)]
     pub enable_dev_signer: bool,
 
-    /// The dynamic-fee pallet target gas price set by block author
-    #[arg(long, default_value = "1")]
-    pub target_gas_price: u64,
-
     /// Maximum allowed gas limit will be `block.gas_limit * execute_gas_limit_multiplier`
     /// when using eth_call/eth_estimateGas.
     #[arg(long, default_value = "10")]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -103,7 +103,6 @@ fp-self-contained = { workspace = true }
 
 # Frontier FRAME
 pallet-base-fee = { workspace = true }
-pallet-dynamic-fee = { workspace = true }
 pallet-ethereum = { workspace = true }
 pallet-evm = { workspace = true }
 pallet-evm-chain-id = { workspace = true }
@@ -193,7 +192,6 @@ std = [
 	"fp-self-contained/std",
 	# Frontier FRAME
 	"pallet-base-fee/std",
-	"pallet-dynamic-fee/std",
 	"pallet-ethereum/std",
 	"pallet-evm/std",
 	"pallet-evm-chain-id/std",
@@ -270,7 +268,6 @@ try-runtime = [
 	# EVM + Frontier
 	"fp-self-contained/try-runtime",
 	"pallet-base-fee/try-runtime",
-	"pallet-dynamic-fee/try-runtime",
 	"pallet-ethereum/try-runtime",
 	"pallet-evm/try-runtime",
 	"pallet-evm-chain-id/try-runtime",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1289,10 +1289,6 @@ parameter_types! {
     pub BoundDivision: U256 = U256::from(1024);
 }
 
-impl pallet_dynamic_fee::Config for Runtime {
-    type MinGasPriceBoundDivisor = BoundDivision;
-}
-
 parameter_types! {
     pub DefaultBaseFeePerGas: U256 = U256::from(20_000_000_000_u128);
     pub DefaultElasticity: Permill = Permill::from_parts(125_000);
@@ -1427,7 +1423,7 @@ construct_runtime!(
         Ethereum: pallet_ethereum = 21,
         EVM: pallet_evm = 22,
         EVMChainId: pallet_evm_chain_id = 23,
-        DynamicFee: pallet_dynamic_fee = 24,
+        // pallet_dynamic_fee was 24
         BaseFee: pallet_base_fee = 25,
 
         Drand: pallet_drand = 26,


### PR DESCRIPTION
## Description

Currently we have dynamic fee pallet and associated inherent data provider in our node. As we use base fee for fee calculations, the dynamic fee pallet and its inherent data are rudiments of the frontier's template. The dynamic fee pallet also introduces a small overhead by performing inherent transaction every block. This PR removes pallet dynamic fee from the runtime and associated inherent data from the node.


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.