### PR TITLE
does a root claim during root unstake

### DIFF
--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -636,7 +636,9 @@ impl<T: Config> Pallet<T> {
 
         // If this is a root-stake
         if netuid == Self::get_root_netuid() {
-            // 5. Adjust root debt for this hotkey and coldkey.
+            // 5.1 Do a root claim
+            Self::do_root_claim(hotkey, coldkey);
+            // 5.2. Adjust root debt for this hotkey and coldkey.
             Self::remove_stake_adjust_debt_for_hotkey_and_coldkey(hotkey, coldkey, alpha);
         }
 


### PR DESCRIPTION
This adds a root claim before unstaking on root.

Although I don't *think* this is needed. The debt should account for the unstaked amount and retain any claimable.  
_This should be tested._