### PR TITLE
[RAO] set transfer toggle default to false

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1116,7 +1116,7 @@ pub mod pallet {
     /// ============================
     #[pallet::storage] // --- MAP ( netuid ) --> transfer_toggle
     pub type TransferToggle<T: Config> =
-        StorageMap<_, Identity, u16, bool, ValueQuery, DefaultTrue<T>>;
+        StorageMap<_, Identity, u16, bool, ValueQuery, DefaultFalse<T>>;
     #[pallet::storage] // --- MAP ( netuid ) --> total_subnet_locked
     pub type SubnetLocked<T: Config> =
         StorageMap<_, Identity, u16, u64, ValueQuery, DefaultZeroU64<T>>;


### PR DESCRIPTION
This PR sets the `TransferToggle` default to `False`, requiring SN Creators to set the toggle to `True` 
