### PR TITLE
[RAO] add migration and set init min lock cost 1 tao

### DIFF
--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -73,6 +73,8 @@ mod hooks {
                 .saturating_add(migrations::migrate_chain_identity::migrate_set_hotkey_identities::<T>())
                 // Migrate Commit-Reval 2.0
                 .saturating_add(migrations::migrate_commit_reveal_v2::migrate_commit_reveal_2::<T>())
+				// Set the min lock cost to 1 TAO; importantly, *before* migrating to RAO
+				.saturating_add(migrations::migrate_set_min_lock_cost::migrate_set_min_lock_cost::<T>())
                 // Migrate to RAO
                 .saturating_add(migrations::migrate_rao::migrate_rao::<T>())
 				// Fix the IsNetworkMember map to be consistent with other storage maps

--- a/pallets/subtensor/src/migrations/migrate_set_min_lock_cost.rs
+++ b/pallets/subtensor/src/migrations/migrate_set_min_lock_cost.rs
@@ -1,0 +1,42 @@
+use alloc::string::String;
+
+use frame_support::IterableStorageMap;
+use frame_support::{traits::Get, weights::Weight};
+
+use super::*;
+
+pub fn migrate_set_min_lock_cost<T: Config>() -> Weight {
+    let migration_name = b"migrate_set_min_lock_cost".to_vec();
+
+    // Initialize the weight with one read operation.
+    let mut weight = T::DbWeight::get().reads(1);
+
+    // Check if the migration has already run
+    if HasMigrationRun::<T>::get(&migration_name) {
+        log::info!(
+            "Migration '{:?}' has already run. Skipping.",
+            migration_name
+        );
+        return weight;
+    }
+    log::info!(
+        "Running migration '{}'",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    // Set min lock cost to 1 TAO
+    NetworkMinLockCost::<T>::put(1_000_000_000);
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+    // Mark the migration as completed
+    HasMigrationRun::<T>::insert(&migration_name, true);
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+    log::info!(
+        "Migration '{:?}' completed.",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    // Return the migration weight.
+    weight
+}

--- a/pallets/subtensor/src/migrations/mod.rs
+++ b/pallets/subtensor/src/migrations/mod.rs
@@ -12,6 +12,7 @@ pub mod migrate_populate_owned_hotkeys;
 pub mod migrate_populate_staking_hotkeys;
 pub mod migrate_rao;
 pub mod migrate_set_min_burn;
+pub mod migrate_set_min_lock_cost;
 pub mod migrate_stake_threshold;
 pub mod migrate_subnet_volume;
 pub mod migrate_to_v1_separate_emission;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -229,7 +229,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 228,
+    spec_version: 229,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1040,7 +1040,7 @@ parameter_types! {
     pub const SubtensorInitialSenateRequiredStakePercentage: u64 = 1; // 1 percent of total stake
     pub const SubtensorInitialNetworkImmunity: u64 = 7 * 7200;
     pub const SubtensorInitialMinAllowedUids: u16 = 128;
-    pub const SubtensorInitialMinLockCost: u64 = 1_000_000_000_000; // 1000 TAO
+    pub const SubtensorInitialMinLockCost: u64 = 1_000_000_000; // 1 TAO
     pub const SubtensorInitialSubnetOwnerCut: u16 = 11_796; // 18 percent
     pub const SubtensorInitialSubnetLimit: u16 = 12;
     pub const SubtensorInitialNetworkLockReductionInterval: u64 = 14 * 7200;


### PR DESCRIPTION
This PR sets the min lock cost for networks to `1 TAO`, which will lower the initial network pools to `1 TAO` as well.   

The alternative is we set a new storage value just for the initial pool lock.