### PR TITLE
Chore/cleanup unused tempo entities

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -337,11 +337,6 @@ pub mod pallet {
         0
     }
     #[pallet::type_value]
-    /// Default value for max tempo
-    pub fn DefaultMaxTempo<T: Config>() -> u16 {
-        30 // 1 hour.
-    }
-    #[pallet::type_value]
     /// Default value for global weight.
     pub fn DefaultTaoWeight<T: Config>() -> u64 {
         T::InitialTaoWeight::get()
@@ -753,14 +748,12 @@ pub mod pallet {
 
     #[pallet::type_value]
     /// Default minimum stake.
-    /// 500k rao matches $0.25 at $500/TAO
     pub fn DefaultMinStake<T: Config>() -> u64 {
         500_000
     }
 
     #[pallet::type_value]
     /// Default staking fee.
-    /// 500k rao matches $0.25 at $500/TAO
     pub fn DefaultStakingFee<T: Config>() -> u64 {
         50_000
     }
@@ -1127,10 +1120,6 @@ pub mod pallet {
     /// =================
     /// ==== Tempos =====
     /// =================
-    #[pallet::storage] // --- ITEM( max_tempo )
-    pub type AvgTempo<T> = StorageValue<_, u16, ValueQuery, DefaultTempo<T>>;
-    #[pallet::storage] // --- ITEM( max_tempo )
-    pub type MaxTempo<T> = StorageValue<_, u16, ValueQuery, DefaultMaxTempo<T>>;
     #[pallet::storage] // --- MAP ( netuid ) --> tempo
     pub type Tempo<T> = StorageMap<_, Identity, u16, u16, ValueQuery, DefaultTempo<T>>;
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -229,7 +229,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 228,
+    spec_version: 229,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description

Remove DefaultMaxTempo, MaxTempo, AvgTempo, and outdated comments about min stake

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please describe): Cleanup

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
