### PR TITLE
enforce merge compatability between all named branches / clean merges

### DIFF
--- a/.github/workflows/require-clean-merges.yml
+++ b/.github/workflows/require-clean-merges.yml
@@ -21,26 +21,36 @@ jobs:
         run: |
           TARGET_BRANCH="${{ github.event.pull_request.base.ref }}"
           if [[ "$TARGET_BRANCH" == "devnet-ready" ]]; then
-            echo "MERGE_BRANCHES=devnet-ready devnet testnet main" >> $GITHUB_ENV
+            echo "MERGE_BRANCHES='devnet testnet main'" >> $GITHUB_ENV
           elif [[ "$TARGET_BRANCH" == "devnet" ]]; then
-            echo "MERGE_BRANCHES=devnet testnet main" >> $GITHUB_ENV
+            echo "MERGE_BRANCHES='testnet main'" >> $GITHUB_ENV
           elif [[ "$TARGET_BRANCH" == "testnet" ]]; then
-            echo "MERGE_BRANCHES=testnet main" >> $GITHUB_ENV
+            echo "MERGE_BRANCHES='main'" >> $GITHUB_ENV
           elif [[ "$TARGET_BRANCH" == "main" ]]; then
-            echo "MERGE_BRANCHES=main" >> $GITHUB_ENV
+            echo "MERGE_BRANCHES=''" >> $GITHUB_ENV
           else
-            echo "MERGE_BRANCHES=devnet-ready devnet testnet main" >> $GITHUB_ENV
+            echo "MERGE_BRANCHES='devnet-ready devnet testnet main'" >> $GITHUB_ENV
           fi
 
       - name: Check Merge Cleanliness
         run: |
+          TARGET_BRANCH="${{ github.event.pull_request.base.ref }}"
+          echo "Fetching all branches..."
+          git fetch --all --prune
+
           for branch in $MERGE_BRANCHES; do
-            echo "Checking merge from $branch into ${{ github.event.pull_request.base.ref }}..."
-            git fetch origin $branch
-            git checkout ${{ github.event.pull_request.base.ref }}
+            echo "Checking merge from $branch into $TARGET_BRANCH..."
+            
+            # Ensure we are on the target branch
+            git checkout $TARGET_BRANCH
+            git reset --hard origin/$TARGET_BRANCH
+
+            # Merge without committing to check for conflicts
             if ! git merge --no-commit --no-ff origin/$branch; then
-              echo "Merge conflict detected when merging $branch into ${{ github.event.pull_request.base.ref }}"
+              echo "❌ Merge conflict detected when merging $branch into $TARGET_BRANCH"
               exit 1
             fi
-            git merge --abort
+            
+            # Abort the merge since we are only testing
+            git merge --abort || true
           done

--- a/.github/workflows/require-clean-merges.yml
+++ b/.github/workflows/require-clean-merges.yml
@@ -20,6 +20,9 @@ jobs:
         id: set-merge-branches
         run: |
           TARGET_BRANCH="${{ github.event.pull_request.base.ref }}"
+          PR_BRANCH="${{ github.event.pull_request.head.ref }}"
+          echo "PR_BRANCH=$PR_BRANCH" >> $GITHUB_ENV
+
           if [[ "$TARGET_BRANCH" == "devnet-ready" ]]; then
             echo "MERGE_BRANCHES=devnet testnet main" >> $GITHUB_ENV
           elif [[ "$TARGET_BRANCH" == "devnet" ]]; then
@@ -35,21 +38,25 @@ jobs:
       - name: Check Merge Cleanliness
         run: |
           TARGET_BRANCH="${{ github.event.pull_request.base.ref }}"
+          PR_BRANCH="${{ github.event.pull_request.head.ref }}"
           echo "Fetching all branches..."
           git fetch --all --prune
 
+          echo "Checking out PR branch: $PR_BRANCH"
+          git checkout $PR_BRANCH
+          git reset --hard origin/$PR_BRANCH
+
           for branch in $MERGE_BRANCHES; do
-            echo "Checking merge from $branch into $TARGET_BRANCH..."
+            echo "Checking merge from $branch into $PR_BRANCH..."
             
-            # Ensure we are on the target branch and reset to its latest remote state
-            git checkout $TARGET_BRANCH
-            git reset --hard origin/$TARGET_BRANCH
+            # Ensure PR branch is up to date
+            git reset --hard origin/$PR_BRANCH
 
             # Merge without committing to check for conflicts
             if git merge --no-commit --no-ff origin/$branch; then
-              echo "✅ Merge from $branch into $TARGET_BRANCH is clean."
+              echo "✅ Merge from $branch into $PR_BRANCH is clean."
             else
-              echo "❌ Merge conflict detected when merging $branch into $TARGET_BRANCH"
+              echo "❌ Merge conflict detected when merging $branch into $PR_BRANCH"
               exit 1
             fi
             

--- a/.github/workflows/require-clean-merges.yml
+++ b/.github/workflows/require-clean-merges.yml
@@ -21,15 +21,15 @@ jobs:
         run: |
           TARGET_BRANCH="${{ github.event.pull_request.base.ref }}"
           if [[ "$TARGET_BRANCH" == "devnet-ready" ]]; then
-            echo "MERGE_BRANCHES='devnet testnet main'" >> $GITHUB_ENV
+            echo "MERGE_BRANCHES=devnet testnet main" >> $GITHUB_ENV
           elif [[ "$TARGET_BRANCH" == "devnet" ]]; then
-            echo "MERGE_BRANCHES='testnet main'" >> $GITHUB_ENV
+            echo "MERGE_BRANCHES=testnet main" >> $GITHUB_ENV
           elif [[ "$TARGET_BRANCH" == "testnet" ]]; then
-            echo "MERGE_BRANCHES='main'" >> $GITHUB_ENV
+            echo "MERGE_BRANCHES=main" >> $GITHUB_ENV
           elif [[ "$TARGET_BRANCH" == "main" ]]; then
-            echo "MERGE_BRANCHES=''" >> $GITHUB_ENV  # No need to merge anything into main
+            echo "MERGE_BRANCHES=" >> $GITHUB_ENV  # No need to merge anything into main
           else
-            echo "MERGE_BRANCHES='devnet-ready devnet testnet main'" >> $GITHUB_ENV
+            echo "MERGE_BRANCHES=devnet-ready devnet testnet main" >> $GITHUB_ENV
           fi
 
       - name: Check Merge Cleanliness

--- a/.github/workflows/require-clean-merges.yml
+++ b/.github/workflows/require-clean-merges.yml
@@ -1,0 +1,46 @@
+name: Require Clean Merges
+
+on:
+  pull_request:
+    branches:
+      - devnet-ready
+      - devnet
+      - testnet
+
+jobs:
+  assert-clean-merges:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Ensures we get all branches for merging
+
+      - name: Determine Target Branch and Set Merge List
+        id: set-merge-branches
+        run: |
+          TARGET_BRANCH="${{ github.event.pull_request.base.ref }}"
+          if [[ "$TARGET_BRANCH" == "devnet-ready" ]]; then
+            echo "MERGE_BRANCHES=devnet-ready devnet testnet main" >> $GITHUB_ENV
+          elif [[ "$TARGET_BRANCH" == "devnet" ]]; then
+            echo "MERGE_BRANCHES=devnet testnet main" >> $GITHUB_ENV
+          elif [[ "$TARGET_BRANCH" == "testnet" ]]; then
+            echo "MERGE_BRANCHES=testnet main" >> $GITHUB_ENV
+          elif [[ "$TARGET_BRANCH" == "main" ]]; then
+            echo "MERGE_BRANCHES=main" >> $GITHUB_ENV
+          else
+            echo "MERGE_BRANCHES=devnet-ready devnet testnet main" >> $GITHUB_ENV"
+          fi
+
+      - name: Check Merge Cleanliness
+        run: |
+          for branch in $MERGE_BRANCHES; do
+            echo "Checking merge from $branch into ${{ github.event.pull_request.base.ref }}..."
+            git fetch origin $branch
+            git checkout ${{ github.event.pull_request.base.ref }}
+            if ! git merge --no-commit --no-ff origin/$branch; then
+              echo "Merge conflict detected when merging $branch into ${{ github.event.pull_request.base.ref }}"
+              exit 1
+            fi
+            git merge --abort
+          done

--- a/.github/workflows/require-clean-merges.yml
+++ b/.github/workflows/require-clean-merges.yml
@@ -29,7 +29,7 @@ jobs:
           elif [[ "$TARGET_BRANCH" == "main" ]]; then
             echo "MERGE_BRANCHES=main" >> $GITHUB_ENV
           else
-            echo "MERGE_BRANCHES=devnet-ready devnet testnet main" >> $GITHUB_ENV"
+            echo "MERGE_BRANCHES=devnet-ready devnet testnet main" >> $GITHUB_ENV
           fi
 
       - name: Check Merge Cleanliness

--- a/.github/workflows/require-clean-merges.yml
+++ b/.github/workflows/require-clean-merges.yml
@@ -21,15 +21,15 @@ jobs:
         run: |
           TARGET_BRANCH="${{ github.event.pull_request.base.ref }}"
           if [[ "$TARGET_BRANCH" == "devnet-ready" ]]; then
-            echo "MERGE_BRANCHES='devnet testnet main'" >> $GITHUB_ENV
+            echo "MERGE_BRANCHES=devnet testnet main" >> $GITHUB_ENV
           elif [[ "$TARGET_BRANCH" == "devnet" ]]; then
-            echo "MERGE_BRANCHES='testnet main'" >> $GITHUB_ENV
+            echo "MERGE_BRANCHES=testnet main" >> $GITHUB_ENV
           elif [[ "$TARGET_BRANCH" == "testnet" ]]; then
-            echo "MERGE_BRANCHES='main'" >> $GITHUB_ENV
+            echo "MERGE_BRANCHES=main" >> $GITHUB_ENV
           elif [[ "$TARGET_BRANCH" == "main" ]]; then
-            echo "MERGE_BRANCHES=''" >> $GITHUB_ENV
+            echo "MERGE_BRANCHES=" >> $GITHUB_ENV  # No need to merge anything into main
           else
-            echo "MERGE_BRANCHES='devnet-ready devnet testnet main'" >> $GITHUB_ENV
+            echo "MERGE_BRANCHES=devnet-ready devnet testnet main" >> $GITHUB_ENV
           fi
 
       - name: Check Merge Cleanliness
@@ -41,9 +41,15 @@ jobs:
           for branch in $MERGE_BRANCHES; do
             echo "Checking merge from $branch into $TARGET_BRANCH..."
             
-            # Ensure we are on the target branch
+            # Ensure we are on the target branch and reset to its latest state
             git checkout $TARGET_BRANCH
             git reset --hard origin/$TARGET_BRANCH
+
+            # Ensure branch exists before attempting a merge
+            if ! git show-ref --verify --quiet "refs/remotes/origin/$branch"; then
+              echo "❌ Branch $branch does not exist on remote, skipping..."
+              continue
+            fi
 
             # Merge without committing to check for conflicts
             if ! git merge --no-commit --no-ff origin/$branch; then

--- a/.github/workflows/require-clean-merges.yml
+++ b/.github/workflows/require-clean-merges.yml
@@ -21,15 +21,15 @@ jobs:
         run: |
           TARGET_BRANCH="${{ github.event.pull_request.base.ref }}"
           if [[ "$TARGET_BRANCH" == "devnet-ready" ]]; then
-            echo "MERGE_BRANCHES=devnet testnet main" >> $GITHUB_ENV
+            echo "MERGE_BRANCHES='devnet testnet main'" >> $GITHUB_ENV
           elif [[ "$TARGET_BRANCH" == "devnet" ]]; then
-            echo "MERGE_BRANCHES=testnet main" >> $GITHUB_ENV
+            echo "MERGE_BRANCHES='testnet main'" >> $GITHUB_ENV
           elif [[ "$TARGET_BRANCH" == "testnet" ]]; then
-            echo "MERGE_BRANCHES=main" >> $GITHUB_ENV
+            echo "MERGE_BRANCHES='main'" >> $GITHUB_ENV
           elif [[ "$TARGET_BRANCH" == "main" ]]; then
-            echo "MERGE_BRANCHES=" >> $GITHUB_ENV  # No need to merge anything into main
+            echo "MERGE_BRANCHES=''" >> $GITHUB_ENV  # No need to merge anything into main
           else
-            echo "MERGE_BRANCHES=devnet-ready devnet testnet main" >> $GITHUB_ENV
+            echo "MERGE_BRANCHES='devnet-ready devnet testnet main'" >> $GITHUB_ENV
           fi
 
       - name: Check Merge Cleanliness
@@ -41,22 +41,18 @@ jobs:
           for branch in $MERGE_BRANCHES; do
             echo "Checking merge from $branch into $TARGET_BRANCH..."
             
-            # Ensure we are on the target branch and reset to its latest state
+            # Ensure we are on the target branch and reset to its latest remote state
             git checkout $TARGET_BRANCH
             git reset --hard origin/$TARGET_BRANCH
 
-            # Ensure branch exists before attempting a merge
-            if ! git show-ref --verify --quiet "refs/remotes/origin/$branch"; then
-              echo "❌ Branch $branch does not exist on remote, skipping..."
-              continue
-            fi
-
             # Merge without committing to check for conflicts
-            if ! git merge --no-commit --no-ff origin/$branch; then
+            if git merge --no-commit --no-ff origin/$branch; then
+              echo "✅ Merge from $branch into $TARGET_BRANCH is clean."
+            else
               echo "❌ Merge conflict detected when merging $branch into $TARGET_BRANCH"
               exit 1
             fi
             
-            # Abort the merge since we are only testing
-            git merge --abort || true
+            # Abort merge if one was started, suppressing errors if no merge happened
+            git merge --abort 2>/dev/null || true
           done


### PR DESCRIPTION
## Description  
This PR adds a GitHub Action that enforces clean merges from upstream branches into a pull request’s target branch. The workflow checks whether the relevant upstream branches can merge without conflicts before allowing the PR to be merged.

## Workflow Behavior  
- **PR into `devnet-ready`** → Ensures `devnet-ready`, `devnet`, `testnet`, and `main` merge cleanly.  
- **PR into `devnet`** → Ensures `devnet`, `testnet`, and `main` merge cleanly.  
- **PR into `testnet`** → Ensures `testnet` and `main` merge cleanly.  
- **PR into `main`** → Ensures `main` merges cleanly.  
- **PR into any other branch** → Defaults to checking all four (`devnet-ready`, `devnet`, `testnet`, and `main`).  

## Implementation Details  
- Uses `git merge --no-commit --no-ff` to test merges without modifying history.  
- If any merge conflict occurs, the workflow fails, preventing the PR from merging.  
- Uses `git merge --abort` to clean up after each merge check.  
- Ensures full repository history is available (`fetch-depth: 0`).  

## Why This Change?  
- Prevents merge conflicts from propagating down the branch hierarchy.  
- Ensures PRs are integration-ready before merging.  
- Improves CI robustness and maintains a clean commit history.