### PR TITLE
stop unneeded on-push CI triggers

### DIFF
--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -5,9 +5,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches: [main, devnet-ready, devnet, testnet, finney]
-
   pull_request:
 
   ## Allow running workflow manually from the Actions tab

--- a/.github/workflows/e2e-bittensor-tests.yml
+++ b/.github/workflows/e2e-bittensor-tests.yml
@@ -5,9 +5,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches: [main, devnet-ready, devnet, testnet, finney]
-
   pull_request:
 
   ## Allow running workflow manually from the Actions tab


### PR DESCRIPTION
We don't need on push triggers for things like e2e tests and rust checks, they already run on all PRs, that is enough