### PR TITLE
Add serve_axon extrinsic validation

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1674,6 +1674,10 @@ pub enum CustomTransactionError {
     InsufficientLiquidity,
     SlippageTooHigh,
     TransferDisallowed,
+    HotKeyNotRegisteredInNetwork,
+    InvalidIpAddress,
+    ServingRateLimitExceeded,
+    InvalidPort,
     BadRequest,
 }
 
@@ -1690,6 +1694,10 @@ impl From<CustomTransactionError> for u8 {
             CustomTransactionError::InsufficientLiquidity => 7,
             CustomTransactionError::SlippageTooHigh => 8,
             CustomTransactionError::TransferDisallowed => 9,
+            CustomTransactionError::HotKeyNotRegisteredInNetwork => 10,
+            CustomTransactionError::InvalidIpAddress => 11,
+            CustomTransactionError::ServingRateLimitExceeded => 12,
+            CustomTransactionError::InvalidPort => 13,
             CustomTransactionError::BadRequest => 255,
         }
     }
@@ -1771,6 +1779,22 @@ where
                 .into()),
                 Error::<T>::TransferDisallowed => Err(InvalidTransaction::Custom(
                     CustomTransactionError::TransferDisallowed.into(),
+                )
+                .into()),
+                Error::<T>::HotKeyNotRegisteredInNetwork => Err(InvalidTransaction::Custom(
+                    CustomTransactionError::HotKeyNotRegisteredInNetwork.into(),
+                )
+                .into()),
+                Error::<T>::InvalidIpAddress => Err(InvalidTransaction::Custom(
+                    CustomTransactionError::InvalidIpAddress.into(),
+                )
+                .into()),
+                Error::<T>::ServingRateLimitExceeded => Err(InvalidTransaction::Custom(
+                    CustomTransactionError::ServingRateLimitExceeded.into(),
+                )
+                .into()),
+                Error::<T>::InvalidPort => Err(InvalidTransaction::Custom(
+                    CustomTransactionError::InvalidPort.into(),
                 )
                 .into()),
                 _ => Err(
@@ -2174,6 +2198,32 @@ where
                         ..Default::default()
                     })
                 }
+            }
+            Some(Call::serve_axon {
+                netuid,
+                version,
+                ip,
+                port,
+                ip_type,
+                protocol,
+                placeholder1,
+                placeholder2,
+            }) => {
+                // Fully validate the user input
+                Self::result_to_validity(
+                    Pallet::<T>::validate_serve_axon(
+                        who,
+                        *netuid,
+                        *version,
+                        *ip,
+                        *port,
+                        *ip_type,
+                        *protocol,
+                        *placeholder1,
+                        *placeholder2,
+                    ),
+                    Self::get_priority_vanilla(),
+                )
             }
             _ => {
                 if let Some(

--- a/pallets/subtensor/src/subnets/serving.rs
+++ b/pallets/subtensor/src/subnets/serving.rs
@@ -69,28 +69,20 @@ impl<T: Config> Pallet<T> {
         // We check the callers (hotkey) signature.
         let hotkey_id = ensure_signed(origin)?;
 
-        // Ensure the hotkey is registered somewhere.
-        ensure!(
-            Self::is_hotkey_registered_on_any_network(&hotkey_id),
-            Error::<T>::HotKeyNotRegisteredInNetwork
-        );
+        // Validate user input
+        Self::validate_serve_axon(
+            &hotkey_id,
+            netuid,
+            version,
+            ip,
+            port,
+            ip_type,
+            protocol,
+            placeholder1,
+            placeholder2,
+        )?;
 
-        // Check the ip signature validity.
-        ensure!(Self::is_valid_ip_type(ip_type), Error::<T>::InvalidIpType);
-        ensure!(
-            Self::is_valid_ip_address(ip_type, ip),
-            Error::<T>::InvalidIpAddress
-        );
-
-        // Get the previous axon information.
-        let mut prev_axon = Self::get_axon_info(netuid, &hotkey_id);
-        let current_block: u64 = Self::get_current_block_as_u64();
-        ensure!(
-            Self::axon_passes_rate_limit(netuid, &prev_axon, current_block),
-            Error::<T>::ServingRateLimitExceeded
-        );
-
-        // Check certificate
+        // Check+insert certificate
         if let Some(certificate) = certificate {
             if let Ok(certificate) = NeuronCertificateOf::try_from(certificate) {
                 NeuronCertificates::<T>::insert(netuid, hotkey_id.clone(), certificate)
@@ -98,6 +90,7 @@ impl<T: Config> Pallet<T> {
         }
 
         // We insert the axon meta.
+        let mut prev_axon = Self::get_axon_info(netuid, &hotkey_id);
         prev_axon.block = Self::get_current_block_as_u64();
         prev_axon.version = version;
         prev_axon.ip = ip;
@@ -331,5 +324,56 @@ impl<T: Config> Pallet<T> {
         }
 
         Ok(true)
+    }
+
+    pub fn validate_serve_axon(
+        hotkey_id: &T::AccountId,
+        netuid: u16,
+        version: u32,
+        ip: u128,
+        port: u16,
+        ip_type: u8,
+        protocol: u8,
+        placeholder1: u8,
+        placeholder2: u8,
+    ) -> Result<(), Error<T>> {
+        // Ensure the hotkey is registered somewhere.
+        ensure!(
+            Self::is_hotkey_registered_on_any_network(hotkey_id),
+            Error::<T>::HotKeyNotRegisteredInNetwork
+        );
+
+        // Check the ip signature validity.
+        ensure!(Self::is_valid_ip_type(ip_type), Error::<T>::InvalidIpType);
+        ensure!(
+            Self::is_valid_ip_address(ip_type, ip),
+            Error::<T>::InvalidIpAddress
+        );
+
+        // Get the previous axon information.
+        let mut prev_axon = Self::get_axon_info(netuid, hotkey_id);
+        let current_block: u64 = Self::get_current_block_as_u64();
+        ensure!(
+            Self::axon_passes_rate_limit(netuid, &prev_axon, current_block),
+            Error::<T>::ServingRateLimitExceeded
+        );
+
+        // Validate axon data with delegate func
+        prev_axon.block = Self::get_current_block_as_u64();
+        prev_axon.version = version;
+        prev_axon.ip = ip;
+        prev_axon.port = port;
+        prev_axon.ip_type = ip_type;
+        prev_axon.protocol = protocol;
+        prev_axon.placeholder1 = placeholder1;
+        prev_axon.placeholder2 = placeholder2;
+
+        let axon_validated = Self::validate_axon_data(&prev_axon);
+        ensure!(
+            axon_validated.is_ok(),
+            axon_validated.err().unwrap_or(Error::<T>::InvalidPort)
+        );
+
+        Ok(())
     }
 }

--- a/pallets/subtensor/src/subnets/serving.rs
+++ b/pallets/subtensor/src/subnets/serving.rs
@@ -169,17 +169,17 @@ impl<T: Config> Pallet<T> {
         // We check the callers (hotkey) signature.
         let hotkey_id = ensure_signed(origin)?;
 
-        // Ensure the hotkey is registered somewhere.
-        ensure!(
-            Self::is_hotkey_registered_on_any_network(&hotkey_id),
-            Error::<T>::HotKeyNotRegisteredInNetwork
-        );
-
         // Check the ip signature validity.
         ensure!(Self::is_valid_ip_type(ip_type), Error::<T>::InvalidIpType);
         ensure!(
             Self::is_valid_ip_address(ip_type, ip),
             Error::<T>::InvalidIpAddress
+        );
+
+        // Ensure the hotkey is registered somewhere.
+        ensure!(
+            Self::is_hotkey_registered_on_any_network(&hotkey_id),
+            Error::<T>::HotKeyNotRegisteredInNetwork
         );
 
         // We get the previous axon info assoicated with this ( netuid, uid )

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -229,7 +229,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 235,
+    spec_version: 236,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
This will fail `serve_axon` extrinsics before inclusion in the block (benefits: footprint, taostats DB size growth rate).

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

Only failing `serve_axon` extrinsics are affected. Instead of receiving extrinsic failure, one of CustomTransactionError values is returned immediately:

- CustomTransactionError::HotKeyNotRegisteredInNetwork => 10,
- CustomTransactionError::InvalidIpAddress => 11,
- CustomTransactionError::ServingRateLimitExceeded => 12,
- CustomTransactionError::InvalidPort => 13,

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
