### PR TITLE
make set diff only root

### DIFF
--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -653,7 +653,7 @@ pub mod pallet {
             netuid: u16,
             difficulty: u64,
         ) -> DispatchResult {
-            pallet_subtensor::Pallet::<T>::ensure_subnet_owner_or_root(origin, netuid)?;
+            ensure_root(origin)?;
             ensure!(
                 pallet_subtensor::Pallet::<T>::if_subnet_exist(netuid),
                 Error::<T>::SubnetDoesNotExist

--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -643,6 +643,18 @@ fn test_sudo_set_difficulty() {
             to_be_set
         ));
         assert_eq!(SubtensorModule::get_difficulty_as_u64(netuid), to_be_set);
+
+        // Test that SN owner can't set difficulty
+        pallet_subtensor::SubnetOwner::<Test>::insert(netuid, U256::from(1));
+        assert_eq!(
+            AdminUtils::sudo_set_difficulty(
+                <<Test as Config>::RuntimeOrigin>::signed(U256::from(1)),
+                netuid,
+                init_value
+            ),
+            Err(DispatchError::BadOrigin)
+        );
+        assert_eq!(SubtensorModule::get_difficulty_as_u64(netuid), to_be_set); // no change
     });
 }
 

--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -81,7 +81,9 @@ mod hooks {
                 // Upgrade identities to V2
                 .saturating_add(migrations::migrate_identities_v2::migrate_identities_to_v2::<T>())
 				// Set the min burn across all subnets to a new minimum
-				.saturating_add(migrations::migrate_set_min_burn::migrate_set_min_burn::<T>());
+				.saturating_add(migrations::migrate_set_min_burn::migrate_set_min_burn::<T>())
+				// Set the min difficulty across all subnets to a new minimum
+				.saturating_add(migrations::migrate_set_min_difficulty::migrate_set_min_difficulty::<T>());
             weight
         }
 

--- a/pallets/subtensor/src/migrations/migrate_set_min_difficulty.rs
+++ b/pallets/subtensor/src/migrations/migrate_set_min_difficulty.rs
@@ -1,0 +1,52 @@
+use alloc::string::String;
+
+use frame_support::IterableStorageMap;
+use frame_support::{traits::Get, weights::Weight};
+
+use super::*;
+
+pub fn migrate_set_min_difficulty<T: Config>() -> Weight {
+    let migration_name = b"migrate_set_min_difficulty".to_vec();
+
+    // Initialize the weight with one read operation.
+    let mut weight = T::DbWeight::get().reads(1);
+
+    // Check if the migration has already run
+    if HasMigrationRun::<T>::get(&migration_name) {
+        log::info!(
+            "Migration '{:?}' has already run. Skipping.",
+            migration_name
+        );
+        return weight;
+    }
+    log::info!(
+        "Running migration '{}'",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    let netuids: Vec<u16> = <NetworksAdded<T> as IterableStorageMap<u16, bool>>::iter()
+        .map(|(netuid, _)| netuid)
+        .collect();
+    weight = weight.saturating_add(T::DbWeight::get().reads(netuids.len() as u64));
+
+    for netuid in netuids.iter().clone() {
+        if *netuid == 0 {
+            continue;
+        }
+        // Set min difficulty to 10 million for all subnets
+        Pallet::<T>::set_min_difficulty(*netuid, 10_000_000);
+        weight = weight.saturating_add(T::DbWeight::get().writes(1));
+    }
+
+    // Mark the migration as completed
+    HasMigrationRun::<T>::insert(&migration_name, true);
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+    log::info!(
+        "Migration '{:?}' completed.",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    // Return the migration weight.
+    weight
+}

--- a/pallets/subtensor/src/migrations/mod.rs
+++ b/pallets/subtensor/src/migrations/mod.rs
@@ -12,6 +12,7 @@ pub mod migrate_populate_owned_hotkeys;
 pub mod migrate_populate_staking_hotkeys;
 pub mod migrate_rao;
 pub mod migrate_set_min_burn;
+pub mod migrate_set_min_difficulty;
 pub mod migrate_stake_threshold;
 pub mod migrate_subnet_volume;
 pub mod migrate_to_v1_separate_emission;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -229,7 +229,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 236,
+    spec_version: 237,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->

This PR makes `sudo_set_difficulty` only call-able by `sudo`, instead of the Subnet creator
## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.