### PR TITLE
Dramatically improve CI & rust cache performance

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -24,6 +24,11 @@ jobs:
           sudo apt-get update &&
           sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
 
+      - name: Utilize Shared Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: "cargo-audit"
+
       - name: Install cargo-audit
         run: cargo install --force cargo-audit
 

--- a/.github/workflows/check-devnet.yml
+++ b/.github/workflows/check-devnet.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Check-out repository under $GITHUB_WORKSPACE
         uses: actions/checkout@v4
-
+        # file change to break cache
       - name: Utilize Shared Rust Cache
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/check-devnet.yml
+++ b/.github/workflows/check-devnet.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Check-out repository under $GITHUB_WORKSPACE
         uses: actions/checkout@v4
-        # file change to break cache
+
       - name: Utilize Shared Rust Cache
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/check-devnet.yml
+++ b/.github/workflows/check-devnet.yml
@@ -20,11 +20,16 @@ jobs:
           sudo apt-get install -y curl clang curl libssl-dev llvm \
                                   libudev-dev protobuf-compiler
 
-      - name: Install substrate-spec-version
-        run: cargo install substrate-spec-version
-
       - name: Check-out repository under $GITHUB_WORKSPACE
         uses: actions/checkout@v4
+
+      - name: Utilize Shared Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: "spec-version"
+
+      - name: Install substrate-spec-version
+        run: cargo install substrate-spec-version
 
       - name: Check that spec_version has been bumped
         run: |

--- a/.github/workflows/check-finney.yml
+++ b/.github/workflows/check-finney.yml
@@ -20,11 +20,16 @@ jobs:
           sudo apt-get install -y curl clang curl libssl-dev llvm \
                                   libudev-dev protobuf-compiler
 
-      - name: Install substrate-spec-version
-        run: cargo install substrate-spec-version
-
       - name: Check-out repository under $GITHUB_WORKSPACE
         uses: actions/checkout@v4
+
+      - name: Utilize Shared Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: "spec-version"
+
+      - name: Install substrate-spec-version
+        run: cargo install substrate-spec-version
 
       - name: Check that spec_version has been bumped
         run: |

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential
 
+      - name: Install Rust Nightly
+        run: rustup install nightly
+
       - name: Utilize Shared Rust Cache
         uses: Swatinem/rust-cache@v2
 
@@ -53,9 +56,6 @@ jobs:
         run: |
           sudo apt-get update &&
           sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
-
-      - name: Install Rust Nightly
-        run: rustup install nightly
 
       - name: Utilize Shared Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -24,25 +24,8 @@ jobs:
   cargo-fmt:
     name: cargo fmt
     runs-on: SubtensorCI
-    strategy:
-      matrix:
-        rust-branch:
-          - nightly-2024-03-05
-        rust-target:
-          - x86_64-unknown-linux-gnu
-          # - x86_64-apple-darwin
-        os:
-          - ubuntu-latest
-          # - macos-latest
-        include:
-          - os: ubuntu-latest
-          # - os: macos-latest
     env:
-      RELEASE_NAME: development
-      # RUSTFLAGS: -A warnings
       RUST_BACKTRACE: full
-      SKIP_WASM_BUILD: 1
-      TARGET: ${{ matrix.rust-target }}
     steps:
       - name: Check-out repository under $GITHUB_WORKSPACE
         uses: actions/checkout@v4
@@ -50,39 +33,18 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential
 
-      - name: Install Rust Nightly
-        uses: actions-rs/toolchain@v1.0.6
-        with:
-          toolchain: nightly
-          components: rustfmt
-          profile: minimal
+      - name: Utilize Shared Rust Cache
+        uses: Swatinem/rust-cache@v2
 
       - name: cargo fmt
-        run: cargo fmt --check --all
+        run: cargo +nightly fmt --check --all
 
   cargo-clippy-default-features:
     name: cargo clippy
     runs-on: SubtensorCI
-    strategy:
-      matrix:
-        rust-branch:
-          - stable
-        rust-target:
-          - x86_64-unknown-linux-gnu
-          # - x86_64-apple-darwin
-        os:
-          - ubuntu-latest
-          # - macos-latest
-        include:
-          - os: ubuntu-latest
-          # - os: macos-latest
     env:
-      RELEASE_NAME: development
-      # RUSTFLAGS: -A warnings
       RUST_BACKTRACE: full
       SKIP_WASM_BUILD: 1
-      TARGET: ${{ matrix.rust-target }}
-      RUST_BIN_DIR: target/${{ matrix.rust-target }}
     steps:
       - name: Check-out repository under $GITHUB_WORKSPACE
         uses: actions/checkout@v4
@@ -93,9 +55,7 @@ jobs:
           sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
 
       - name: Utilize Shared Rust Cache
-        uses: Swatinem/rust-cache@v2.2.1
-        with:
-          key: ${{ matrix.os }}-${{ env.RUST_BIN_DIR }}
+        uses: Swatinem/rust-cache@v2
 
       - name: cargo clippy --workspace --all-targets -- -D warnings
         run: cargo clippy --workspace --all-targets -- -D warnings
@@ -103,23 +63,10 @@ jobs:
   cargo-check-lints:
     name: check custom lints
     runs-on: SubtensorCI
-    strategy:
-      matrix:
-        rust-branch:
-          - stable
-        rust-target:
-          - x86_64-unknown-linux-gnu
-        # - x86_64-apple-darwin
-        os:
-          - ubuntu-latest
-          # - macos-latest
     env:
-      RELEASE_NAME: development
       RUSTFLAGS: -D warnings
       RUST_BACKTRACE: full
       SKIP_WASM_BUILD: 1
-      TARGET: ${{ matrix.rust-target }}
-      RUST_BIN_DIR: target/${{ matrix.rust-target }}
     steps:
       - name: Check-out repository under $GITHUB_WORKSPACE
         uses: actions/checkout@v4
@@ -129,17 +76,8 @@ jobs:
           sudo apt-get update &&
           sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
 
-      - name: Install Rust ${{ matrix.rust-branch }}
-        uses: actions-rs/toolchain@v1.0.6
-        with:
-          toolchain: ${{ matrix.rust-branch }}
-          components: rustfmt, clippy
-          profile: minimal
-
       - name: Utilize Shared Rust Cache
-        uses: Swatinem/rust-cache@v2.2.1
-        with:
-          key: ${{ matrix.os }}-${{ env.RUST_BIN_DIR }}
+        uses: Swatinem/rust-cache@v2
 
       - name: check lints
         run: |
@@ -150,63 +88,9 @@ jobs:
   cargo-clippy-all-features:
     name: cargo clippy --all-features
     runs-on: SubtensorCI
-    strategy:
-      matrix:
-        rust-target:
-          - x86_64-unknown-linux-gnu
-          # - x86_64-apple-darwin
-        os:
-          - ubuntu-latest
-          # - macos-latest
-        include:
-          - os: ubuntu-latest
-          # - os: macos-latest
     env:
-      RELEASE_NAME: development
-      # RUSTFLAGS: -A warnings
       RUST_BACKTRACE: full
-      RUST_BIN_DIR: target/${{ matrix.rust-target }}
       SKIP_WASM_BUILD: 1
-      TARGET: ${{ matrix.rust-target }}
-    steps:
-      - name: Check-out repository under $GITHUB_WORKSPACE
-        uses: actions/checkout@v2
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update &&
-          sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
-
-      - name: Utilize Shared Rust Cache
-        uses: Swatinem/rust-cache@v2.2.1
-        with:
-          key: ${{ matrix.os }}-${{ env.RUST_BIN_DIR }}
-
-      - name: cargo clippy --workspace --all-targets --all-features -- -D warnings
-        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
-
-  # runs cargo test --workspace
-  cargo-test:
-    name: cargo test
-    runs-on: SubtensorCI
-    strategy:
-      matrix:
-        rust-target:
-          - x86_64-unknown-linux-gnu
-          # - x86_64-apple-darwin
-        os:
-          - ubuntu-latest
-          # - macos-latest
-        include:
-          - os: ubuntu-latest
-          # - os: macos-latest
-    env:
-      RELEASE_NAME: development
-      # RUSTFLAGS: -A warnings
-      RUST_BACKTRACE: full
-      RUST_BIN_DIR: target/${{ matrix.rust-target }}
-      SKIP_WASM_BUILD: 1
-      TARGET: ${{ matrix.rust-target }}
     steps:
       - name: Check-out repository under $GITHUB_WORKSPACE
         uses: actions/checkout@v4
@@ -216,10 +100,30 @@ jobs:
           sudo apt-get update &&
           sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
 
-      - name: Utilize Rust shared cached
-        uses: Swatinem/rust-cache@v2.2.1
-        with:
-          key: ${{ matrix.os }}-${{ env.RUST_BIN_DIR }}
+      - name: Utilize Shared Rust Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: cargo clippy --workspace --all-targets --all-features -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+  # runs cargo test --workspace --all-features
+  cargo-test:
+    name: cargo test
+    runs-on: SubtensorCI
+    env:
+      RUST_BACKTRACE: full
+      SKIP_WASM_BUILD: 1
+    steps:
+      - name: Check-out repository under $GITHUB_WORKSPACE
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update &&
+          sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
+
+      - name: Utilize Shared Rust Cache
+        uses: Swatinem/rust-cache@v2
 
       - name: cargo test --workspace --all-features
         run: cargo test --workspace --all-features
@@ -228,26 +132,9 @@ jobs:
   cargo-fix:
     name: cargo fix
     runs-on: SubtensorCI
-    strategy:
-      matrix:
-        rust-branch:
-          - stable
-        rust-target:
-          - x86_64-unknown-linux-gnu
-          # - x86_64-apple-darwin
-        os:
-          - ubuntu-latest
-          # - macos-latest
-        include:
-          - os: ubuntu-latest
-          # - os: macos-latest
     env:
-      RELEASE_NAME: development
-      # RUSTFLAGS: -A warnings
       RUST_BACKTRACE: full
-      RUST_BIN_DIR: target/${{ matrix.rust-target }}
       SKIP_WASM_BUILD: 1
-      TARGET: ${{ matrix.rust-target }}
     steps:
       - name: Check-out repository under $GITHUB_WORKSPACE
         uses: actions/checkout@v4
@@ -257,10 +144,8 @@ jobs:
           sudo apt-get update &&
           sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
 
-      - name: Utilize Rust shared cached
-        uses: Swatinem/rust-cache@v2.2.1
-        with:
-          key: ${{ matrix.os }}-${{ env.RUST_BIN_DIR }}
+      - name: Utilize Shared Rust Cache
+        uses: Swatinem/rust-cache@v2
 
       - name: cargo fix --workspace
         run: |
@@ -280,13 +165,16 @@ jobs:
     runs-on: SubtensorCI
 
     steps:
-      - name: Install Zepter
-        run: cargo install --locked -q zepter && zepter --version
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Dont clone historic commits.
+
+      - name: Utilize Shared Rust Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install Zepter
+        run: cargo install --locked -q zepter && zepter --version
 
       - name: Check features
         run: zepter run check

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -34,7 +34,9 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y build-essential
 
       - name: Install Rust Nightly
-        run: rustup install nightly
+        run: |
+          rustup install nightly
+          rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt
 
       - name: Utilize Shared Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -54,6 +54,9 @@ jobs:
           sudo apt-get update &&
           sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
 
+      - name: Install Rust Nightly
+        run: rustup install nightly
+
       - name: Utilize Shared Rust Cache
         uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/check-testnet.yml
+++ b/.github/workflows/check-testnet.yml
@@ -20,11 +20,16 @@ jobs:
           sudo apt-get install -y curl clang curl libssl-dev llvm \
                                   libudev-dev protobuf-compiler
 
-      - name: Install substrate-spec-version
-        run: cargo install substrate-spec-version
-
       - name: Check-out repository under $GITHUB_WORKSPACE
         uses: actions/checkout@v4
+
+      - name: Utilize Shared Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: "spec-version"
+
+      - name: Install substrate-spec-version
+        run: cargo install substrate-spec-version
 
       - name: Check that spec_version has been bumped
         run: |

--- a/.github/workflows/e2e-bittensor-tests.yml
+++ b/.github/workflows/e2e-bittensor-tests.yml
@@ -22,40 +22,19 @@ env:
 jobs:
   run:
     runs-on: SubtensorCI
-    strategy:
-      matrix:
-        rust-branch:
-          - nightly-2024-03-05
-        rust-target:
-          - x86_64-unknown-linux-gnu
-          # - x86_64-apple-darwin
-        os:
-          - ubuntu-latest
-          # - macos-latest
-        include:
-          - os: ubuntu-latest
-          # - os: macos-latest
     env:
-      RELEASE_NAME: development
-      RUSTV: ${{ matrix.rust-branch }}
       RUST_BACKTRACE: full
-      RUST_BIN_DIR: target/${{ matrix.rust-target }}
-      TARGET: ${{ matrix.rust-target }}
     steps:
       - name: Check-out repository under $GITHUB_WORKSPACE
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: Utilize Shared Rust Cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Install dependencies
         run: |
           sudo apt-get update &&
           sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
-
-      - name: Install Rust ${{ matrix.rust-branch }}
-        uses: actions-rs/toolchain@v1.0.6
-        with:
-          toolchain: ${{ matrix.rust-branch }}
-          components: rustfmt
-          profile: minimal
 
       - name: Clone bittensor repo
         run: git clone https://github.com/opentensor/bittensor.git

--- a/.github/workflows/try-runtime.yml
+++ b/.github/workflows/try-runtime.yml
@@ -50,7 +50,7 @@ jobs:
 
   check-finney:
     name: check finney
-    # if: github.base_ref == 'testnet' || github.base_ref == 'devnet' || github.base_ref == 'main'
+    if: github.base_ref == 'testnet' || github.base_ref == 'devnet' || github.base_ref == 'main'
     runs-on: SubtensorCI
     steps:
       - name: Checkout sources

--- a/.github/workflows/try-runtime.yml
+++ b/.github/workflows/try-runtime.yml
@@ -16,6 +16,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
+      - name: Utilize Shared Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: "try-runtime"
+
       - name: Run Try Runtime Checks
         uses: "paritytech/try-runtime-gha@v0.1.0"
         with:
@@ -31,6 +36,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
+      - name: Utilize Shared Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: "try-runtime"
+
       - name: Run Try Runtime Checks
         uses: "paritytech/try-runtime-gha@v0.1.0"
         with:
@@ -45,6 +55,12 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+
+      - name: Utilize Shared Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: "try-runtime"
+
       - name: Run Try Runtime Checks
         uses: "paritytech/try-runtime-gha@v0.1.0"
         with:

--- a/.github/workflows/try-runtime.yml
+++ b/.github/workflows/try-runtime.yml
@@ -50,7 +50,7 @@ jobs:
 
   check-finney:
     name: check finney
-    if: github.base_ref == 'testnet' || github.base_ref == 'devnet' || github.base_ref == 'main'
+    # if: github.base_ref == 'testnet' || github.base_ref == 'devnet' || github.base_ref == 'main'
     runs-on: SubtensorCI
     steps:
       - name: Checkout sources

--- a/.github/workflows/update-chainspec.yml
+++ b/.github/workflows/update-chainspec.yml
@@ -29,14 +29,6 @@ jobs:
       github.event.pull_request.head.ref != 'testnet' &&
       github.event.pull_request.head.ref != 'main'
 
-    strategy:
-      matrix:
-        rust-target:
-          - x86_64-unknown-linux-gnu
-        os:
-          - ubuntu-latest
-        include:
-          - os: ubuntu-latest
     env:
       RUST_BACKTRACE: full
     steps:
@@ -49,9 +41,7 @@ jobs:
           sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
 
       - name: Utilize Shared Rust Cache
-        uses: Swatinem/rust-cache@v2.2.1
-        with:
-          key: ubuntu-latest-target/x86_64-unknown-linux-gnu
+        uses: Swatinem/rust-cache@v2
 
       - name: Build chainspecs
         run: ./scripts/build_all_chainspecs.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1785,7 +1785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145d32e826a7748b69ee8fc62d3e6355ff7f1051df53141e7048162fc90481b"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.96",
 ]
 
 [[package]]


### PR DESCRIPTION
* everything now uses the same cache key except try runtime and spec version check which use their own keys
* versions fixed for rust cache and checkout action
* removed matrix strategy across the board since it is not used anymore
* generally cleaned up CI


much much faster

![image](https://github.com/user-attachments/assets/91a9a289-00a7-4b78-806d-967434c1620f)
