### PR TITLE
Feat/delegate info dtao

### DIFF
--- a/pallets/subtensor/runtime-api/src/lib.rs
+++ b/pallets/subtensor/runtime-api/src/lib.rs
@@ -19,7 +19,7 @@ sp_api::decl_runtime_apis! {
     pub trait DelegateInfoRuntimeApi {
         fn get_delegates() -> Vec<DelegateInfo<AccountId32>>;
         fn get_delegate( delegate_account: AccountId32 ) -> Option<DelegateInfo<AccountId32>>;
-        fn get_delegated( delegatee_account: AccountId32 ) -> Vec<(DelegateInfo<AccountId32>, Compact<u64>)>;
+        fn get_delegated( delegatee_account: AccountId32 ) -> Vec<(DelegateInfo<AccountId32>, (Compact<u16>, Compact<u64>))>;
     }
 
     pub trait NeuronInfoRuntimeApi {

--- a/pallets/subtensor/src/rpc_info/delegate_info.rs
+++ b/pallets/subtensor/src/rpc_info/delegate_info.rs
@@ -151,16 +151,22 @@ impl<T: Config> Pallet<T> {
     ///
     pub fn get_delegated(
         delegatee: T::AccountId,
-    ) -> Vec<(DelegateInfo<T::AccountId>, Compact<u64>)> {
-        let mut delegates: Vec<(DelegateInfo<T::AccountId>, Compact<u64>)> = Vec::new();
+    ) -> Vec<(DelegateInfo<T::AccountId>, (Compact<u16>, Compact<u64>))> {
+        let mut delegates: Vec<(DelegateInfo<T::AccountId>, (Compact<u16>, Compact<u64>))> =
+            Vec::new();
         for delegate in <Delegates<T> as IterableStorageMap<T::AccountId, u16>>::iter_keys() {
             // Staked to this delegate, so add to list
             for (netuid, _) in Alpha::<T>::iter_prefix((delegate.clone(), delegatee.clone())) {
                 let delegate_info = Self::get_delegate_by_existing_account(delegate.clone(), true);
                 delegates.push((
                     delegate_info,
-                    Self::get_stake_for_hotkey_and_coldkey_on_subnet(&delegate, &delegatee, netuid)
+                    (
+                        netuid.into(),
+                        Self::get_stake_for_hotkey_and_coldkey_on_subnet(
+                            &delegate, &delegatee, netuid,
+                        )
                         .into(),
+                    ),
                 ));
             }
         }

--- a/pallets/subtensor/src/rpc_info/delegate_info.rs
+++ b/pallets/subtensor/src/rpc_info/delegate_info.rs
@@ -1,18 +1,18 @@
 use super::*;
 use frame_support::pallet_prelude::{Decode, Encode};
-use frame_support::storage::IterableStorageMap;
-use frame_support::IterableStorageDoubleMap;
+use frame_support::IterableStorageMap;
 use safe_math::*;
 use substrate_fixed::types::U64F64;
 extern crate alloc;
+use alloc::collections::BTreeMap;
 use codec::Compact;
 
-#[freeze_struct("66105c2cfec0608d")]
+#[freeze_struct("f729f2481d94a1de")]
 #[derive(Decode, Encode, PartialEq, Eq, Clone, Debug, TypeInfo)]
 pub struct DelegateInfo<AccountId: TypeInfo + Encode + Decode> {
     delegate_ss58: AccountId,
     take: Compact<u16>,
-    nominators: Vec<(AccountId, Compact<u64>)>, // map of nominator_ss58 to stake amount
+    nominators: Vec<(AccountId, Vec<(Compact<u16>, Compact<u64>)>)>, // map of nominator_ss58 to netuid and stake amount
     owner_ss58: AccountId,
     registrations: Vec<Compact<u16>>, // Vec of netuid this delegate is registered on
     validator_permits: Vec<Compact<u16>>, // Vec of netuid this delegate has validator permit on
@@ -49,19 +49,38 @@ impl<T: Config> Pallet<T> {
         Self::return_per_1000_tao(take, total_stake, emissions_per_day)
     }
 
-    fn get_delegate_by_existing_account(delegate: AccountIdOf<T>) -> DelegateInfo<T::AccountId> {
-        let mut nominators = Vec::<(T::AccountId, Compact<u64>)>::new();
+    fn get_delegate_by_existing_account(
+        delegate: AccountIdOf<T>,
+        skip_nominators: bool,
+    ) -> DelegateInfo<T::AccountId> {
+        let mut nominators = Vec::<(T::AccountId, Vec<(Compact<u16>, Compact<u64>)>)>::new();
+        let mut nominator_map = BTreeMap::<T::AccountId, Vec<(Compact<u16>, Compact<u64>)>>::new();
 
-        for (nominator, stake) in
-            <Stake<T> as IterableStorageDoubleMap<T::AccountId, T::AccountId, u64>>::iter_prefix(
-                delegate.clone(),
-            )
-        {
-            if stake == 0 {
-                continue;
+        if !skip_nominators {
+            let mut alpha_share_pools = vec![];
+            for netuid in Self::get_all_subnet_netuids() {
+                let alpha_share_pool = Self::get_alpha_share_pool(delegate.clone(), netuid);
+                alpha_share_pools.push(alpha_share_pool);
             }
-            // Only add nominators with stake
-            nominators.push((nominator.clone(), stake.into()));
+
+            for ((nominator, netuid), alpha_stake) in Alpha::<T>::iter_prefix((delegate.clone(),)) {
+                if alpha_stake == 0 {
+                    continue;
+                }
+
+                if let Some(alpha_share_pool) = alpha_share_pools.get(netuid as usize) {
+                    let coldkey_stake = alpha_share_pool.get_value_from_shares(alpha_stake);
+
+                    nominator_map
+                        .entry(nominator.clone())
+                        .or_insert(Vec::new())
+                        .push((netuid.into(), coldkey_stake.into()));
+                }
+            }
+
+            for (nominator, stakes) in nominator_map {
+                nominators.push((nominator, stakes));
+            }
         }
 
         let registrations = Self::get_registered_networks_for_hotkey(&delegate.clone());
@@ -112,7 +131,7 @@ impl<T: Config> Pallet<T> {
             return None;
         }
 
-        let delegate_info = Self::get_delegate_by_existing_account(delegate.clone());
+        let delegate_info = Self::get_delegate_by_existing_account(delegate.clone(), false);
         Some(delegate_info)
     }
 
@@ -121,7 +140,7 @@ impl<T: Config> Pallet<T> {
     pub fn get_delegates() -> Vec<DelegateInfo<T::AccountId>> {
         let mut delegates = Vec::<DelegateInfo<T::AccountId>>::new();
         for delegate in <Delegates<T> as IterableStorageMap<T::AccountId, u16>>::iter_keys() {
-            let delegate_info = Self::get_delegate_by_existing_account(delegate.clone());
+            let delegate_info = Self::get_delegate_by_existing_account(delegate.clone(), false);
             delegates.push(delegate_info);
         }
 
@@ -136,16 +155,14 @@ impl<T: Config> Pallet<T> {
         let mut delegates: Vec<(DelegateInfo<T::AccountId>, Compact<u64>)> = Vec::new();
         for delegate in <Delegates<T> as IterableStorageMap<T::AccountId, u16>>::iter_keys() {
             // Staked to this delegate, so add to list
-            let delegate_info = Self::get_delegate_by_existing_account(delegate.clone());
-            delegates.push((
-                delegate_info,
-                Self::get_stake_for_hotkey_and_coldkey_on_subnet(
-                    &delegatee,
-                    &delegate,
-                    Self::get_root_netuid(),
-                )
-                .into(),
-            ));
+            for (netuid, _) in Alpha::<T>::iter_prefix((delegate.clone(), delegatee.clone())) {
+                let delegate_info = Self::get_delegate_by_existing_account(delegate.clone(), true);
+                delegates.push((
+                    delegate_info,
+                    Self::get_stake_for_hotkey_and_coldkey_on_subnet(&delegate, &delegatee, netuid)
+                        .into(),
+                ));
+            }
         }
 
         delegates

--- a/primitives/share-pool/src/lib.rs
+++ b/primitives/share-pool/src/lib.rs
@@ -63,6 +63,22 @@ where
         .saturating_to_num::<u64>()
     }
 
+    pub fn get_value_from_shares(&self, current_share: U64F64) -> u64 {
+        let shared_value: U64F64 = self.state_ops.get_shared_value();
+        let denominator: U64F64 = self.state_ops.get_denominator();
+
+        let maybe_value_per_share = shared_value.checked_div(denominator);
+        (if let Some(value_per_share) = maybe_value_per_share {
+            value_per_share.saturating_mul(current_share)
+        } else {
+            shared_value
+                .saturating_mul(current_share)
+                .checked_div(denominator)
+                .unwrap_or(U64F64::saturating_from_num(0))
+        })
+        .saturating_to_num::<u64>()
+    }
+
     pub fn try_get_value(&self, key: &K) -> Result<u64, ()> {
         match self.state_ops.try_get_share(key) {
             Ok(_) => Ok(self.get_value(key)),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2062,7 +2062,7 @@ impl_runtime_apis! {
             SubtensorModule::get_delegate(delegate_account)
         }
 
-        fn get_delegated(delegatee_account: AccountId32) -> Vec<(DelegateInfo<AccountId32>, Compact<u64>)> {
+        fn get_delegated(delegatee_account: AccountId32) -> Vec<(DelegateInfo<AccountId32>, (Compact<u16>, Compact<u64>))> {
             SubtensorModule::get_delegated(delegatee_account)
         }
     }


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
This PR makes delegate info useful for dTAO. It pulls all the nominators and their stake across all subnets.

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change
This is a breaking change as it changes the content meaning and return type of the delegate info calls. 
However, the previous contents are not very useful. 

`get_delegated` is changed as the `delegate_info` for each element of the returned list `Vec<(DelegateInfo, (u16, u64))>` has the field `nominators` set to an empty `vec`. This speeds up the query as we're grabbing the delegates that one coldkey is staked to, so there's no need to grab all the other nominators. The stake for this coldkey is already included in the list. Also note that the return type itself has changed to be a tuple of the both the `delegate_info` and a tuple of `(netuid, alpha_stake)`.

For `get_delegate` and `get_delegates`, the return types are the same. 

However, in the `DelegateInfo` type, the field `nominators` is a different type that now includes the netuid for each nominator. `Vec<(AccountId, Vec<(Compact<u16>, Compact<u64>)>)>`, or a list of nominator-tuples with their address and a list of netuids they are staked-to under this hotkey and the amount in alpha.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.