### PR TITLE
remove CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @unconst


### PR DESCRIPTION
removes CODEOWNERS file since it has been making it so 100% of merges have to bypass merge protection