### PR TITLE
Set initial tempo to 360

### DIFF
--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -133,7 +133,7 @@ parameter_types! {
     pub const SDebug:u64 = 1;
     pub const InitialRho: u16 = 30;
     pub const InitialKappa: u16 = 32_767;
-    pub const InitialTempo: u16 = 0;
+    pub const InitialTempo: u16 = 360;
     pub const SelfOwnership: u64 = 2;
     pub const InitialImmunityPeriod: u16 = 2;
     pub const InitialMaxAllowedUids: u16 = 2;

--- a/pallets/subtensor/src/tests/networks.rs
+++ b/pallets/subtensor/src/tests/networks.rs
@@ -326,3 +326,20 @@ fn test_register_subnet_high_lock_cost() {
         assert_eq!(SubnetAlphaIn::<Test>::get(netuid), lock_cost);
     })
 }
+
+#[test]
+fn test_tempo_greater_than_weight_set_rate_limit() {
+    new_test_ext(1).execute_with(|| {
+        let subnet_owner_hotkey = U256::from(1);
+        let subnet_owner_coldkey = U256::from(2);
+
+        let netuid = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
+
+        // Get tempo
+        let tempo = SubtensorModule::get_tempo(netuid);
+
+        let weights_set_rate_limit = SubtensorModule::get_weights_set_rate_limit(netuid);
+
+        assert!(tempo as u64 >= weights_set_rate_limit);
+    })
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1024,7 +1024,7 @@ impl pallet_commitments::Config for Runtime {
 }
 
 #[cfg(not(feature = "fast-blocks"))]
-pub const INITIAL_SUBNET_TEMPO: u16 = 99;
+pub const INITIAL_SUBNET_TEMPO: u16 = 360;
 
 #[cfg(feature = "fast-blocks")]
 pub const INITIAL_SUBNET_TEMPO: u16 = 10;


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
Changes the initial tempo to `360` from `99`.

Adds a test to ensure the default tempo is greater than the default weight-set rate limit

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.