### PR TITLE
add root set sn moving alpha

### DIFF
--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -28,8 +28,8 @@ pub mod pallet {
     use frame_support::{dispatch::DispatchResult, pallet_prelude::StorageMap};
     use frame_system::pallet_prelude::*;
     use pallet_evm_chain_id::{self, ChainId};
-	use substrate_fixed::types::I96F32;
     use sp_runtime::BoundedVec;
+    use substrate_fixed::types::I96F32;
 
     /// The main data structure of the module.
     #[pallet::pallet]
@@ -1379,7 +1379,7 @@ pub mod pallet {
             Ok(())
         }
 
-		///
+        ///
         ///
         /// # Arguments
         /// * `origin` - The origin of the call, which must be the root account.
@@ -1393,15 +1393,12 @@ pub mod pallet {
         /// Weight is handled by the `#[pallet::weight]` attribute.
         #[pallet::call_index(63)]
         #[pallet::weight((0, DispatchClass::Operational, Pays::No))]
-        pub fn sudo_set_subnet_moving_alpha(
-            origin: OriginFor<T>,
-			alpha: I96F32,
-        ) -> DispatchResult {
+        pub fn sudo_set_subnet_moving_alpha(origin: OriginFor<T>, alpha: I96F32) -> DispatchResult {
             ensure_root(origin)?;
-			let alpha: I96F32 = I96F32::saturating_from_num(alpha);
+            let alpha: I96F32 = I96F32::saturating_from_num(alpha);
             pallet_subtensor::SubnetMovingAlpha::<T>::set(alpha);
 
-			log::debug!("SubnetMovingAlphaSet( alpha: {:?} )", alpha);
+            log::debug!("SubnetMovingAlphaSet( alpha: {:?} )", alpha);
             Ok(())
         }
     }

--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -28,6 +28,7 @@ pub mod pallet {
     use frame_support::{dispatch::DispatchResult, pallet_prelude::StorageMap};
     use frame_system::pallet_prelude::*;
     use pallet_evm_chain_id::{self, ChainId};
+	use substrate_fixed::types::I96F32;
     use sp_runtime::BoundedVec;
 
     /// The main data structure of the module.
@@ -1375,6 +1376,32 @@ pub mod pallet {
                     enabled,
                 });
             }
+            Ok(())
+        }
+
+		///
+        ///
+        /// # Arguments
+        /// * `origin` - The origin of the call, which must be the root account.
+        /// * `precompile_id` - The identifier of the EVM precompile to toggle.
+        /// * `enabled` - The new enablement state of the precompile.
+        ///
+        /// # Errors
+        /// * `BadOrigin` - If the caller is not the root account.
+        ///
+        /// # Weight
+        /// Weight is handled by the `#[pallet::weight]` attribute.
+        #[pallet::call_index(63)]
+        #[pallet::weight((0, DispatchClass::Operational, Pays::No))]
+        pub fn sudo_set_subnet_moving_alpha(
+            origin: OriginFor<T>,
+			alpha: I96F32,
+        ) -> DispatchResult {
+            ensure_root(origin)?;
+			let alpha: I96F32 = I96F32::saturating_from_num(alpha);
+            pallet_subtensor::SubnetMovingAlpha::<T>::set(alpha);
+
+			log::debug!("SubnetMovingAlphaSet( alpha: {:?} )", alpha);
             Ok(())
         }
     }

--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -1395,7 +1395,6 @@ pub mod pallet {
         #[pallet::weight((0, DispatchClass::Operational, Pays::No))]
         pub fn sudo_set_subnet_moving_alpha(origin: OriginFor<T>, alpha: I96F32) -> DispatchResult {
             ensure_root(origin)?;
-            let alpha: I96F32 = I96F32::saturating_from_num(alpha);
             pallet_subtensor::SubnetMovingAlpha::<T>::set(alpha);
 
             log::debug!("SubnetMovingAlphaSet( alpha: {:?} )", alpha);

--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -10,6 +10,7 @@ use pallet_subtensor::Error as SubtensorError;
 use pallet_subtensor::Event;
 use sp_consensus_grandpa::AuthorityId as GrandpaId;
 use sp_core::{Pair, U256, ed25519};
+use substrate_fixed::types::I96F32;
 
 use crate::Error;
 use crate::pallet::PrecompileEnable;
@@ -1447,5 +1448,20 @@ fn test_sudo_toggle_evm_precompile() {
 
         let final_enabled = PrecompileEnable::<Test>::get(precompile_id);
         assert!(final_enabled);
+    });
+}
+
+#[test]
+fn test_sudo_root_sets_subnet_moving_alpha() {
+    new_test_ext().execute_with(|| {
+        let alpha: I96F32 = I96F32::saturating_from_num(0.5);
+        assert_eq!(pallet_subtensor::SubnetMovingAlpha::<Test>::get(), 0);
+
+        assert_ok!(AdminUtils::sudo_set_subnet_moving_alpha(
+            <<Test as Config>::RuntimeOrigin>::root(),
+            alpha
+        ));
+
+        assert_eq!(pallet_subtensor::SubnetMovingAlpha::<Test>::get(), alpha);
     });
 }

--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -1455,7 +1455,8 @@ fn test_sudo_toggle_evm_precompile() {
 fn test_sudo_root_sets_subnet_moving_alpha() {
     new_test_ext().execute_with(|| {
         let alpha: I96F32 = I96F32::saturating_from_num(0.5);
-        assert_eq!(pallet_subtensor::SubnetMovingAlpha::<Test>::get(), 0);
+        let initial = pallet_subtensor::SubnetMovingAlpha::<Test>::get();
+        assert!(initial != alpha);
 
         assert_ok!(AdminUtils::sudo_set_subnet_moving_alpha(
             <<Test as Config>::RuntimeOrigin>::root(),


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->

Adds a call for root to set the `SubnetMovingAlpha` term via `AdminUtils`



## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.