### PR TITLE
fix: rename rao_emission to alpha_emission

### DIFF
--- a/pallets/subtensor/src/epoch/run_epoch.rs
+++ b/pallets/subtensor/src/epoch/run_epoch.rs
@@ -360,9 +360,6 @@ impl<T: Config> Pallet<T> {
     ///  * 'alpha_emission': ( u64 ):
     ///     - The total emission for the epoch.
     ///
-    ///  * 'debug' ( bool ):
-    ///     - Print debugging outputs.
-    ///
     #[allow(clippy::indexing_slicing)]
     pub fn epoch(netuid: u16, alpha_emission: u64) -> Vec<(T::AccountId, u64, u64)> {
         // Get subnetwork size.

--- a/pallets/subtensor/src/epoch/run_epoch.rs
+++ b/pallets/subtensor/src/epoch/run_epoch.rs
@@ -357,14 +357,14 @@ impl<T: Config> Pallet<T> {
     ///  * 'netuid': ( u16 ):
     ///     - The network to distribute the emission onto.
     ///
-    ///  * 'rao_emission': ( u64 ):
+    ///  * 'alpha_emission': ( u64 ):
     ///     - The total emission for the epoch.
     ///
     ///  * 'debug' ( bool ):
     ///     - Print debugging outputs.
     ///
     #[allow(clippy::indexing_slicing)]
-    pub fn epoch(netuid: u16, rao_emission: u64) -> Vec<(T::AccountId, u64, u64)> {
+    pub fn epoch(netuid: u16, alpha_emission: u64) -> Vec<(T::AccountId, u64, u64)> {
         // Get subnetwork size.
         let n: u16 = Self::get_subnetwork_n(netuid);
         log::trace!("Number of Neurons in Network: {:?}", n);
@@ -601,12 +601,12 @@ impl<T: Config> Pallet<T> {
             }
         }
 
-        // Compute rao based emission scores. range: I96F32(0, rao_emission)
-        let float_rao_emission: I96F32 = I96F32::saturating_from_num(rao_emission);
+        // Compute rao based emission scores. range: I96F32(0, alpha_emission)
+        let float_alpha_emission: I96F32 = I96F32::saturating_from_num(alpha_emission);
 
         let server_emission: Vec<I96F32> = normalized_server_emission
             .iter()
-            .map(|se: &I32F32| I96F32::saturating_from_num(*se).saturating_mul(float_rao_emission))
+            .map(|se: &I32F32| I96F32::saturating_from_num(*se).saturating_mul(float_alpha_emission))
             .collect();
         let server_emission: Vec<u64> = server_emission
             .iter()
@@ -615,7 +615,7 @@ impl<T: Config> Pallet<T> {
 
         let validator_emission: Vec<I96F32> = normalized_validator_emission
             .iter()
-            .map(|ve: &I32F32| I96F32::saturating_from_num(*ve).saturating_mul(float_rao_emission))
+            .map(|ve: &I32F32| I96F32::saturating_from_num(*ve).saturating_mul(float_alpha_emission))
             .collect();
         let validator_emission: Vec<u64> = validator_emission
             .iter()
@@ -625,7 +625,7 @@ impl<T: Config> Pallet<T> {
         // Only used to track emission in storage.
         let combined_emission: Vec<I96F32> = normalized_combined_emission
             .iter()
-            .map(|ce: &I32F32| I96F32::saturating_from_num(*ce).saturating_mul(float_rao_emission))
+            .map(|ce: &I32F32| I96F32::saturating_from_num(*ce).saturating_mul(float_alpha_emission))
             .collect();
         let combined_emission: Vec<u64> = combined_emission
             .iter()


### PR DESCRIPTION
## Type of Change
I think name of the second argument for the following method should be updated because the emission is actually alpha emission.
```rust
pub fn epoch(netuid: u16, rao_emission: u64) -> Vec<(T::AccountId, u64, u64)>
```

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
