### PR TITLE
Feat/sn owner hotkey change

### DIFF
--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -1420,7 +1420,7 @@ pub mod pallet {
             hotkey: T::AccountId,
         ) -> DispatchResult {
             pallet_subtensor::Pallet::<T>::ensure_subnet_owner_or_root(origin.clone(), netuid)?;
-            pallet_subtensor::Pallet::<T>::set_subnet_owner_hotkey(netuid, hotkey);
+            pallet_subtensor::Pallet::<T>::set_subnet_owner_hotkey(netuid, &hotkey);
 
             log::debug!(
                 "SubnetOwnerHotkeySet( netuid: {:?}, hotkey: {:?} )",

--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -1403,7 +1403,7 @@ pub mod pallet {
         /// Change the SubnetOwnerHotkey for a given subnet.
         ///
         /// # Arguments
-        /// * `origin` - The origin of the call, which must be the root account.
+        /// * `origin` - The origin of the call, which must be the subnet owner.
         /// * `netuid` - The unique identifier for the subnet.
         /// * `hotkey` - The new hotkey for the subnet owner.
         ///
@@ -1419,7 +1419,7 @@ pub mod pallet {
             netuid: u16,
             hotkey: T::AccountId,
         ) -> DispatchResult {
-            pallet_subtensor::Pallet::<T>::ensure_subnet_owner_or_root(origin.clone(), netuid)?;
+            pallet_subtensor::Pallet::<T>::ensure_subnet_owner(origin.clone(), netuid)?;
             pallet_subtensor::Pallet::<T>::set_subnet_owner_hotkey(netuid, &hotkey);
 
             log::debug!(

--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -1399,6 +1399,36 @@ pub mod pallet {
             log::debug!("SubnetMovingAlphaSet( alpha: {:?} )", alpha);
             Ok(())
         }
+
+        /// Change the SubnetOwnerHotkey for a given subnet.
+        ///
+        /// # Arguments
+        /// * `origin` - The origin of the call, which must be the root account.
+        /// * `netuid` - The unique identifier for the subnet.
+        /// * `hotkey` - The new hotkey for the subnet owner.
+        ///
+        /// # Errors
+        /// * `BadOrigin` - If the caller is not the subnet owner or root account.
+        ///
+        /// # Weight
+        /// Weight is handled by the `#[pallet::weight]` attribute.
+        #[pallet::call_index(64)]
+        #[pallet::weight((0, DispatchClass::Operational, Pays::No))]
+        pub fn sudo_set_subnet_owner_hotkey(
+            origin: OriginFor<T>,
+            netuid: u16,
+            hotkey: T::AccountId,
+        ) -> DispatchResult {
+            pallet_subtensor::Pallet::<T>::ensure_subnet_owner_or_root(origin.clone(), netuid)?;
+            pallet_subtensor::Pallet::<T>::set_subnet_owner_hotkey(netuid, hotkey);
+
+            log::debug!(
+                "SubnetOwnerHotkeySet( netuid: {:?}, hotkey: {:?} )",
+                netuid,
+                hotkey
+            );
+            Ok(())
+        }
     }
 }
 

--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -1466,3 +1466,46 @@ fn test_sudo_root_sets_subnet_moving_alpha() {
         assert_eq!(pallet_subtensor::SubnetMovingAlpha::<Test>::get(), alpha);
     });
 }
+
+#[test]
+fn test_sudo_set_subnet_owner_hotkey() {
+    new_test_ext().execute_with(|| {
+        let netuid: u16 = 1;
+
+        let coldkey: U256 = U256::from(1);
+        let hotkey: U256 = U256::from(2);
+        let new_hotkey: U256 = U256::from(3);
+
+        let coldkey_origin = <<Test as Config>::RuntimeOrigin>::signed(coldkey);
+        let root = RuntimeOrigin::root();
+        let random_account = RuntimeOrigin::signed(U256::from(123456));
+
+        pallet_subtensor::SubnetOwner::<Test>::insert(netuid, coldkey);
+        pallet_subtensor::SubnetOwnerHotkey::<Test>::insert(netuid, hotkey);
+        assert_eq!(
+            pallet_subtensor::SubnetOwnerHotkey::<Test>::get(netuid),
+            hotkey
+        );
+
+        assert_ok!(AdminUtils::sudo_set_subnet_owner_hotkey(
+            coldkey_origin,
+            netuid,
+            new_hotkey
+        ));
+
+        assert_eq!(
+            pallet_subtensor::SubnetOwnerHotkey::<Test>::get(netuid),
+            new_hotkey
+        );
+
+        assert_noop!(
+            AdminUtils::sudo_set_subnet_owner_hotkey(random_account, netuid, new_hotkey),
+            DispatchError::BadOrigin
+        );
+
+        assert_noop!(
+            AdminUtils::sudo_set_subnet_owner_hotkey(root, netuid, new_hotkey),
+            DispatchError::BadOrigin
+        );
+    });
+}

--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -271,5 +271,11 @@ mod events {
         /// Parameters:
         /// (netuid, bool)
         TransferToggle(u16, bool),
+
+        /// The owner hotkey for a subnet has been set.
+        ///
+        /// Parameters:
+        /// (netuid, new_hotkey)
+        SubnetOwnerHotkeySet(u16, T::AccountId),
     }
 }

--- a/pallets/subtensor/src/utils/misc.rs
+++ b/pallets/subtensor/src/utils/misc.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
     Error,
-    system::{ensure_root, ensure_signed_or_root, pallet_prelude::BlockNumberFor},
+    system::{ensure_root, ensure_signed, ensure_signed_or_root, pallet_prelude::BlockNumberFor},
 };
 use safe_math::*;
 use sp_core::Get;
@@ -19,6 +19,15 @@ impl<T: Config> Pallet<T> {
             Ok(Some(who)) if SubnetOwner::<T>::get(netuid) == who => Ok(()),
             Ok(Some(_)) => Err(DispatchError::BadOrigin),
             Ok(None) => Ok(()),
+            Err(x) => Err(x.into()),
+        }
+    }
+
+    pub fn ensure_subnet_owner(o: T::RuntimeOrigin, netuid: u16) -> Result<(), DispatchError> {
+        let coldkey = ensure_signed(o);
+        match coldkey {
+            Ok(who) if SubnetOwner::<T>::get(netuid) == who => Ok(()),
+            Ok(_) => Err(DispatchError::BadOrigin),
             Err(x) => Err(x.into()),
         }
     }

--- a/pallets/subtensor/src/utils/misc.rs
+++ b/pallets/subtensor/src/utils/misc.rs
@@ -744,8 +744,19 @@ impl<T: Config> Pallet<T> {
         Self::deposit_event(Event::DissolveNetworkScheduleDurationSet(duration));
     }
 
-    pub fn set_subnet_owner_hotkey(netuid: u16, hotkey: T::AccountId) {
-        SubnetOwnerHotkey::<T>::insert(netuid, hotkey);
-        Self::deposit_event(Event::SubnetOwnerHotkeySet(netuid, hotkey));
+    /// Set the owner hotkey for a subnet.
+    ///
+    /// # Arguments
+    ///
+    /// * `netuid` - The unique identifier for the subnet.
+    /// * `hotkey` - The new hotkey for the subnet owner.
+    ///
+    /// # Effects
+    ///
+    /// * Update the SubnetOwnerHotkey storage.
+    /// * Emits a SubnetOwnerHotkeySet event.
+    pub fn set_subnet_owner_hotkey(netuid: u16, hotkey: &T::AccountId) {
+        SubnetOwnerHotkey::<T>::insert(netuid, hotkey.clone());
+        Self::deposit_event(Event::SubnetOwnerHotkeySet(netuid, hotkey.clone()));
     }
 }

--- a/pallets/subtensor/src/utils/misc.rs
+++ b/pallets/subtensor/src/utils/misc.rs
@@ -743,4 +743,9 @@ impl<T: Config> Pallet<T> {
         DissolveNetworkScheduleDuration::<T>::set(duration);
         Self::deposit_event(Event::DissolveNetworkScheduleDurationSet(duration));
     }
+
+    pub fn set_subnet_owner_hotkey(netuid: u16, hotkey: T::AccountId) {
+        SubnetOwnerHotkey::<T>::insert(netuid, hotkey);
+        Self::deposit_event(Event::SubnetOwnerHotkeySet(netuid, hotkey));
+    }
 }


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
Allow the SN Owner to set the `SubnetOwnerHotkey` storage.

Note: this *does not* swap the hotkey. It *only* updates the storage value.

## Related Issue(s)

- Closes #1344 

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.