### PR TITLE
don't use abs directly

### DIFF
--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -546,8 +546,12 @@ impl<T: Config> Pallet<T> {
         amount: u64,
     ) -> u64 {
         let mut alpha_share_pool = Self::get_alpha_share_pool(hotkey.clone(), netuid);
+        // We expect to add a positive amount here.
         let actual_alpha = alpha_share_pool.update_value_for_one(coldkey, amount as i64);
-        actual_alpha.unsigned_abs()
+
+        // We should return a positive amount, or 0 if the operation failed.
+        // e.g. the stake was removed due to precision issues.
+        actual_alpha.max(0).unsigned_abs()
     }
 
     pub fn try_increase_stake_for_hotkey_and_coldkey_on_subnet(
@@ -576,6 +580,8 @@ impl<T: Config> Pallet<T> {
         amount: u64,
     ) -> u64 {
         let mut alpha_share_pool = Self::get_alpha_share_pool(hotkey.clone(), netuid);
+
+        // We expect a negative value here
         let mut actual_alpha = 0;
         if let Ok(value) = alpha_share_pool.try_get_value(coldkey) {
             if value >= amount {
@@ -583,7 +589,11 @@ impl<T: Config> Pallet<T> {
                     alpha_share_pool.update_value_for_one(coldkey, (amount as i64).neg());
             }
         }
-        actual_alpha.unsigned_abs()
+
+        // Get the negation of the removed alpha, and clamp at 0.
+        // This ensures we return a positive value, but only if
+        // `actual_alpha` was negative (i.e. a decrease in stake).
+        actual_alpha.neg().max(0).unsigned_abs()
     }
 
     /// Calculates Some(Alpha) returned from pool by staking operation


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
Avoids the direcet use of `unsigned_abs` for stake-pool functions, which could be problematic.

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.