### PR TITLE
use smaller DefaultPendingCooldown for fast-blocks

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -728,6 +728,10 @@ pub mod pallet {
     #[pallet::type_value]
     /// Default value for applying pending items (e.g. childkeys).
     pub fn DefaultPendingCooldown<T: Config>() -> u64 {
+        if cfg!(feature = "fast-blocks") {
+            return 15;
+        }
+
         7_200
     }
 

--- a/pallets/subtensor/src/tests/children.rs
+++ b/pallets/subtensor/src/tests/children.rs
@@ -3953,6 +3953,13 @@ fn test_dividend_distribution_with_children_same_coldkey_owner() {
 #[test]
 fn test_pending_cooldown_one_day() {
     let curr_block = 1;
+
+    let expected_cooldown = if cfg!(feature = "fast-blocks") {
+        15
+    } else {
+        7_200
+    };
+
     new_test_ext(curr_block).execute_with(|| {
         let coldkey = U256::from(1);
         let hotkey = U256::from(2);
@@ -3980,6 +3987,6 @@ fn test_pending_cooldown_one_day() {
             pending_children.0,
             vec![(proportion1, child1), (proportion2, child2)]
         );
-        assert_eq!(pending_children.1, curr_block + 7_200);
+        assert_eq!(pending_children.1, curr_block + expected_cooldown);
     });
 }

--- a/pallets/subtensor/src/tests/children.rs
+++ b/pallets/subtensor/src/tests/children.rs
@@ -3949,3 +3949,29 @@ fn test_dividend_distribution_with_children_same_coldkey_owner() {
         );
     });
 }
+
+#[test]
+fn test_pending_cooldown_one_day() {
+	let curr_block = 1;
+    new_test_ext(curr_block).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let child1 = U256::from(3);
+        let child2 = U256::from(4);
+        let netuid: u16 = 1;
+        let proportion1: u64 = 1000;
+        let proportion2: u64 = 2000;
+
+        // Add network and register hotkey
+        add_network(netuid, 13, 0);
+        register_ok_neuron(netuid, hotkey, coldkey, 0);
+
+        // Set multiple children
+        mock_schedule_children(&coldkey, &hotkey, netuid, &[(proportion1, child1), (proportion2, child2)]);
+
+        // Verify pending map
+		let pending_children = PendingChildKeys::<Test>::get(netuid, hotkey);
+		assert_eq!(pending_children.0, vec![(proportion1, child1), (proportion2, child2)]);
+		assert_eq!(pending_children.1, curr_block + 7_200);
+    });
+}

--- a/pallets/subtensor/src/tests/children.rs
+++ b/pallets/subtensor/src/tests/children.rs
@@ -3952,7 +3952,7 @@ fn test_dividend_distribution_with_children_same_coldkey_owner() {
 
 #[test]
 fn test_pending_cooldown_one_day() {
-	let curr_block = 1;
+    let curr_block = 1;
     new_test_ext(curr_block).execute_with(|| {
         let coldkey = U256::from(1);
         let hotkey = U256::from(2);
@@ -3967,11 +3967,19 @@ fn test_pending_cooldown_one_day() {
         register_ok_neuron(netuid, hotkey, coldkey, 0);
 
         // Set multiple children
-        mock_schedule_children(&coldkey, &hotkey, netuid, &[(proportion1, child1), (proportion2, child2)]);
+        mock_schedule_children(
+            &coldkey,
+            &hotkey,
+            netuid,
+            &[(proportion1, child1), (proportion2, child2)],
+        );
 
         // Verify pending map
-		let pending_children = PendingChildKeys::<Test>::get(netuid, hotkey);
-		assert_eq!(pending_children.0, vec![(proportion1, child1), (proportion2, child2)]);
-		assert_eq!(pending_children.1, curr_block + 7_200);
+        let pending_children = PendingChildKeys::<Test>::get(netuid, hotkey);
+        assert_eq!(
+            pending_children.0,
+            vec![(proportion1, child1), (proportion2, child2)]
+        );
+        assert_eq!(pending_children.1, curr_block + 7_200);
     });
 }


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
Adds a check for `fast-blocks` feature to the `DefaultPendingCooldown` value so e2e tests can run faster.

## Related Issue(s)

- Closes #1367 

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.