### PR TITLE
call `validate` in `pre_dispatch` to have same validations 

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -2207,9 +2207,13 @@ where
         self,
         who: &Self::AccountId,
         call: &Self::Call,
-        _info: &DispatchInfoOf<Self::Call>,
-        _len: usize,
+        info: &DispatchInfoOf<Self::Call>,
+        len: usize,
     ) -> Result<Self::Pre, TransactionValidityError> {
+        // We need to perform same checks as Self::validate so that
+        // the validation is performed during Executive::apply_extrinsic as well.
+        // this prevents inclusion of invalid tx in a block by malicious block author.
+        self.validate(who, call, info, len)?;
         match call.is_sub_type() {
             Some(Call::add_stake { .. }) => {
                 let transaction_fee = 100000;


### PR DESCRIPTION
## Description
This PR fixes a bug in the runtime which can allow malicious block author to include invalid txs in a block. It fixes the issue by doing the same checks as `validate` in `pre_dispatch` method of `SubtensorSignedExtension`.

The inclusion of same checks in `pre_dispatch` mean that the checks are being run during `Executive::apply_extrinsic` when the block is being executed against the current state.

## Related Issue(s)

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

## Additional Notes
