### PR TITLE
Add `#[precompile::view]` attribute to `getTotalColdkeyStake` and `getTotalHotkeyStake`

### DIFF
--- a/precompiles/src/staking.rs
+++ b/precompiles/src/staking.rs
@@ -275,6 +275,7 @@ where
     }
 
     #[precompile::public("getTotalColdkeyStake(bytes32)")]
+    #[precompile::view]
     fn get_total_coldkey_stake(
         _handle: &mut impl PrecompileHandle,
         coldkey: H256,
@@ -292,6 +293,7 @@ where
     }
 
     #[precompile::public("getTotalHotkeyStake(bytes32)")]
+    #[precompile::view]
     fn get_total_hotkey_stake(
         _handle: &mut impl PrecompileHandle,
         hotkey: H256,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -205,7 +205,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 246,
+    spec_version: 247,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
- added view attribute to getTotalColdkeyStake and getTotalHotkeyStake functions

## Description
These functions in the staking precompile ([which I added, and also got recently merged in](https://github.com/opentensor/subtensor/pull/1159) 😭) cannot be called from within static contexts (i.e. `view` and `pure`) functions, even though they do not actually modify state. This PR addresses this issue.

## Related Issue(s)

- Closes #1345

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules