### PR TITLE
Burn miner emission to SNOwner hotkey

### DIFF
--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -375,8 +375,19 @@ impl<T: Config> Pallet<T> {
 
         // Distribute mining incentives.
         for (hotkey, incentive) in incentives {
-            // Increase stake for miner.
             log::debug!("incentives: hotkey: {:?}", incentive);
+
+            if let Ok(owner_hotkey) = SubnetOwnerHotkey::<T>::try_get(netuid) {
+                if hotkey == owner_hotkey {
+                    log::debug!(
+                        "incentives: hotkey: {:?} is SN owner hotkey, skipping {:?}",
+                        hotkey,
+                        incentive
+                    );
+                    continue; // Skip/burn miner-emission for SN owner hotkey.
+                }
+            }
+            // Increase stake for miner.
             Self::increase_stake_for_hotkey_and_coldkey_on_subnet(
                 &hotkey.clone(),
                 &Owner::<T>::get(hotkey.clone()),

--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -266,8 +266,6 @@ impl<T: Config> Pallet<T> {
             pending_swapped,
             owner_cut
         );
-        // Setup.
-        let zero: I96F32 = asfloat!(0.0);
 
         // Run the epoch.
         let hotkey_emission: Vec<(T::AccountId, u64, u64)> =
@@ -296,6 +294,25 @@ impl<T: Config> Pallet<T> {
         }
         log::debug!("incentives: {:?}", incentives);
         log::debug!("dividends: {:?}", dividends);
+
+        Self::distribute_dividends_and_incentives(
+            netuid,
+            pending_tao,
+            owner_cut,
+            incentives,
+            dividends,
+        );
+    }
+
+    pub fn distribute_dividends_and_incentives(
+        netuid: u16,
+        pending_tao: u64,
+        owner_cut: u64,
+        incentives: BTreeMap<T::AccountId, u64>,
+        dividends: BTreeMap<T::AccountId, I96F32>,
+    ) {
+        // Setup.
+        let zero: I96F32 = asfloat!(0.0);
 
         // Accumulate root divs and alpha_divs. For each hotkey we compute their
         // local and root dividend proportion based on their alpha_stake/root_stake

--- a/pallets/subtensor/src/epoch/math.rs
+++ b/pallets/subtensor/src/epoch/math.rs
@@ -604,6 +604,22 @@ pub fn mask_diag_sparse(sparse_matrix: &[Vec<(u16, I32F32)>]) -> Vec<Vec<(u16, I
         .collect()
 }
 
+// Return a new sparse matrix with a masked out diagonal of input sparse matrix,
+// except for the diagonal entry at except_index.
+#[allow(dead_code)]
+pub fn mask_diag_sparse_except_index(
+    sparse_matrix: &[Vec<(u16, I32F32)>],
+    except_index: u16,
+) -> Vec<Vec<(u16, I32F32)>> {
+    // Store the diagonal entry at except_index
+    let diag_at_index = sparse_matrix[except_index as usize][except_index as usize].clone();
+    // Mask out the diagonal
+    let mut result = mask_diag_sparse(sparse_matrix);
+    // Replace the diagonal entry at except_index
+    result[except_index as usize][except_index as usize] = diag_at_index;
+    result
+}
+
 // Remove cells from sparse matrix where the mask function of two vectors is true.
 #[allow(dead_code, clippy::indexing_slicing)]
 pub fn vec_mask_sparse_matrix(

--- a/pallets/subtensor/src/epoch/math.rs
+++ b/pallets/subtensor/src/epoch/math.rs
@@ -569,6 +569,33 @@ pub fn inplace_mask_diag(matrix: &mut [Vec<I32F32>]) {
     });
 }
 
+// Mask out the diagonal of the input matrix in-place, except for the diagonal entry at except_index.
+#[allow(dead_code)]
+pub fn inplace_mask_diag_except_index(matrix: &mut [Vec<I32F32>], except_index: u16) {
+    let Some(first_row) = matrix.first() else {
+        return;
+    };
+    if first_row.is_empty() {
+        return;
+    }
+    assert_eq!(matrix.len(), first_row.len());
+
+    let diag_at_index = matrix
+        .get(except_index as usize)
+        .and_then(|row| row.get(except_index as usize))
+        .cloned();
+
+    inplace_mask_diag(matrix);
+
+    matrix.get_mut(except_index as usize).map(|row| {
+        row.get_mut(except_index as usize).map(|value| {
+            if let Some(diag_at_index) = diag_at_index {
+                *value = diag_at_index;
+            }
+        })
+    });
+}
+
 // Return a new sparse matrix that replaces masked rows with an empty vector placeholder.
 #[allow(dead_code)]
 pub fn mask_rows_sparse(
@@ -611,23 +638,20 @@ pub fn mask_diag_sparse_except_index(
     sparse_matrix: &[Vec<(u16, I32F32)>],
     except_index: u16,
 ) -> Vec<Vec<(u16, I32F32)>> {
-    // Store the diagonal entry at except_index
-    let diag_at_index = sparse_matrix
-        .get(except_index as usize)
-        .and_then(|row| row.get(except_index as usize))
-        .cloned();
-    // Mask out the diagonal
-    let mut result = mask_diag_sparse(sparse_matrix);
-    // Replace the diagonal entry at except_index using only get_mut or map
-    result.get_mut(except_index as usize).map(|row| {
-        row.get_mut(except_index as usize).map(|value| {
-            if let Some(diag_at_index) = diag_at_index {
-                *value = diag_at_index;
-            }
+    sparse_matrix
+        .iter()
+        .enumerate()
+        .map(|(i, sparse_row)| {
+            sparse_row
+                .iter()
+                .filter(|(j, _)| {
+                    // Is not a diagonal OR is the diagonal at except_index
+                    i != (*j as usize) || (i == except_index as usize && *j == except_index)
+                })
+                .copied()
+                .collect()
         })
-    });
-
-    result
+        .collect()
 }
 
 // Remove cells from sparse matrix where the mask function of two vectors is true.

--- a/pallets/subtensor/src/epoch/math.rs
+++ b/pallets/subtensor/src/epoch/math.rs
@@ -612,11 +612,21 @@ pub fn mask_diag_sparse_except_index(
     except_index: u16,
 ) -> Vec<Vec<(u16, I32F32)>> {
     // Store the diagonal entry at except_index
-    let diag_at_index = sparse_matrix[except_index as usize][except_index as usize].clone();
+    let diag_at_index = sparse_matrix
+        .get(except_index as usize)
+        .and_then(|row| row.get(except_index as usize))
+        .cloned();
     // Mask out the diagonal
     let mut result = mask_diag_sparse(sparse_matrix);
-    // Replace the diagonal entry at except_index
-    result[except_index as usize][except_index as usize] = diag_at_index;
+    // Replace the diagonal entry at except_index using only get_mut or map
+    result.get_mut(except_index as usize).map(|row| {
+        row.get_mut(except_index as usize).map(|value| {
+            if let Some(diag_at_index) = diag_at_index {
+                *value = diag_at_index;
+            }
+        })
+    });
+
     result
 }
 

--- a/pallets/subtensor/src/epoch/run_epoch.rs
+++ b/pallets/subtensor/src/epoch/run_epoch.rs
@@ -111,6 +111,9 @@ impl<T: Config> Pallet<T> {
         // == Weights ==
         // =============
 
+        // Get owner uid.
+        let owner_uid: Option<u16> = Self::get_owner_uid(netuid);
+
         // Access network weights row unnormalized.
         let mut weights: Vec<Vec<I32F32>> = Self::get_weights(netuid);
         log::trace!("W:\n{:?}\n", &weights);
@@ -119,7 +122,13 @@ impl<T: Config> Pallet<T> {
         inplace_mask_rows(&validator_forbids, &mut weights);
         log::trace!("W (permit): {:?}", &weights);
 
-        // Remove self-weight by masking diagonal.
+        // Remove self-weight by masking diagonal; keep owner_uid self-weight.
+        if let Some(owner_uid) = owner_uid {
+            inplace_mask_diag_except_index(&mut weights, owner_uid);
+        } else {
+            inplace_mask_diag(&mut weights);
+        }
+
         inplace_mask_diag(&mut weights);
         log::trace!("W (permit+diag):\n{:?}\n", &weights);
 

--- a/pallets/subtensor/src/tests/math.rs
+++ b/pallets/subtensor/src/tests/math.rs
@@ -58,7 +58,13 @@ fn assert_sparse_mat_compare(
 ) {
     assert!(ma.len() == mb.len());
     for row in 0..ma.len() {
-        assert!(ma[row].len() == mb[row].len());
+        assert!(
+            ma[row].len() == mb[row].len(),
+            "row: {}, ma: {:?}, mb: {:?}",
+            row,
+            ma[row],
+            mb[row]
+        );
         for j in 0..ma[row].len() {
             assert!(ma[row][j].0 == mb[row][j].0); // u16
             assert_float_compare(ma[row][j].1, mb[row][j].1, epsilon) // I32F32
@@ -1035,6 +1041,27 @@ fn test_math_inplace_mask_diag() {
 }
 
 #[test]
+fn test_math_inplace_mask_diag_except_index() {
+    let vector: Vec<f32> = vec![1., 2., 3., 4., 5., 6., 7., 8., 9.];
+    let rows = 3;
+
+    for i in 0..rows {
+        let mut target: Vec<f32> = vec![0., 2., 3., 4., 0., 6., 7., 8., 0.];
+        let row = i * rows;
+        let col = i;
+        target[row + col] = vector[row + col];
+
+        let mut mat = vec_to_mat_fixed(&vector, rows, false);
+        inplace_mask_diag_except_index(&mut mat, i as u16);
+        assert_mat_compare(
+            &mat,
+            &vec_to_mat_fixed(&target, rows, false),
+            I32F32::from_num(0),
+        );
+    }
+}
+
+#[test]
 fn test_math_mask_rows_sparse() {
     let input: Vec<f32> = vec![1., 2., 3., 4., 5., 6., 7., 8., 9.];
     let mat = vec_to_sparse_mat_fixed(&input, 3, false);
@@ -1103,6 +1130,58 @@ fn test_math_mask_diag_sparse() {
         &vec_to_sparse_mat_fixed(&target, 3, false),
         I32F32::from_num(0),
     );
+}
+
+#[test]
+fn test_math_mask_diag_sparse_except_index() {
+    let rows = 3;
+
+    let vector: Vec<f32> = vec![1., 2., 3., 4., 5., 6., 7., 8., 9.];
+    let mat = vec_to_sparse_mat_fixed(&vector, rows, false);
+
+    for i in 0..rows {
+        let mut target: Vec<f32> = vec![0., 2., 3., 4., 0., 6., 7., 8., 0.];
+        let row = i * rows;
+        let col = i;
+        target[row + col] = vector[row + col];
+
+        let result = mask_diag_sparse_except_index(&mat, i as u16);
+        let target_as_mat = vec_to_sparse_mat_fixed(&target, rows, false);
+
+        assert_sparse_mat_compare(&result, &target_as_mat, I32F32::from_num(0));
+    }
+
+    let vector: Vec<f32> = vec![1., 0., 0., 0., 5., 0., 0., 0., 9.];
+    let mat = vec_to_sparse_mat_fixed(&vector, rows, false);
+
+    for i in 0..rows {
+        let mut target: Vec<f32> = vec![0., 0., 0., 0., 0., 0., 0., 0., 0.];
+        let row = i * rows;
+        let col = i;
+        target[row + col] = vector[row + col];
+
+        let result = mask_diag_sparse_except_index(&mat, i as u16);
+        let target_as_mat = vec_to_sparse_mat_fixed(&target, rows, false);
+        assert_eq!(result.len(), target_as_mat.len());
+
+        assert_sparse_mat_compare(&result, &target_as_mat, I32F32::from_num(0));
+    }
+
+    for i in 0..rows {
+        let vector: Vec<f32> = vec![0., 0., 0., 0., 0., 0., 0., 0., 0.];
+        let mat = vec_to_sparse_mat_fixed(&vector, rows, false);
+
+        let mut target: Vec<f32> = vec![0., 0., 0., 0., 0., 0., 0., 0., 0.];
+        let row = i * rows;
+        let col = i;
+        target[row + col] = vector[row + col];
+
+        let result = mask_diag_sparse_except_index(&mat, i as u16);
+        let target_as_mat = vec_to_sparse_mat_fixed(&target, rows, false);
+        assert_eq!(result.len(), target_as_mat.len());
+
+        assert_sparse_mat_compare(&result, &target_as_mat, I32F32::from_num(0));
+    }
 }
 
 #[test]

--- a/pallets/subtensor/src/utils/misc.rs
+++ b/pallets/subtensor/src/utils/misc.rs
@@ -736,11 +736,9 @@ impl<T: Config> Pallet<T> {
 
     // Get the uid of the Owner Hotkey for a subnet.
     pub fn get_owner_uid(netuid: u16) -> Option<u16> {
-        let owner_hotkey = SubnetOwnerHotkey::<T>::get(netuid);
-        if Uids::<T>::contains_key(netuid, &owner_hotkey) {
-            Some(Uids::<T>::get(netuid, &owner_hotkey))
-        } else {
-            None
+        match SubnetOwnerHotkey::<T>::try_get(netuid) {
+            Ok(owner_hotkey) => Uids::<T>::get(netuid, &owner_hotkey),
+            Err(_) => None,
         }
     }
 }

--- a/pallets/subtensor/src/utils/misc.rs
+++ b/pallets/subtensor/src/utils/misc.rs
@@ -733,4 +733,14 @@ impl<T: Config> Pallet<T> {
         SubnetOwnerHotkey::<T>::insert(netuid, hotkey.clone());
         Self::deposit_event(Event::SubnetOwnerHotkeySet(netuid, hotkey.clone()));
     }
+
+    // Get the uid of the Owner Hotkey for a subnet.
+    pub fn get_owner_uid(netuid: u16) -> Option<u16> {
+        let owner_hotkey = SubnetOwnerHotkey::<T>::get(netuid);
+        if Uids::<T>::contains_key(netuid, &owner_hotkey) {
+            Some(Uids::<T>::get(netuid, &owner_hotkey))
+        } else {
+            None
+        }
+    }
 }


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
Burns the miner emission sent to the SNOwner hotkey.  
This also allows the SNOwner hotkey to set a self-weight.

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.