### PR TITLE
Fix limit swap

### DIFF
--- a/pallets/subtensor/src/staking/move_stake.rs
+++ b/pallets/subtensor/src/staking/move_stake.rs
@@ -330,13 +330,20 @@ impl<T: Config> Pallet<T> {
             check_transfer_toggle,
         )?;
 
+        // Calculate the amount that should be moved in this operation
+        let move_amount = if alpha_amount < max_amount {
+            alpha_amount
+        } else {
+            max_amount
+        };
+
         // Unstake from the origin subnet, returning TAO (or a 1:1 equivalent).
         let fee = DefaultStakingFee::<T>::get().safe_div(2);
         let tao_unstaked = Self::unstake_from_subnet(
             origin_hotkey,
             origin_coldkey,
             origin_netuid,
-            alpha_amount,
+            move_amount,
             fee,
         );
 


### PR DESCRIPTION
## Description
Fix limit swap: It currently moves the full amount instead of slippage-safe amount in case if partial flag is enabled.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
