### PR TITLE
Feat/rate limit set weights version key

### DIFF
--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -260,29 +260,26 @@ pub mod pallet {
                 Error::<T>::SubnetDoesNotExist
             );
 
-            match origin.into() {
-                Ok(RawOrigin::Signed(who)) => {
-                    // SN Owner
-                    // Ensure the origin passes the rate limit.
-                    ensure!(
-                        pallet_subtensor::Pallet::<T>::passes_rate_limit_on_subnet(
-                            &TransactionType::SetWeightsVersionKey,
-                            &who,
-                            netuid,
-                        ),
-                        pallet_subtensor::Error::<T>::TxRateLimitExceeded
-                    );
-
-                    // Set last transaction block
-                    let current_block = pallet_subtensor::Pallet::<T>::get_current_block_as_u64();
-                    pallet_subtensor::Pallet::<T>::set_last_transaction_block_on_subnet(
+            if let Ok(RawOrigin::Signed(who)) = origin.into() {
+                // SN Owner
+                // Ensure the origin passes the rate limit.
+                ensure!(
+                    pallet_subtensor::Pallet::<T>::passes_rate_limit_on_subnet(
+                        &TransactionType::SetWeightsVersionKey,
                         &who,
                         netuid,
-                        &TransactionType::SetWeightsVersionKey,
-                        current_block,
-                    );
-                }
-                _ => (),
+                    ),
+                    pallet_subtensor::Error::<T>::TxRateLimitExceeded
+                );
+
+                // Set last transaction block
+                let current_block = pallet_subtensor::Pallet::<T>::get_current_block_as_u64();
+                pallet_subtensor::Pallet::<T>::set_last_transaction_block_on_subnet(
+                    &who,
+                    netuid,
+                    &TransactionType::SetWeightsVersionKey,
+                    current_block,
+                );
             }
 
             pallet_subtensor::Pallet::<T>::set_weights_version_key(netuid, weights_version_key);

--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -171,9 +171,8 @@ fn test_sudo_set_weights_version_key_rate_limit() {
         let sn_owner = U256::from(1);
         add_network(netuid, 10);
         // Set the Subnet Owner
-        SubnetOwner::insert(netuid, sn_owner);
+        SubnetOwner::<Test>::insert(netuid, sn_owner);
 
-        let init_value: u64 = SubtensorModule::get_weights_version_key(netuid);
         let rate_limit = WeightsVersionKeyRateLimit::<Test>::get();
         let tempo: u16 = Tempo::<Test>::get(netuid);
 
@@ -189,7 +188,7 @@ fn test_sudo_set_weights_version_key_rate_limit() {
         // Try to set again with
         // Assert rate limit not passed
         assert!(SubtensorModule::passes_rate_limit_on_subnet(
-            &TransactionType::SetWeightsVersionKey,
+            &pallet_subtensor::utils::rate_limiting::TransactionType::SetWeightsVersionKey,
             &sn_owner,
             netuid
         ));
@@ -201,13 +200,13 @@ fn test_sudo_set_weights_version_key_rate_limit() {
                 netuid,
                 to_be_set + 1
             ),
-            Error::<Test>::TxRateLimitExceeded
+            pallet_subtensor::Error::<Test>::TxRateLimitExceeded
         );
 
         // Wait for rate limit to pass
         run_to_block(rate_limit_period + 2);
         assert!(SubtensorModule::passes_rate_limit_on_subnet(
-            &TransactionType::SetWeightsVersionKey,
+            &pallet_subtensor::utils::rate_limiting::TransactionType::SetWeightsVersionKey,
             &sn_owner,
             netuid
         ));

--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -187,7 +187,7 @@ fn test_sudo_set_weights_version_key_rate_limit() {
 
         // Try to set again with
         // Assert rate limit not passed
-        assert!(SubtensorModule::passes_rate_limit_on_subnet(
+        assert!(!SubtensorModule::passes_rate_limit_on_subnet(
             &pallet_subtensor::utils::rate_limiting::TransactionType::SetWeightsVersionKey,
             &sn_owner,
             netuid

--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -5,7 +5,7 @@ use frame_support::{
     traits::Hooks,
 };
 use frame_system::Config;
-use pallet_subtensor::Error as SubtensorError;
+use pallet_subtensor::{Error as SubtensorError, SubnetOwner, Tempo, WeightsVersionKeyRateLimit};
 // use pallet_subtensor::{migrations, Event};
 use pallet_subtensor::Event;
 use sp_consensus_grandpa::AuthorityId as GrandpaId;
@@ -159,6 +159,69 @@ fn test_sudo_set_weights_version_key() {
             to_be_set
         ));
         assert_eq!(SubtensorModule::get_weights_version_key(netuid), to_be_set);
+    });
+}
+
+#[test]
+fn test_sudo_set_weights_version_key_rate_limit() {
+    new_test_ext().execute_with(|| {
+        let netuid: u16 = 1;
+        let to_be_set: u64 = 10;
+
+        let sn_owner = U256::from(1);
+        add_network(netuid, 10);
+        // Set the Subnet Owner
+        SubnetOwner::insert(netuid, sn_owner);
+
+        let init_value: u64 = SubtensorModule::get_weights_version_key(netuid);
+        let rate_limit = WeightsVersionKeyRateLimit::<Test>::get();
+        let tempo: u16 = Tempo::<Test>::get(netuid);
+
+        let rate_limit_period = rate_limit * (tempo as u64);
+
+        assert_ok!(AdminUtils::sudo_set_weights_version_key(
+            <<Test as Config>::RuntimeOrigin>::signed(sn_owner),
+            netuid,
+            to_be_set
+        ));
+        assert_eq!(SubtensorModule::get_weights_version_key(netuid), to_be_set);
+
+        // Try to set again with
+        // Assert rate limit not passed
+        assert!(SubtensorModule::passes_rate_limit_on_subnet(
+            &TransactionType::SetWeightsVersionKey,
+            &sn_owner,
+            netuid
+        ));
+
+        // Try transaction
+        assert_noop!(
+            AdminUtils::sudo_set_weights_version_key(
+                <<Test as Config>::RuntimeOrigin>::signed(sn_owner),
+                netuid,
+                to_be_set + 1
+            ),
+            Error::<Test>::TxRateLimitExceeded
+        );
+
+        // Wait for rate limit to pass
+        run_to_block(rate_limit_period + 2);
+        assert!(SubtensorModule::passes_rate_limit_on_subnet(
+            &TransactionType::SetWeightsVersionKey,
+            &sn_owner,
+            netuid
+        ));
+
+        // Try transaction
+        assert_ok!(AdminUtils::sudo_set_weights_version_key(
+            <<Test as Config>::RuntimeOrigin>::signed(sn_owner),
+            netuid,
+            to_be_set + 1
+        ));
+        assert_eq!(
+            SubtensorModule::get_weights_version_key(netuid),
+            to_be_set + 1
+        );
     });
 }
 

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -509,6 +509,12 @@ pub mod pallet {
         T::InitialNetworkRateLimit::get()
     }
     #[pallet::type_value]
+    /// Default value for weights version key rate limit.
+    /// In units of tempos.
+    pub fn DefaultWeightsVersionKeyRateLimit<T: Config>() -> u64 {
+        5 // 5 tempos
+    }
+    #[pallet::type_value]
     /// Default value for pending emission.
     pub fn DefaultPendingEmission<T: Config>() -> u64 {
         0
@@ -1077,6 +1083,10 @@ pub mod pallet {
     pub type NetworkRateLimit<T> = StorageValue<_, u64, ValueQuery, DefaultNetworkRateLimit<T>>;
     #[pallet::storage] // --- ITEM( nominator_min_required_stake )
     pub type NominatorMinRequiredStake<T> = StorageValue<_, u64, ValueQuery, DefaultZeroU64<T>>;
+    #[pallet::storage]
+    /// ITEM( weights_version_key_rate_limit ) --- Rate limit in tempos.
+    pub type WeightsVersionKeyRateLimit<T> =
+        StorageValue<_, u64, ValueQuery, DefaultWeightsVersionKeyRateLimit<T>>;
 
     /// ============================
     /// ==== Subnet Locks =====


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
Add a rate limit to the `sudo_set_weights_version_key` call so SubnetOwner can only change it every so often.
The value is set in multiples of `tempos` and the default is `5` tempos

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.