### PR TITLE
Split target folders for fast and non-fast block's chain

### DIFF
--- a/scripts/localnet.sh
+++ b/scripts/localnet.sh
@@ -15,63 +15,66 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 # The base directory of the subtensor project
 BASE_DIR="$SCRIPT_DIR/.."
 
-# get parameters
 # Get the value of fast_blocks from the first argument
 fast_blocks=${1:-"True"}
 
-# Check the value of fast_blocks
+# Define the target directory for compilation
 if [ "$fast_blocks" == "False" ]; then
   # Block of code to execute if fast_blocks is False
   echo "fast_blocks is Off"
   : "${CHAIN:=local}"
   : "${BUILD_BINARY:=1}"
   : "${FEATURES:="pow-faucet"}"
+  BUILD_DIR="$BASE_DIR/target/non-fast-blocks"
 else
   # Block of code to execute if fast_blocks is not False
   echo "fast_blocks is On"
   : "${CHAIN:=local}"
   : "${BUILD_BINARY:=1}"
   : "${FEATURES:="pow-faucet fast-blocks"}"
+  BUILD_DIR="$BASE_DIR/target/fast-blocks"
 fi
+
+# Ensure the build directory exists
+mkdir -p "$BUILD_DIR"
 
 SPEC_PATH="${SCRIPT_DIR}/specs/"
 FULL_PATH="$SPEC_PATH$CHAIN.json"
 
-# Kill any existing nodes which may have not exited correctly after a previous
-# run.
+# Kill any existing nodes which may have not exited correctly after a previous run.
 pkill -9 'node-subtensor'
 
 if [ ! -d "$SPEC_PATH" ]; then
   echo "*** Creating directory ${SPEC_PATH}..."
-  mkdir $SPEC_PATH
+  mkdir -p "$SPEC_PATH"
 fi
 
 if [[ $BUILD_BINARY == "1" ]]; then
   echo "*** Building substrate binary..."
-  cargo build --workspace --profile=release --features "$FEATURES" --manifest-path "$BASE_DIR/Cargo.toml"
+  CARGO_TARGET_DIR="$BUILD_DIR" cargo build --workspace --profile=release --features "$FEATURES" --manifest-path "$BASE_DIR/Cargo.toml"
   echo "*** Binary compiled"
 fi
 
 echo "*** Building chainspec..."
-"$BASE_DIR/target/release/node-subtensor" build-spec --disable-default-bootnode --raw --chain $CHAIN >$FULL_PATH
+"$BUILD_DIR/release/node-subtensor" build-spec --disable-default-bootnode --raw --chain $CHAIN >$FULL_PATH
 echo "*** Chainspec built and output to file"
 
-# generate node keys
-$BASE_DIR/target/release/node-subtensor key generate-node-key --chain="$FULL_PATH" --base-path /tmp/alice
-$BASE_DIR/target/release/node-subtensor key generate-node-key --chain="$FULL_PATH" --base-path /tmp/bob
+# Generate node keys
+"$BUILD_DIR/release/node-subtensor" key generate-node-key --chain="$FULL_PATH" --base-path /tmp/alice
+"$BUILD_DIR/release/node-subtensor" key generate-node-key --chain="$FULL_PATH" --base-path /tmp/bob
 
 if [ $NO_PURGE -eq 1 ]; then
   echo "*** Purging previous state skipped..."
 else
   echo "*** Purging previous state..."
-  "$BASE_DIR/target/release/node-subtensor" purge-chain -y --base-path /tmp/bob --chain="$FULL_PATH" >/dev/null 2>&1
-  "$BASE_DIR/target/release/node-subtensor" purge-chain -y --base-path /tmp/alice --chain="$FULL_PATH" >/dev/null 2>&1
+  "$BUILD_DIR/release/node-subtensor" purge-chain -y --base-path /tmp/bob --chain="$FULL_PATH" >/dev/null 2>&1
+  "$BUILD_DIR/release/node-subtensor" purge-chain -y --base-path /tmp/alice --chain="$FULL_PATH" >/dev/null 2>&1
   echo "*** Previous chainstate purged"
 fi
 
 echo "*** Starting localnet nodes..."
 alice_start=(
-  "$BASE_DIR/target/release/node-subtensor"
+  "$BUILD_DIR/release/node-subtensor"
   --base-path /tmp/alice
   --chain="$FULL_PATH"
   --alice
@@ -85,7 +88,7 @@ alice_start=(
 )
 
 bob_start=(
-  "$BASE_DIR"/target/release/node-subtensor
+  "$BUILD_DIR/release/node-subtensor"
   --base-path /tmp/bob
   --chain="$FULL_PATH"
   --bob
@@ -96,7 +99,6 @@ bob_start=(
   --allow-private-ipv4
   --discover-local
   --unsafe-force-node-key-generation
-#  --offchain-worker=Never
 )
 
 trap 'pkill -P $$' EXIT SIGINT SIGTERM


### PR DESCRIPTION
We need this to be able to run tests in parallel with a fast or non-fast blocks.