### PR TITLE
Ema slowdown hyperparam

### DIFF
--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -1414,6 +1414,35 @@ pub mod pallet {
             );
             Ok(())
         }
+
+        ///
+        ///
+        /// # Arguments
+        /// * `origin` - The origin of the call, which must be the root account.
+        /// * `ema_alpha_period` - Number of blocks for EMA price to halve
+        ///
+        /// # Errors
+        /// * `BadOrigin` - If the caller is not the root account.
+        ///
+        /// # Weight
+        /// Weight is handled by the `#[pallet::weight]` attribute.
+        #[pallet::call_index(65)]
+        #[pallet::weight((0, DispatchClass::Operational, Pays::No))]
+        pub fn sudo_set_ema_price_halving_period(
+            origin: OriginFor<T>,
+            netuid: u16,
+            ema_halving: u64,
+        ) -> DispatchResult {
+            ensure_root(origin)?;
+            pallet_subtensor::EMAPriceHalvingBlocks::<T>::set(netuid, ema_halving);
+
+            log::debug!(
+                "EMAPriceHalvingBlocks( netuid: {:?}, ema_halving: {:?} )",
+                netuid,
+                ema_halving
+            );
+            Ok(())
+        }
     }
 }
 

--- a/pallets/admin-utils/src/tests/mock.rs
+++ b/pallets/admin-utils/src/tests/mock.rs
@@ -134,6 +134,7 @@ parameter_types! {
     pub const InitialColdkeySwapScheduleDuration: u64 = 5 * 24 * 60 * 60 / 12; // 5 days
     pub const InitialDissolveNetworkScheduleDuration: u64 = 5 * 24 * 60 * 60 / 12; // 5 days
     pub const InitialTaoWeight: u64 = u64::MAX/10; // 10% global weight.
+    pub const InitialEmaPriceHalvingPeriod: u64 = 201_600_u64; // 4 weeks
 }
 
 impl pallet_subtensor::Config for Test {
@@ -197,6 +198,7 @@ impl pallet_subtensor::Config for Test {
     type InitialColdkeySwapScheduleDuration = InitialColdkeySwapScheduleDuration;
     type InitialDissolveNetworkScheduleDuration = InitialDissolveNetworkScheduleDuration;
     type InitialTaoWeight = InitialTaoWeight;
+    type InitialEmaPriceHalvingPeriod = InitialEmaPriceHalvingPeriod;
 }
 
 #[derive_impl(frame_system::config_preludes::TestDefaultConfig)]

--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -1669,3 +1669,32 @@ fn test_sudo_set_subnet_owner_hotkey() {
         );
     });
 }
+
+// cargo test --package pallet-admin-utils --lib -- tests::test_sudo_set_ema_halving --exact --show-output
+#[test]
+fn test_sudo_set_ema_halving() {
+    new_test_ext().execute_with(|| {
+        let netuid: u16 = 1;
+        let to_be_set: u64 = 10;
+        add_network(netuid, 10);
+
+        let value_before: u64 = pallet_subtensor::EMAPriceHalvingBlocks::<Test>::get(netuid);
+        assert_eq!(
+            AdminUtils::sudo_set_ema_price_halving_period(
+                <<Test as Config>::RuntimeOrigin>::signed(U256::from(1)),
+                netuid,
+                to_be_set
+            ),
+            Err(DispatchError::BadOrigin)
+        );
+        let value_after_1: u64 = pallet_subtensor::EMAPriceHalvingBlocks::<Test>::get(netuid);
+        assert_eq!(value_after_1, value_before);
+        assert_ok!(AdminUtils::sudo_set_ema_price_halving_period(
+            <<Test as Config>::RuntimeOrigin>::root(),
+            netuid,
+            to_be_set
+        ));
+        let value_after_2: u64 = pallet_subtensor::EMAPriceHalvingBlocks::<Test>::get(netuid);
+        assert_eq!(value_after_2, to_be_set);
+    });
+}

--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -1687,6 +1687,19 @@ fn test_sudo_set_ema_halving() {
             ),
             Err(DispatchError::BadOrigin)
         );
+        let value_after_0: u64 = pallet_subtensor::EMAPriceHalvingBlocks::<Test>::get(netuid);
+        assert_eq!(value_after_0, value_before);
+
+        let owner = U256::from(10);
+        pallet_subtensor::SubnetOwner::<Test>::insert(netuid, owner);
+        assert_eq!(
+            AdminUtils::sudo_set_ema_price_halving_period(
+                <<Test as Config>::RuntimeOrigin>::signed(owner),
+                netuid,
+                to_be_set
+            ),
+            Err(DispatchError::BadOrigin)
+        );
         let value_after_1: u64 = pallet_subtensor::EMAPriceHalvingBlocks::<Test>::get(netuid);
         assert_eq!(value_after_1, value_before);
         assert_ok!(AdminUtils::sudo_set_ema_price_halving_period(

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -396,6 +396,11 @@ pub mod pallet {
         0
     }
     #[pallet::type_value]
+    /// Default EMA price halving blocks
+    pub fn DefaultEMAPriceMovingBlocks<T: Config>() -> u64 {
+        201_600
+    }
+    #[pallet::type_value]
     /// Default registrations this block.
     pub fn DefaultBurn<T: Config>() -> u64 {
         T::InitialBurn::get()
@@ -1283,6 +1288,10 @@ pub mod pallet {
     /// --- MAP ( netuid ) --> Registrations of this Block.
     pub type RegistrationsThisBlock<T> =
         StorageMap<_, Identity, u16, u16, ValueQuery, DefaultRegistrationsThisBlock<T>>;
+    #[pallet::storage]
+    /// --- MAP ( netuid ) --> Halving time of average moving price.
+    pub type EMAPriceHalvingBlocks<T> =
+        StorageMap<_, Identity, u16, u64, ValueQuery, DefaultEMAPriceMovingBlocks<T>>;
     #[pallet::storage]
     /// --- MAP ( netuid ) --> global_RAO_recycled_for_registration
     pub type RAORecycledForRegistration<T> =

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -398,7 +398,7 @@ pub mod pallet {
     #[pallet::type_value]
     /// Default EMA price halving blocks
     pub fn DefaultEMAPriceMovingBlocks<T: Config>() -> u64 {
-        201_600
+        T::InitialEmaPriceHalvingPeriod::get()
     }
     #[pallet::type_value]
     /// Default registrations this block.

--- a/pallets/subtensor/src/macros/config.rs
+++ b/pallets/subtensor/src/macros/config.rs
@@ -207,5 +207,8 @@ mod config {
         /// Initial TAO weight.
         #[pallet::constant]
         type InitialTaoWeight: Get<u64>;
+        /// Initial EMA price halving period
+        #[pallet::constant]
+        type InitialEmaPriceHalvingPeriod: Get<u64>;
     }
 }

--- a/pallets/subtensor/src/tests/coinbase.rs
+++ b/pallets/subtensor/src/tests/coinbase.rs
@@ -218,8 +218,8 @@ fn test_coinbase_moving_prices() {
         SubnetMovingPrice::<Test>::insert(netuid, I96F32::from_num(0));
         SubnetMovingAlpha::<Test>::set(I96F32::from_num(0.1));
 
-        // EMA price 14 days after registration
-        System::set_block_number(7_200 * 14);
+        // EMA price 28 days after registration
+        System::set_block_number(7_200 * 28);
 
         // Run moving 14 times.
         for _ in 0..14 {
@@ -274,7 +274,7 @@ fn test_update_moving_price_after_time() {
         SubnetMovingPrice::<Test>::insert(netuid, I96F32::from_num(0));
 
         // Registered long time ago
-        System::set_block_number(72_000_500);
+        System::set_block_number(144_000_500);
         NetworkRegisteredAt::<Test>::insert(netuid, 500);
 
         SubtensorModule::update_moving_price(netuid);

--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -184,6 +184,7 @@ parameter_types! {
     pub const InitialColdkeySwapScheduleDuration: u64 =  5 * 24 * 60 * 60 / 12; // Default as 5 days
     pub const InitialDissolveNetworkScheduleDuration: u64 =  5 * 24 * 60 * 60 / 12; // Default as 5 days
     pub const InitialTaoWeight: u64 = 0; // 100% global weight.
+    pub const InitialEmaPriceHalvingPeriod: u64 = 201_600_u64; // 4 weeks
 }
 
 // Configure collective pallet for council
@@ -406,6 +407,7 @@ impl crate::Config for Test {
     type InitialColdkeySwapScheduleDuration = InitialColdkeySwapScheduleDuration;
     type InitialDissolveNetworkScheduleDuration = InitialDissolveNetworkScheduleDuration;
     type InitialTaoWeight = InitialTaoWeight;
+    type InitialEmaPriceHalvingPeriod = InitialEmaPriceHalvingPeriod;
 }
 
 pub struct OriginPrivilegeCmp;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1017,6 +1017,7 @@ parameter_types! {
     pub const InitialColdkeySwapScheduleDuration: BlockNumber = 5 * 24 * 60 * 60 / 12; // 5 days
     pub const InitialDissolveNetworkScheduleDuration: BlockNumber = 5 * 24 * 60 * 60 / 12; // 5 days
     pub const SubtensorInitialTaoWeight: u64 = 971_718_665_099_567_868; // 0.05267697438728329% tao weight.
+    pub const InitialEmaPriceHalvingPeriod: u64 = 201_600_u64; // 4 weeks
 }
 
 impl pallet_subtensor::Config for Runtime {
@@ -1080,6 +1081,7 @@ impl pallet_subtensor::Config for Runtime {
     type Preimages = Preimage;
     type InitialColdkeySwapScheduleDuration = InitialColdkeySwapScheduleDuration;
     type InitialDissolveNetworkScheduleDuration = InitialDissolveNetworkScheduleDuration;
+    type InitialEmaPriceHalvingPeriod = InitialEmaPriceHalvingPeriod;
 }
 
 use sp_runtime::BoundedVec;


### PR DESCRIPTION
## Description

This PR introduces the EMA price halving hyperparameter. The meaning of this parameter can be best explained under the assumption of a constant price and SubnetMovingAlpha == 0.5: It is how many blocks it will take in order for the distance between current EMA of price and current price to shorten by half.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

