### PR TITLE
add runtimeAPI for new dyn staking fee

### DIFF
--- a/pallets/subtensor/runtime-api/src/lib.rs
+++ b/pallets/subtensor/runtime-api/src/lib.rs
@@ -46,6 +46,7 @@ sp_api::decl_runtime_apis! {
         fn get_stake_info_for_coldkey( coldkey_account: AccountId32 ) -> Vec<StakeInfo<AccountId32>>;
         fn get_stake_info_for_coldkeys( coldkey_accounts: Vec<AccountId32> ) -> Vec<(AccountId32, Vec<StakeInfo<AccountId32>>)>;
         fn get_stake_info_for_hotkey_coldkey_netuid( hotkey_account: AccountId32, coldkey_account: AccountId32, netuid: u16 ) -> Option<StakeInfo<AccountId32>>;
+        fn get_stake_fee_for_hotkey_coldkey_netuid( hotkey_account: AccountId32, coldkey_account: AccountId32, origin_netuid: u16, destination_netuid: u16, amount: i64 ) -> u64;
     }
 
     pub trait SubnetRegistrationRuntimeApi {

--- a/pallets/subtensor/runtime-api/src/lib.rs
+++ b/pallets/subtensor/runtime-api/src/lib.rs
@@ -46,7 +46,7 @@ sp_api::decl_runtime_apis! {
         fn get_stake_info_for_coldkey( coldkey_account: AccountId32 ) -> Vec<StakeInfo<AccountId32>>;
         fn get_stake_info_for_coldkeys( coldkey_accounts: Vec<AccountId32> ) -> Vec<(AccountId32, Vec<StakeInfo<AccountId32>>)>;
         fn get_stake_info_for_hotkey_coldkey_netuid( hotkey_account: AccountId32, coldkey_account: AccountId32, netuid: u16 ) -> Option<StakeInfo<AccountId32>>;
-        fn get_stake_fee( origin_hotkey_account: Option<AccountId32>, origin_coldkey_account: AccountId32, destination_hotkey_account: Option<AccountId32>, destination_coldkey_account: AccountId32, origin_netuid: Option<u16>, destination_netuid: Option<u16>, amount: i64 ) -> u64;
+        fn get_stake_fee( origin: Option<(AccountId32, u16)>, origin_coldkey_account: AccountId32, destination: Option<(AccountId32, u16)>, destination_coldkey_account: AccountId32, amount: u64 ) -> u64;
     }
 
     pub trait SubnetRegistrationRuntimeApi {

--- a/pallets/subtensor/runtime-api/src/lib.rs
+++ b/pallets/subtensor/runtime-api/src/lib.rs
@@ -46,7 +46,7 @@ sp_api::decl_runtime_apis! {
         fn get_stake_info_for_coldkey( coldkey_account: AccountId32 ) -> Vec<StakeInfo<AccountId32>>;
         fn get_stake_info_for_coldkeys( coldkey_accounts: Vec<AccountId32> ) -> Vec<(AccountId32, Vec<StakeInfo<AccountId32>>)>;
         fn get_stake_info_for_hotkey_coldkey_netuid( hotkey_account: AccountId32, coldkey_account: AccountId32, netuid: u16 ) -> Option<StakeInfo<AccountId32>>;
-        fn get_stake_fee_for_hotkey_coldkey_netuid( hotkey_account: AccountId32, coldkey_account: AccountId32, origin_netuid: u16, destination_netuid: u16, amount: i64 ) -> u64;
+        fn get_stake_fee( origin_hotkey_account: AccountId32, origin_coldkey_account: AccountId32, destination_hotkey_account: AccountId32, destination_coldkey_account: AccountId32, origin_netuid: Option<u16>, destination_netuid: Option<u16>, amount: i64 ) -> u64;
     }
 
     pub trait SubnetRegistrationRuntimeApi {

--- a/pallets/subtensor/runtime-api/src/lib.rs
+++ b/pallets/subtensor/runtime-api/src/lib.rs
@@ -46,7 +46,7 @@ sp_api::decl_runtime_apis! {
         fn get_stake_info_for_coldkey( coldkey_account: AccountId32 ) -> Vec<StakeInfo<AccountId32>>;
         fn get_stake_info_for_coldkeys( coldkey_accounts: Vec<AccountId32> ) -> Vec<(AccountId32, Vec<StakeInfo<AccountId32>>)>;
         fn get_stake_info_for_hotkey_coldkey_netuid( hotkey_account: AccountId32, coldkey_account: AccountId32, netuid: u16 ) -> Option<StakeInfo<AccountId32>>;
-        fn get_stake_fee( origin_hotkey_account: AccountId32, origin_coldkey_account: AccountId32, destination_hotkey_account: AccountId32, destination_coldkey_account: AccountId32, origin_netuid: Option<u16>, destination_netuid: Option<u16>, amount: i64 ) -> u64;
+        fn get_stake_fee( origin_hotkey_account: Option<AccountId32>, origin_coldkey_account: AccountId32, destination_hotkey_account: Option<AccountId32>, destination_coldkey_account: AccountId32, origin_netuid: Option<u16>, destination_netuid: Option<u16>, amount: i64 ) -> u64;
     }
 
     pub trait SubnetRegistrationRuntimeApi {

--- a/pallets/subtensor/src/rpc_info/stake_info.rs
+++ b/pallets/subtensor/src/rpc_info/stake_info.rs
@@ -116,28 +116,21 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn get_stake_fee(
-        origin_hotkey_account: Option<T::AccountId>,
+        origin: Option<(T::AccountId, u16)>,
         _origin_coldkey_account: T::AccountId,
-        _destination_hotkey_account: Option<T::AccountId>,
+        _destination: Option<(T::AccountId, u16)>,
         _destination_coldkey_account: T::AccountId,
-        origin_netuid: Option<u16>,
-        _destination_netuid: Option<u16>,
-        amount: i64,
+        amount: u64,
     ) -> u64 {
-        if amount >= 0 || origin_netuid.is_none() {
-            // Adding stake
-            DefaultStakingFee::<T>::get()
-        } else {
-            match (origin_netuid, origin_hotkey_account) {
-                (Some(origin_netuid), Some(origin_hotkey_account)) => {
-                    // Calculate fee for unstake (negative amount)
-                    Self::calculate_staking_fee(
-                        origin_netuid,
-                        &origin_hotkey_account,
-                        I96F32::saturating_from_num(amount.neg()),
-                    )
-                }
-                _ => DefaultStakingFee::<T>::get(),
+        match origin {
+            Some((origin_hotkey_account, origin_netuid)) => Self::calculate_staking_fee(
+                origin_netuid,
+                &origin_hotkey_account,
+                I96F32::saturating_from_num(amount),
+            ),
+            None => {
+                // Adding stake (comes from no netuid)
+                DefaultStakingFee::<T>::get()
             }
         }
     }

--- a/pallets/subtensor/src/rpc_info/stake_info.rs
+++ b/pallets/subtensor/src/rpc_info/stake_info.rs
@@ -115,9 +115,11 @@ impl<T: Config> Pallet<T> {
         })
     }
 
-    pub fn get_stake_fee_for_hotkey_coldkey_netuid(
-        hotkey_account: T::AccountId,
-        _coldkey_account: T::AccountId,
+    pub fn get_stake_fee(
+        origin_hotkey_account: T::AccountId,
+        _origin_coldkey_account: T::AccountId,
+        _destination_hotkey_account: T::AccountId,
+        _destination_coldkey_account: T::AccountId,
         origin_netuid: Option<u16>,
         _destination_netuid: Option<u16>,
         amount: i64,
@@ -129,7 +131,7 @@ impl<T: Config> Pallet<T> {
             // Calculate fee for unstake (negative amount)
             Self::calculate_staking_fee(
                 origin_netuid.unwrap_or(Self::get_root_netuid()),
-                &hotkey_account,
+                &origin_hotkey_account,
                 I96F32::saturating_from_num(amount.neg()),
             )
         }

--- a/pallets/subtensor/src/rpc_info/stake_info.rs
+++ b/pallets/subtensor/src/rpc_info/stake_info.rs
@@ -1,6 +1,5 @@
 use super::*;
 use frame_support::pallet_prelude::{Decode, Encode};
-use sp_std::ops::Neg;
 extern crate alloc;
 use codec::Compact;
 use substrate_fixed::types::I96F32;

--- a/pallets/subtensor/src/rpc_info/stake_info.rs
+++ b/pallets/subtensor/src/rpc_info/stake_info.rs
@@ -116,9 +116,9 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn get_stake_fee(
-        origin_hotkey_account: T::AccountId,
+        origin_hotkey_account: Option<T::AccountId>,
         _origin_coldkey_account: T::AccountId,
-        _destination_hotkey_account: T::AccountId,
+        _destination_hotkey_account: Option<T::AccountId>,
         _destination_coldkey_account: T::AccountId,
         origin_netuid: Option<u16>,
         _destination_netuid: Option<u16>,
@@ -128,12 +128,17 @@ impl<T: Config> Pallet<T> {
             // Adding stake
             DefaultStakingFee::<T>::get()
         } else {
-            // Calculate fee for unstake (negative amount)
-            Self::calculate_staking_fee(
-                origin_netuid.unwrap_or(Self::get_root_netuid()),
-                &origin_hotkey_account,
-                I96F32::saturating_from_num(amount.neg()),
-            )
+            match (origin_netuid, origin_hotkey_account) {
+                (Some(origin_netuid), Some(origin_hotkey_account)) => {
+                    // Calculate fee for unstake (negative amount)
+                    Self::calculate_staking_fee(
+                        origin_netuid,
+                        &origin_hotkey_account,
+                        I96F32::saturating_from_num(amount.neg()),
+                    )
+                }
+                _ => DefaultStakingFee::<T>::get(),
+            }
         }
     }
 }

--- a/pallets/subtensor/src/rpc_info/stake_info.rs
+++ b/pallets/subtensor/src/rpc_info/stake_info.rs
@@ -118,16 +118,17 @@ impl<T: Config> Pallet<T> {
     pub fn get_stake_fee_for_hotkey_coldkey_netuid(
         hotkey_account: T::AccountId,
         _coldkey_account: T::AccountId,
-        origin_netuid: u16,
-        _destination_netuid: u16,
+        origin_netuid: Option<u16>,
+        _destination_netuid: Option<u16>,
         amount: i64,
     ) -> u64 {
-        if amount >= 0 {
+        if amount >= 0 || origin_netuid.is_none() {
+            // Adding stake
             DefaultStakingFee::<T>::get()
         } else {
             // Calculate fee for unstake (negative amount)
             Self::calculate_staking_fee(
-                origin_netuid,
+                origin_netuid.unwrap_or(Self::get_root_netuid()),
                 &hotkey_account,
                 I96F32::saturating_from_num(amount.neg()),
             )

--- a/pallets/subtensor/src/rpc_info/stake_info.rs
+++ b/pallets/subtensor/src/rpc_info/stake_info.rs
@@ -1,7 +1,9 @@
 use super::*;
 use frame_support::pallet_prelude::{Decode, Encode};
+use sp_std::ops::Neg;
 extern crate alloc;
 use codec::Compact;
+use substrate_fixed::types::I96F32;
 
 #[freeze_struct("5cfb3c84c3af3116")]
 #[derive(Decode, Encode, PartialEq, Eq, Clone, Debug, TypeInfo)]
@@ -111,5 +113,24 @@ impl<T: Config> Pallet<T> {
             drain: 0.into(),
             is_registered,
         })
+    }
+
+    pub fn get_stake_fee_for_hotkey_coldkey_netuid(
+        hotkey_account: T::AccountId,
+        _coldkey_account: T::AccountId,
+        origin_netuid: u16,
+        _destination_netuid: u16,
+        amount: i64,
+    ) -> u64 {
+        if amount >= 0 {
+            DefaultStakingFee::<T>::get()
+        } else {
+            // Calculate fee for unstake (negative amount)
+            Self::calculate_staking_fee(
+                origin_netuid,
+                &hotkey_account,
+                I96F32::saturating_from_num(amount.neg()),
+            )
+        }
     }
 }

--- a/pallets/subtensor/src/tests/staking2.rs
+++ b/pallets/subtensor/src/tests/staking2.rs
@@ -623,3 +623,152 @@ fn test_try_associate_hotkey() {
         assert_eq!(SubtensorModule::get_owned_hotkeys(&coldkey2).len(), 0);
     });
 }
+
+#[test]
+fn test_stake_fee_api() {
+    new_test_ext(1).execute_with(|| {
+        let hotkey1 = U256::from(1);
+        let coldkey1 = U256::from(2);
+        let hotkey2 = U256::from(3);
+        let coldkey2 = U256::from(4);
+
+        let netuid0 = 1;
+        let netuid1 = 2;
+        let root_netuid = SubtensorModule::get_root_netuid();
+
+        let alpha_divs = 100_000_000_000;
+        let total_hotkey_alpha = 100_000_000_000;
+        let tao_in = 100_000_000_000; // 100 TAO
+        let reciprocal_price = 2; // 1 / price
+        let stake_amount = 100_000_000_000;
+
+        let default_fee = DefaultStakingFee::<Test>::get();
+
+        // Setup alpha out
+        SubnetAlphaOut::<Test>::insert(netuid0, 100_000_000_000);
+        SubnetAlphaOut::<Test>::insert(netuid1, 100_000_000_000);
+        // Set pools using price
+        SubnetAlphaIn::<Test>::insert(netuid0, tao_in * reciprocal_price);
+        SubnetTAO::<Test>::insert(netuid0, tao_in);
+        SubnetAlphaIn::<Test>::insert(netuid1, tao_in * reciprocal_price);
+        SubnetTAO::<Test>::insert(netuid1, tao_in);
+
+        // Setup alpha divs for hotkey1
+        AlphaDividendsPerSubnet::<Test>::insert(netuid0, hotkey1, alpha_divs);
+        AlphaDividendsPerSubnet::<Test>::insert(netuid1, hotkey1, alpha_divs);
+
+        // Setup total hotkey alpha for hotkey1
+        TotalHotkeyAlpha::<Test>::insert(hotkey1, netuid0, total_hotkey_alpha);
+        TotalHotkeyAlpha::<Test>::insert(hotkey1, netuid1, total_hotkey_alpha);
+
+        // Test stake fee for add_stake
+        let stake_fee_0 = SubtensorModule::get_stake_fee(
+            None,
+            coldkey1,
+            Some((hotkey1, netuid0)),
+            coldkey1,
+            stake_amount,
+        ); // Default for adding stake
+        assert_eq!(stake_fee_0, default_fee);
+
+        // Test stake fee for remove on root
+        let stake_fee_1 = SubtensorModule::get_stake_fee(
+            Some((hotkey1, root_netuid)),
+            coldkey1,
+            None,
+            coldkey1,
+            stake_amount,
+        ); // Default for removing stake from root
+        assert_eq!(stake_fee_1, default_fee);
+
+        // Test stake fee for move from root to non-root
+        let stake_fee_2 = SubtensorModule::get_stake_fee(
+            Some((hotkey1, root_netuid)),
+            coldkey1,
+            Some((hotkey1, netuid0)),
+            coldkey1,
+            stake_amount,
+        ); // Default for moving stake from root to non-root
+        assert_eq!(stake_fee_2, default_fee);
+
+        // Test stake fee for move between hotkeys on root
+        let stake_fee_3 = SubtensorModule::get_stake_fee(
+            Some((hotkey1, root_netuid)),
+            coldkey1,
+            Some((hotkey2, root_netuid)),
+            coldkey1,
+            stake_amount,
+        ); // Default for moving stake between hotkeys on root
+        assert_eq!(stake_fee_3, default_fee);
+
+        // Test stake fee for move between coldkeys on root
+        let stake_fee_4 = SubtensorModule::get_stake_fee(
+            Some((hotkey1, root_netuid)),
+            coldkey1,
+            Some((hotkey1, root_netuid)),
+            coldkey2,
+            stake_amount,
+        ); // Default for moving stake between coldkeys on root
+        assert_eq!(stake_fee_4, default_fee);
+
+        // Test stake fee for *swap* from non-root to root
+        let stake_fee_5 = SubtensorModule::get_stake_fee(
+            Some((hotkey1, netuid0)),
+            coldkey1,
+            Some((hotkey1, root_netuid)),
+            coldkey1,
+            stake_amount,
+        ); // Charged a dynamic fee
+        let dynamic_fee_5 = SubtensorModule::calculate_staking_fee(
+            netuid0,
+            &hotkey1,
+            I96F32::from_num(stake_amount),
+        );
+        assert_eq!(stake_fee_5, dynamic_fee_5);
+
+        // Test stake fee for move between hotkeys on non-root
+        let stake_fee_6 = SubtensorModule::get_stake_fee(
+            Some((hotkey1, netuid0)),
+            coldkey1,
+            Some((hotkey2, netuid0)),
+            coldkey1,
+            stake_amount,
+        ); // Charged a dynamic fee
+        let dynamic_fee_6 = SubtensorModule::calculate_staking_fee(
+            netuid0,
+            &hotkey1,
+            I96F32::from_num(stake_amount),
+        );
+        assert_eq!(stake_fee_6, dynamic_fee_6);
+
+        // Test stake fee for move between coldkeys on non-root
+        let stake_fee_7 = SubtensorModule::get_stake_fee(
+            Some((hotkey1, netuid0)),
+            coldkey1,
+            Some((hotkey1, netuid0)),
+            coldkey2,
+            stake_amount,
+        ); // Charged a dynamic fee
+        let dynamic_fee_7 = SubtensorModule::calculate_staking_fee(
+            netuid0,
+            &hotkey1,
+            I96F32::from_num(stake_amount),
+        );
+        assert_eq!(stake_fee_7, dynamic_fee_7);
+
+        // Test stake fee for *swap* from non-root to non-root
+        let stake_fee_8 = SubtensorModule::get_stake_fee(
+            Some((hotkey1, netuid0)),
+            coldkey1,
+            Some((hotkey1, netuid1)),
+            coldkey1,
+            stake_amount,
+        ); // Charged a dynamic fee
+        let dynamic_fee_8 = SubtensorModule::calculate_staking_fee(
+            netuid0,
+            &hotkey1,
+            I96F32::from_num(stake_amount),
+        );
+        assert_eq!(stake_fee_8, dynamic_fee_8);
+    });
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2066,6 +2066,10 @@ impl_runtime_apis! {
         fn get_stake_info_for_hotkey_coldkey_netuid( hotkey_account: AccountId32, coldkey_account: AccountId32, netuid: u16 ) -> Option<StakeInfo<AccountId32>> {
             SubtensorModule::get_stake_info_for_hotkey_coldkey_netuid( hotkey_account, coldkey_account, netuid )
         }
+
+        fn get_stake_fee_for_hotkey_coldkey_netuid( hotkey_account: AccountId32, coldkey_account: AccountId32, origin_netuid: u16, destination_netuid: u16, amount: i64 ) -> u64 {
+            SubtensorModule::get_stake_fee_for_hotkey_coldkey_netuid( hotkey_account, coldkey_account, origin_netuid, destination_netuid, amount )
+        }
     }
 
     impl subtensor_custom_rpc_runtime_api::SubnetRegistrationRuntimeApi<Block> for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2067,8 +2067,8 @@ impl_runtime_apis! {
             SubtensorModule::get_stake_info_for_hotkey_coldkey_netuid( hotkey_account, coldkey_account, netuid )
         }
 
-        fn get_stake_fee_for_hotkey_coldkey_netuid( hotkey_account: AccountId32, coldkey_account: AccountId32, origin_netuid: Option<u16>, destination_netuid: Option<u16>, amount: i64 ) -> u64 {
-            SubtensorModule::get_stake_fee_for_hotkey_coldkey_netuid( hotkey_account, coldkey_account, origin_netuid, destination_netuid, amount )
+        fn get_stake_fee( origin_hotkey_account: AccountId32, origin_coldkey_account: AccountId32, destination_hotkey_account: AccountId32, destination_coldkey_account: AccountId32, origin_netuid: Option<u16>, destination_netuid: Option<u16>, amount: i64 ) -> u64 {
+            SubtensorModule::get_stake_fee( origin_hotkey_account, origin_coldkey_account, destination_hotkey_account, destination_coldkey_account, origin_netuid, destination_netuid, amount )
         }
     }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -205,7 +205,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 248,
+    spec_version: 249,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2067,8 +2067,8 @@ impl_runtime_apis! {
             SubtensorModule::get_stake_info_for_hotkey_coldkey_netuid( hotkey_account, coldkey_account, netuid )
         }
 
-        fn get_stake_fee( origin_hotkey_account: Option<AccountId32>, origin_coldkey_account: AccountId32, destination_hotkey_account: Option<AccountId32>, destination_coldkey_account: AccountId32, origin_netuid: Option<u16>, destination_netuid: Option<u16>, amount: i64 ) -> u64 {
-            SubtensorModule::get_stake_fee( origin_hotkey_account, origin_coldkey_account, destination_hotkey_account, destination_coldkey_account, origin_netuid, destination_netuid, amount )
+        fn get_stake_fee( origin: Option<(AccountId32, u16)>, origin_coldkey_account: AccountId32, destination: Option<(AccountId32, u16)>, destination_coldkey_account: AccountId32, amount: u64 ) -> u64 {
+            SubtensorModule::get_stake_fee( origin, origin_coldkey_account, destination, destination_coldkey_account, amount )
         }
     }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2067,7 +2067,7 @@ impl_runtime_apis! {
             SubtensorModule::get_stake_info_for_hotkey_coldkey_netuid( hotkey_account, coldkey_account, netuid )
         }
 
-        fn get_stake_fee_for_hotkey_coldkey_netuid( hotkey_account: AccountId32, coldkey_account: AccountId32, origin_netuid: u16, destination_netuid: u16, amount: i64 ) -> u64 {
+        fn get_stake_fee_for_hotkey_coldkey_netuid( hotkey_account: AccountId32, coldkey_account: AccountId32, origin_netuid: Option<u16>, destination_netuid: Option<u16>, amount: i64 ) -> u64 {
             SubtensorModule::get_stake_fee_for_hotkey_coldkey_netuid( hotkey_account, coldkey_account, origin_netuid, destination_netuid, amount )
         }
     }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2067,7 +2067,7 @@ impl_runtime_apis! {
             SubtensorModule::get_stake_info_for_hotkey_coldkey_netuid( hotkey_account, coldkey_account, netuid )
         }
 
-        fn get_stake_fee( origin_hotkey_account: AccountId32, origin_coldkey_account: AccountId32, destination_hotkey_account: AccountId32, destination_coldkey_account: AccountId32, origin_netuid: Option<u16>, destination_netuid: Option<u16>, amount: i64 ) -> u64 {
+        fn get_stake_fee( origin_hotkey_account: Option<AccountId32>, origin_coldkey_account: AccountId32, destination_hotkey_account: Option<AccountId32>, destination_coldkey_account: AccountId32, origin_netuid: Option<u16>, destination_netuid: Option<u16>, amount: i64 ) -> u64 {
             SubtensorModule::get_stake_fee( origin_hotkey_account, origin_coldkey_account, destination_hotkey_account, destination_coldkey_account, origin_netuid, destination_netuid, amount )
         }
     }


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
Adds a runtime API 
```
stakeInfoRuntimeApi.getStakeFee( 
  origin: Option<(AccountId32, u16)>,
  origin_coldkey_account: AccountId32,
  destination: Option<(AccountId32, u16)>,
  destination_coldkey_account: AccountId32,
  amount: u64
) -> u64 
``` 
to get the staking fee for a staking operation.

The extra params are for future-proofing.

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.