### PR TITLE
calculate staking fee based on everything

### DIFF
--- a/pallets/subtensor/src/staking/move_stake.rs
+++ b/pallets/subtensor/src/staking/move_stake.rs
@@ -339,8 +339,10 @@ impl<T: Config> Pallet<T> {
 
         // Unstake from the origin subnet, returning TAO (or a 1:1 equivalent).
         let fee = Self::calculate_staking_fee(
-            origin_netuid,
-            origin_hotkey,
+            Some((origin_hotkey, origin_netuid)),
+            origin_coldkey,
+            Some((destination_hotkey, destination_netuid)),
+            destination_coldkey,
             I96F32::saturating_from_num(alpha_amount),
         )
         .safe_div(2);

--- a/pallets/subtensor/src/staking/remove_stake.rs
+++ b/pallets/subtensor/src/staking/remove_stake.rs
@@ -59,8 +59,10 @@ impl<T: Config> Pallet<T> {
 
         // 3. Swap the alpba to tao and update counters for this subnet.
         let fee = Self::calculate_staking_fee(
-            netuid,
-            &hotkey,
+            Some((&hotkey, netuid)),
+            &coldkey,
+            None,
+            &coldkey,
             I96F32::saturating_from_num(alpha_unstaked),
         );
         let tao_unstaked: u64 =
@@ -133,8 +135,10 @@ impl<T: Config> Pallet<T> {
             let alpha_unstaked =
                 Self::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
             let fee = Self::calculate_staking_fee(
-                netuid,
-                &hotkey,
+                Some((&hotkey, netuid)),
+                &coldkey,
+                None,
+                &coldkey,
                 I96F32::saturating_from_num(alpha_unstaked),
             );
 
@@ -208,8 +212,10 @@ impl<T: Config> Pallet<T> {
                 let alpha_unstaked =
                     Self::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
                 let fee = Self::calculate_staking_fee(
-                    netuid,
-                    &hotkey,
+                    Some((&hotkey, netuid)),
+                    &coldkey,
+                    None,
+                    &coldkey,
                     I96F32::saturating_from_num(alpha_unstaked),
                 );
 
@@ -315,8 +321,10 @@ impl<T: Config> Pallet<T> {
 
         // 4. Swap the alpha to tao and update counters for this subnet.
         let fee = Self::calculate_staking_fee(
-            netuid,
-            &hotkey,
+            Some((&hotkey, netuid)),
+            &coldkey,
+            None,
+            &coldkey,
             I96F32::saturating_from_num(alpha_unstaked),
         );
         let tao_unstaked =

--- a/pallets/subtensor/src/tests/swap_coldkey.rs
+++ b/pallets/subtensor/src/tests/swap_coldkey.rs
@@ -540,7 +540,13 @@ fn test_swap_concurrent_modifications() {
         let additional_stake = 500_000_000_000;
         let initial_stake_alpha =
             I96F32::from(initial_stake).saturating_mul(SubtensorModule::get_alpha_price(netuid));
-        let fee = SubtensorModule::calculate_staking_fee(netuid, &hotkey, initial_stake_alpha);
+        let fee = SubtensorModule::calculate_staking_fee(
+            None,
+            &new_coldkey,
+            Some((&hotkey, netuid)),
+            &new_coldkey,
+            initial_stake_alpha,
+        );
 
         // Setup initial state
         add_network(netuid, 1, 1);


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
Changes the staking fee calculation to consider the origin/destination netuids and the origin/destination hotkeys and coldkeys. 

Some params are not used and are for future-proofing


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.