### PR TITLE
Feat/sn 73 dissolve migration

### DIFF
--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -1389,40 +1389,42 @@ mod dispatches {
 		.saturating_add(T::DbWeight::get().reads(6))
 		.saturating_add(T::DbWeight::get().writes(31)), DispatchClass::Operational, Pays::Yes))]
         pub fn schedule_dissolve_network(
-            origin: OriginFor<T>,
-            netuid: u16,
+            _origin: OriginFor<T>,
+            _netuid: u16,
         ) -> DispatchResultWithPostInfo {
-            let who = ensure_signed(origin)?;
+            Err(Error::<T>::CallDisabled.into())
 
-            let current_block: BlockNumberFor<T> = <frame_system::Pallet<T>>::block_number();
-            let duration: BlockNumberFor<T> = DissolveNetworkScheduleDuration::<T>::get();
-            let when: BlockNumberFor<T> = current_block.saturating_add(duration);
+            // let who = ensure_signed(origin)?;
 
-            let call = Call::<T>::dissolve_network {
-                coldkey: who.clone(),
-                netuid,
-            };
+            // let current_block: BlockNumberFor<T> = <frame_system::Pallet<T>>::block_number();
+            // let duration: BlockNumberFor<T> = DissolveNetworkScheduleDuration::<T>::get();
+            // let when: BlockNumberFor<T> = current_block.saturating_add(duration);
 
-            let bound_call = T::Preimages::bound(LocalCallOf::<T>::from(call.clone()))
-                .map_err(|_| Error::<T>::FailedToSchedule)?;
+            // let call = Call::<T>::dissolve_network {
+            //     coldkey: who.clone(),
+            //     netuid,
+            // };
 
-            T::Scheduler::schedule(
-                DispatchTime::At(when),
-                None,
-                63,
-                frame_system::RawOrigin::Root.into(),
-                bound_call,
-            )
-            .map_err(|_| Error::<T>::FailedToSchedule)?;
+            // let bound_call = T::Preimages::bound(LocalCallOf::<T>::from(call.clone()))
+            //     .map_err(|_| Error::<T>::FailedToSchedule)?;
 
-            // Emit the SwapScheduled event
-            Self::deposit_event(Event::DissolveNetworkScheduled {
-                account: who.clone(),
-                netuid,
-                execution_block: when,
-            });
+            // T::Scheduler::schedule(
+            //     DispatchTime::At(when),
+            //     None,
+            //     63,
+            //     frame_system::RawOrigin::Root.into(),
+            //     bound_call,
+            // )
+            // .map_err(|_| Error::<T>::FailedToSchedule)?;
 
-            Ok(().into())
+            // // Emit the SwapScheduled event
+            // Self::deposit_event(Event::DissolveNetworkScheduled {
+            //     account: who.clone(),
+            //     netuid,
+            //     execution_block: when,
+            // });
+
+            // Ok(().into())
         }
 
         /// ---- Set prometheus information for the neuron.

--- a/pallets/subtensor/src/macros/errors.rs
+++ b/pallets/subtensor/src/macros/errors.rs
@@ -193,5 +193,7 @@ mod errors {
         TransferDisallowed,
         /// Activity cutoff is being set too low.
         ActivityCutoffTooLow,
+        /// Call is disabled
+        CallDisabled,
     }
 }

--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -81,7 +81,9 @@ mod hooks {
                 // Remove Stake map entries
 				.saturating_add(migrations::migrate_remove_stake_map::migrate_remove_stake_map::<T>())
                 // Remove unused maps entries
-				.saturating_add(migrations::migrate_remove_unused_maps_and_values::migrate_remove_unused_maps_and_values::<T>());
+				.saturating_add(migrations::migrate_remove_unused_maps_and_values::migrate_remove_unused_maps_and_values::<T>())
+				// Migrate dissolve sn73
+				.saturating_add(migrations::migrate_dissolve_sn73::migrate_dissolve_sn73::<T>());
             weight
         }
 

--- a/pallets/subtensor/src/migrations/migrate_dissolve_sn73.rs
+++ b/pallets/subtensor/src/migrations/migrate_dissolve_sn73.rs
@@ -49,7 +49,7 @@ pub fn migrate_dissolve_sn73<T: Config>() -> Weight {
     // Iterate over every hotkey and distribute the TAO from the pool
     // using previous total alpha as the denominator
     for hotkey in hotkeys_to_remove.iter() {
-		log::debug!("Hotkey: {}", hotkey);
+        log::debug!("Hotkey: {}", hotkey);
 
         let total_hotkey_alpha_i = TotalHotkeyAlpha::<T>::get(hotkey.clone(), this_netuid);
         let total_hotkey_alpha = I96F32::from_num(total_hotkey_alpha_i);

--- a/pallets/subtensor/src/migrations/migrate_dissolve_sn73.rs
+++ b/pallets/subtensor/src/migrations/migrate_dissolve_sn73.rs
@@ -72,7 +72,7 @@ pub fn migrate_dissolve_sn73<T: Config>() -> Weight {
                 continue;
             }
 
-            coldkeys_to_remove.push(coldkey);
+            coldkeys_to_remove.push(coldkey.clone());
 
             let alpha = I96F32::from_num(alpha_i);
             let coldkey_share: I96F32 = alpha.saturating_div(total_hotkey_shares);
@@ -108,8 +108,8 @@ pub fn migrate_dissolve_sn73<T: Config>() -> Weight {
 
     // Clear hotkeys
     for hotkey in hotkeys_to_remove {
-        TotalHotkeyAlpha::<T>::remove(hotkey, this_netuid);
-        TotalHotkeyShares::<T>::remove(hotkey, this_netuid);
+        TotalHotkeyAlpha::<T>::remove(hotkey.clone(), this_netuid);
+        TotalHotkeyShares::<T>::remove(hotkey.clone(), this_netuid);
         weight = weight.saturating_add(T::DbWeight::get().writes(2));
     }
 
@@ -133,10 +133,10 @@ pub fn migrate_dissolve_sn73<T: Config>() -> Weight {
     weight = weight.saturating_add(T::DbWeight::get().writes(7));
 
     // Clear trackers
-    AlphaDividendsPerSubnet::<T>::clear_prefix(this_netuid, u32::MAX, None);
-    weight = weight.saturating_add(T::DbWeight::get().writes(1));
-    TaoDividendsPerSubnet::<T>::clear_prefix(this_netuid, u32::MAX, None);
-    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+    let clear_results_0 = AlphaDividendsPerSubnet::<T>::clear_prefix(this_netuid, u32::MAX, None);
+    weight = weight.saturating_add(T::DbWeight::get().writes(clear_results_0.unique.into()));
+    let clear_results_1 = TaoDividendsPerSubnet::<T>::clear_prefix(this_netuid, u32::MAX, None);
+    weight = weight.saturating_add(T::DbWeight::get().writes(clear_results_1.unique.into()));
 
     // Adjust total stake
     TotalStake::<T>::mutate(|total| {
@@ -149,8 +149,8 @@ pub fn migrate_dissolve_sn73<T: Config>() -> Weight {
     weight = weight.saturating_add(T::DbWeight::get().writes(1));
 
     // Clear child keys
-    PendingChildKeys::<T>::clear_prefix(this_netuid, u32::MAX, None);
-    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+    let clear_results_2 = PendingChildKeys::<T>::clear_prefix(this_netuid, u32::MAX, None);
+    weight = weight.saturating_add(T::DbWeight::get().writes(clear_results_2.unique.into()));
 
     let mut childkeys_to_remove: Vec<T::AccountId> = Vec::new();
     for (childkey, netuid_i, _parents) in ParentKeys::<T>::iter() {

--- a/pallets/subtensor/src/migrations/migrate_dissolve_sn73.rs
+++ b/pallets/subtensor/src/migrations/migrate_dissolve_sn73.rs
@@ -185,6 +185,11 @@ pub fn migrate_dissolve_sn73<T: Config>() -> Weight {
         ChildKeys::<T>::remove(parent_key, this_netuid);
         weight = weight.saturating_add(T::DbWeight::get().writes(1));
     }
+
+	// Clear reg allowed maps
+	NetworkRegistrationAllowed::<T>::remove(this_netuid);
+	NetworkPowRegistrationAllowed::<T>::remove(this_netuid);
+	weight = weight.saturating_add(T::DbWeight::get().writes(2));
     // ======== End Migration Logic ========
 
     // Mark the migration as completed

--- a/pallets/subtensor/src/migrations/migrate_dissolve_sn73.rs
+++ b/pallets/subtensor/src/migrations/migrate_dissolve_sn73.rs
@@ -186,10 +186,10 @@ pub fn migrate_dissolve_sn73<T: Config>() -> Weight {
         weight = weight.saturating_add(T::DbWeight::get().writes(1));
     }
 
-	// Clear reg allowed maps
-	NetworkRegistrationAllowed::<T>::remove(this_netuid);
-	NetworkPowRegistrationAllowed::<T>::remove(this_netuid);
-	weight = weight.saturating_add(T::DbWeight::get().writes(2));
+    // Clear reg allowed maps
+    NetworkRegistrationAllowed::<T>::remove(this_netuid);
+    NetworkPowRegistrationAllowed::<T>::remove(this_netuid);
+    weight = weight.saturating_add(T::DbWeight::get().writes(2));
     // ======== End Migration Logic ========
 
     // Mark the migration as completed

--- a/pallets/subtensor/src/migrations/migrate_dissolve_sn73.rs
+++ b/pallets/subtensor/src/migrations/migrate_dissolve_sn73.rs
@@ -49,7 +49,7 @@ pub fn migrate_dissolve_sn73<T: Config>() -> Weight {
     // Iterate over every hotkey and distribute the TAO from the pool
     // using previous total alpha as the denominator
     for hotkey in hotkeys_to_remove.iter() {
-        log::debug!("Hotkey: {}", hotkey);
+        log::debug!("Hotkey: {:?}", hotkey.clone());
 
         let total_hotkey_alpha_i = TotalHotkeyAlpha::<T>::get(hotkey.clone(), this_netuid);
         let total_hotkey_alpha = I96F32::from_num(total_hotkey_alpha_i);

--- a/pallets/subtensor/src/migrations/migrate_dissolve_sn73.rs
+++ b/pallets/subtensor/src/migrations/migrate_dissolve_sn73.rs
@@ -1,0 +1,197 @@
+use alloc::string::String;
+
+use frame_support::{traits::Get, weights::Weight};
+use substrate_fixed::types::I96F32;
+
+use super::*;
+
+pub fn migrate_dissolve_sn73<T: Config>() -> Weight {
+    let migration_name = b"migrate_dissolve_sn73".to_vec();
+    let this_netuid = 73;
+
+    // Initialize the weight with one read operation.
+    let mut weight = T::DbWeight::get().reads(1);
+
+    // Check if the migration has already run
+    if HasMigrationRun::<T>::get(&migration_name) {
+        log::info!(
+            "Migration '{:?}' has already run. Skipping.",
+            migration_name
+        );
+        return weight;
+    }
+    log::info!(
+        "Running migration '{}'",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    // ======== Migration Logic ========
+
+    // Get the subnet TAO
+    let subnet_tao = I96F32::from_num(SubnetTAO::<T>::get(this_netuid));
+    weight = weight.saturating_add(T::DbWeight::get().reads(1));
+
+    let mut total_alpha: I96F32 = I96F32::from_num(0);
+    // Iterate over every hotkey and sum up the total alpha
+    let mut hotkeys_to_remove: Vec<T::AccountId> = Vec::new();
+    for (hotkey, netuid_i, total_hotkey_alpha) in TotalHotkeyAlpha::<T>::iter() {
+        weight = weight.saturating_add(T::DbWeight::get().reads(1));
+        if netuid_i != this_netuid {
+            continue;
+        }
+
+        hotkeys_to_remove.push(hotkey);
+        total_alpha = total_alpha.saturating_add(I96F32::from_num(total_hotkey_alpha));
+    }
+
+    // Iterate over every hotkey and distribute the TAO from the pool
+    // using previous total alpha as the denominator
+    for (hotkey, netuid_i, total_hotkey_alpha_i) in TotalHotkeyAlpha::<T>::iter() {
+        if netuid_i != this_netuid {
+            continue;
+        }
+
+        let total_hotkey_alpha = I96F32::from_num(total_hotkey_alpha_i);
+        weight = weight.saturating_add(T::DbWeight::get().reads(1));
+
+        // Get the total hotkey shares
+        let total_hotkey_shares =
+            I96F32::from_num(TotalHotkeyShares::<T>::get(hotkey.clone(), this_netuid));
+        weight = weight.saturating_add(T::DbWeight::get().reads(1));
+
+        // Get the equivalent amount of TAO
+        let hotkey_tao: I96F32 = total_hotkey_alpha
+            .saturating_div(total_alpha)
+            .saturating_mul(subnet_tao);
+
+        let mut coldkeys_to_remove: Vec<T::AccountId> = Vec::new();
+        // Distribute the TAO to each of the stakers to the hotkey
+        for ((coldkey, netuid_i), alpha_i) in Alpha::<T>::iter_prefix((&hotkey,)) {
+            weight = weight.saturating_add(T::DbWeight::get().reads(1));
+            if netuid_i != this_netuid {
+                continue;
+            }
+
+            coldkeys_to_remove.push(coldkey);
+
+            let alpha = I96F32::from_num(alpha_i);
+            let coldkey_share: I96F32 = alpha.saturating_div(total_hotkey_shares);
+            let coldkey_tao = coldkey_share.saturating_mul(hotkey_tao);
+            let coldkey_alpha = coldkey_share.saturating_mul(total_hotkey_alpha);
+
+            // Distribute the TAO to the coldkey
+            let as_tao: u64 = coldkey_tao.saturating_to_num::<u64>();
+            let as_alpha: u64 = coldkey_alpha.saturating_to_num::<u64>();
+
+            if as_tao > 0 {
+                Pallet::<T>::add_balance_to_coldkey_account(&coldkey, as_tao);
+                weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
+
+                // Emit event
+                Pallet::<T>::deposit_event(Event::StakeRemoved(
+                    coldkey.clone(),
+                    hotkey.clone(),
+                    as_tao,
+                    as_alpha,
+                    this_netuid,
+                ));
+            }
+        }
+        // Clear coldkeys
+        for coldkey in coldkeys_to_remove {
+            Alpha::<T>::remove((&hotkey, coldkey, this_netuid));
+            weight = weight.saturating_add(T::DbWeight::get().writes(1));
+        }
+    }
+
+    // === Clear storage entries ===
+
+    // Clear hotkeys
+    for hotkey in hotkeys_to_remove {
+        TotalHotkeyAlpha::<T>::remove(hotkey, this_netuid);
+        TotalHotkeyShares::<T>::remove(hotkey, this_netuid);
+        weight = weight.saturating_add(T::DbWeight::get().writes(2));
+    }
+
+    // Clear pool
+    SubnetTAO::<T>::remove(this_netuid);
+    SubnetAlphaIn::<T>::remove(this_netuid);
+    weight = weight.saturating_add(T::DbWeight::get().writes(2));
+
+    // Clear AlphaOut
+    SubnetAlphaOut::<T>::remove(this_netuid);
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+    // Clear pending emissions
+    SubnetTaoInEmission::<T>::remove(this_netuid);
+    SubnetAlphaInEmission::<T>::remove(this_netuid);
+    SubnetAlphaOutEmission::<T>::remove(this_netuid);
+    PendingEmission::<T>::remove(this_netuid);
+    PendingRootDivs::<T>::remove(this_netuid);
+    PendingAlphaSwapped::<T>::remove(this_netuid);
+    PendingOwnerCut::<T>::remove(this_netuid);
+    weight = weight.saturating_add(T::DbWeight::get().writes(7));
+
+    // Clear trackers
+    AlphaDividendsPerSubnet::<T>::clear_prefix(this_netuid, u32::MAX, None);
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+    TaoDividendsPerSubnet::<T>::clear_prefix(this_netuid, u32::MAX, None);
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+    // Adjust total stake
+    TotalStake::<T>::mutate(|total| {
+        *total = total.saturating_sub(subnet_tao.saturating_to_num::<u64>());
+    });
+    weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
+
+    // Clear subnet volume
+    SubnetVolume::<T>::remove(this_netuid);
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+    // Clear child keys
+    PendingChildKeys::<T>::clear_prefix(this_netuid, u32::MAX, None);
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+    let mut childkeys_to_remove: Vec<T::AccountId> = Vec::new();
+    for (childkey, netuid_i, _parents) in ParentKeys::<T>::iter() {
+        weight = weight.saturating_add(T::DbWeight::get().reads(1));
+        if netuid_i != this_netuid {
+            continue;
+        }
+
+        childkeys_to_remove.push(childkey);
+    }
+
+    let mut parent_keys_to_remove: Vec<T::AccountId> = Vec::new();
+    for (parent_key, netuid_i, _children) in ChildKeys::<T>::iter() {
+        weight = weight.saturating_add(T::DbWeight::get().reads(1));
+        if netuid_i != this_netuid {
+            continue;
+        }
+
+        parent_keys_to_remove.push(parent_key);
+    }
+
+    for child_key in childkeys_to_remove {
+        ParentKeys::<T>::remove(child_key, this_netuid);
+        weight = weight.saturating_add(T::DbWeight::get().writes(1));
+    }
+
+    for parent_key in parent_keys_to_remove {
+        ChildKeys::<T>::remove(parent_key, this_netuid);
+        weight = weight.saturating_add(T::DbWeight::get().writes(1));
+    }
+    // ======== End Migration Logic ========
+
+    // Mark the migration as completed
+    HasMigrationRun::<T>::insert(&migration_name, true);
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+    log::info!(
+        "Migration '{:?}' completed.",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    // Return the migration weight.
+    weight
+}

--- a/pallets/subtensor/src/migrations/migrate_dissolve_sn73.rs
+++ b/pallets/subtensor/src/migrations/migrate_dissolve_sn73.rs
@@ -25,179 +25,185 @@ pub fn migrate_dissolve_sn73<T: Config>() -> Weight {
         String::from_utf8_lossy(&migration_name)
     );
 
-    // ======== Migration Logic ========
+    if NetworksAdded::<T>::get(this_netuid) {
+        // Subnet exists, skip
+        log::info!("Subnet was already added, skipping");
+    } else {
+        // ======== Migration Logic ========
 
-    // Get the subnet TAO
-    let subnet_tao = I96F32::from_num(SubnetTAO::<T>::get(this_netuid));
-    weight = weight.saturating_add(T::DbWeight::get().reads(1));
-    log::debug!("Subnet TAO: {}", subnet_tao);
-
-    let mut total_alpha: I96F32 = I96F32::from_num(0);
-    // Iterate over every hotkey and sum up the total alpha
-    let mut hotkeys_to_remove: Vec<T::AccountId> = Vec::new();
-    for (hotkey, netuid_i, total_hotkey_alpha) in TotalHotkeyAlpha::<T>::iter() {
+        // Get the subnet TAO
+        let subnet_tao = I96F32::from_num(SubnetTAO::<T>::get(this_netuid));
         weight = weight.saturating_add(T::DbWeight::get().reads(1));
-        if netuid_i != this_netuid {
-            continue;
-        }
+        log::debug!("Subnet TAO: {}", subnet_tao);
 
-        hotkeys_to_remove.push(hotkey);
-        total_alpha = total_alpha.saturating_add(I96F32::from_num(total_hotkey_alpha));
-    }
-    log::debug!("Total alpha: {}", total_alpha);
-
-    // Iterate over every hotkey and distribute the TAO from the pool
-    // using previous total alpha as the denominator
-    for hotkey in hotkeys_to_remove.iter() {
-        log::debug!("Hotkey: {:?}", hotkey.clone());
-
-        let total_hotkey_alpha_i = TotalHotkeyAlpha::<T>::get(hotkey.clone(), this_netuid);
-        let total_hotkey_alpha = I96F32::from_num(total_hotkey_alpha_i);
-        weight = weight.saturating_add(T::DbWeight::get().reads(1));
-
-        // Get the total hotkey shares
-        let total_hotkey_shares =
-            I96F32::from_num(TotalHotkeyShares::<T>::get(hotkey.clone(), this_netuid));
-        weight = weight.saturating_add(T::DbWeight::get().reads(1));
-        log::debug!("Total hotkey shares: {}", total_hotkey_shares);
-
-        // Get the equivalent amount of TAO
-        let hotkey_tao: I96F32 = total_hotkey_alpha
-            .saturating_div(total_alpha)
-            .saturating_mul(subnet_tao);
-        log::debug!("Total hotkey alpha: {}", total_hotkey_alpha);
-        log::debug!("Hotkey TAO: {}", hotkey_tao);
-
-        let mut coldkeys_to_remove: Vec<T::AccountId> = Vec::new();
-        // Distribute the TAO to each of the stakers to the hotkey
-        for ((coldkey, netuid_i), alpha_i) in Alpha::<T>::iter_prefix((&hotkey,)) {
+        let mut total_alpha: I96F32 = I96F32::from_num(0);
+        // Iterate over every hotkey and sum up the total alpha
+        let mut hotkeys_to_remove: Vec<T::AccountId> = Vec::new();
+        for (hotkey, netuid_i, total_hotkey_alpha) in TotalHotkeyAlpha::<T>::iter() {
             weight = weight.saturating_add(T::DbWeight::get().reads(1));
             if netuid_i != this_netuid {
                 continue;
             }
 
-            coldkeys_to_remove.push(coldkey.clone());
+            hotkeys_to_remove.push(hotkey);
+            total_alpha = total_alpha.saturating_add(I96F32::from_num(total_hotkey_alpha));
+        }
+        log::debug!("Total alpha: {}", total_alpha);
 
-            let alpha_shares = I96F32::from_num(alpha_i);
-            let coldkey_share: I96F32 = alpha_shares.saturating_div(total_hotkey_shares);
-            let coldkey_tao = coldkey_share.saturating_mul(hotkey_tao);
-            let coldkey_alpha = coldkey_share.saturating_mul(total_hotkey_alpha);
-            log::debug!("Alpha shares: {}", alpha_shares);
-            log::debug!("Coldkey share: {}", coldkey_share);
-            log::debug!("Coldkey TAO: {}", coldkey_tao);
+        // Iterate over every hotkey and distribute the TAO from the pool
+        // using previous total alpha as the denominator
+        for hotkey in hotkeys_to_remove.iter() {
+            log::debug!("Hotkey: {:?}", hotkey.clone());
 
-            // Distribute the TAO to the coldkey
-            let as_tao: u64 = coldkey_tao.saturating_to_num::<u64>();
-            let as_alpha: u64 = coldkey_alpha.saturating_to_num::<u64>();
+            let total_hotkey_alpha_i = TotalHotkeyAlpha::<T>::get(hotkey.clone(), this_netuid);
+            let total_hotkey_alpha = I96F32::from_num(total_hotkey_alpha_i);
+            weight = weight.saturating_add(T::DbWeight::get().reads(1));
 
-            if as_tao > 0 {
-                Pallet::<T>::add_balance_to_coldkey_account(&coldkey, as_tao);
-                weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
+            // Get the total hotkey shares
+            let total_hotkey_shares =
+                I96F32::from_num(TotalHotkeyShares::<T>::get(hotkey.clone(), this_netuid));
+            weight = weight.saturating_add(T::DbWeight::get().reads(1));
+            log::debug!("Total hotkey shares: {}", total_hotkey_shares);
 
-                // Emit event
-                Pallet::<T>::deposit_event(Event::StakeRemoved(
-                    coldkey.clone(),
-                    hotkey.clone(),
-                    as_tao,
-                    as_alpha,
-                    this_netuid,
-                ));
+            // Get the equivalent amount of TAO
+            let hotkey_tao: I96F32 = total_hotkey_alpha
+                .saturating_div(total_alpha)
+                .saturating_mul(subnet_tao);
+            log::debug!("Total hotkey alpha: {}", total_hotkey_alpha);
+            log::debug!("Hotkey TAO: {}", hotkey_tao);
+
+            let mut coldkeys_to_remove: Vec<T::AccountId> = Vec::new();
+            // Distribute the TAO to each of the stakers to the hotkey
+            for ((coldkey, netuid_i), alpha_i) in Alpha::<T>::iter_prefix((&hotkey,)) {
+                weight = weight.saturating_add(T::DbWeight::get().reads(1));
+                if netuid_i != this_netuid {
+                    continue;
+                }
+
+                coldkeys_to_remove.push(coldkey.clone());
+
+                let alpha_shares = I96F32::from_num(alpha_i);
+                let coldkey_share: I96F32 = alpha_shares.saturating_div(total_hotkey_shares);
+                let coldkey_tao = coldkey_share.saturating_mul(hotkey_tao);
+                let coldkey_alpha = coldkey_share.saturating_mul(total_hotkey_alpha);
+                log::debug!("Alpha shares: {}", alpha_shares);
+                log::debug!("Coldkey share: {}", coldkey_share);
+                log::debug!("Coldkey TAO: {}", coldkey_tao);
+
+                // Distribute the TAO to the coldkey
+                let as_tao: u64 = coldkey_tao.saturating_to_num::<u64>();
+                let as_alpha: u64 = coldkey_alpha.saturating_to_num::<u64>();
+
+                if as_tao > 0 {
+                    Pallet::<T>::add_balance_to_coldkey_account(&coldkey, as_tao);
+                    weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
+
+                    // Emit event
+                    Pallet::<T>::deposit_event(Event::StakeRemoved(
+                        coldkey.clone(),
+                        hotkey.clone(),
+                        as_tao,
+                        as_alpha,
+                        this_netuid,
+                    ));
+                }
+            }
+            // Clear coldkeys
+            for coldkey in coldkeys_to_remove {
+                Alpha::<T>::remove((&hotkey, coldkey, this_netuid));
+                weight = weight.saturating_add(T::DbWeight::get().writes(1));
             }
         }
-        // Clear coldkeys
-        for coldkey in coldkeys_to_remove {
-            Alpha::<T>::remove((&hotkey, coldkey, this_netuid));
+
+        // === Clear storage entries ===
+        // Clear subnet owner and hotkey
+        SubnetOwner::<T>::remove(this_netuid);
+        SubnetOwnerHotkey::<T>::remove(this_netuid);
+        weight = weight.saturating_add(T::DbWeight::get().writes(2));
+
+        // Clear hotkeys
+        for hotkey in hotkeys_to_remove {
+            TotalHotkeyAlpha::<T>::remove(hotkey.clone(), this_netuid);
+            TotalHotkeyShares::<T>::remove(hotkey.clone(), this_netuid);
+            weight = weight.saturating_add(T::DbWeight::get().writes(2));
+        }
+
+        // Clear pool
+        SubnetTAO::<T>::remove(this_netuid);
+        SubnetAlphaIn::<T>::remove(this_netuid);
+        weight = weight.saturating_add(T::DbWeight::get().writes(2));
+
+        // Clear AlphaOut
+        SubnetAlphaOut::<T>::remove(this_netuid);
+        weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+        // Clear pending emissions
+        SubnetTaoInEmission::<T>::remove(this_netuid);
+        SubnetAlphaInEmission::<T>::remove(this_netuid);
+        SubnetAlphaOutEmission::<T>::remove(this_netuid);
+        PendingEmission::<T>::remove(this_netuid);
+        PendingRootDivs::<T>::remove(this_netuid);
+        PendingAlphaSwapped::<T>::remove(this_netuid);
+        PendingOwnerCut::<T>::remove(this_netuid);
+        weight = weight.saturating_add(T::DbWeight::get().writes(7));
+
+        // Clear trackers
+        let clear_results_0 =
+            AlphaDividendsPerSubnet::<T>::clear_prefix(this_netuid, u32::MAX, None);
+        weight = weight.saturating_add(T::DbWeight::get().writes(clear_results_0.unique.into()));
+        let clear_results_1 = TaoDividendsPerSubnet::<T>::clear_prefix(this_netuid, u32::MAX, None);
+        weight = weight.saturating_add(T::DbWeight::get().writes(clear_results_1.unique.into()));
+
+        // Adjust total stake
+        TotalStake::<T>::mutate(|total| {
+            *total = total.saturating_sub(subnet_tao.saturating_to_num::<u64>());
+        });
+        weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
+
+        // Clear subnet volume
+        SubnetVolume::<T>::remove(this_netuid);
+        weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+        // Clear child keys
+        let clear_results_2 = PendingChildKeys::<T>::clear_prefix(this_netuid, u32::MAX, None);
+        weight = weight.saturating_add(T::DbWeight::get().writes(clear_results_2.unique.into()));
+
+        let mut childkeys_to_remove: Vec<T::AccountId> = Vec::new();
+        for (childkey, netuid_i, _parents) in ParentKeys::<T>::iter() {
+            weight = weight.saturating_add(T::DbWeight::get().reads(1));
+            if netuid_i != this_netuid {
+                continue;
+            }
+
+            childkeys_to_remove.push(childkey);
+        }
+
+        let mut parent_keys_to_remove: Vec<T::AccountId> = Vec::new();
+        for (parent_key, netuid_i, _children) in ChildKeys::<T>::iter() {
+            weight = weight.saturating_add(T::DbWeight::get().reads(1));
+            if netuid_i != this_netuid {
+                continue;
+            }
+
+            parent_keys_to_remove.push(parent_key);
+        }
+
+        for child_key in childkeys_to_remove {
+            ParentKeys::<T>::remove(child_key, this_netuid);
             weight = weight.saturating_add(T::DbWeight::get().writes(1));
         }
-    }
 
-    // === Clear storage entries ===
-    // Clear subnet owner and hotkey
-    SubnetOwner::<T>::remove(this_netuid);
-    SubnetOwnerHotkey::<T>::remove(this_netuid);
-    weight = weight.saturating_add(T::DbWeight::get().writes(2));
+        for parent_key in parent_keys_to_remove {
+            ChildKeys::<T>::remove(parent_key, this_netuid);
+            weight = weight.saturating_add(T::DbWeight::get().writes(1));
+        }
 
-    // Clear hotkeys
-    for hotkey in hotkeys_to_remove {
-        TotalHotkeyAlpha::<T>::remove(hotkey.clone(), this_netuid);
-        TotalHotkeyShares::<T>::remove(hotkey.clone(), this_netuid);
+        // Clear reg allowed maps
+        NetworkRegistrationAllowed::<T>::remove(this_netuid);
+        NetworkPowRegistrationAllowed::<T>::remove(this_netuid);
         weight = weight.saturating_add(T::DbWeight::get().writes(2));
+        // ======== End Migration Logic ========
     }
-
-    // Clear pool
-    SubnetTAO::<T>::remove(this_netuid);
-    SubnetAlphaIn::<T>::remove(this_netuid);
-    weight = weight.saturating_add(T::DbWeight::get().writes(2));
-
-    // Clear AlphaOut
-    SubnetAlphaOut::<T>::remove(this_netuid);
-    weight = weight.saturating_add(T::DbWeight::get().writes(1));
-
-    // Clear pending emissions
-    SubnetTaoInEmission::<T>::remove(this_netuid);
-    SubnetAlphaInEmission::<T>::remove(this_netuid);
-    SubnetAlphaOutEmission::<T>::remove(this_netuid);
-    PendingEmission::<T>::remove(this_netuid);
-    PendingRootDivs::<T>::remove(this_netuid);
-    PendingAlphaSwapped::<T>::remove(this_netuid);
-    PendingOwnerCut::<T>::remove(this_netuid);
-    weight = weight.saturating_add(T::DbWeight::get().writes(7));
-
-    // Clear trackers
-    let clear_results_0 = AlphaDividendsPerSubnet::<T>::clear_prefix(this_netuid, u32::MAX, None);
-    weight = weight.saturating_add(T::DbWeight::get().writes(clear_results_0.unique.into()));
-    let clear_results_1 = TaoDividendsPerSubnet::<T>::clear_prefix(this_netuid, u32::MAX, None);
-    weight = weight.saturating_add(T::DbWeight::get().writes(clear_results_1.unique.into()));
-
-    // Adjust total stake
-    TotalStake::<T>::mutate(|total| {
-        *total = total.saturating_sub(subnet_tao.saturating_to_num::<u64>());
-    });
-    weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
-
-    // Clear subnet volume
-    SubnetVolume::<T>::remove(this_netuid);
-    weight = weight.saturating_add(T::DbWeight::get().writes(1));
-
-    // Clear child keys
-    let clear_results_2 = PendingChildKeys::<T>::clear_prefix(this_netuid, u32::MAX, None);
-    weight = weight.saturating_add(T::DbWeight::get().writes(clear_results_2.unique.into()));
-
-    let mut childkeys_to_remove: Vec<T::AccountId> = Vec::new();
-    for (childkey, netuid_i, _parents) in ParentKeys::<T>::iter() {
-        weight = weight.saturating_add(T::DbWeight::get().reads(1));
-        if netuid_i != this_netuid {
-            continue;
-        }
-
-        childkeys_to_remove.push(childkey);
-    }
-
-    let mut parent_keys_to_remove: Vec<T::AccountId> = Vec::new();
-    for (parent_key, netuid_i, _children) in ChildKeys::<T>::iter() {
-        weight = weight.saturating_add(T::DbWeight::get().reads(1));
-        if netuid_i != this_netuid {
-            continue;
-        }
-
-        parent_keys_to_remove.push(parent_key);
-    }
-
-    for child_key in childkeys_to_remove {
-        ParentKeys::<T>::remove(child_key, this_netuid);
-        weight = weight.saturating_add(T::DbWeight::get().writes(1));
-    }
-
-    for parent_key in parent_keys_to_remove {
-        ChildKeys::<T>::remove(parent_key, this_netuid);
-        weight = weight.saturating_add(T::DbWeight::get().writes(1));
-    }
-
-    // Clear reg allowed maps
-    NetworkRegistrationAllowed::<T>::remove(this_netuid);
-    NetworkPowRegistrationAllowed::<T>::remove(this_netuid);
-    weight = weight.saturating_add(T::DbWeight::get().writes(2));
-    // ======== End Migration Logic ========
 
     // Mark the migration as completed
     HasMigrationRun::<T>::insert(&migration_name, true);

--- a/pallets/subtensor/src/migrations/migrate_dissolve_sn73.rs
+++ b/pallets/subtensor/src/migrations/migrate_dissolve_sn73.rs
@@ -105,6 +105,10 @@ pub fn migrate_dissolve_sn73<T: Config>() -> Weight {
     }
 
     // === Clear storage entries ===
+    // Clear subnet owner and hotkey
+    SubnetOwner::<T>::remove(this_netuid);
+    SubnetOwnerHotkey::<T>::remove(this_netuid);
+    weight = weight.saturating_add(T::DbWeight::get().writes(2));
 
     // Clear hotkeys
     for hotkey in hotkeys_to_remove {

--- a/pallets/subtensor/src/migrations/mod.rs
+++ b/pallets/subtensor/src/migrations/mod.rs
@@ -4,6 +4,7 @@ pub mod migrate_commit_reveal_v2;
 pub mod migrate_create_root_network;
 pub mod migrate_delete_subnet_21;
 pub mod migrate_delete_subnet_3;
+pub mod migrate_dissolve_sn73;
 pub mod migrate_fix_is_network_member;
 pub mod migrate_identities_v2;
 pub mod migrate_init_total_issuance;

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -489,6 +489,11 @@ fn test_migrate_dissolve_sn73_removes_entries() {
         // Set sn volume
         SubnetVolume::<Test>::insert(this_netuid, 123);
 
+        // Set alpha out
+        SubnetAlphaOut::<Test>::insert(this_netuid, 100_000_000_000);
+        // Set alpha in
+        SubnetAlphaIn::<Test>::insert(this_netuid, 100_000_000_000);
+
         // Set reg allowed maps
         NetworkRegistrationAllowed::<Test>::insert(this_netuid, true);
         NetworkPowRegistrationAllowed::<Test>::insert(this_netuid, true);

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -489,6 +489,10 @@ fn test_migrate_dissolve_sn73_removes_entries() {
         // Set sn volume
         SubnetVolume::<Test>::insert(this_netuid, 123);
 
+		// Set reg allowed maps
+		NetworkRegistrationAllowed::<Test>::insert(this_netuid, true);
+		NetworkPowRegistrationAllowed::<Test>::insert(this_netuid, true);
+
         // === All maps are non-default ===
 
         // Run existing remove network dissolve

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -573,6 +573,10 @@ fn test_migrate_dissolve_sn73_removes_entries() {
 
         // Verify sn volume is removed
         assert!(SubnetVolume::<Test>::try_get(this_netuid).is_err());
+
+		// verify reg allowed maps are removed
+		assert!(NetworkRegistrationAllowed::<Test>::try_get(this_netuid).is_err());
+		assert!(NetworkPowRegistrationAllowed::<Test>::try_get(this_netuid).is_err());
     });
 }
 

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -489,9 +489,9 @@ fn test_migrate_dissolve_sn73_removes_entries() {
         // Set sn volume
         SubnetVolume::<Test>::insert(this_netuid, 123);
 
-		// Set reg allowed maps
-		NetworkRegistrationAllowed::<Test>::insert(this_netuid, true);
-		NetworkPowRegistrationAllowed::<Test>::insert(this_netuid, true);
+        // Set reg allowed maps
+        NetworkRegistrationAllowed::<Test>::insert(this_netuid, true);
+        NetworkPowRegistrationAllowed::<Test>::insert(this_netuid, true);
 
         // === All maps are non-default ===
 
@@ -578,9 +578,9 @@ fn test_migrate_dissolve_sn73_removes_entries() {
         // Verify sn volume is removed
         assert!(SubnetVolume::<Test>::try_get(this_netuid).is_err());
 
-		// verify reg allowed maps are removed
-		assert!(NetworkRegistrationAllowed::<Test>::try_get(this_netuid).is_err());
-		assert!(NetworkPowRegistrationAllowed::<Test>::try_get(this_netuid).is_err());
+        // verify reg allowed maps are removed
+        assert!(NetworkRegistrationAllowed::<Test>::try_get(this_netuid).is_err());
+        assert!(NetworkPowRegistrationAllowed::<Test>::try_get(this_netuid).is_err());
     });
 }
 

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -506,53 +506,41 @@ fn test_migrate_dissolve_sn73_removes_entries() {
         assert_eq!(SubnetVolume::<Test>::get(this_netuid), 0);
 
         for (childkey, netuid_i) in ParentKeys::<Test>::iter_keys() {
-            if netuid_i != this_netuid {
-                continue;
-            }
-
-            assert!(false, "Child key {} should be removed", childkey);
+            assert_ne!(
+                netuid_i, this_netuid,
+                "Child key {} should be removed",
+                childkey
+            );
         }
 
         for (parent_key, netuid_i) in ChildKeys::<Test>::iter_keys() {
-            if netuid_i != this_netuid {
-                continue;
-            }
-
-            assert!(false, "Parent key {} should be removed", parent_key);
+            assert_ne!(
+                netuid_i, this_netuid,
+                "Parent key {} should be removed",
+                parent_key
+            );
         }
 
         // Verify all the stake entries are removed
         for (hk, ck, netuid_i) in Alpha::<Test>::iter_keys() {
-            if netuid_i != this_netuid {
-                continue;
-            }
-
-            assert!(
-                false,
+            assert_ne!(
+                netuid_i, this_netuid,
                 "Stake entry for {} {} {} should be removed",
                 hk, ck, netuid_i
             );
         }
 
         for (hk, netuid_i) in TotalHotkeyAlpha::<Test>::iter_keys() {
-            if netuid_i != this_netuid {
-                continue;
-            }
-
-            assert!(
-                false,
+            assert_ne!(
+                netuid_i, this_netuid,
                 "Total alpha entry for {} {} should be removed",
                 hk, netuid_i
             );
         }
 
         for (ck, netuid_i) in TotalHotkeyShares::<Test>::iter_keys() {
-            if netuid_i != this_netuid {
-                continue;
-            }
-
-            assert!(
-                false,
+            assert_ne!(
+                netuid_i, this_netuid,
                 "Total shares entry for {} {} should be removed",
                 ck, netuid_i
             );

--- a/pallets/subtensor/src/tests/networks.rs
+++ b/pallets/subtensor/src/tests/networks.rs
@@ -42,245 +42,245 @@ fn test_registration_ok() {
     })
 }
 
-#[test]
-fn test_schedule_dissolve_network_execution() {
-    new_test_ext(1).execute_with(|| {
-        let block_number: u64 = 0;
-        let netuid: u16 = 2;
-        let tempo: u16 = 13;
-        let hotkey_account_id: U256 = U256::from(1);
-        let coldkey_account_id = U256::from(0); // Neighbour of the beast, har har
-        let (nonce, work): (u64, Vec<u8>) = SubtensorModule::create_work_for_block_number(
-            netuid,
-            block_number,
-            129123813,
-            &hotkey_account_id,
-        );
+// #[test]
+// fn test_schedule_dissolve_network_execution() {
+//     new_test_ext(1).execute_with(|| {
+//         let block_number: u64 = 0;
+//         let netuid: u16 = 2;
+//         let tempo: u16 = 13;
+//         let hotkey_account_id: U256 = U256::from(1);
+//         let coldkey_account_id = U256::from(0); // Neighbour of the beast, har har
+//         let (nonce, work): (u64, Vec<u8>) = SubtensorModule::create_work_for_block_number(
+//             netuid,
+//             block_number,
+//             129123813,
+//             &hotkey_account_id,
+//         );
 
-        //add network
-        add_network(netuid, tempo, 0);
+//         //add network
+//         add_network(netuid, tempo, 0);
 
-        assert_ok!(SubtensorModule::register(
-            <<Test as Config>::RuntimeOrigin>::signed(hotkey_account_id),
-            netuid,
-            block_number,
-            nonce,
-            work.clone(),
-            hotkey_account_id,
-            coldkey_account_id
-        ));
+//         assert_ok!(SubtensorModule::register(
+//             <<Test as Config>::RuntimeOrigin>::signed(hotkey_account_id),
+//             netuid,
+//             block_number,
+//             nonce,
+//             work.clone(),
+//             hotkey_account_id,
+//             coldkey_account_id
+//         ));
 
-        assert!(SubtensorModule::if_subnet_exist(netuid));
+//         assert!(SubtensorModule::if_subnet_exist(netuid));
 
-        assert_ok!(SubtensorModule::schedule_dissolve_network(
-            <<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id),
-            netuid
-        ));
+//         assert_ok!(SubtensorModule::schedule_dissolve_network(
+//             <<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id),
+//             netuid
+//         ));
 
-        let current_block = System::block_number();
-        let execution_block = current_block + DissolveNetworkScheduleDuration::<Test>::get();
+//         let current_block = System::block_number();
+//         let execution_block = current_block + DissolveNetworkScheduleDuration::<Test>::get();
 
-        System::assert_last_event(
-            Event::DissolveNetworkScheduled {
-                account: coldkey_account_id,
-                netuid,
-                execution_block,
-            }
-            .into(),
-        );
+//         System::assert_last_event(
+//             Event::DissolveNetworkScheduled {
+//                 account: coldkey_account_id,
+//                 netuid,
+//                 execution_block,
+//             }
+//             .into(),
+//         );
 
-        run_to_block(execution_block);
-        assert!(!SubtensorModule::if_subnet_exist(netuid));
-    })
-}
-
-#[test]
-fn test_non_owner_schedule_dissolve_network_execution() {
-    new_test_ext(1).execute_with(|| {
-        let block_number: u64 = 0;
-        let netuid: u16 = 2;
-        let tempo: u16 = 13;
-        let hotkey_account_id: U256 = U256::from(1);
-        let coldkey_account_id = U256::from(0); // Neighbour of the beast, har har
-        let non_network_owner_account_id = U256::from(2); //
-        let (nonce, work): (u64, Vec<u8>) = SubtensorModule::create_work_for_block_number(
-            netuid,
-            block_number,
-            129123813,
-            &hotkey_account_id,
-        );
-
-        //add network
-        add_network(netuid, tempo, 0);
-
-        assert_ok!(SubtensorModule::register(
-            <<Test as Config>::RuntimeOrigin>::signed(hotkey_account_id),
-            netuid,
-            block_number,
-            nonce,
-            work.clone(),
-            hotkey_account_id,
-            coldkey_account_id
-        ));
-
-        assert!(SubtensorModule::if_subnet_exist(netuid));
-
-        assert_ok!(SubtensorModule::schedule_dissolve_network(
-            <<Test as Config>::RuntimeOrigin>::signed(non_network_owner_account_id),
-            netuid
-        ));
-
-        let current_block = System::block_number();
-        let execution_block = current_block + DissolveNetworkScheduleDuration::<Test>::get();
-
-        System::assert_last_event(
-            Event::DissolveNetworkScheduled {
-                account: non_network_owner_account_id,
-                netuid,
-                execution_block,
-            }
-            .into(),
-        );
-
-        run_to_block(execution_block);
-        // network exists since the caller is no the network owner
-        assert!(SubtensorModule::if_subnet_exist(netuid));
-    })
-}
+//         run_to_block(execution_block);
+//         assert!(!SubtensorModule::if_subnet_exist(netuid));
+//     })
+// }
 
 #[test]
-fn test_new_owner_schedule_dissolve_network_execution() {
-    new_test_ext(1).execute_with(|| {
-        let block_number: u64 = 0;
-        let netuid: u16 = 2;
-        let tempo: u16 = 13;
-        let hotkey_account_id: U256 = U256::from(1);
-        let coldkey_account_id = U256::from(0); // Neighbour of the beast, har har
-        let new_network_owner_account_id = U256::from(2); //
-        let (nonce, work): (u64, Vec<u8>) = SubtensorModule::create_work_for_block_number(
-            netuid,
-            block_number,
-            129123813,
-            &hotkey_account_id,
-        );
+// fn test_non_owner_schedule_dissolve_network_execution() {
+//     new_test_ext(1).execute_with(|| {
+//         let block_number: u64 = 0;
+//         let netuid: u16 = 2;
+//         let tempo: u16 = 13;
+//         let hotkey_account_id: U256 = U256::from(1);
+//         let coldkey_account_id = U256::from(0); // Neighbour of the beast, har har
+//         let non_network_owner_account_id = U256::from(2); //
+//         let (nonce, work): (u64, Vec<u8>) = SubtensorModule::create_work_for_block_number(
+//             netuid,
+//             block_number,
+//             129123813,
+//             &hotkey_account_id,
+//         );
 
-        //add network
-        add_network(netuid, tempo, 0);
+//         //add network
+//         add_network(netuid, tempo, 0);
 
-        assert_ok!(SubtensorModule::register(
-            <<Test as Config>::RuntimeOrigin>::signed(hotkey_account_id),
-            netuid,
-            block_number,
-            nonce,
-            work.clone(),
-            hotkey_account_id,
-            coldkey_account_id
-        ));
+//         assert_ok!(SubtensorModule::register(
+//             <<Test as Config>::RuntimeOrigin>::signed(hotkey_account_id),
+//             netuid,
+//             block_number,
+//             nonce,
+//             work.clone(),
+//             hotkey_account_id,
+//             coldkey_account_id
+//         ));
 
-        assert!(SubtensorModule::if_subnet_exist(netuid));
+//         assert!(SubtensorModule::if_subnet_exist(netuid));
 
-        // the account is not network owner when schedule the call
-        assert_ok!(SubtensorModule::schedule_dissolve_network(
-            <<Test as Config>::RuntimeOrigin>::signed(new_network_owner_account_id),
-            netuid
-        ));
+//         assert_ok!(SubtensorModule::schedule_dissolve_network(
+//             <<Test as Config>::RuntimeOrigin>::signed(non_network_owner_account_id),
+//             netuid
+//         ));
 
-        let current_block = System::block_number();
-        let execution_block = current_block + DissolveNetworkScheduleDuration::<Test>::get();
+//         let current_block = System::block_number();
+//         let execution_block = current_block + DissolveNetworkScheduleDuration::<Test>::get();
 
-        System::assert_last_event(
-            Event::DissolveNetworkScheduled {
-                account: new_network_owner_account_id,
-                netuid,
-                execution_block,
-            }
-            .into(),
-        );
-        run_to_block(current_block + 1);
-        // become network owner after call scheduled
-        crate::SubnetOwner::<Test>::insert(netuid, new_network_owner_account_id);
+//         System::assert_last_event(
+//             Event::DissolveNetworkScheduled {
+//                 account: non_network_owner_account_id,
+//                 netuid,
+//                 execution_block,
+//             }
+//             .into(),
+//         );
 
-        run_to_block(execution_block);
-        // network exists since the caller is no the network owner
-        assert!(!SubtensorModule::if_subnet_exist(netuid));
-    })
-}
+//         run_to_block(execution_block);
+//         // network exists since the caller is no the network owner
+//         assert!(SubtensorModule::if_subnet_exist(netuid));
+//     })
+// }
 
-#[test]
-fn test_schedule_dissolve_network_execution_with_coldkey_swap() {
-    new_test_ext(1).execute_with(|| {
-        let block_number: u64 = 0;
-        let netuid: u16 = 2;
-        let tempo: u16 = 13;
-        let hotkey_account_id: U256 = U256::from(1);
-        let coldkey_account_id = U256::from(0); // Neighbour of the beast, har har
-        let new_network_owner_account_id = U256::from(2); //
+// #[test]
+// fn test_new_owner_schedule_dissolve_network_execution() {
+//     new_test_ext(1).execute_with(|| {
+//         let block_number: u64 = 0;
+//         let netuid: u16 = 2;
+//         let tempo: u16 = 13;
+//         let hotkey_account_id: U256 = U256::from(1);
+//         let coldkey_account_id = U256::from(0); // Neighbour of the beast, har har
+//         let new_network_owner_account_id = U256::from(2); //
+//         let (nonce, work): (u64, Vec<u8>) = SubtensorModule::create_work_for_block_number(
+//             netuid,
+//             block_number,
+//             129123813,
+//             &hotkey_account_id,
+//         );
 
-        SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, 1000000000000000);
+//         //add network
+//         add_network(netuid, tempo, 0);
 
-        let (nonce, work): (u64, Vec<u8>) = SubtensorModule::create_work_for_block_number(
-            netuid,
-            block_number,
-            129123813,
-            &hotkey_account_id,
-        );
+//         assert_ok!(SubtensorModule::register(
+//             <<Test as Config>::RuntimeOrigin>::signed(hotkey_account_id),
+//             netuid,
+//             block_number,
+//             nonce,
+//             work.clone(),
+//             hotkey_account_id,
+//             coldkey_account_id
+//         ));
 
-        //add network
-        add_network(netuid, tempo, 0);
+//         assert!(SubtensorModule::if_subnet_exist(netuid));
 
-        assert_ok!(SubtensorModule::register(
-            <<Test as Config>::RuntimeOrigin>::signed(hotkey_account_id),
-            netuid,
-            block_number,
-            nonce,
-            work.clone(),
-            hotkey_account_id,
-            coldkey_account_id
-        ));
+//         // the account is not network owner when schedule the call
+//         assert_ok!(SubtensorModule::schedule_dissolve_network(
+//             <<Test as Config>::RuntimeOrigin>::signed(new_network_owner_account_id),
+//             netuid
+//         ));
 
-        assert!(SubtensorModule::if_subnet_exist(netuid));
+//         let current_block = System::block_number();
+//         let execution_block = current_block + DissolveNetworkScheduleDuration::<Test>::get();
 
-        // the account is not network owner when schedule the call
-        assert_ok!(SubtensorModule::schedule_swap_coldkey(
-            <<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id),
-            new_network_owner_account_id
-        ));
+//         System::assert_last_event(
+//             Event::DissolveNetworkScheduled {
+//                 account: new_network_owner_account_id,
+//                 netuid,
+//                 execution_block,
+//             }
+//             .into(),
+//         );
+//         run_to_block(current_block + 1);
+//         // become network owner after call scheduled
+//         crate::SubnetOwner::<Test>::insert(netuid, new_network_owner_account_id);
 
-        let current_block = System::block_number();
-        let execution_block = current_block + ColdkeySwapScheduleDuration::<Test>::get();
+//         run_to_block(execution_block);
+//         // network exists since the caller is no the network owner
+//         assert!(!SubtensorModule::if_subnet_exist(netuid));
+//     })
+// }
 
-        run_to_block(execution_block - 1);
+// #[test]
+// fn test_schedule_dissolve_network_execution_with_coldkey_swap() {
+//     new_test_ext(1).execute_with(|| {
+//         let block_number: u64 = 0;
+//         let netuid: u16 = 2;
+//         let tempo: u16 = 13;
+//         let hotkey_account_id: U256 = U256::from(1);
+//         let coldkey_account_id = U256::from(0); // Neighbour of the beast, har har
+//         let new_network_owner_account_id = U256::from(2); //
 
-        // the account is not network owner when schedule the call
-        assert_ok!(SubtensorModule::schedule_dissolve_network(
-            <<Test as Config>::RuntimeOrigin>::signed(new_network_owner_account_id),
-            netuid
-        ));
+//         SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, 1000000000000000);
 
-        System::assert_last_event(
-            Event::DissolveNetworkScheduled {
-                account: new_network_owner_account_id,
-                netuid,
-                execution_block: DissolveNetworkScheduleDuration::<Test>::get() + execution_block
-                    - 1,
-            }
-            .into(),
-        );
+//         let (nonce, work): (u64, Vec<u8>) = SubtensorModule::create_work_for_block_number(
+//             netuid,
+//             block_number,
+//             129123813,
+//             &hotkey_account_id,
+//         );
 
-        run_to_block(execution_block);
-        assert_eq!(
-            crate::SubnetOwner::<Test>::get(netuid),
-            new_network_owner_account_id
-        );
+//         //add network
+//         add_network(netuid, tempo, 0);
 
-        let current_block = System::block_number();
-        let execution_block = current_block + DissolveNetworkScheduleDuration::<Test>::get();
+//         assert_ok!(SubtensorModule::register(
+//             <<Test as Config>::RuntimeOrigin>::signed(hotkey_account_id),
+//             netuid,
+//             block_number,
+//             nonce,
+//             work.clone(),
+//             hotkey_account_id,
+//             coldkey_account_id
+//         ));
 
-        run_to_block(execution_block);
-        // network exists since the caller is no the network owner
-        assert!(!SubtensorModule::if_subnet_exist(netuid));
-    })
-}
+//         assert!(SubtensorModule::if_subnet_exist(netuid));
+
+//         // the account is not network owner when schedule the call
+//         assert_ok!(SubtensorModule::schedule_swap_coldkey(
+//             <<Test as Config>::RuntimeOrigin>::signed(coldkey_account_id),
+//             new_network_owner_account_id
+//         ));
+
+//         let current_block = System::block_number();
+//         let execution_block = current_block + ColdkeySwapScheduleDuration::<Test>::get();
+
+//         run_to_block(execution_block - 1);
+
+//         // the account is not network owner when schedule the call
+//         assert_ok!(SubtensorModule::schedule_dissolve_network(
+//             <<Test as Config>::RuntimeOrigin>::signed(new_network_owner_account_id),
+//             netuid
+//         ));
+
+//         System::assert_last_event(
+//             Event::DissolveNetworkScheduled {
+//                 account: new_network_owner_account_id,
+//                 netuid,
+//                 execution_block: DissolveNetworkScheduleDuration::<Test>::get() + execution_block
+//                     - 1,
+//             }
+//             .into(),
+//         );
+
+//         run_to_block(execution_block);
+//         assert_eq!(
+//             crate::SubnetOwner::<Test>::get(netuid),
+//             new_network_owner_account_id
+//         );
+
+//         let current_block = System::block_number();
+//         let execution_block = current_block + DissolveNetworkScheduleDuration::<Test>::get();
+
+//         run_to_block(execution_block);
+//         // network exists since the caller is no the network owner
+//         assert!(!SubtensorModule::if_subnet_exist(netuid));
+//     })
+// }
 
 // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --package pallet-subtensor --lib -- tests::networks::test_register_subnet_low_lock_cost --exact --show-output --nocapture
 #[test]

--- a/pallets/subtensor/src/tests/networks.rs
+++ b/pallets/subtensor/src/tests/networks.rs
@@ -1,6 +1,5 @@
 use super::mock::*;
 use crate::*;
-use crate::{ColdkeySwapScheduleDuration, DissolveNetworkScheduleDuration, Event};
 use frame_support::assert_ok;
 use frame_system::Config;
 use sp_core::U256;
@@ -94,7 +93,7 @@ fn test_registration_ok() {
 //     })
 // }
 
-#[test]
+// #[test]
 // fn test_non_owner_schedule_dissolve_network_execution() {
 //     new_test_ext(1).execute_with(|| {
 //         let block_number: u64 = 0;


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
Adds a migration to unstake all of the SN73 stakers and clear the pool and storage maps.
Also disables the call to `schedule_dissolve`


## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

Disables `schedule_dissolve`

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.