### PR TITLE
Feat/record initial subnet tao in totalstake

### DIFF
--- a/.github/workflows/check-finney.yml
+++ b/.github/workflows/check-finney.yml
@@ -2,7 +2,6 @@ name: Finney Deploy Check
 
 on:
   pull_request:
-    branches: [finney, main]
     types: [labeled, unlabeled, synchronize, opened]
 
 env:

--- a/.github/workflows/check-finney.yml
+++ b/.github/workflows/check-finney.yml
@@ -2,6 +2,7 @@ name: Finney Deploy Check
 
 on:
   pull_request:
+    branches: [finney, main]
     types: [labeled, unlabeled, synchronize, opened]
 
 env:

--- a/.github/workflows/try-runtime.yml
+++ b/.github/workflows/try-runtime.yml
@@ -50,7 +50,7 @@ jobs:
 
   check-finney:
     name: check finney
-    if: github.base_ref == 'testnet' || github.base_ref == 'devnet' || github.base_ref == 'main'
+    # if: github.base_ref == 'testnet' || github.base_ref == 'devnet' || github.base_ref == 'main'
     runs-on: SubtensorCI
     steps:
       - name: Checkout sources

--- a/pallets/subtensor/src/subnets/subnet.rs
+++ b/pallets/subtensor/src/subnets/subnet.rs
@@ -217,6 +217,11 @@ impl<T: Config> Pallet<T> {
             Self::burn_tokens(actual_tao_lock_amount_less_pool_tao);
         }
 
+        if actual_tao_lock_amount > 0 && pool_initial_tao > 0 {
+            // Record in TotalStake the initial TAO in the pool.
+            Self::increase_total_stake(pool_initial_tao);
+        }
+
         // --- 15. Add the identity if it exists
         if let Some(identity_value) = identity {
             ensure!(

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -34,20 +34,21 @@ fn test_initialise_ti() {
     use frame_support::traits::OnRuntimeUpgrade;
 
     new_test_ext(1).execute_with(|| {
-        crate::SubnetLocked::<Test>::insert(1, 100);
-        crate::SubnetLocked::<Test>::insert(2, 5);
         pallet_balances::TotalIssuance::<Test>::put(1000);
-        crate::TotalStake::<Test>::put(25);
+        crate::SubnetTAO::<Test>::insert(1, 100);
+        crate::SubnetTAO::<Test>::insert(2, 5);
 
         // Ensure values are NOT initialized prior to running migration
         assert!(crate::TotalIssuance::<Test>::get() == 0);
+		assert!(crate::TotalStake::<Test>::get() == 0);
 
         crate::migrations::migrate_init_total_issuance::initialise_total_issuance::Migration::<Test>::on_runtime_upgrade();
 
         // Ensure values were initialized correctly
+		assert!(crate::TotalStake::<Test>::get() == 105);
         assert!(
             crate::TotalIssuance::<Test>::get()
-                == 105u64.saturating_add(1000).saturating_add(25)
+                == 105u64.saturating_add(1000)
         );
     });
 }

--- a/pallets/subtensor/src/tests/staking.rs
+++ b/pallets/subtensor/src/tests/staking.rs
@@ -57,8 +57,11 @@ fn test_add_stake_ok_no_emission() {
             0
         );
 
-        // Also total stake should be zero
-        assert_eq!(SubtensorModule::get_total_stake(), 0);
+        // Also total stake should be equal to the network initial lock
+        assert_eq!(
+            SubtensorModule::get_total_stake(),
+            SubtensorModule::get_network_min_lock()
+        );
 
         // Transfer to hotkey account, and check if the result is ok
         assert_ok!(SubtensorModule::add_stake(
@@ -79,7 +82,10 @@ fn test_add_stake_ok_no_emission() {
         assert_eq!(SubtensorModule::get_coldkey_balance(&coldkey_account_id), 1);
 
         // Check if total stake has increased accordingly.
-        assert_eq!(SubtensorModule::get_total_stake(), amount);
+        assert_eq!(
+            SubtensorModule::get_total_stake(),
+            amount + SubtensorModule::get_network_min_lock()
+        );
     });
 }
 
@@ -358,7 +364,10 @@ fn test_remove_stake_ok_no_emission() {
         register_ok_neuron(netuid, hotkey_account_id, coldkey_account_id, 192213123);
 
         // Some basic assertions
-        assert_eq!(SubtensorModule::get_total_stake(), 0);
+        assert_eq!(
+            SubtensorModule::get_total_stake(),
+            SubtensorModule::get_network_min_lock()
+        );
         assert_eq!(
             SubtensorModule::get_total_stake_for_hotkey(&hotkey_account_id),
             0
@@ -387,7 +396,10 @@ fn test_remove_stake_ok_no_emission() {
             SubtensorModule::get_total_stake_for_hotkey(&hotkey_account_id),
             0
         );
-        assert_eq!(SubtensorModule::get_total_stake(), fee);
+        assert_eq!(
+            SubtensorModule::get_total_stake(),
+            SubtensorModule::get_network_min_lock() + fee
+        );
     });
 }
 
@@ -403,7 +415,10 @@ fn test_remove_stake_amount_too_low() {
         register_ok_neuron(netuid, hotkey_account_id, coldkey_account_id, 192213123);
 
         // Some basic assertions
-        assert_eq!(SubtensorModule::get_total_stake(), 0);
+        assert_eq!(
+            SubtensorModule::get_total_stake(),
+            SubtensorModule::get_network_min_lock()
+        );
         assert_eq!(
             SubtensorModule::get_total_stake_for_hotkey(&hotkey_account_id),
             0
@@ -515,7 +530,10 @@ fn test_remove_stake_total_balance_no_change() {
         register_ok_neuron(netuid, hotkey_account_id, coldkey_account_id, 192213123);
 
         // Some basic assertions
-        assert_eq!(SubtensorModule::get_total_stake(), 0);
+        assert_eq!(
+            SubtensorModule::get_total_stake(),
+            SubtensorModule::get_network_min_lock()
+        );
         assert_eq!(
             SubtensorModule::get_total_stake_for_hotkey(&hotkey_account_id),
             0
@@ -549,7 +567,10 @@ fn test_remove_stake_total_balance_no_change() {
             SubtensorModule::get_total_stake_for_hotkey(&hotkey_account_id),
             0
         );
-        assert_eq!(SubtensorModule::get_total_stake(), fee);
+        assert_eq!(
+            SubtensorModule::get_total_stake(),
+            SubtensorModule::get_network_min_lock() + fee
+        );
 
         // Check total balance is equal to the added stake. Even after remove stake (no fee, includes reserved/locked balance)
         let total_balance = Balances::total_balance(&coldkey_account_id);
@@ -648,7 +669,10 @@ fn test_remove_stake_total_issuance_no_change() {
         SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, amount);
 
         // Some basic assertions
-        assert_eq!(SubtensorModule::get_total_stake(), 0);
+        assert_eq!(
+            SubtensorModule::get_total_stake(),
+            SubtensorModule::get_network_min_lock()
+        );
         assert_eq!(
             SubtensorModule::get_total_stake_for_hotkey(&hotkey_account_id),
             0
@@ -697,7 +721,7 @@ fn test_remove_stake_total_issuance_no_change() {
         );
         assert_abs_diff_eq!(
             SubtensorModule::get_total_stake(),
-            fee * 2,
+            fee * 2 + SubtensorModule::get_network_min_lock(),
             epsilon = fee / 1000
         );
 
@@ -762,8 +786,11 @@ fn test_add_stake_to_hotkey_account_ok() {
         let netuid: u16 = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
         register_ok_neuron(netuid, hotkey_id, coldkey_id, 192213123);
 
-        // There is not stake in the system at first, so result should be 0;
-        assert_eq!(SubtensorModule::get_total_stake(), 0);
+        // There is no stake in the system at first, other than the network initial lock so result;
+        assert_eq!(
+            SubtensorModule::get_total_stake(),
+            SubtensorModule::get_network_min_lock()
+        );
 
         SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
             &hotkey_id,
@@ -2497,7 +2524,11 @@ fn test_stake_overflow() {
         );
 
         // Check if total stake has increased accordingly.
-        assert_abs_diff_eq!(SubtensorModule::get_total_stake(), amount, epsilon = 10);
+        assert_abs_diff_eq!(
+            SubtensorModule::get_total_stake(),
+            amount + SubtensorModule::get_network_min_lock(),
+            epsilon = 10
+        );
     });
 }
 

--- a/pallets/subtensor/src/utils/try_state.rs
+++ b/pallets/subtensor/src/utils/try_state.rs
@@ -6,16 +6,11 @@ impl<T: Config> Pallet<T> {
     /// Checks [`TotalIssuance`] equals the sum of currency issuance, total stake, and total subnet
     /// locked.
     pub(crate) fn check_total_issuance() -> Result<(), sp_runtime::TryRuntimeError> {
-        // Get the total subnet locked amount
-        let total_subnet_locked = Self::get_total_subnet_locked();
-
         // Get the total currency issuance
         let currency_issuance = T::Currency::total_issuance();
 
         // Calculate the expected total issuance
-        let expected_total_issuance = currency_issuance
-            .saturating_add(TotalStake::<T>::get())
-            .saturating_add(total_subnet_locked);
+        let expected_total_issuance = currency_issuance.saturating_add(TotalStake::<T>::get());
 
         // Verify the diff between calculated TI and actual TI is less than delta
         //

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -205,7 +205,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 250,
+    spec_version: 251,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
Fixes an issue with TotalStake tracker to record the initial SubnetTAO for a new subnet in `TotalStake` as intended.

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.