### PR TITLE
Add transferStake and swapStake precompile for EVM

### DIFF
--- a/precompiles/src/solidity/stakingV2.sol
+++ b/precompiles/src/solidity/stakingV2.sol
@@ -23,6 +23,30 @@ interface IStaking {
     function addStake(bytes32 hotkey, uint256 amount, uint256 netuid) external payable;
 
     /**
+     * @dev Swaps a subtensor stake from one subnet to another.
+     *
+     * This function allows external accounts and contracts to swap a subtensor stake between two different subnets.
+     * It effectively calls `swap_stake` on the subtensor pallet with specified hotkey, origin subnet, destination subnet,
+     * and alpha amount as parameters.
+     *
+     * @param hotkey The hotkey public key (32 bytes).
+     * @param originNetuid The subnet to swap from (uint256).
+     * @param destinationNetuid The subnet to swap to (uint256).
+     * @param alphaAmount The amount to swap in rao
+     *
+     * Requirements:
+     * - `hotkey` must be a valid hotkey registered on the network, ensuring that the stake is
+     *   correctly attributed.
+     * - `originNetuid` and `destinationNetuid` must be valid subnets on the network.
+     */
+    function swapStake(
+      bytes32 hotkey,
+      uint256 originNetuid,
+      uint256 destinationNetuid,
+      uint256 alphaAmount
+    ) external;
+
+    /**
      * @dev Removes a subtensor stake `amount` from the specified `hotkey`.
      *
      * This function allows external accounts and contracts to unstake TAO from the subtensor pallet,
@@ -44,6 +68,34 @@ interface IStaking {
         bytes32 hotkey,
         uint256 amount,
         uint256 netuid
+    ) external;
+
+    /**
+     * @dev Transfers a subtensor stake from one hotkey to another.
+     *
+     * This function allows external accounts and contracts to transfer a subtensor stake from one hotkey to another.
+     * It effectively calls `transfer_stake` on the subtensor pallet with specified destination coldkey, hotkey, origin subnet,
+     * destination subnet, and alpha amount as parameters.
+     *
+     * @param destinationColdkey The coldkey public key (32 bytes) of the destination account.
+     * @param hotkey The hotkey public key (32 bytes) of the source account.
+     * @param originNetuid The subnet to transfer from (uint256).
+     * @param destinationNetuid The subnet to transfer to (uint256).
+     * @param alphaAmount The amount to transfer in rao.
+     *
+     * Requirements:
+     * - `hotkey` must be a valid hotkey registered on the network, ensuring that the stake is
+     *   correctly attributed.
+     * - `destinationColdkey` must be a valid coldkey registered on the network, ensuring that the stake is
+     *   correctly attributed.
+     * - `originNetuid` and `destinationNetuid` must be valid subnets on the network.
+     */
+    function transferStake(
+        bytes32 destinationColdkey,
+        bytes32 hotkey,
+        uint256 originNetuid,
+        uint256 destinationNetuid,
+        uint256 alphaAmount
     ) external;
 
     /**

--- a/precompiles/src/staking.rs
+++ b/precompiles/src/staking.rs
@@ -99,6 +99,28 @@ where
         handle.try_dispatch_runtime_call::<R, _>(call, RawOrigin::Signed(account_id))
     }
 
+    #[precompile::public("swapStake(bytes32,uint256,uint256,uint256)")]
+    fn swap_stake(
+        handle: &mut impl PrecompileHandle,
+        hotkey: H256,
+        origin_netuid: U256,
+        destination_netuid: U256,
+        alpha_amount: U256,
+    ) -> EvmResult<()> {
+        let account_id = handle.caller_account_id::<R>();
+        let hotkey = R::AccountId::from(hotkey.0);
+        let origin_netuid = try_u16_from_u256(origin_netuid)?;
+        let destination_netuid = try_u16_from_u256(destination_netuid)?;
+        let alpha_amount = alpha_amount.unique_saturated_into();
+        let call = pallet_subtensor::Call::<R>::swap_stake {
+            hotkey,
+            origin_netuid,
+            destination_netuid,
+            alpha_amount,
+        };
+        handle.try_dispatch_runtime_call::<R, _>(call, RawOrigin::Signed(account_id))
+    }
+
     #[precompile::public("removeStake(bytes32,uint256,uint256)")]
     fn remove_stake(
         handle: &mut impl PrecompileHandle,
@@ -114,6 +136,32 @@ where
             hotkey,
             netuid,
             amount_unstaked,
+        };
+
+        handle.try_dispatch_runtime_call::<R, _>(call, RawOrigin::Signed(account_id))
+    }
+
+    #[precompile::public("transferStake(bytes32,bytes32,uint256,uint256,uint256)")]
+    fn transfer_stake(
+        handle: &mut impl PrecompileHandle,
+        destination_coldkey: H256,
+        hotkey: H256,
+        origin_netuid: U256,
+        destination_netuid: U256,
+        alpha_amount: U256,
+    ) -> EvmResult<()> {
+        let account_id = handle.caller_account_id::<R>();
+        let destination_coldkey = R::AccountId::from(destination_coldkey.0);
+        let hotkey = R::AccountId::from(hotkey.0);
+        let origin_netuid = try_u16_from_u256(origin_netuid)?;
+        let destination_netuid = try_u16_from_u256(destination_netuid)?;
+        let alpha_amount = alpha_amount.unique_saturated_into();
+        let call = pallet_subtensor::Call::<R>::transfer_stake {
+            destination_coldkey,
+            hotkey,
+            origin_netuid,
+            destination_netuid,
+            alpha_amount,
         };
 
         handle.try_dispatch_runtime_call::<R, _>(call, RawOrigin::Signed(account_id))


### PR DESCRIPTION
## Description
This PR aims to add two other precompiled methods:
- `swapStake(bytes32,uint256,uint256,uint256)`
- `transferStake(bytes32,bytes32,uint256,uint256,uint256)`

swapStake would allow EVM users / contracts to swap from one subnet to another subnet while sticking to the same hotkey

transferStake would allow EVM users / contracts to transfer their coldkey stake from one coldkey to another coldkey

## Related Issue(s)

- N.A.

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x]  New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.