### PR TITLE
Hotfix/dont max upscale bonds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,9 +1075,9 @@ checksum = "fd6c0e7b807d60291f42f33f58480c0bfafe28ed08286446f45e463728cf9c1c"
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "812acba72f0a070b003d3697490d2b55b837230ae7c6c6497f05cc2ddbb8d938"
 dependencies = [
  "jobserver",
  "libc",
@@ -4247,7 +4247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7807,14 +7807,15 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.13"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom",
  "libc",
+ "spin 0.9.8",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
@@ -7998,7 +7999,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.13",
+ "ring 0.17.8",
  "rustls-webpki",
  "sct",
 ]
@@ -8030,7 +8031,7 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.13",
+ "ring 0.17.8",
  "untrusted 0.9.0",
 ]
 
@@ -9281,7 +9282,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.13",
+ "ring 0.17.8",
  "untrusted 0.9.0",
 ]
 
@@ -9704,7 +9705,7 @@ dependencies = [
  "chacha20poly1305",
  "curve25519-dalek",
  "rand_core",
- "ring 0.17.13",
+ "ring 0.17.8",
  "rustc_version 0.4.1",
  "sha2 0.10.8",
  "subtle 2.6.1",
@@ -12275,7 +12276,7 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
 dependencies = [
- "ring 0.17.13",
+ "ring 0.17.8",
  "untrusted 0.9.0",
 ]
 

--- a/pallets/subtensor/src/epoch/math.rs
+++ b/pallets/subtensor/src/epoch/math.rs
@@ -549,6 +549,24 @@ pub fn inplace_mask_rows(mask: &[bool], matrix: &mut [Vec<I32F32>]) {
         });
 }
 
+// Apply column mask to matrix, mask=true will mask out, i.e. set to 0.
+// Assumes each column has the same length.
+#[allow(dead_code)]
+pub fn inplace_mask_cols(mask: &[bool], matrix: &mut [Vec<I32F32>]) {
+    let Some(first_row) = matrix.first() else {
+        return;
+    };
+    assert_eq!(mask.len(), first_row.len());
+    let zero: I32F32 = I32F32::saturating_from_num(0);
+    matrix.iter_mut().for_each(|row_elem| {
+        row_elem.iter_mut().zip(mask).for_each(|(elem, mask_col)| {
+            if *mask_col {
+                *elem = zero;
+            }
+        });
+    });
+}
+
 // Mask out the diagonal of the input matrix in-place.
 #[allow(dead_code)]
 pub fn inplace_mask_diag(matrix: &mut [Vec<I32F32>]) {

--- a/pallets/subtensor/src/epoch/math.rs
+++ b/pallets/subtensor/src/epoch/math.rs
@@ -26,6 +26,11 @@ pub fn fixed_to_u16(x: I32F32) -> u16 {
 }
 
 #[allow(dead_code)]
+pub fn fixed_to_u32(x: I32F32) -> u32 {
+    x.saturating_to_num::<u32>()
+}
+
+#[allow(dead_code)]
 pub fn fixed_to_u64(x: I32F32) -> u64 {
     x.saturating_to_num::<u64>()
 }
@@ -61,6 +66,11 @@ pub fn fixed_proportion_to_u16(x: I32F32) -> u16 {
 }
 
 #[allow(dead_code)]
+pub fn fixed_proportion_to_u32(x: I32F32) -> u32 {
+    fixed_to_u32(x.saturating_mul(I32F32::saturating_from_num(u32::MAX)))
+}
+
+#[allow(dead_code)]
 pub fn vec_fixed32_to_u64(vec: Vec<I32F32>) -> Vec<u64> {
     vec.into_iter().map(fixed_to_u64).collect()
 }
@@ -88,6 +98,11 @@ pub fn vec_u16_proportions_to_fixed(vec: Vec<u16>) -> Vec<I32F32> {
 #[allow(dead_code)]
 pub fn vec_fixed_proportions_to_u16(vec: Vec<I32F32>) -> Vec<u16> {
     vec.into_iter().map(fixed_proportion_to_u16).collect()
+}
+
+#[allow(dead_code)]
+pub fn vec_fixed_proportions_to_u32(vec: Vec<I32F32>) -> Vec<u32> {
+    vec.into_iter().map(fixed_proportion_to_u32).collect()
 }
 
 #[allow(dead_code)]

--- a/pallets/subtensor/src/epoch/math.rs
+++ b/pallets/subtensor/src/epoch/math.rs
@@ -674,6 +674,26 @@ pub fn vec_mask_sparse_matrix(
     result
 }
 
+// Remove cells from sparse matrix where the mask function of a scalar and a vector is true.
+#[allow(dead_code, clippy::indexing_slicing)]
+pub fn scalar_vec_mask_sparse_matrix(
+    sparse_matrix: &[Vec<(u16, I32F32)>],
+    scalar: u64,
+    vector: &[u64],
+    mask_fn: &dyn Fn(u64, u64) -> bool,
+) -> Vec<Vec<(u16, I32F32)>> {
+    let n: usize = sparse_matrix.len();
+    let mut result: Vec<Vec<(u16, I32F32)>> = vec![vec![]; n];
+    for (i, sparse_row) in sparse_matrix.iter().enumerate() {
+        for (j, value) in sparse_row {
+            if !mask_fn(scalar, vector[*j as usize]) {
+                result[i].push((*j, *value));
+            }
+        }
+    }
+    result
+}
+
 // Row-wise matrix-vector hadamard product.
 #[allow(dead_code)]
 pub fn row_hadamard(matrix: &[Vec<I32F32>], vector: &[I32F32]) -> Vec<Vec<I32F32>> {

--- a/pallets/subtensor/src/epoch/run_epoch.rs
+++ b/pallets/subtensor/src/epoch/run_epoch.rs
@@ -347,13 +347,13 @@ impl<T: Config> Pallet<T> {
             .for_each(|(i, ((new_permit, validator_permit), ema_bond))| {
                 // Set bonds only if uid retains validator permit, otherwise clear bonds.
                 if *new_permit {
-                    let new_bonds_row: Vec<(u16, u16)> = (0..n)
-                        .zip(vec_fixed_proportions_to_u16(ema_bond.clone()))
+                    let new_bonds_row: Vec<(u16, u32)> = (0..n)
+                        .zip(vec_fixed_proportions_to_u32(ema_bond.clone()))
                         .collect();
                     Bonds::<T>::insert(netuid, i as u16, new_bonds_row);
                 } else if validator_permit {
                     // Only overwrite the intersection.
-                    let new_empty_bonds_row: Vec<(u16, u16)> = vec![];
+                    let new_empty_bonds_row: Vec<(u16, u32)> = vec![];
                     Bonds::<T>::insert(netuid, i as u16, new_empty_bonds_row);
                 }
             });
@@ -728,14 +728,14 @@ impl<T: Config> Pallet<T> {
             .for_each(|(i, ((new_permit, validator_permit), ema_bond))| {
                 // Set bonds only if uid retains validator permit, otherwise clear bonds.
                 if *new_permit {
-                    let new_bonds_row: Vec<(u16, u16)> = ema_bond
+                    let new_bonds_row: Vec<(u16, u32)> = ema_bond
                         .iter()
-                        .map(|(j, value)| (*j, fixed_proportion_to_u16(*value)))
+                        .map(|(j, value)| (*j, fixed_proportion_to_u32(*value)))
                         .collect();
                     Bonds::<T>::insert(netuid, i as u16, new_bonds_row);
                 } else if validator_permit {
                     // Only overwrite the intersection.
-                    let new_empty_bonds_row: Vec<(u16, u16)> = vec![];
+                    let new_empty_bonds_row: Vec<(u16, u32)> = vec![];
                     Bonds::<T>::insert(netuid, i as u16, new_empty_bonds_row);
                 }
             });
@@ -820,12 +820,12 @@ impl<T: Config> Pallet<T> {
         weights
     }
 
-    /// Output unnormalized sparse bonds, input bonds are assumed to be column max-upscaled in u16.
+    /// Output unnormalized sparse bonds.
     pub fn get_bonds_sparse(netuid: u16) -> Vec<Vec<(u16, I32F32)>> {
         let n: usize = Self::get_subnetwork_n(netuid) as usize;
         let mut bonds: Vec<Vec<(u16, I32F32)>> = vec![vec![]; n];
         for (uid_i, bonds_vec) in
-            <Bonds<T> as IterableStorageDoubleMap<u16, u16, Vec<(u16, u16)>>>::iter_prefix(netuid)
+            <Bonds<T> as IterableStorageDoubleMap<u16, u16, Vec<(u16, u32)>>>::iter_prefix(netuid)
                 .filter(|(uid_i, _)| *uid_i < n as u16)
         {
             for (uid_j, bonds_ij) in bonds_vec {
@@ -838,12 +838,12 @@ impl<T: Config> Pallet<T> {
         bonds
     }
 
-    /// Output unnormalized bonds in [n, n] matrix, input bonds are assumed to be column max-upscaled in u16.
+    /// Output unnormalized bonds in [n, n] matrix.
     pub fn get_bonds(netuid: u16) -> Vec<Vec<I32F32>> {
         let n: usize = Self::get_subnetwork_n(netuid) as usize;
         let mut bonds: Vec<Vec<I32F32>> = vec![vec![I32F32::saturating_from_num(0.0); n]; n];
         for (uid_i, bonds_vec) in
-            <Bonds<T> as IterableStorageDoubleMap<u16, u16, Vec<(u16, u16)>>>::iter_prefix(netuid)
+            <Bonds<T> as IterableStorageDoubleMap<u16, u16, Vec<(u16, u32)>>>::iter_prefix(netuid)
                 .filter(|(uid_i, _)| *uid_i < n as u16)
         {
             for (uid_j, bonds_ij) in bonds_vec.into_iter().filter(|(uid_j, _)| *uid_j < n as u16) {

--- a/pallets/subtensor/src/epoch/run_epoch.rs
+++ b/pallets/subtensor/src/epoch/run_epoch.rs
@@ -327,6 +327,8 @@ impl<T: Config> Pallet<T> {
         ValidatorPermit::<T>::insert(netuid, new_validator_permits.clone());
 
         // Column max-upscale EMA bonds for storage: max_i w_ij = 1.
+        inplace_col_max_upscale(&mut ema_bonds);
+        // Then normalize.
         inplace_col_normalize(&mut ema_bonds);
         new_validator_permits
             .iter()
@@ -713,6 +715,8 @@ impl<T: Config> Pallet<T> {
         ValidatorPermit::<T>::insert(netuid, new_validator_permits.clone());
 
         // Column max-upscale EMA bonds for storage: max_i w_ij = 1.
+        inplace_col_max_upscale_sparse(&mut ema_bonds, n);
+        // Then normalize.
         inplace_col_normalize_sparse(&mut ema_bonds, n);
         new_validator_permits
             .iter()

--- a/pallets/subtensor/src/epoch/run_epoch.rs
+++ b/pallets/subtensor/src/epoch/run_epoch.rs
@@ -713,7 +713,7 @@ impl<T: Config> Pallet<T> {
         ValidatorPermit::<T>::insert(netuid, new_validator_permits.clone());
 
         // Column max-upscale EMA bonds for storage: max_i w_ij = 1.
-		inplace_col_normalize_sparse(&mut ema_bonds, n);
+        inplace_col_normalize_sparse(&mut ema_bonds, n);
         new_validator_permits
             .iter()
             .zip(validator_permits)

--- a/pallets/subtensor/src/epoch/run_epoch.rs
+++ b/pallets/subtensor/src/epoch/run_epoch.rs
@@ -713,7 +713,7 @@ impl<T: Config> Pallet<T> {
         ValidatorPermit::<T>::insert(netuid, new_validator_permits.clone());
 
         // Column max-upscale EMA bonds for storage: max_i w_ij = 1.
-        inplace_col_max_upscale_sparse(&mut ema_bonds, n);
+		inplace_col_normalize_sparse(&mut ema_bonds, n);
         new_validator_permits
             .iter()
             .zip(validator_permits)

--- a/pallets/subtensor/src/epoch/run_epoch.rs
+++ b/pallets/subtensor/src/epoch/run_epoch.rs
@@ -327,7 +327,7 @@ impl<T: Config> Pallet<T> {
         ValidatorPermit::<T>::insert(netuid, new_validator_permits.clone());
 
         // Column max-upscale EMA bonds for storage: max_i w_ij = 1.
-        inplace_col_max_upscale(&mut ema_bonds);
+        inplace_col_normalize(&mut ema_bonds);
         new_validator_permits
             .iter()
             .zip(validator_permits)

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -666,8 +666,8 @@ pub mod pallet {
         vec![]
     }
     #[pallet::type_value]
-    /// Value definition for bonds with type vector of (u16, u16).
-    pub fn DefaultBonds<T: Config>() -> Vec<(u16, u16)> {
+    /// Value definition for bonds with type vector of (u16, u32).
+    pub fn DefaultBonds<T: Config>() -> Vec<(u16, u32)> {
         vec![]
     }
     #[pallet::type_value]
@@ -1416,7 +1416,7 @@ pub mod pallet {
         u16,
         Identity,
         u16,
-        Vec<(u16, u16)>,
+        Vec<(u16, u32)>,
         ValueQuery,
         DefaultBonds<T>,
     >;

--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -81,7 +81,9 @@ mod hooks {
                 // Remove Stake map entries
 				.saturating_add(migrations::migrate_remove_stake_map::migrate_remove_stake_map::<T>())
                 // Remove unused maps entries
-				.saturating_add(migrations::migrate_remove_unused_maps_and_values::migrate_remove_unused_maps_and_values::<T>());
+				.saturating_add(migrations::migrate_remove_unused_maps_and_values::migrate_remove_unused_maps_and_values::<T>())
+				// Reset Bonds
+				.saturating_add(migrations::migrate_reset_bonds::migrate_reset_bonds::<T>());
             weight
         }
 

--- a/pallets/subtensor/src/migrations/migrate_reset_bonds.rs
+++ b/pallets/subtensor/src/migrations/migrate_reset_bonds.rs
@@ -26,7 +26,7 @@ pub fn migrate_reset_bonds<T: Config>() -> Weight {
         String::from_utf8_lossy(&migration_name)
     );
 
-    /// ===== Migration Body =====
+    // ===== Migration Body =====
     // Clear all bonds
     let mut curr = Bonds::<T>::clear(u32::MAX, None);
     weight = weight
@@ -37,7 +37,7 @@ pub fn migrate_reset_bonds<T: Config>() -> Weight {
             .saturating_add(T::DbWeight::get().reads_writes(curr.loops as u64, curr.unique as u64));
     }
 
-    /// ===== Migration End =====
+    // ===== Migration End =====
     // -----------------------------
     // Mark the migration as done
     // -----------------------------

--- a/pallets/subtensor/src/migrations/migrate_reset_bonds.rs
+++ b/pallets/subtensor/src/migrations/migrate_reset_bonds.rs
@@ -1,0 +1,54 @@
+use super::*;
+use frame_support::weights::Weight;
+use log;
+use scale_info::prelude::string::String;
+
+pub fn migrate_reset_bonds<T: Config>() -> Weight {
+    use frame_support::traits::Get;
+    let migration_name = b"migrate_reset_bonds".to_vec();
+
+    // Start counting weight
+    let mut weight = T::DbWeight::get().reads(1);
+
+    // Check if we already ran this migration
+    if HasMigrationRun::<T>::get(&migration_name) {
+        log::info!(
+            target: "runtime",
+            "Migration '{:?}' has already run. Skipping.",
+            String::from_utf8_lossy(&migration_name)
+        );
+        return weight;
+    }
+
+    log::info!(
+        target: "runtime",
+        "Running migration '{}'",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    /// ===== Migration Body =====
+    // Clear all bonds
+    let mut curr = Bonds::<T>::clear(u32::MAX, None);
+    weight = weight
+        .saturating_add(T::DbWeight::get().reads_writes(curr.loops as u64, curr.unique as u64));
+    while curr.maybe_cursor.is_some() {
+        curr = Bonds::<T>::clear(u32::MAX, curr.maybe_cursor.as_deref());
+        weight = weight
+            .saturating_add(T::DbWeight::get().reads_writes(curr.loops as u64, curr.unique as u64));
+    }
+
+    /// ===== Migration End =====
+    // -----------------------------
+    // Mark the migration as done
+    // -----------------------------
+    HasMigrationRun::<T>::insert(&migration_name, true);
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+    log::info!(
+        target: "runtime",
+        "Migration '{}' completed successfully.",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    weight
+}

--- a/pallets/subtensor/src/migrations/mod.rs
+++ b/pallets/subtensor/src/migrations/mod.rs
@@ -11,6 +11,7 @@ pub mod migrate_populate_owned_hotkeys;
 pub mod migrate_rao;
 pub mod migrate_remove_stake_map;
 pub mod migrate_remove_unused_maps_and_values;
+pub mod migrate_reset_bonds;
 pub mod migrate_set_min_burn;
 pub mod migrate_set_min_difficulty;
 pub mod migrate_stake_threshold;

--- a/pallets/subtensor/src/rpc_info/neuron_info.rs
+++ b/pallets/subtensor/src/rpc_info/neuron_info.rs
@@ -3,7 +3,7 @@ use frame_support::pallet_prelude::{Decode, Encode};
 extern crate alloc;
 use codec::Compact;
 
-#[freeze_struct("d6da7340b3350951")]
+#[freeze_struct("31bcfd3825aca916")]
 #[derive(Decode, Encode, PartialEq, Eq, Clone, Debug, TypeInfo)]
 pub struct NeuronInfo<AccountId: TypeInfo + Encode + Decode> {
     hotkey: AccountId,
@@ -24,7 +24,7 @@ pub struct NeuronInfo<AccountId: TypeInfo + Encode + Decode> {
     last_update: Compact<u64>,
     validator_permit: bool,
     weights: Vec<(Compact<u16>, Compact<u16>)>, // Vec of (uid, weight)
-    bonds: Vec<(Compact<u16>, Compact<u16>)>,   // Vec of (uid, bond)
+    bonds: Vec<(Compact<u16>, Compact<u32>)>,   // Vec of (uid, bond)
     pruning_score: Compact<u16>,
 }
 
@@ -115,7 +115,7 @@ impl<T: Config> Pallet<T> {
                     None
                 }
             })
-            .collect::<Vec<(Compact<u16>, Compact<u16>)>>();
+            .collect::<Vec<(Compact<u16>, Compact<u32>)>>();
         let stake: Vec<(T::AccountId, Compact<u64>)> = vec![(
             coldkey.clone(),
             Self::get_stake_for_hotkey_on_subnet(&hotkey, netuid).into(),

--- a/pallets/subtensor/src/subnets/uids.rs
+++ b/pallets/subtensor/src/subnets/uids.rs
@@ -23,7 +23,7 @@ impl<T: Config> Pallet<T> {
         Consensus::<T>::mutate(netuid, |v| Self::set_element_at(v, neuron_index, 0));
         Incentive::<T>::mutate(netuid, |v| Self::set_element_at(v, neuron_index, 0));
         Dividends::<T>::mutate(netuid, |v| Self::set_element_at(v, neuron_index, 0));
-		Bonds::<T>::mutate(netuid, |v| Self::set_element_at(v, neuron_index, 0));
+        Bonds::<T>::remove(netuid, neuron_uid); // Remove bonds for Validator.
     }
 
     /// Replace the neuron under this uid.

--- a/pallets/subtensor/src/subnets/uids.rs
+++ b/pallets/subtensor/src/subnets/uids.rs
@@ -23,6 +23,7 @@ impl<T: Config> Pallet<T> {
         Consensus::<T>::mutate(netuid, |v| Self::set_element_at(v, neuron_index, 0));
         Incentive::<T>::mutate(netuid, |v| Self::set_element_at(v, neuron_index, 0));
         Dividends::<T>::mutate(netuid, |v| Self::set_element_at(v, neuron_index, 0));
+		Bonds::<T>::mutate(netuid, |v| Self::set_element_at(v, neuron_index, 0));
     }
 
     /// Replace the neuron under this uid.

--- a/pallets/subtensor/src/tests/epoch.rs
+++ b/pallets/subtensor/src/tests/epoch.rs
@@ -713,7 +713,7 @@ fn test_512_graph() {
                     assert_eq!(SubtensorModule::get_dividends_for_uid(netuid, uid), 1023); // Note D = floor(1 / 64 * 65_535) = 1023
                     assert_eq!(SubtensorModule::get_emission_for_uid(netuid, uid), 7812500); // Note E = 0.5 / 200 * 1_000_000_000 = 7_812_500
                     assert_eq!(bonds[uid as usize][validator], 0.0);
-                    assert_eq!(bonds[uid as usize][server], I32F32::from_num(65_535));
+                    assert_eq!(bonds[uid as usize][server], I32F32::from_num(7_489));
                     // Note B_ij = floor(1 / 64 * 65_535) / 65_535 = 1023 / 65_535, then max-upscaled to 65_535
                 }
                 for uid in servers {
@@ -1060,10 +1060,10 @@ fn test_bonds() {
 			P: [0.0499999989, 0.0999999992, 0.1500000006, 0.2000000011, 0.049998779, 0.1000006103, 0.1499963375, 0.2000042726]
 			emaB: [[(4, 0.2499999937), (5, 0.2499999953), (6, 0.2499999937), (7, 0.2499999937)], [(4, 0.4999999942), (5, 0.499999997), (6, 0.4999999942), (7, 0.4999999942)], [(4, 0.7499999937), (5, 0.7499999981), (6, 0.7499999995), (7, 0.7499999995)], [(4, 1), (5, 1), (6, 1), (7, 1)], [], [], [], []] */
 		let bonds = SubtensorModule::get_bonds( netuid );
-		assert_eq!(bonds[0][4], 16383);
-		assert_eq!(bonds[1][4], 32767);
-		assert_eq!(bonds[2][4], 49151);
-		assert_eq!(bonds[3][4], 65535);
+		assert_eq!(bonds[0][4], 2_147_430);
+		assert_eq!(bonds[1][4], 4_294_861);
+		assert_eq!(bonds[2][4], 6_442_293);
+		assert_eq!(bonds[3][4], 8_589_724);
 
 		// === Set self-weight only on val1
 		let uid = 0;
@@ -1107,10 +1107,10 @@ fn test_bonds() {
 			P: [0.0449983515, 0.1011105615, 0.1516672159, 0.2022238704, 0.049998779, 0.1000006103, 0.1499963377, 0.2000042726]
 			emaB: [[(4, 0.2225175085), (5, 0.2225175085), (6, 0.2225175085), (7, 0.2225175085)], [(4, 0.499993208), (5, 0.4999932083), (6, 0.4999932083), (7, 0.4999932083)], [(4, 0.7499966028), (5, 0.7499966032), (6, 0.7499966032), (7, 0.7499966032)], [(4, 1), (5, 1), (6, 1), (7, 1)], [], [], [], []] */
 		let bonds = SubtensorModule::get_bonds( netuid );
-		assert_eq!(bonds[0][4], 14582);
-		assert_eq!(bonds[1][4], 32767);
-		assert_eq!(bonds[2][4], 49151);
-		assert_eq!(bonds[3][4], 65535);
+		assert_eq!(bonds[0][4], 0);
+		assert_eq!(bonds[1][4], 42_948_61);
+		assert_eq!(bonds[2][4], 6_442_293);
+		assert_eq!(bonds[3][4], 8_589_724);
 
 		// === Set self-weight only on val2
 		let uid = 1;
@@ -1143,10 +1143,10 @@ fn test_bonds() {
 			P: [0.040496806, 0.0909997837, 0.157929636, 0.2105737738, 0.049998779, 0.1000006103, 0.1499963377, 0.2000042726]
 			emaB: [[(4, 0.192316476), (5, 0.192316476), (6, 0.192316476), (7, 0.192316476)], [(4, 0.4321515555), (5, 0.4321515558), (6, 0.4321515558), (7, 0.4321515558)], [(4, 0.7499967015), (5, 0.7499967027), (6, 0.7499967027), (7, 0.7499967027)], [(4, 1), (5, 1), (6, 1), (7, 1)], [], [], [], []] */
 		let bonds = SubtensorModule::get_bonds( netuid );
-		assert_eq!(bonds[0][4], 12603);
-		assert_eq!(bonds[1][4], 28321);
-		assert_eq!(bonds[2][4], 49151);
-		assert_eq!(bonds[3][4], 65535);
+		assert_eq!(bonds[0][4], 0);
+		assert_eq!(bonds[1][4], 0);
+		assert_eq!(bonds[2][4], 6_442_293);
+		assert_eq!(bonds[3][4], 8_589_724);
 
 		// === Set self-weight only on val3
 		let uid = 2;
@@ -1179,10 +1179,10 @@ fn test_bonds() {
 			P: [0.0999999999, 0.2, 0.2999999998, 0.4, 0, 0, 0, 0]
 			emaB: [[(4, 0.1923094518), (5, 0.1923094518), (6, 0.1923094518), (7, 0.1923094518)], [(4, 0.4321507583), (5, 0.4321507583), (6, 0.4321507583), (7, 0.4321507583)], [(4, 0.7499961846), (5, 0.7499961846), (6, 0.7499961846), (7, 0.7499961846)], [(4, 1), (5, 1), (6, 1), (7, 1)], [], [], [], []] */
 		let bonds = SubtensorModule::get_bonds( netuid );
-		assert_eq!(bonds[0][7], 12602);
-		assert_eq!(bonds[1][7], 28320);
-		assert_eq!(bonds[2][7], 49150);
-		assert_eq!(bonds[3][7], 65535);
+		assert_eq!(bonds[0][7], 0);
+		assert_eq!(bonds[1][7], 0);
+		assert_eq!(bonds[2][7], 0);
+		assert_eq!(bonds[3][7], 0);
 
 		// === Set val3->srv4: 1
 		assert_ok!(SubtensorModule::set_weights(RuntimeOrigin::signed(U256::from(2)), netuid, vec![7], vec![u16::MAX], 0));
@@ -1214,10 +1214,10 @@ fn test_bonds() {
 			P: [0.0364437331, 0.081898629, 0.1635654932, 0.2180921442, 0, 0, 0, 0.5]
 			emaB: [[(4, 0.1922941932), (5, 0.1922941932), (6, 0.1922941932), (7, 0.1671024568)], [(4, 0.4321354993), (5, 0.4321354993), (6, 0.4321354993), (7, 0.3755230587)], [(4, 0.7499809256), (5, 0.7499809256), (6, 0.7499809256), (7, 0.749983425)], [(4, 1), (5, 1), (6, 1), (7, 1)], [], [], [], []] */
 		let bonds = SubtensorModule::get_bonds( netuid );
-		assert_eq!(bonds[0][7], 10951);
-		assert_eq!(bonds[1][7], 24609);
-		assert_eq!(bonds[2][7], 49150);
-		assert_eq!(bonds[3][7], 65535);
+		assert_eq!(bonds[0][7], 0);
+		assert_eq!(bonds[1][7], 0);
+		assert_eq!(bonds[2][7], 25_770_353);
+		assert_eq!(bonds[3][7], 34_360_471);
 
         next_block();
 		if sparse { SubtensorModule::epoch( netuid, 1_000_000_000 ); }
@@ -1235,10 +1235,10 @@ fn test_bonds() {
 			P: [0.0327994274, 0.0737066122, 0.1686381293, 0.2248558307, 0, 0, 0, 0.5]
 			emaB: [[(4, 0.1922789337), (5, 0.1922789337), (6, 0.1922789337), (7, 0.1458686984)], [(4, 0.4321202405), (5, 0.4321202405), (6, 0.4321202405), (7, 0.3277949789)], [(4, 0.749965667), (5, 0.749965667), (6, 0.749965667), (7, 0.74998335)], [(4, 1), (5, 1), (6, 1), (7, 1)], [], [], [], []] */
 		let bonds = SubtensorModule::get_bonds( netuid );
-		assert_eq!(bonds[0][7], 9559);
-		assert_eq!(bonds[1][7], 21482);
-		assert_eq!(bonds[2][7], 49150);
-		assert_eq!(bonds[3][7], 65535);
+		assert_eq!(bonds[0][7], 0);
+		assert_eq!(bonds[1][7], 0);
+		assert_eq!(bonds[2][7], 25_770_353);
+		assert_eq!(bonds[3][7], 34_360_471);
 
         next_block();
 		if sparse { SubtensorModule::epoch( netuid, 1_000_000_000 ); }
@@ -1256,10 +1256,10 @@ fn test_bonds() {
 			P: [0.029518068, 0.0663361375, 0.1732031347, 0.2309426593, 0, 0, 0, 0.5]
 			emaB: [[(4, 0.192263675), (5, 0.192263675), (6, 0.192263675), (7, 0.1278155716)], [(4, 0.4321049813), (5, 0.4321049813), (6, 0.4321049813), (7, 0.2872407278)], [(4, 0.7499504078), (5, 0.7499504078), (6, 0.7499504078), (7, 0.7499832863)], [(4, 1), (5, 1), (6, 1), (7, 1)], [], [], [], []] */
 		let bonds = SubtensorModule::get_bonds( netuid );
-		assert_eq!(bonds[0][7], 8376);
-		assert_eq!(bonds[1][7], 18824);
-		assert_eq!(bonds[2][7], 49150);
-		assert_eq!(bonds[3][7], 65535);
+		assert_eq!(bonds[0][7], 0);
+		assert_eq!(bonds[1][7], 0);
+		assert_eq!(bonds[2][7], 25_770_353);
+		assert_eq!(bonds[3][7], 34_360_471);
 
 		next_block();
 		if sparse { SubtensorModule::epoch( netuid, 1_000_000_000 ); }
@@ -1401,12 +1401,12 @@ fn test_bonds_with_liquid_alpha() {
         // Active stake: [1, 2, 3, 4]
         // ΔB = W◦S = [0.25*1, 0.5*2, 0.75*3, 1.0*4] = [0.25, 1.0, 2.25, 4.0]
         // Normalize ΔB: [0.25/7.5, 1.0/7.5, 2.25/7.5, 4.0/7.5] = [0.0333, 0.1333, 0.3, 0.5333]
-        // Final bonds for netuid: [16383, 32767, 49151, 65535]
+        // Final bonds for netuid: [530, 1_061, 1_591, 2_122]
 
-        assert_eq!(bonds[0][4], 16383); // Note: Calculated as explained above
-        assert_eq!(bonds[1][4], 32767); // Note: Calculated as explained above
-        assert_eq!(bonds[2][4], 49151); // Note: Calculated as explained above
-        assert_eq!(bonds[3][4], 65535); // Note: Calculated as explained above
+        assert_eq!(bonds[0][4], 17_385_264); // Note: Calculated as explained above
+        assert_eq!(bonds[1][4], 34_770_528); // Note: Calculated as explained above
+        assert_eq!(bonds[2][4], 52_155_793); // Note: Calculated as explained above
+        assert_eq!(bonds[3][4], 69_541_058); // Note: Calculated as explained above
 
         // === Set self-weight only on val1
         let uid = 0;
@@ -1425,10 +1425,10 @@ fn test_bonds_with_liquid_alpha() {
         }
 
         let bonds = SubtensorModule::get_bonds(netuid);
-        assert_eq!(bonds[0][4], 2862);
-        assert_eq!(bonds[1][4], 32767);
-        assert_eq!(bonds[2][4], 49151);
-        assert_eq!(bonds[3][4], 65535);
+        assert_eq!(bonds[0][4], 0);
+        assert_eq!(bonds[1][4], 34_770_528);
+        assert_eq!(bonds[2][4], 52_155_793);
+        assert_eq!(bonds[3][4], 69_541_058);
 
         // === Set self-weight only on val2
         let uid = 1;
@@ -1488,10 +1488,10 @@ fn test_bonds_with_liquid_alpha() {
             Pruning Scores: [0.0016997808, 0.0151777493, 0.2070524206, 0.2760700488, 0.049998779, 0.1000006103, 0.1499963377, 0.2000042726]
         */
 
-        assert_eq!(bonds[0][4], 435);
-        assert_eq!(bonds[1][4], 4985);
-        assert_eq!(bonds[2][4], 49151);
-        assert_eq!(bonds[3][4], 65535);
+        assert_eq!(bonds[0][4], 0);
+        assert_eq!(bonds[1][4], 0);
+        assert_eq!(bonds[2][4], 52155793);
+        assert_eq!(bonds[3][4], 69_541_058);
     });
 }
 
@@ -1623,7 +1623,7 @@ fn test_active_stake() {
                 assert_eq!(*i, 0);
             }
             for i in bond.iter().take(n as usize).skip((n / 2) as usize) {
-                assert_eq!(*i, I32F32::from_num(65_535)); // floor(0.5*(2^16-1))/(2^16-1), then max-upscale to 65_535
+                assert_eq!(*i, I32F32::from_num(26_843_545)); // floor(0.5*(2^32-1))/(2^32-1)
             }
         }
         let activity_cutoff: u64 = SubtensorModule::get_activity_cutoff(netuid) as u64;
@@ -1669,22 +1669,19 @@ fn test_active_stake() {
         P: [0.275, 0.2249999999, 0.25, 0.25]
         P (u16): [65535, 53619, 59577, 59577] */
         let bonds = SubtensorModule::get_bonds(netuid);
-        assert_eq!(SubtensorModule::get_dividends_for_uid(netuid, 0), 36044); // Note D = floor((0.5 * 0.9 + 0.1) * 65_535)
-        assert_eq!(SubtensorModule::get_emission_for_uid(netuid, 0), 274999999); // Note E = 0.5 * 0.55 * 1_000_000_000 = 275_000_000 (discrepancy)
+        assert_eq!(SubtensorModule::get_dividends_for_uid(netuid, 0), 65_535); // Note D = floor((0.5 * 0.9 + 0.1) * 65_535)
+        assert_eq!(
+            SubtensorModule::get_emission_for_uid(netuid, 0),
+            500_000_000
+        ); // Note E = 0.5 * 0.55 * 1_000_000_000 = 275_000_000 (discrepancy)
         for server in ((n / 2) as usize)..n as usize {
-            assert_eq!(bonds[0][server], I32F32::from_num(65_535)); // floor(0.55*(2^16-1))/(2^16-1), then max-upscale
+            assert_eq!(bonds[0][server], I32F32::from_num(107_374_182)); // floor(0.55*(2^16-1))/(2^16-1), then max-upscale
         }
         for validator in 1..(n / 2) {
-            assert_eq!(
-                SubtensorModule::get_dividends_for_uid(netuid, validator),
-                29490
-            ); // Note D = floor((0.5 * 0.9) * 65_535)
-            assert_eq!(
-                SubtensorModule::get_emission_for_uid(netuid, validator),
-                224999999
-            ); // Note E = 0.5 * 0.45 * 1_000_000_000 = 225_000_000 (discrepancy)
+            assert_eq!(SubtensorModule::get_dividends_for_uid(netuid, validator), 0); // Note D = floor((0.5 * 0.9) * 65_535)
+            assert_eq!(SubtensorModule::get_emission_for_uid(netuid, validator), 0); // Note E = 0.5 * 0.45 * 1_000_000_000 = 225_000_000 (discrepancy)
             for server in ((n / 2) as usize)..n as usize {
-                assert_eq!(bonds[validator as usize][server], I32F32::from_num(53619));
+                assert_eq!(bonds[validator as usize][server], I32F32::from_num(0));
                 // floor(0.45*(2^16-1))/(2^16-1), then max-upscale
             }
         }
@@ -1730,15 +1727,21 @@ fn test_active_stake() {
         P: [0.272501133, 0.2274988669, 0.25, 0.25]
         P (u16): [65535, 54711, 60123, 60123] */
         let bonds = SubtensorModule::get_bonds(netuid);
-        assert_eq!(SubtensorModule::get_dividends_for_uid(netuid, 0), 35716); // Note D = floor((0.55 * 0.9 + 0.5 * 0.1) * 65_535)
-        assert_eq!(SubtensorModule::get_emission_for_uid(netuid, 0), 272501132); // Note E = 0.5 * (0.55 * 0.9 + 0.5 * 0.1) * 1_000_000_000 = 272_500_000 (discrepancy)
+        assert_eq!(SubtensorModule::get_dividends_for_uid(netuid, 0), 32_767); // Note D = floor((0.55 * 0.9 + 0.5 * 0.1) * 65_535)
+        assert_eq!(
+            SubtensorModule::get_emission_for_uid(netuid, 0),
+            250_000_000
+        ); // Note E = 0.5 * (0.55 * 0.9 + 0.5 * 0.1) * 1_000_000_000 = 272_500_000 (discrepancy)
         for server in ((n / 2) as usize)..n as usize {
-            assert_eq!(bonds[0][server], I32F32::from_num(65_535)); // floor((0.55 * 0.9 + 0.5 * 0.1)*(2^16-1))/(2^16-1), then max-upscale
+            assert_eq!(bonds[0][server], I32F32::from_num(53_687_090)); // floor((0.55 * 0.9 + 0.5 * 0.1)*(2^16-1))/(2^16-1), then max-upscale
         }
-        assert_eq!(SubtensorModule::get_dividends_for_uid(netuid, 1), 29818); // Note D = floor((0.45 * 0.9 + 0.5 * 0.1) * 65_535)
-        assert_eq!(SubtensorModule::get_emission_for_uid(netuid, 1), 227498866); // Note E = 0.5 * (0.45 * 0.9 + 0.5 * 0.1) * 1_000_000_000 = 227_500_000 (discrepancy)
+        assert_eq!(SubtensorModule::get_dividends_for_uid(netuid, 1), 32_767); // Note D = floor((0.45 * 0.9 + 0.5 * 0.1) * 65_535)
+        assert_eq!(
+            SubtensorModule::get_emission_for_uid(netuid, 1),
+            250_000_000
+        ); // Note E = 0.5 * (0.45 * 0.9 + 0.5 * 0.1) * 1_000_000_000 = 227_500_000 (discrepancy)
         for server in ((n / 2) as usize)..n as usize {
-            assert_eq!(bonds[1][server], I32F32::from_num(54712)); // floor((0.45 * 0.9 + 0.5 * 0.1)/(0.55 * 0.9 + 0.5 * 0.1)*(2^16-1))
+            assert_eq!(bonds[1][server], I32F32::from_num(53_687_090)); // floor((0.45 * 0.9 + 0.5 * 0.1)/(0.55 * 0.9 + 0.5 * 0.1)*(2^16-1))
         }
     });
 }
@@ -1925,8 +1928,8 @@ fn test_outdated_weights() {
         let bonds = SubtensorModule::get_bonds(netuid);
         assert_eq!(SubtensorModule::get_dividends_for_uid(netuid, 0), 32767); // Note D = floor(0.5 * 65_535)
         assert_eq!(SubtensorModule::get_emission_for_uid(netuid, 0), 250000000); // Note E = 0.5 * 0.5 * 1_000_000_000 = 249311245
-        assert_eq!(bonds[0][2], I32F32::from_num(65_535)); // floor(0.5*(2^16-1))/(2^16-1), then max-upscale
-        assert_eq!(bonds[0][3], I32F32::from_num(65_535)); // only uid0 has updated weights for new reg
+        assert_eq!(bonds[0][2], I32F32::from_num(47_721_615)); // floor(0.5*(2^16-1))/(2^16-1), then max-upscale
+        assert_eq!(bonds[0][3], I32F32::from_num(0)); // only uid0 has updated weights for new reg
     });
 }
 

--- a/pallets/subtensor/src/tests/epoch.rs
+++ b/pallets/subtensor/src/tests/epoch.rs
@@ -2127,6 +2127,186 @@ fn test_zero_weights() {
     });
 }
 
+// Test that recently/deregistered miner bonds are cleared before EMA.
+#[test]
+fn test_deregistered_miner_bonds() {
+    new_test_ext(1).execute_with(|| {
+        let sparse: bool = true;
+        let n: u16 = 4;
+        let netuid: u16 = 1;
+        let high_tempo: u16 = u16::MAX - 1; // high tempo to skip automatic epochs in on_initialize, use manual epochs instead
+
+        let stake: u64 = 1;
+        add_network(netuid, high_tempo, 0);
+        SubtensorModule::set_max_allowed_uids(netuid, n);
+        SubtensorModule::set_weights_set_rate_limit(netuid, 0);
+        SubtensorModule::set_max_registrations_per_block(netuid, n);
+        SubtensorModule::set_target_registrations_per_interval(netuid, n);
+        SubtensorModule::set_min_allowed_weights(netuid, 0);
+        SubtensorModule::set_max_weight_limit(netuid, u16::MAX);
+        SubtensorModule::set_bonds_penalty(netuid, u16::MAX);
+        assert_eq!(SubtensorModule::get_registrations_this_block(netuid), 0);
+
+        // === Register [validator1, validator2, server1, server2]
+        let block_number = System::block_number();
+        for key in 0..n as u64 {
+            SubtensorModule::add_balance_to_coldkey_account(&U256::from(key), stake);
+            let (nonce, work): (u64, Vec<u8>) = SubtensorModule::create_work_for_block_number(
+                netuid,
+                block_number,
+                key * 1_000_000,
+                &U256::from(key),
+            );
+            assert_ok!(SubtensorModule::register(
+                RuntimeOrigin::signed(U256::from(key)),
+                netuid,
+                block_number,
+                nonce,
+                work,
+                U256::from(key),
+                U256::from(key)
+            ));
+            SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
+                &U256::from(key),
+                &U256::from(key),
+                netuid,
+                stake,
+            );
+        }
+        assert_eq!(SubtensorModule::get_subnetwork_n(netuid), n);
+        assert_eq!(SubtensorModule::get_registrations_this_block(netuid), 4);
+
+        // === Issue validator permits
+        SubtensorModule::set_max_allowed_validators(netuid, n);
+        assert_eq!(SubtensorModule::get_max_allowed_validators(netuid), n);
+        SubtensorModule::epoch(netuid, 1_000_000_000); // run first epoch to set allowed validators
+        assert_eq!(SubtensorModule::get_registrations_this_block(netuid), 4);
+        next_block(); // run to next block to ensure weights are set on nodes after their registration block
+        assert_eq!(SubtensorModule::get_registrations_this_block(netuid), 0);
+
+        // === Set weights [val1->srv1: 2/3, val1->srv2: 1/3, val2->srv1: 2/3, val2->srv2: 1/3]
+        for uid in 0..(n / 2) as u64 {
+            assert_ok!(SubtensorModule::set_weights(
+                RuntimeOrigin::signed(U256::from(uid)),
+                netuid,
+                ((n / 2)..n).collect(),
+                vec![2 * (u16::MAX / 3), u16::MAX / 3],
+                0
+            ));
+        }
+
+        // Set tempo high so we don't automatically run epochs
+        SubtensorModule::set_tempo(netuid, high_tempo);
+
+        // Run 2 blocks
+        next_block();
+        next_block();
+
+        // set tempo to 2 blocks
+        SubtensorModule::set_tempo(netuid, 2);
+        // Run epoch
+        if sparse {
+            SubtensorModule::epoch(netuid, 1_000_000_000);
+        } else {
+            SubtensorModule::epoch_dense(netuid, 1_000_000_000);
+        }
+
+        // Check the bond values for the servers
+        let bonds = SubtensorModule::get_bonds(netuid);
+        let bond_0_2 = bonds[0][2];
+        let bond_0_3 = bonds[0][3];
+
+        // Non-zero bonds
+        assert!(bond_0_2 > 0);
+        assert!(bond_0_3 > 0);
+
+        // Set tempo high so we don't automatically run epochs
+        SubtensorModule::set_tempo(netuid, high_tempo);
+
+        // Run one more block
+        next_block();
+
+        // === Dereg server2 at uid3 (least emission) + register new key over uid3
+        let new_key: u64 = n as u64; // register a new key while at max capacity, which means the least incentive uid will be deregistered
+        let block_number = System::block_number();
+        let (nonce, work): (u64, Vec<u8>) = SubtensorModule::create_work_for_block_number(
+            netuid,
+            block_number,
+            0,
+            &U256::from(new_key),
+        );
+        assert_eq!(SubtensorModule::get_max_registrations_per_block(netuid), n);
+        assert_eq!(SubtensorModule::get_registrations_this_block(netuid), 0);
+        assert_ok!(SubtensorModule::register(
+            RuntimeOrigin::signed(U256::from(new_key)),
+            netuid,
+            block_number,
+            nonce,
+            work,
+            U256::from(new_key),
+            U256::from(new_key)
+        ));
+        let deregistered_uid: u16 = n - 1; // since uid=n-1 only recieved 1/3 of weight, it will get pruned first
+        assert_eq!(
+            U256::from(new_key),
+            SubtensorModule::get_hotkey_for_net_and_uid(netuid, deregistered_uid)
+                .expect("Not registered")
+        );
+
+        // Set weights again so they're active.
+        for uid in 0..(n / 2) as u64 {
+            assert_ok!(SubtensorModule::set_weights(
+                RuntimeOrigin::signed(U256::from(uid)),
+                netuid,
+                ((n / 2)..n).collect(),
+                vec![2 * (u16::MAX / 3), u16::MAX / 3],
+                0
+            ));
+        }
+
+        // Run 1 block
+        next_block();
+        // Assert block at registration happened after the last tempo
+        let block_at_registration = SubtensorModule::get_neuron_block_at_registration(netuid, 3);
+        let block_number = System::block_number();
+        assert!(
+            block_at_registration >= block_number - 2,
+            "block at registration: {}, block number: {}",
+            block_at_registration,
+            block_number
+        );
+
+        // set tempo to 2 blocks
+        SubtensorModule::set_tempo(netuid, 2);
+        // Run epoch again.
+        if sparse {
+            SubtensorModule::epoch(netuid, 1_000_000_000);
+        } else {
+            SubtensorModule::epoch_dense(netuid, 1_000_000_000);
+        }
+
+        // Check the bond values for the servers
+        let bonds = SubtensorModule::get_bonds(netuid);
+        let bond_0_2_new = bonds[0][2];
+        let bond_0_3_new = bonds[0][3];
+
+        // We expect the old bonds for server2, (uid3), to be reset.
+        // For server1, (uid2), the bond should be higher than before.
+        assert!(
+            bond_0_2_new > bond_0_2,
+            "bond_0_2_new: {}, bond_0_2: {}",
+            bond_0_2_new,
+            bond_0_2
+        );
+        assert!(
+            bond_0_3_new <= bond_0_3,
+            "bond_0_3_new: {}, bond_0_3: {}",
+            bond_0_3_new,
+            bond_0_3
+        );
+    });
+}
+
 // Test that epoch assigns validator permits to highest stake uids, varies uid interleaving and stake values.
 #[test]
 fn test_validator_permits() {

--- a/pallets/subtensor/src/tests/math.rs
+++ b/pallets/subtensor/src/tests/math.rs
@@ -1221,6 +1221,45 @@ fn test_math_vec_mask_sparse_matrix() {
 }
 
 #[test]
+fn test_math_scalar_vec_mask_sparse_matrix() {
+    let vector: Vec<f32> = vec![1., 2., 3., 4., 5., 6., 7., 8., 9.];
+    let target: Vec<f32> = vec![0., 2., 3., 0., 5., 6., 0., 8., 9.];
+    let mat = vec_to_sparse_mat_fixed(&vector, 3, false);
+    let scalar: u64 = 1;
+    let masking_vector: Vec<u64> = vec![1, 4, 7];
+    let result = scalar_vec_mask_sparse_matrix(&mat, scalar, &masking_vector, &|a, b| a == b);
+    assert_sparse_mat_compare(
+        &result,
+        &vec_to_sparse_mat_fixed(&target, 3, false),
+        I32F32::from_num(0),
+    );
+
+    let vector: Vec<f32> = vec![1., 2., 3., 4., 5., 6., 7., 8., 9.];
+    let target: Vec<f32> = vec![1., 2., 0., 4., 5., 0., 7., 8., 0.];
+    let mat = vec_to_sparse_mat_fixed(&vector, 3, false);
+    let scalar: u64 = 5;
+    let masking_vector: Vec<u64> = vec![1, 4, 7];
+    let result = scalar_vec_mask_sparse_matrix(&mat, scalar, &masking_vector, &|a, b| a <= b);
+    assert_sparse_mat_compare(
+        &result,
+        &vec_to_sparse_mat_fixed(&target, 3, false),
+        I32F32::from_num(0),
+    );
+
+    let vector: Vec<f32> = vec![1., 2., 3., 4., 5., 6., 7., 8., 9.];
+    let target: Vec<f32> = vec![0., 0., 3., 0., 0., 6., 0., 0., 9.];
+    let mat = vec_to_sparse_mat_fixed(&vector, 3, false);
+    let scalar: u64 = 5;
+    let masking_vector: Vec<u64> = vec![1, 4, 7];
+    let result = scalar_vec_mask_sparse_matrix(&mat, scalar, &masking_vector, &|a, b| a >= b);
+    assert_sparse_mat_compare(
+        &result,
+        &vec_to_sparse_mat_fixed(&target, 3, false),
+        I32F32::from_num(0),
+    );
+}
+
+#[test]
 fn test_math_row_hadamard() {
     let vector: Vec<I32F32> = vec_to_fixed(&[1., 2., 3., 4.]);
     let matrix: Vec<f32> = vec![1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12.];

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -205,7 +205,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 252,
+    spec_version: 253,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
- Removes the max_upscale of bonds
- Removes the bond normalization steps.
- Clears bonds for new miners since the last tempo.
- Clears bonds from a de-registered validator


## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.