### PR TITLE
Feat/reset bonds on dereg

### DIFF
--- a/pallets/subtensor/src/epoch/run_epoch.rs
+++ b/pallets/subtensor/src/epoch/run_epoch.rs
@@ -22,6 +22,10 @@ impl<T: Config> Pallet<T> {
         let current_block: u64 = Self::get_current_block_as_u64();
         log::trace!("current_block:\n{:?}\n", current_block);
 
+        // Get tempo.
+        let tempo: u64 = Self::get_tempo(netuid).into();
+        log::trace!("tempo: {:?}", tempo);
+
         // Get activity cutoff.
         let activity_cutoff: u64 = Self::get_activity_cutoff(netuid) as u64;
         log::trace!("activity_cutoff:\n{:?}\n", activity_cutoff);
@@ -44,7 +48,7 @@ impl<T: Config> Pallet<T> {
         let block_at_registration: Vec<u64> = Self::get_block_at_registration(netuid);
         log::trace!("Block at registration:\n{:?}\n", &block_at_registration);
 
-        // Outdated matrix, updated_ij=True if i has last updated (weights) after j has last registered.
+        // Outdated matrix, outdated_ij=True if i has last updated (weights) after j has last registered.
         let outdated: Vec<Vec<bool>> = last_update
             .iter()
             .map(|updated| {
@@ -55,6 +59,16 @@ impl<T: Config> Pallet<T> {
             })
             .collect();
         log::trace!("Outdated:\n{:?}\n", &outdated);
+
+        // Recently registered matrix, recently_ij=True if last_tempo was *before* j was last registered.
+        // Mask if: the last tempo block happened *before* the registration block
+        // ==> last_tempo <= registered
+        let last_tempo: u64 = current_block.saturating_sub(tempo);
+        let recently_registered: Vec<bool> = block_at_registration
+            .iter()
+            .map(|registered| last_tempo <= *registered)
+            .collect();
+        log::trace!("Recently registered:\n{:?}\n", &recently_registered);
 
         // ===========
         // == Stake ==
@@ -185,7 +199,8 @@ impl<T: Config> Pallet<T> {
 
         // Access network bonds.
         let mut bonds: Vec<Vec<I32F32>> = Self::get_bonds(netuid);
-        inplace_mask_matrix(&outdated, &mut bonds); // mask outdated bonds
+        // Remove bonds referring to neurons that have registered since last tempo.
+        inplace_mask_cols(&recently_registered, &mut bonds); // mask recently registered bonds
         inplace_col_normalize(&mut bonds); // sum_i b_ij = 1
         log::trace!("B:\n{:?}\n", &bonds);
 
@@ -386,6 +401,10 @@ impl<T: Config> Pallet<T> {
         let current_block: u64 = Self::get_current_block_as_u64();
         log::trace!("current_block: {:?}", current_block);
 
+        // Get tempo.
+        let tempo: u64 = Self::get_tempo(netuid).into();
+        log::trace!("tempo:\n{:?}\n", tempo);
+
         // Get activity cutoff.
         let activity_cutoff: u64 = Self::get_activity_cutoff(netuid) as u64;
         log::trace!("activity_cutoff: {:?}", activity_cutoff);
@@ -548,12 +567,15 @@ impl<T: Config> Pallet<T> {
         let mut bonds: Vec<Vec<(u16, I32F32)>> = Self::get_bonds_sparse(netuid);
         log::trace!("B: {:?}", &bonds);
 
-        // Remove bonds referring to deregistered neurons.
-        bonds = vec_mask_sparse_matrix(
+        // Remove bonds referring to neurons that have registered since last tempo.
+        // Mask if: the last tempo block happened *before* the registration block
+        // ==> last_tempo <= registered
+        let last_tempo: u64 = current_block.saturating_sub(tempo);
+        bonds = scalar_vec_mask_sparse_matrix(
             &bonds,
-            &last_update,
+            last_tempo,
             &block_at_registration,
-            &|updated, registered| updated <= registered,
+            &|last_tempo, registered| last_tempo <= registered,
         );
         log::trace!("B (outdatedmask): {:?}", &bonds);
 

--- a/pallets/subtensor/src/subnets/uids.rs
+++ b/pallets/subtensor/src/subnets/uids.rs
@@ -23,6 +23,7 @@ impl<T: Config> Pallet<T> {
         Consensus::<T>::mutate(netuid, |v| Self::set_element_at(v, neuron_index, 0));
         Incentive::<T>::mutate(netuid, |v| Self::set_element_at(v, neuron_index, 0));
         Dividends::<T>::mutate(netuid, |v| Self::set_element_at(v, neuron_index, 0));
+        Bonds::<T>::remove(netuid, neuron_uid); // Remove bonds for Validator.
     }
 
     /// Replace the neuron under this uid.

--- a/pallets/subtensor/src/tests/epoch.rs
+++ b/pallets/subtensor/src/tests/epoch.rs
@@ -983,25 +983,25 @@ fn test_512_graph_random_weights() {
 // }
 
 fn next_block_no_epoch(netuid: u16) -> u64 {
-	// high tempo to skip automatic epochs in on_initialize
-	let high_tempo: u16 = u16::MAX - 1;
-	let old_tempo: u16 = SubtensorModule::get_tempo(netuid);
+    // high tempo to skip automatic epochs in on_initialize
+    let high_tempo: u16 = u16::MAX - 1;
+    let old_tempo: u16 = SubtensorModule::get_tempo(netuid);
 
-	SubtensorModule::set_tempo(netuid, high_tempo);
-	let new_block = next_block();
-	SubtensorModule::set_tempo(netuid, old_tempo);
+    SubtensorModule::set_tempo(netuid, high_tempo);
+    let new_block = next_block();
+    SubtensorModule::set_tempo(netuid, old_tempo);
 
-	new_block
+    new_block
 }
 
 fn run_to_block_no_epoch(netuid: u16, n: u64) {
-	// high tempo to skip automatic epochs in on_initialize
-	let high_tempo: u16 = u16::MAX - 1;
-	let old_tempo: u16 = SubtensorModule::get_tempo(netuid);
+    // high tempo to skip automatic epochs in on_initialize
+    let high_tempo: u16 = u16::MAX - 1;
+    let old_tempo: u16 = SubtensorModule::get_tempo(netuid);
 
-	SubtensorModule::set_tempo(netuid, high_tempo);
-	run_to_block(n);
-	SubtensorModule::set_tempo(netuid, old_tempo);
+    SubtensorModule::set_tempo(netuid, high_tempo);
+    run_to_block(n);
+    SubtensorModule::set_tempo(netuid, old_tempo);
 }
 
 // Test bonds exponential moving average over a sequence of epochs.

--- a/pallets/subtensor/src/tests/math.rs
+++ b/pallets/subtensor/src/tests/math.rs
@@ -1221,6 +1221,45 @@ fn test_math_vec_mask_sparse_matrix() {
 }
 
 #[test]
+fn test_math_scalar_vec_mask_sparse_matrix() {
+    let vector: Vec<f32> = vec![1., 2., 3., 4., 5., 6., 7., 8., 9.];
+    let target: Vec<f32> = vec![0., 2., 3., 0., 5., 6., 0., 8., 9.];
+    let mat = vec_to_sparse_mat_fixed(&vector, 3, false);
+    let scalar: u64 = 1;
+    let masking_vector: Vec<u64> = vec![1, 4, 7];
+    let result = scalar_vec_mask_sparse_matrix(&mat, scalar, &masking_vector, &|a, b| a == b);
+    assert_sparse_mat_compare(
+        &result,
+        &vec_to_sparse_mat_fixed(&target, 3, false),
+        I32F32::from_num(0),
+    );
+
+    let vector: Vec<f32> = vec![1., 2., 3., 4., 5., 6., 7., 8., 9.];
+    let target: Vec<f32> = vec![1., 2., 0., 4., 5., 0., 7., 8., 0.];
+    let mat = vec_to_sparse_mat_fixed(&vector, 3, false);
+    let scalar: u64 = 5;
+    let masking_vector: Vec<u64> = vec![1, 4, 7];
+    let result = scalar_vec_mask_sparse_matrix(&mat, scalar, &masking_vector, &|a, b| a <= b);
+    assert_sparse_mat_compare(
+        &result,
+        &vec_to_sparse_mat_fixed(&target, 3, false),
+        I32F32::from_num(0),
+    );
+
+    let vector: Vec<f32> = vec![1., 2., 3., 4., 5., 6., 7., 8., 9.];
+    let target: Vec<f32> = vec![0., 0., 3., 0., 0., 6., 0., 0., 9.];
+    let mat = vec_to_sparse_mat_fixed(&vector, 3, false);
+    let scalar: u64 = 5;
+    let masking_vector: Vec<u64> = vec![1, 4, 7];
+    let result = scalar_vec_mask_sparse_matrix(&mat, scalar, &masking_vector, &|a, b| a >= b);
+    assert_sparse_mat_compare(
+        &result,
+        &vec_to_sparse_mat_fixed(&target, 3, false),
+        I32F32::from_num(0),
+    );
+}
+
+#[test]
 fn test_math_row_hadamard() {
     let vector: Vec<I32F32> = vec_to_fixed(&[1., 2., 3., 4.]);
     let matrix: Vec<f32> = vec![1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12.];


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
- Reset the bonds on deregistration of validator
- mask old bonds during epoch for deregistered miners.

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.