### PR TITLE
Adjust staking fees

### DIFF
--- a/pallets/subtensor/src/tests/staking2.rs
+++ b/pallets/subtensor/src/tests/staking2.rs
@@ -914,5 +914,35 @@ fn test_stake_fee_calculation() {
             I96F32::from_num(stake_amount),
         ); // Charged a dynamic fee
         assert_ne!(stake_fee_5, default_fee);
+
+        // Test stake fee for move between hotkeys on non-root
+        let stake_fee_6 = SubtensorModule::calculate_staking_fee(
+            Some((&hotkey1, netuid0)),
+            &coldkey1,
+            Some((&hotkey2, netuid0)),
+            &coldkey1,
+            I96F32::from_num(stake_amount),
+        ); // Charge the default fee
+        assert_eq!(stake_fee_6, default_fee);
+
+        // Test stake fee for move between coldkeys on non-root
+        let stake_fee_7 = SubtensorModule::calculate_staking_fee(
+            Some((&hotkey1, netuid0)),
+            &coldkey1,
+            Some((&hotkey1, netuid0)),
+            &coldkey2,
+            I96F32::from_num(stake_amount),
+        ); // Charge the default fee; stake did not leave the subnet.
+        assert_eq!(stake_fee_7, default_fee);
+
+        // Test stake fee for *swap* from non-root to non-root
+        let stake_fee_8 = SubtensorModule::calculate_staking_fee(
+            Some((&hotkey1, netuid0)),
+            &coldkey1,
+            Some((&hotkey1, netuid1)),
+            &coldkey1,
+            I96F32::from_num(stake_amount),
+        ); // Charged a dynamic fee
+        assert_ne!(stake_fee_8, default_fee);
     });
 }

--- a/pallets/subtensor/src/tests/staking2.rs
+++ b/pallets/subtensor/src/tests/staking2.rs
@@ -914,35 +914,5 @@ fn test_stake_fee_calculation() {
             I96F32::from_num(stake_amount),
         ); // Charged a dynamic fee
         assert_ne!(stake_fee_5, default_fee);
-
-        // Test stake fee for move between hotkeys on non-root
-        let stake_fee_6 = SubtensorModule::calculate_staking_fee(
-            Some((&hotkey1, netuid0)),
-            &coldkey1,
-            Some((&hotkey2, netuid0)),
-            &coldkey1,
-            I96F32::from_num(stake_amount),
-        ); // Charge the default fee
-        assert_eq!(stake_fee_6, default_fee);
-
-        // Test stake fee for move between coldkeys on non-root
-        let stake_fee_7 = SubtensorModule::calculate_staking_fee(
-            Some((&hotkey1, netuid0)),
-            &coldkey1,
-            Some((&hotkey1, netuid0)),
-            &coldkey2,
-            I96F32::from_num(stake_amount),
-        ); // Charge the default fee; stake did not leave the subnet.
-        assert_eq!(stake_fee_7, default_fee);
-
-        // Test stake fee for *swap* from non-root to non-root
-        let stake_fee_8 = SubtensorModule::calculate_staking_fee(
-            Some((&hotkey1, netuid0)),
-            &coldkey1,
-            Some((&hotkey1, netuid1)),
-            &coldkey1,
-            I96F32::from_num(stake_amount),
-        ); // Charged a dynamic fee
-        assert_ne!(stake_fee_8, default_fee);
     });
 }


### PR DESCRIPTION
## Description

Make staking fees minimum proportional to 44% APY on all staking transactions except add_stake.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
