### PR TITLE
Fix/runs epoch before start call

### DIFF
--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -45,7 +45,8 @@ impl<T: Config> Pallet<T> {
         log::debug!("All subnet netuids: {:?}", subnets);
         // Filter out subnets with no first emission block number.
         let subnets_to_emit_to: Vec<u16> = subnets
-            .iter()
+            .clone()
+            .into_iter()
             .filter(|netuid| FirstEmissionBlockNumber::<T>::get(*netuid).is_some())
             .collect();
         log::debug!("Subnets to emit to: {:?}", subnets_to_emit_to);

--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -37,17 +37,23 @@ impl<T: Config> Pallet<T> {
         let current_block: u64 = Self::get_current_block_as_u64();
         log::debug!("Current block: {:?}", current_block);
 
-        // --- 1. Get all netuids (filter out root and new subnet without first emission block)
+        // --- 1. Get all netuids (filter out root)
         let subnets: Vec<u16> = Self::get_all_subnet_netuids()
             .into_iter()
             .filter(|netuid| *netuid != 0)
-            .filter(|netuid| FirstEmissionBlockNumber::<T>::get(*netuid).is_some())
             .collect();
         log::debug!("All subnet netuids: {:?}", subnets);
+        // Filter out subnets with no first emission block number.
+        let subnets_to_emit_to: Vec<u16> = subnets
+            .iter()
+            .filter(|netuid| FirstEmissionBlockNumber::<T>::get(*netuid).is_some())
+            .collect();
+        log::debug!("Subnets to emit to: {:?}", subnets_to_emit_to);
 
         // --- 2. Get sum of tao reserves ( in a later version we will switch to prices. )
         let mut total_moving_prices: I96F32 = I96F32::saturating_from_num(0.0);
-        for netuid_i in subnets.iter() {
+        // Only get price EMA for subnets that we emit to.
+        for netuid_i in subnets_to_emit_to.iter() {
             // Get and update the moving price of each subnet adding the total together.
             total_moving_prices =
                 total_moving_prices.saturating_add(Self::get_moving_alpha_price(*netuid_i));
@@ -59,7 +65,8 @@ impl<T: Config> Pallet<T> {
         let mut tao_in: BTreeMap<u16, I96F32> = BTreeMap::new();
         let mut alpha_in: BTreeMap<u16, I96F32> = BTreeMap::new();
         let mut alpha_out: BTreeMap<u16, I96F32> = BTreeMap::new();
-        for netuid_i in subnets.iter() {
+        // Only calculate for subnets that we are emitting to.
+        for netuid_i in subnets_to_emit_to.iter() {
             // Get subnet price.
             let price_i: I96F32 = Self::get_alpha_price(*netuid_i);
             log::debug!("price_i: {:?}", price_i);
@@ -104,7 +111,7 @@ impl<T: Config> Pallet<T> {
         // --- 4. Injection.
         // Actually perform the injection of alpha_in, alpha_out and tao_in into the subnet pool.
         // This operation changes the pool liquidity each block.
-        for netuid_i in subnets.iter() {
+        for netuid_i in subnets_to_emit_to.iter() {
             // Inject Alpha in.
             let alpha_in_i: u64 = tou64!(*alpha_in.get(netuid_i).unwrap_or(&asfloat!(0)));
             SubnetAlphaInEmission::<T>::insert(*netuid_i, alpha_in_i);
@@ -136,7 +143,7 @@ impl<T: Config> Pallet<T> {
         // Owner cuts are accumulated and then fed to the drain at the end of this func.
         let cut_percent: I96F32 = Self::get_float_subnet_owner_cut();
         let mut owner_cuts: BTreeMap<u16, I96F32> = BTreeMap::new();
-        for netuid_i in subnets.iter() {
+        for netuid_i in subnets_to_emit_to.iter() {
             // Get alpha out.
             let alpha_out_i: I96F32 = *alpha_out.get(netuid_i).unwrap_or(&asfloat!(0));
             log::debug!("alpha_out_i: {:?}", alpha_out_i);
@@ -155,7 +162,7 @@ impl<T: Config> Pallet<T> {
 
         // --- 6. Seperate out root dividends in alpha and sell them into tao.
         // Then accumulate those dividends for later.
-        for netuid_i in subnets.iter() {
+        for netuid_i in subnets_to_emit_to.iter() {
             // Get remaining alpha out.
             let alpha_out_i: I96F32 = *alpha_out.get(netuid_i).unwrap_or(&asfloat!(0.0));
             log::debug!("alpha_out_i: {:?}", alpha_out_i);
@@ -200,12 +207,14 @@ impl<T: Config> Pallet<T> {
         }
 
         // --- 7 Update moving prices after using them in the emission calculation.
-        for netuid_i in subnets.iter() {
+        // Only update price EMA for subnets that we emit to.
+        for netuid_i in subnets_to_emit_to.iter() {
             // Update moving prices after using them above.
             Self::update_moving_price(*netuid_i);
         }
 
         // --- 7. Drain pending emission through the subnet based on tempo.
+        // Run the epoch for *all* subnets, even if we don't emit anything.
         for &netuid in subnets.iter() {
             // Pass on subnets that have not reached their tempo.
             if Self::should_run_epoch(netuid, current_block) {

--- a/pallets/subtensor/src/tests/epoch.rs
+++ b/pallets/subtensor/src/tests/epoch.rs
@@ -983,28 +983,6 @@ fn test_512_graph_random_weights() {
 //     });
 // }
 
-fn next_block_no_epoch(netuid: u16) -> u64 {
-    // high tempo to skip automatic epochs in on_initialize
-    let high_tempo: u16 = u16::MAX - 1;
-    let old_tempo: u16 = SubtensorModule::get_tempo(netuid);
-
-    SubtensorModule::set_tempo(netuid, high_tempo);
-    let new_block = next_block();
-    SubtensorModule::set_tempo(netuid, old_tempo);
-
-    new_block
-}
-
-fn run_to_block_no_epoch(netuid: u16, n: u64) {
-    // high tempo to skip automatic epochs in on_initialize
-    let high_tempo: u16 = u16::MAX - 1;
-    let old_tempo: u16 = SubtensorModule::get_tempo(netuid);
-
-    SubtensorModule::set_tempo(netuid, high_tempo);
-    run_to_block(n);
-    SubtensorModule::set_tempo(netuid, old_tempo);
-}
-
 // Test bonds exponential moving average over a sequence of epochs.
 #[test]
 fn test_bonds() {

--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -595,6 +595,30 @@ pub(crate) fn run_to_block(n: u64) {
 }
 
 #[allow(dead_code)]
+pub(crate) fn next_block_no_epoch(netuid: u16) -> u64 {
+    // high tempo to skip automatic epochs in on_initialize
+    let high_tempo: u16 = u16::MAX - 1;
+    let old_tempo: u16 = SubtensorModule::get_tempo(netuid);
+
+    SubtensorModule::set_tempo(netuid, high_tempo);
+    let new_block = next_block();
+    SubtensorModule::set_tempo(netuid, old_tempo);
+
+    new_block
+}
+
+#[allow(dead_code)]
+pub(crate) fn run_to_block_no_epoch(netuid: u16, n: u64) {
+    // high tempo to skip automatic epochs in on_initialize
+    let high_tempo: u16 = u16::MAX - 1;
+    let old_tempo: u16 = SubtensorModule::get_tempo(netuid);
+
+    SubtensorModule::set_tempo(netuid, high_tempo);
+    run_to_block(n);
+    SubtensorModule::set_tempo(netuid, old_tempo);
+}
+
+#[allow(dead_code)]
 pub(crate) fn step_epochs(count: u16, netuid: u16) {
     for _ in 0..count {
         let blocks_to_next_epoch = SubtensorModule::blocks_until_next_epoch(


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
This fixes #1436 by allowing the epoch to run before the start call has been run.
Also adds tests
- no emission happens during this period
- epoch runs during this period
- drain pending emission function runs epoch with no emission pending

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.