### PR TITLE
Fix/min burn set low on new subnet

### DIFF
--- a/pallets/subtensor/src/subnets/subnet.rs
+++ b/pallets/subtensor/src/subnets/subnet.rs
@@ -239,7 +239,7 @@ impl<T: Config> Pallet<T> {
             netuid_to_register,
             mechid
         );
-        Self::deposit_event(Event::NetworkAdded(netuid_to_register, 0));
+        Self::deposit_event(Event::NetworkAdded(netuid_to_register, mechid));
 
         // --- 17. Return success.
         Ok(())

--- a/pallets/subtensor/src/subnets/subnet.rs
+++ b/pallets/subtensor/src/subnets/subnet.rs
@@ -272,7 +272,6 @@ impl<T: Config> Pallet<T> {
         Self::set_target_registrations_per_interval(netuid, 1);
         Self::set_adjustment_alpha(netuid, 17_893_341_751_498_265_066); // 18_446_744_073_709_551_615 * 0.97 = 17_893_341_751_498_265_066
         Self::set_immunity_period(netuid, 5000);
-        Self::set_min_burn(netuid, 1);
         Self::set_min_difficulty(netuid, u64::MAX);
         Self::set_max_difficulty(netuid, u64::MAX);
 

--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -152,7 +152,7 @@ parameter_types! {
     pub const InitialTxDelegateTakeRateLimit: u64 = 1; // 1 block take rate limit for testing
     pub const InitialTxChildKeyTakeRateLimit: u64 = 1; // 1 block take rate limit for testing
     pub const InitialBurn: u64 = 0;
-    pub const InitialMinBurn: u64 = 0;
+    pub const InitialMinBurn: u64 = 500_000;
     pub const InitialMaxBurn: u64 = 1_000_000_000;
     pub const InitialValidatorPruneLen: u64 = 0;
     pub const InitialScalingLawPower: u16 = 50;

--- a/pallets/subtensor/src/tests/subnet.rs
+++ b/pallets/subtensor/src/tests/subnet.rs
@@ -225,7 +225,7 @@ fn test_do_start_call_ok_with_same_block_number_after_coinbase() {
 
 #[test]
 fn test_register_network_min_burn_at_default() {
-    new_test_ext(0).execute_with(|| {
+    new_test_ext(1).execute_with(|| {
         let sn_owner_coldkey = U256::from(0);
         let sn_owner_hotkey = U256::from(1);
         let cost = SubtensorModule::get_network_lock_cost();
@@ -245,13 +245,13 @@ fn test_register_network_min_burn_at_default() {
             .filter(|event| {
                 matches!(
                     event.event,
-                    RuntimeEvent::SubtensorModule(SubtensorEvent::NetworkAdded(_, _))
+                    RuntimeEvent::SubtensorModule(Event::<Test>::NetworkAdded(..))
                 )
             })
             .last()
             .unwrap();
         let netuid = match min_burn_event.event {
-            RuntimeEvent::SubtensorModule(SubtensorEvent::NetworkAdded(netuid, _)) => netuid,
+            RuntimeEvent::SubtensorModule(Event::<Test>::NetworkAdded(netuid, _)) => netuid,
             _ => panic!("Expected NetworkAdded event"),
         };
 

--- a/pallets/subtensor/src/tests/subnet.rs
+++ b/pallets/subtensor/src/tests/subnet.rs
@@ -248,10 +248,10 @@ fn test_register_network_min_burn_at_default() {
                     RuntimeEvent::SubtensorModule(Event::<Test>::NetworkAdded(..))
                 )
             })
-            .last()
-            .unwrap();
-        let netuid = match min_burn_event.event {
-            RuntimeEvent::SubtensorModule(Event::<Test>::NetworkAdded(netuid, _)) => netuid,
+            .last();
+
+        let netuid = match min_burn_event.map(|event| event.event.clone()) {
+            Some(RuntimeEvent::SubtensorModule(Event::<Test>::NetworkAdded(netuid, _))) => netuid,
             _ => panic!("Expected NetworkAdded event"),
         };
 

--- a/pallets/subtensor/src/tests/subnet.rs
+++ b/pallets/subtensor/src/tests/subnet.rs
@@ -222,3 +222,40 @@ fn test_do_start_call_ok_with_same_block_number_after_coinbase() {
         }
     });
 }
+
+#[test]
+fn test_register_network_min_burn_at_default() {
+    new_test_ext(0).execute_with(|| {
+        let sn_owner_coldkey = U256::from(0);
+        let sn_owner_hotkey = U256::from(1);
+        let cost = SubtensorModule::get_network_lock_cost();
+
+        // Give coldkey enough for lock
+        SubtensorModule::add_balance_to_coldkey_account(&sn_owner_coldkey, cost + 10_000_000_000);
+
+        // Register network
+        assert_ok!(SubtensorModule::register_network(
+            <<Test as Config>::RuntimeOrigin>::signed(sn_owner_coldkey),
+            sn_owner_hotkey
+        ));
+        // Get last events
+        let events = System::events();
+        let min_burn_event = events
+            .iter()
+            .filter(|event| {
+                matches!(
+                    event.event,
+                    RuntimeEvent::SubtensorModule(SubtensorEvent::NetworkAdded(_, _))
+                )
+            })
+            .last()
+            .unwrap();
+        let netuid = match min_burn_event.event {
+            RuntimeEvent::SubtensorModule(SubtensorEvent::NetworkAdded(netuid, _)) => netuid,
+            _ => panic!("Expected NetworkAdded event"),
+        };
+
+        // Check min burn is set to default
+        assert_eq!(MinBurn::<Test>::get(netuid), InitialMinBurn::get());
+    });
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -207,7 +207,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 255,
+    spec_version: 256,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
Removes the explicit set of min_burn on new network registration.
Tests that the value stays at default.

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x]  Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.