### PR TITLE
feat/Multiple Revealed Commitments

### DIFF
--- a/pallets/commitments/src/lib.rs
+++ b/pallets/commitments/src/lib.rs
@@ -527,10 +527,7 @@ impl<T: Config> Pallet<T> {
                             .ok();
 
                         let Some(sig) = sig else {
-                            remain_fields.push(Data::TimelockEncrypted {
-                                encrypted,
-                                reveal_round,
-                            });
+                            log::warn!("No sig after deserialization");
                             continue;
                         };
 
@@ -546,10 +543,7 @@ impl<T: Config> Pallet<T> {
                             .ok();
 
                         let Some(commit) = commit else {
-                            remain_fields.push(Data::TimelockEncrypted {
-                                encrypted,
-                                reveal_round,
-                            });
+                            log::warn!("No commit after deserialization");
                             continue;
                         };
 
@@ -562,10 +556,7 @@ impl<T: Config> Pallet<T> {
                                 .unwrap_or_default();
 
                         if decrypted_bytes.is_empty() {
-                            remain_fields.push(Data::TimelockEncrypted {
-                                encrypted,
-                                reveal_round,
-                            });
+                            log::warn!("Bytes were decrypted for {:?} but they are empty", who);
                             continue;
                         }
 

--- a/pallets/commitments/src/lib.rs
+++ b/pallets/commitments/src/lib.rs
@@ -570,7 +570,6 @@ impl<T: Config> Pallet<T> {
                         }
 
                         revealed_fields.push(decrypted_bytes);
-
                     }
 
                     other => remain_fields.push(other),
@@ -581,7 +580,7 @@ impl<T: Config> Pallet<T> {
                 let mut existing_reveals =
                     RevealedCommitments::<T>::get(netuid, &who).unwrap_or_default();
 
-                let current_block = <frame_system::Pallet<T>>::block_number();    
+                let current_block = <frame_system::Pallet<T>>::block_number();
                 let block_u64 = current_block.saturated_into::<u64>();
 
                 // Push newly revealed items onto the tail of existing_reveals and emit the event
@@ -596,7 +595,6 @@ impl<T: Config> Pallet<T> {
 
                 RevealedCommitments::<T>::insert(netuid, &who, existing_reveals);
             }
-
 
             registration.info.fields = BoundedVec::try_from(remain_fields)
                 .map_err(|_| "Failed to build BoundedVec for remain_fields")?;

--- a/pallets/commitments/src/lib.rs
+++ b/pallets/commitments/src/lib.rs
@@ -584,6 +584,12 @@ impl<T: Config> Pallet<T> {
                     });
                 }
 
+                const MAX_REVEALS: usize = 10;
+                if existing_reveals.len() > MAX_REVEALS {
+                    let remove_count = existing_reveals.len() - MAX_REVEALS;
+                    existing_reveals.drain(0..remove_count);
+                }
+
                 RevealedCommitments::<T>::insert(netuid, &who, existing_reveals);
             }
 

--- a/pallets/commitments/src/lib.rs
+++ b/pallets/commitments/src/lib.rs
@@ -586,7 +586,7 @@ impl<T: Config> Pallet<T> {
 
                 const MAX_REVEALS: usize = 10;
                 if existing_reveals.len() > MAX_REVEALS {
-                    let remove_count = existing_reveals.len() - MAX_REVEALS;
+                    let remove_count = existing_reveals.len().saturating_sub(MAX_REVEALS);
                     existing_reveals.drain(0..remove_count);
                 }
 

--- a/pallets/commitments/src/mock.rs
+++ b/pallets/commitments/src/mock.rs
@@ -207,6 +207,7 @@ use tle::{ibe::fullident::Identity, stream_ciphers::AESGCMStreamCipherProvider, 
 pub const DRAND_QUICKNET_PUBKEY_HEX: &str = "83cf0f2896adee7eb8b5f01fcad3912212c437e0073e911fb90022d3e760183c8c4b450b6\
      a0a6c3ac6a5776a2d1064510d1fec758c921cc22b0e17e63aaf4bcb5ed66304de9cf809b\
      d274ca73bab4af5a6e9c76a4bc09e76eae8991ef5ece45a";
+pub const DRAND_QUICKNET_SIG_2000_HEX: &str = "b6cb8f482a0b15d45936a4c4ea08e98a087e71787caee3f4d07a8a9843b1bc5423c6b3c22f446488b3137eaca799c77e"; // round 20000
 pub const DRAND_QUICKNET_SIG_HEX: &str = "b44679b9a59af2ec876b1a6b1ad52ea9b1615fc3982b19576350f93447cb1125e342b73a8dd2bacbe47e4b6b63ed5e39";
 
 /// Inserts a Drand pulse for `round` with the given `signature_bytes`.

--- a/pallets/commitments/src/tests.rs
+++ b/pallets/commitments/src/tests.rs
@@ -1686,7 +1686,8 @@ fn revealed_commitments_keeps_only_10_newest_with_individual_single_field_commit
             );
         }
 
-        let revealed = RevealedCommitments::<Test>::get(netuid, who).unwrap();
+        let revealed =
+            RevealedCommitments::<Test>::get(netuid, who).expect("expected to not panic");
         assert_eq!(
             revealed.len(),
             10,

--- a/pallets/commitments/src/tests.rs
+++ b/pallets/commitments/src/tests.rs
@@ -15,7 +15,7 @@ use frame_support::{
     BoundedVec, assert_noop, assert_ok,
     traits::{Currency, Get, ReservableCurrency},
 };
-use frame_system::Pallet as System;
+use frame_system::{Pallet as System, RawOrigin};
 
 #[allow(clippy::indexing_slicing)]
 #[test]
@@ -1422,5 +1422,152 @@ fn timelocked_index_complex_scenario_works() {
         );
 
         assert_eq!(idx.len(), 0, "All users revealed => index is empty");
+    });
+}
+
+#[allow(clippy::indexing_slicing)]
+#[test]
+fn reveal_timelocked_bad_timelocks_are_removed() {
+    new_test_ext().execute_with(|| {
+        //
+        // 1) Prepare multiple Data::TimelockEncrypted fields with different “badness” scenarios + one good field
+        //
+        // Round used for valid Drand signature
+        let valid_round = 1000;
+        // Round used for intentionally invalid Drand signature
+        let invalid_sig_round = 999;
+        // Round that has *no* Drand pulse => timelock remains stored, not revealed yet
+        let no_pulse_round = 2001;
+
+        // (a) TLE #1: Round=999 => Drand pulse *exists* but signature is invalid => skip/deleted
+        let plaintext_1 = b"BadSignature";
+        let ciphertext_1 = produce_ciphertext(plaintext_1, invalid_sig_round);
+        let tle_bad_sig = Data::TimelockEncrypted {
+            encrypted: ciphertext_1,
+            reveal_round: invalid_sig_round,
+        };
+
+        // (b) TLE #2: Round=1000 => Drand signature is valid, but ciphertext is corrupted => skip/deleted
+        let plaintext_2 = b"CorruptedCiphertext";
+        let good_ct_2 = produce_ciphertext(plaintext_2, valid_round);
+        let mut corrupted_ct_2 = good_ct_2.into_inner();
+        if !corrupted_ct_2.is_empty() {
+            corrupted_ct_2[0] ^= 0xFF; // flip a byte
+        }
+        let tle_corrupted = Data::TimelockEncrypted {
+            encrypted: corrupted_ct_2.try_into().expect("Expected not to panic"),
+            reveal_round: valid_round,
+        };
+
+        // (c) TLE #3: Round=1000 => Drand signature valid, ciphertext good, *but* plaintext is empty => skip/deleted
+        let empty_good_ct = produce_ciphertext(&[], valid_round);
+        let tle_empty_plaintext = Data::TimelockEncrypted {
+            encrypted: empty_good_ct,
+            reveal_round: valid_round,
+        };
+
+        // (d) TLE #4: Round=1000 => Drand signature valid, ciphertext valid, nonempty plaintext => should be revealed
+        let plaintext_4 = b"Hello, I decrypt fine!";
+        let good_ct_4 = produce_ciphertext(plaintext_4, valid_round);
+        let tle_good = Data::TimelockEncrypted {
+            encrypted: good_ct_4,
+            reveal_round: valid_round,
+        };
+
+        // (e) TLE #5: Round=2001 => no Drand pulse => remains in storage
+        let plaintext_5 = b"Still waiting for next round!";
+        let good_ct_5 = produce_ciphertext(plaintext_5, no_pulse_round);
+        let tle_no_pulse = Data::TimelockEncrypted {
+            encrypted: good_ct_5,
+            reveal_round: no_pulse_round,
+        };
+
+        //
+        // 2) Assemble them all in one CommitmentInfo
+        //
+        let fields = vec![
+            tle_bad_sig,         // #1
+            tle_corrupted,       // #2
+            tle_empty_plaintext, // #3
+            tle_good,            // #4
+            tle_no_pulse,        // #5
+        ];
+        let fields_bounded = BoundedVec::try_from(fields).expect("Should not exceed MaxFields");
+        let info = CommitmentInfo {
+            fields: fields_bounded,
+        };
+
+        //
+        // 3) Insert the commitment
+        //
+        let who = 123;
+        let netuid = 777;
+        System::<Test>::set_block_number(1);
+        assert_ok!(Pallet::<Test>::set_commitment(
+            RawOrigin::Signed(who).into(),
+            netuid,
+            Box::new(info)
+        ));
+
+        //
+        // 4) Insert pulses:
+        //    - Round=999 => invalid signature => attempts to parse => fails => remove TLE #1
+        //    - Round=1000 => valid signature => TLE #2 is corrupted => remove; #3 empty => remove; #4 reveals successfully
+        //    - Round=2001 => no signature => TLE #5 remains
+        //
+        let bad_sig = [0x33u8; 10]; // obviously invalid for TinyBLS
+        insert_drand_pulse(invalid_sig_round, &bad_sig);
+
+        let drand_sig_1000 = hex::decode(DRAND_QUICKNET_SIG_HEX).expect("Expected not to panic");
+        insert_drand_pulse(valid_round, &drand_sig_1000);
+
+        //
+        // 5) Call reveal => “bad” items are removed, “good” is revealed, “not ready” remains
+        //
+        System::<Test>::set_block_number(2);
+        assert_ok!(Pallet::<Test>::reveal_timelocked_commitments());
+
+        //
+        // 6) Check final storage
+        //
+        // (a) TLE #5 => still in fields => same user remains in CommitmentOf => TimelockedIndex includes them
+        let registration_after =
+            CommitmentOf::<Test>::get(netuid, who).expect("Should still exist");
+        assert_eq!(
+            registration_after.info.fields.len(),
+            1,
+            "Only the unrevealed TLE #5 should remain"
+        );
+        let leftover = &registration_after.info.fields[0];
+        match leftover {
+            Data::TimelockEncrypted { reveal_round, .. } => {
+                assert_eq!(*reveal_round, no_pulse_round, "Should be TLE #5 leftover");
+            }
+            _ => panic!("Expected the leftover field to be TLE #5"),
+        };
+        assert!(
+            TimelockedIndex::<Test>::get().contains(&(netuid, who)),
+            "Still in index because there's one remaining timelock (#5)."
+        );
+
+        // (b) TLE #4 => revealed => check that the plaintext matches
+        let revealed = RevealedCommitments::<Test>::get(netuid, who)
+            .expect("Should have at least one revealed item for TLE #4");
+        let (revealed_bytes, reveal_block) = &revealed[0];
+        assert_eq!(*reveal_block, 2, "Revealed at block #2");
+
+        let revealed_str = sp_std::str::from_utf8(revealed_bytes)
+            .expect("Truncated bytes should be valid UTF-8 in this test");
+
+        let original_str =
+            sp_std::str::from_utf8(plaintext_4).expect("plaintext_4 should be valid UTF-8");
+
+        assert_eq!(
+            revealed_str, original_str,
+            "Expected revealed data to match the original plaintext"
+        );
+
+        // (c) TLE #1 / #2 / #3 => removed => do NOT appear in leftover fields, nor in revealed (they were invalid)
+        assert_eq!(revealed.len(), 1, "Only TLE #4 ended up in revealed list");
     });
 }

--- a/pallets/commitments/src/tests.rs
+++ b/pallets/commitments/src/tests.rs
@@ -449,6 +449,7 @@ fn reveal_timelocked_commitment_empty_decrypted_data_is_skipped() {
     });
 }
 
+#[allow(clippy::indexing_slicing)]
 #[test]
 fn reveal_timelocked_commitment_single_field_entry_is_removed_after_reveal() {
     new_test_ext().execute_with(|| {
@@ -1260,7 +1261,8 @@ fn timelocked_index_complex_scenario_works() {
             }
         };
 
-        let make_raw_data = |payload: &[u8]| Data::Raw(payload.to_vec().try_into().unwrap());
+        let make_raw_data =
+            |payload: &[u8]| Data::Raw(payload.to_vec().try_into().expect("expected to not panic"));
 
         // ----------------------------------------------------
         // (1) USER A => no timelocks => NOT in index
@@ -1340,7 +1342,7 @@ fn timelocked_index_complex_scenario_works() {
         // ----------------------------------------------------
         let b_timelock_2 = make_timelock_data(b"B TLE #2", 2000);
         let info_b3 = CommitmentInfo::<TestMaxFields> {
-            fields: BoundedVec::try_from(vec![b_timelock_2]).unwrap(),
+            fields: BoundedVec::try_from(vec![b_timelock_2]).expect("expected to not panic"),
         };
         assert_ok!(Pallet::<Test>::set_commitment(
             RuntimeOrigin::signed(user_b),
@@ -1356,7 +1358,7 @@ fn timelocked_index_complex_scenario_works() {
         // ----------------------------------------------------
         let c_timelock_1 = make_timelock_data(b"C TLE #1", 2000);
         let info_c1 = CommitmentInfo::<TestMaxFields> {
-            fields: BoundedVec::try_from(vec![c_timelock_1]).unwrap(),
+            fields: BoundedVec::try_from(vec![c_timelock_1]).expect("expected to not panic"),
         };
         assert_ok!(Pallet::<Test>::set_commitment(
             RuntimeOrigin::signed(user_c),

--- a/pallets/commitments/src/tests.rs
+++ b/pallets/commitments/src/tests.rs
@@ -451,37 +451,6 @@ fn reveal_timelocked_commitment_empty_decrypted_data_is_skipped() {
 }
 
 #[test]
-fn reveal_timelocked_commitment_decode_failure_is_skipped() {
-    new_test_ext().execute_with(|| {
-        let who = 999;
-        let netuid = 8;
-        let commit_block = 42u64;
-        System::<Test>::set_block_number(commit_block);
-        let plaintext = vec![0xAA, 0xBB, 0xCC, 0xDD, 0xEE];
-        let reveal_round = 1000;
-        let real_ct = produce_ciphertext(&plaintext, reveal_round);
-        let data = Data::TimelockEncrypted {
-            encrypted: real_ct,
-            reveal_round,
-        };
-        let fields = BoundedVec::try_from(vec![data]).expect("Expected not to panic");
-        let info = CommitmentInfo { fields };
-        let origin = RuntimeOrigin::signed(who);
-        assert_ok!(Pallet::<Test>::set_commitment(
-            origin,
-            netuid,
-            Box::new(info)
-        ));
-        let sig_bytes =
-            hex::decode(DRAND_QUICKNET_SIG_HEX.as_bytes()).expect("Expected not to panic");
-        insert_drand_pulse(reveal_round, &sig_bytes);
-        System::<Test>::set_block_number(9999);
-        assert_ok!(Pallet::<Test>::reveal_timelocked_commitments());
-        assert!(RevealedCommitments::<Test>::get(netuid, who).is_none());
-    });
-}
-
-#[test]
 fn reveal_timelocked_commitment_single_field_entry_is_removed_after_reveal() {
     new_test_ext().execute_with(|| {
         let message_text = b"Single field timelock test!";

--- a/pallets/commitments/src/tests.rs
+++ b/pallets/commitments/src/tests.rs
@@ -1703,8 +1703,7 @@ fn revealed_commitments_keeps_only_10_newest_with_individual_single_field_commit
             assert_eq!(
                 revealed_str, expected_str,
                 "Revealed data #{} should match the truncated TLE #{}",
-                idx,
-                expected_i
+                idx, expected_i
             );
 
             let expected_reveal_block = expected_i as u64 + 1;

--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -85,7 +85,9 @@ mod hooks {
                 // Set last emission block number for all existed subnets before start call feature applied
                 .saturating_add(migrations::migrate_set_first_emission_block_number::migrate_set_first_emission_block_number::<T>())
                 // Remove all zero value entries in TotalHotkeyAlpha
-                .saturating_add(migrations::migrate_remove_zero_total_hotkey_alpha::migrate_remove_zero_total_hotkey_alpha::<T>());
+                .saturating_add(migrations::migrate_remove_zero_total_hotkey_alpha::migrate_remove_zero_total_hotkey_alpha::<T>())
+                // Wipe existing items to prevent bad decoding for new type
+                .saturating_add(migrations::migrate_upgrade_revealed_commitments::migrate_upgrade_revealed_commitments::<T>());
             weight
         }
 

--- a/pallets/subtensor/src/migrations/migrate_upgrade_revealed_commitments.rs
+++ b/pallets/subtensor/src/migrations/migrate_upgrade_revealed_commitments.rs
@@ -1,0 +1,58 @@
+use super::*;
+use crate::HasMigrationRun;
+use frame_support::{traits::Get, weights::Weight};
+use scale_info::prelude::string::String;
+use sp_io::{KillStorageResult, hashing::twox_128, storage::clear_prefix};
+
+pub fn migrate_upgrade_revealed_commitments<T: Config>() -> Weight {
+    let migration_name = b"migrate_revealed_commitments_v2".to_vec();
+    let mut weight = T::DbWeight::get().reads(1);
+
+    if HasMigrationRun::<T>::get(&migration_name) {
+        log::info!(
+            "Migration '{:?}' has already run. Skipping.",
+            migration_name
+        );
+        return weight;
+    }
+
+    log::info!(
+        "Running migration '{}'",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    // -------------------------------------------------------------
+    // 1) Clear the old `RevealedCommitments` storage from the `Commitments` pallet
+    // -------------------------------------------------------------
+    let mut revealed_commitments_prefix = Vec::new();
+    revealed_commitments_prefix.extend_from_slice(&twox_128("Commitments".as_bytes()));
+    revealed_commitments_prefix.extend_from_slice(&twox_128("RevealedCommitments".as_bytes()));
+
+    let removal_result = clear_prefix(&revealed_commitments_prefix, Some(u32::MAX));
+    let removed_entries_count = match removal_result {
+        KillStorageResult::AllRemoved(removed) => removed as u64,
+        KillStorageResult::SomeRemaining(removed) => {
+            log::warn!("Failed to remove some items during `migrate_revealed_commitments`.");
+            removed as u64
+        }
+    };
+    weight = weight.saturating_add(T::DbWeight::get().writes(removed_entries_count));
+
+    log::info!(
+        "Removed {} entries from `RevealedCommitments`.",
+        removed_entries_count
+    );
+
+    // -------------------------------------------------------------
+    // 2) Mark this migration as completed
+    // -------------------------------------------------------------
+    HasMigrationRun::<T>::insert(&migration_name, true);
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+    log::info!(
+        "Migration '{}' completed successfully.",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    weight
+}

--- a/pallets/subtensor/src/migrations/mod.rs
+++ b/pallets/subtensor/src/migrations/mod.rs
@@ -21,3 +21,4 @@ pub mod migrate_to_v1_separate_emission;
 pub mod migrate_to_v2_fixed_total_stake;
 pub mod migrate_total_issuance;
 pub mod migrate_transfer_ownership_to_foundation;
+pub mod migrate_upgrade_revealed_commitments;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -207,7 +207,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 258,
+    spec_version: 259,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
- Modifies `RevealedCommitments` to support multiple revealed commitments and adds the relevant migration. 
- Removes the encoding requirement at the end the reveal step and stores the decrypted bytes instead.
- Adds improved logic for handling undecodable timelocked commitments. 
- Adds tests