### PR TITLE
Do not use saturating_sub for signed types

### DIFF
--- a/pallets/subtensor/src/coinbase/block_emission.rs
+++ b/pallets/subtensor/src/coinbase/block_emission.rs
@@ -1,7 +1,10 @@
 use super::*;
 use frame_support::traits::Get;
 use safe_math::*;
-use substrate_fixed::{transcendental::log2, types::I96F32};
+use substrate_fixed::{
+    transcendental::log2,
+    types::{I96F32, U96F32},
+};
 
 impl<T: Config> Pallet<T> {
     /// Calculates the dynamic TAO emission for a given subnet.
@@ -31,15 +34,15 @@ impl<T: Config> Pallet<T> {
         alpha_block_emission: u64,
     ) -> (u64, u64, u64) {
         // Init terms.
-        let mut tao_in_emission: I96F32 = I96F32::saturating_from_num(tao_emission);
-        let float_alpha_block_emission: I96F32 = I96F32::saturating_from_num(alpha_block_emission);
+        let mut tao_in_emission: U96F32 = U96F32::saturating_from_num(tao_emission);
+        let float_alpha_block_emission: U96F32 = U96F32::saturating_from_num(alpha_block_emission);
 
         // Get alpha price for subnet.
-        let alpha_price: I96F32 = Self::get_alpha_price(netuid);
+        let alpha_price: U96F32 = Self::get_alpha_price(netuid);
         log::debug!("{:?} - alpha_price: {:?}", netuid, alpha_price);
 
         // Get initial alpha_in
-        let mut alpha_in_emission: I96F32 = I96F32::saturating_from_num(tao_emission)
+        let mut alpha_in_emission: U96F32 = U96F32::saturating_from_num(tao_emission)
             .checked_div(alpha_price)
             .unwrap_or(float_alpha_block_emission);
 
@@ -60,11 +63,11 @@ impl<T: Config> Pallet<T> {
         }
 
         // Avoid rounding errors.
-        if tao_in_emission < I96F32::saturating_from_num(1)
-            || alpha_in_emission < I96F32::saturating_from_num(1)
+        if tao_in_emission < U96F32::saturating_from_num(1)
+            || alpha_in_emission < U96F32::saturating_from_num(1)
         {
-            alpha_in_emission = I96F32::saturating_from_num(0);
-            tao_in_emission = I96F32::saturating_from_num(0);
+            alpha_in_emission = U96F32::saturating_from_num(0);
+            tao_in_emission = U96F32::saturating_from_num(0);
         }
 
         // Set Alpha in emission.

--- a/pallets/subtensor/src/coinbase/block_step.rs
+++ b/pallets/subtensor/src/coinbase/block_step.rs
@@ -1,7 +1,7 @@
 use super::*;
 use frame_support::storage::IterableStorageMap;
 use safe_math::*;
-use substrate_fixed::types::{I96F32, I110F18};
+use substrate_fixed::types::{U96F32, U110F18};
 
 impl<T: Config + pallet_drand::Config> Pallet<T> {
     /// Executes the necessary operations for each block.
@@ -11,8 +11,8 @@ impl<T: Config + pallet_drand::Config> Pallet<T> {
         // --- 1. Adjust difficulties.
         Self::adjust_registration_terms_for_networks();
         // --- 2. Get the current coinbase emission.
-        let block_emission: I96F32 =
-            I96F32::saturating_from_num(Self::get_block_emission().unwrap_or(0));
+        let block_emission: U96F32 =
+            U96F32::saturating_from_num(Self::get_block_emission().unwrap_or(0));
         log::debug!("Block emission: {:?}", block_emission);
         // --- 3. Run emission through network.
         Self::run_coinbase(block_emission);
@@ -191,7 +191,7 @@ impl<T: Config + pallet_drand::Config> Pallet<T> {
     }
 
     /// Calculates the upgraded difficulty by multiplying the current difficulty by the ratio ( reg_actual + reg_target / reg_target + reg_target )
-    /// We use I110F18 to avoid any overflows on u64. Also min_difficulty and max_difficulty bound the range.
+    /// We use U110F18 to avoid any overflows on u64. Also min_difficulty and max_difficulty bound the range.
     ///
     pub fn upgraded_difficulty(
         netuid: u16,
@@ -199,25 +199,25 @@ impl<T: Config + pallet_drand::Config> Pallet<T> {
         registrations_this_interval: u16,
         target_registrations_per_interval: u16,
     ) -> u64 {
-        let updated_difficulty: I110F18 = I110F18::saturating_from_num(current_difficulty)
-            .saturating_mul(I110F18::saturating_from_num(
+        let updated_difficulty: U110F18 = U110F18::saturating_from_num(current_difficulty)
+            .saturating_mul(U110F18::saturating_from_num(
                 registrations_this_interval.saturating_add(target_registrations_per_interval),
             ))
-            .safe_div(I110F18::saturating_from_num(
+            .safe_div(U110F18::saturating_from_num(
                 target_registrations_per_interval.saturating_add(target_registrations_per_interval),
             ));
-        let alpha: I110F18 = I110F18::saturating_from_num(Self::get_adjustment_alpha(netuid))
-            .safe_div(I110F18::saturating_from_num(u64::MAX));
-        let next_value: I110F18 = alpha
-            .saturating_mul(I110F18::saturating_from_num(current_difficulty))
+        let alpha: U110F18 = U110F18::saturating_from_num(Self::get_adjustment_alpha(netuid))
+            .safe_div(U110F18::saturating_from_num(u64::MAX));
+        let next_value: U110F18 = alpha
+            .saturating_mul(U110F18::saturating_from_num(current_difficulty))
             .saturating_add(
-                I110F18::saturating_from_num(1.0)
+                U110F18::saturating_from_num(1.0)
                     .saturating_sub(alpha)
                     .saturating_mul(updated_difficulty),
             );
-        if next_value >= I110F18::saturating_from_num(Self::get_max_difficulty(netuid)) {
+        if next_value >= U110F18::saturating_from_num(Self::get_max_difficulty(netuid)) {
             Self::get_max_difficulty(netuid)
-        } else if next_value <= I110F18::saturating_from_num(Self::get_min_difficulty(netuid)) {
+        } else if next_value <= U110F18::saturating_from_num(Self::get_min_difficulty(netuid)) {
             return Self::get_min_difficulty(netuid);
         } else {
             return next_value.saturating_to_num::<u64>();
@@ -225,7 +225,7 @@ impl<T: Config + pallet_drand::Config> Pallet<T> {
     }
 
     /// Calculates the upgraded burn by multiplying the current burn by the ratio ( reg_actual + reg_target / reg_target + reg_target )
-    /// We use I110F18 to avoid any overflows on u64. Also min_burn and max_burn bound the range.
+    /// We use U110F18 to avoid any overflows on u64. Also min_burn and max_burn bound the range.
     ///
     pub fn upgraded_burn(
         netuid: u16,
@@ -233,25 +233,25 @@ impl<T: Config + pallet_drand::Config> Pallet<T> {
         registrations_this_interval: u16,
         target_registrations_per_interval: u16,
     ) -> u64 {
-        let updated_burn: I110F18 = I110F18::saturating_from_num(current_burn)
-            .saturating_mul(I110F18::saturating_from_num(
+        let updated_burn: U110F18 = U110F18::saturating_from_num(current_burn)
+            .saturating_mul(U110F18::saturating_from_num(
                 registrations_this_interval.saturating_add(target_registrations_per_interval),
             ))
-            .safe_div(I110F18::saturating_from_num(
+            .safe_div(U110F18::saturating_from_num(
                 target_registrations_per_interval.saturating_add(target_registrations_per_interval),
             ));
-        let alpha: I110F18 = I110F18::saturating_from_num(Self::get_adjustment_alpha(netuid))
-            .safe_div(I110F18::saturating_from_num(u64::MAX));
-        let next_value: I110F18 = alpha
-            .saturating_mul(I110F18::saturating_from_num(current_burn))
+        let alpha: U110F18 = U110F18::saturating_from_num(Self::get_adjustment_alpha(netuid))
+            .safe_div(U110F18::saturating_from_num(u64::MAX));
+        let next_value: U110F18 = alpha
+            .saturating_mul(U110F18::saturating_from_num(current_burn))
             .saturating_add(
-                I110F18::saturating_from_num(1.0)
+                U110F18::saturating_from_num(1.0)
                     .saturating_sub(alpha)
                     .saturating_mul(updated_burn),
             );
-        if next_value >= I110F18::saturating_from_num(Self::get_max_burn_as_u64(netuid)) {
+        if next_value >= U110F18::saturating_from_num(Self::get_max_burn_as_u64(netuid)) {
             Self::get_max_burn_as_u64(netuid)
-        } else if next_value <= I110F18::saturating_from_num(Self::get_min_burn_as_u64(netuid)) {
+        } else if next_value <= U110F18::saturating_from_num(Self::get_min_burn_as_u64(netuid)) {
             return Self::get_min_burn_as_u64(netuid);
         } else {
             return next_value.saturating_to_num::<u64>();

--- a/pallets/subtensor/src/rpc_info/stake_info.rs
+++ b/pallets/subtensor/src/rpc_info/stake_info.rs
@@ -2,7 +2,7 @@ use super::*;
 use frame_support::pallet_prelude::{Decode, Encode};
 extern crate alloc;
 use codec::Compact;
-use substrate_fixed::types::I96F32;
+use substrate_fixed::types::U96F32;
 
 #[freeze_struct("5cfb3c84c3af3116")]
 #[derive(Decode, Encode, PartialEq, Eq, Clone, Debug, TypeInfo)]
@@ -139,7 +139,7 @@ impl<T: Config> Pallet<T> {
             &origin_coldkey_account,
             destination_,
             &destination_coldkey_account,
-            I96F32::saturating_from_num(amount),
+            U96F32::saturating_from_num(amount),
         )
     }
 }

--- a/pallets/subtensor/src/staking/helpers.rs
+++ b/pallets/subtensor/src/staking/helpers.rs
@@ -1,5 +1,6 @@
 use super::*;
-use substrate_fixed::types::I96F32;
+use safe_math::*;
+use substrate_fixed::types::U96F32;
 
 use frame_support::traits::{
     Imbalance,
@@ -46,10 +47,10 @@ impl<T: Config> Pallet<T> {
         Self::get_all_subnet_netuids()
             .iter()
             .map(|netuid| {
-                let alpha: I96F32 = I96F32::saturating_from_num(
+                let alpha: U96F32 = U96F32::saturating_from_num(
                     Self::get_stake_for_hotkey_on_subnet(hotkey, *netuid),
                 );
-                let tao_price: I96F32 = Self::get_alpha_price(*netuid);
+                let tao_price: U96F32 = Self::get_alpha_price(*netuid);
                 alpha.saturating_mul(tao_price).saturating_to_num::<u64>()
             })
             .sum()
@@ -66,9 +67,9 @@ impl<T: Config> Pallet<T> {
                 for (netuid, _) in Alpha::<T>::iter_prefix((hotkey, coldkey)) {
                     let alpha_stake =
                         Self::get_stake_for_hotkey_and_coldkey_on_subnet(hotkey, coldkey, netuid);
-                    let tao_price: I96F32 = Self::get_alpha_price(netuid);
+                    let tao_price: U96F32 = Self::get_alpha_price(netuid);
                     total_stake = total_stake.saturating_add(
-                        I96F32::saturating_from_num(alpha_stake)
+                        U96F32::saturating_from_num(alpha_stake)
                             .saturating_mul(tao_price)
                             .saturating_to_num::<u64>(),
                     );
@@ -128,10 +129,9 @@ impl<T: Config> Pallet<T> {
     pub fn get_hotkey_take(hotkey: &T::AccountId) -> u16 {
         Delegates::<T>::get(hotkey)
     }
-    pub fn get_hotkey_take_float(hotkey: &T::AccountId) -> I96F32 {
-        I96F32::saturating_from_num(Self::get_hotkey_take(hotkey))
-            .checked_div(I96F32::saturating_from_num(u16::MAX))
-            .unwrap_or(I96F32::saturating_from_num(0.0))
+    pub fn get_hotkey_take_float(hotkey: &T::AccountId) -> U96F32 {
+        U96F32::saturating_from_num(Self::get_hotkey_take(hotkey))
+            .safe_div(U96F32::saturating_from_num(u16::MAX))
     }
 
     /// Returns true if the hotkey account has been created.

--- a/pallets/subtensor/src/staking/move_stake.rs
+++ b/pallets/subtensor/src/staking/move_stake.rs
@@ -1,7 +1,7 @@
 use super::*;
 use safe_math::*;
 use sp_core::Get;
-use substrate_fixed::types::{I96F32, U64F64};
+use substrate_fixed::types::{U64F64, U96F32};
 
 impl<T: Config> Pallet<T> {
     /// Moves stake from one hotkey to another across subnets.
@@ -343,7 +343,7 @@ impl<T: Config> Pallet<T> {
             origin_coldkey,
             Some((destination_hotkey, destination_netuid)),
             destination_coldkey,
-            I96F32::saturating_from_num(alpha_amount),
+            U96F32::saturating_from_num(alpha_amount),
         )
         .safe_div(2);
 

--- a/pallets/subtensor/src/staking/remove_stake.rs
+++ b/pallets/subtensor/src/staking/remove_stake.rs
@@ -1,5 +1,5 @@
 use super::*;
-use substrate_fixed::types::I96F32;
+use substrate_fixed::types::U96F32;
 
 impl<T: Config> Pallet<T> {
     /// ---- The implementation for the extrinsic remove_stake: Removes stake from a hotkey account and adds it onto a coldkey.
@@ -63,7 +63,7 @@ impl<T: Config> Pallet<T> {
             &coldkey,
             None,
             &coldkey,
-            I96F32::saturating_from_num(alpha_unstaked),
+            U96F32::saturating_from_num(alpha_unstaked),
         );
         let tao_unstaked: u64 =
             Self::unstake_from_subnet(&hotkey, &coldkey, netuid, alpha_unstaked, fee);
@@ -139,7 +139,7 @@ impl<T: Config> Pallet<T> {
                 &coldkey,
                 None,
                 &coldkey,
-                I96F32::saturating_from_num(alpha_unstaked),
+                U96F32::saturating_from_num(alpha_unstaked),
             );
 
             if alpha_unstaked > 0 {
@@ -216,7 +216,7 @@ impl<T: Config> Pallet<T> {
                     &coldkey,
                     None,
                     &coldkey,
-                    I96F32::saturating_from_num(alpha_unstaked),
+                    U96F32::saturating_from_num(alpha_unstaked),
                 );
 
                 if alpha_unstaked > 0 {
@@ -325,7 +325,7 @@ impl<T: Config> Pallet<T> {
             &coldkey,
             None,
             &coldkey,
-            I96F32::saturating_from_num(alpha_unstaked),
+            U96F32::saturating_from_num(alpha_unstaked),
         );
         let tao_unstaked =
             Self::unstake_from_subnet(&hotkey, &coldkey, netuid, possible_alpha, fee);

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -2,7 +2,7 @@ use super::*;
 use safe_math::*;
 use share_pool::{SharePool, SharePoolDataOperations};
 use sp_std::ops::Neg;
-use substrate_fixed::types::{I64F64, I96F32, I110F18, U64F64};
+use substrate_fixed::types::{I64F64, I96F32, U64F64, U96F32, U110F18};
 
 impl<T: Config> Pallet<T> {
     /// Retrieves the total alpha issuance for a given subnet.
@@ -30,34 +30,35 @@ impl<T: Config> Pallet<T> {
     ///
     /// # Returns
     /// * `I96F32` - The price of alpha for the specified subnet.
-    pub fn get_alpha_price(netuid: u16) -> I96F32 {
+    pub fn get_alpha_price(netuid: u16) -> U96F32 {
         if netuid == Self::get_root_netuid() {
-            return I96F32::saturating_from_num(1.0); // Root.
+            return U96F32::saturating_from_num(1.0); // Root.
         }
         if SubnetMechanism::<T>::get(netuid) == 0 {
-            return I96F32::saturating_from_num(1.0); // Stable
+            return U96F32::saturating_from_num(1.0); // Stable
         }
         if SubnetAlphaIn::<T>::get(netuid) == 0 {
-            I96F32::saturating_from_num(0)
+            U96F32::saturating_from_num(0)
         } else {
-            I96F32::saturating_from_num(SubnetTAO::<T>::get(netuid))
-                .checked_div(I96F32::saturating_from_num(SubnetAlphaIn::<T>::get(netuid)))
-                .unwrap_or(I96F32::saturating_from_num(0))
+            U96F32::saturating_from_num(SubnetTAO::<T>::get(netuid))
+                .checked_div(U96F32::saturating_from_num(SubnetAlphaIn::<T>::get(netuid)))
+                .unwrap_or(U96F32::saturating_from_num(0))
         }
     }
-    pub fn get_moving_alpha_price(netuid: u16) -> I96F32 {
+    pub fn get_moving_alpha_price(netuid: u16) -> U96F32 {
+        let one = U96F32::saturating_from_num(1.0);
         if netuid == Self::get_root_netuid() {
             // Root.
-            I96F32::saturating_from_num(1.0)
+            one
         } else if SubnetMechanism::<T>::get(netuid) == 0 {
             // Stable
-            I96F32::saturating_from_num(1.0)
+            one
         } else {
-            SubnetMovingPrice::<T>::get(netuid)
+            U96F32::saturating_from_num(SubnetMovingPrice::<T>::get(netuid))
         }
     }
     pub fn update_moving_price(netuid: u16) {
-        let blocks_since_registration = I96F32::saturating_from_num(
+        let blocks_since_registration = U96F32::saturating_from_num(
             Self::get_current_block_as_u64().saturating_sub(NetworkRegisteredAt::<T>::get(netuid)),
         );
 
@@ -66,16 +67,20 @@ impl<T: Config> Pallet<T> {
         // will take in order for the distance between current EMA of price and current price to shorten
         // by half.
         let halving_time = EMAPriceHalvingBlocks::<T>::get(netuid);
-        let alpha: I96F32 =
-            SubnetMovingAlpha::<T>::get().saturating_mul(blocks_since_registration.safe_div(
-                blocks_since_registration.saturating_add(I96F32::saturating_from_num(halving_time)),
-            ));
-        let minus_alpha: I96F32 = I96F32::saturating_from_num(1.0).saturating_sub(alpha);
-        let current_price: I96F32 = alpha
-            .saturating_mul(Self::get_alpha_price(netuid).min(I96F32::saturating_from_num(1.0)));
-        let current_moving: I96F32 =
-            minus_alpha.saturating_mul(Self::get_moving_alpha_price(netuid));
-        let new_moving: I96F32 = current_price.saturating_add(current_moving);
+        let current_ma_unsigned = U96F32::saturating_from_num(SubnetMovingAlpha::<T>::get());
+        let alpha: U96F32 = current_ma_unsigned.saturating_mul(blocks_since_registration.safe_div(
+            blocks_since_registration.saturating_add(U96F32::saturating_from_num(halving_time)),
+        ));
+        // Because alpha = b / (b + h), where b and h > 0, alpha < 1, so 1 - alpha > 0.
+        // We can use unsigned type here: U96F32
+        let one_minus_alpha: U96F32 = U96F32::saturating_from_num(1.0).saturating_sub(alpha);
+        let current_price: U96F32 = alpha
+            .saturating_mul(Self::get_alpha_price(netuid).min(U96F32::saturating_from_num(1.0)));
+        let current_moving: U96F32 =
+            one_minus_alpha.saturating_mul(Self::get_moving_alpha_price(netuid));
+        // Convert batch to signed I96F32 to avoid migration of SubnetMovingPrice for now``
+        let new_moving: I96F32 =
+            I96F32::saturating_from_num(current_price.saturating_add(current_moving));
         SubnetMovingPrice::<T>::insert(netuid, new_moving);
     }
 
@@ -83,28 +88,28 @@ impl<T: Config> Pallet<T> {
     ///
     /// This function performs the following steps:
     /// 1. Fetches the global weight from storage using the TaoWeight storage item.
-    /// 2. Converts the retrieved u64 value to a fixed-point number (I96F32).
+    /// 2. Converts the retrieved u64 value to a fixed-point number (U96F32).
     /// 3. Normalizes the weight by dividing it by the maximum possible u64 value.
-    /// 4. Returns the normalized weight as an I96F32 fixed-point number.
+    /// 4. Returns the normalized weight as an U96F32 fixed-point number.
     ///
     /// The normalization ensures that the returned value is always between 0 and 1,
     /// regardless of the actual stored weight value.
     ///
     /// # Returns
-    /// * `I96F32` - The normalized global global weight as a fixed-point number between 0 and 1.
+    /// * `U96F32` - The normalized global global weight as a fixed-point number between 0 and 1.
     ///
     /// # Note
     /// This function uses saturating division to prevent potential overflow errors.
-    pub fn get_tao_weight() -> I96F32 {
+    pub fn get_tao_weight() -> U96F32 {
         // Step 1: Fetch the global weight from storage
         let stored_weight = TaoWeight::<T>::get();
 
-        // Step 2: Convert the u64 weight to I96F32
-        let weight_fixed = I96F32::saturating_from_num(stored_weight);
+        // Step 2: Convert the u64 weight to U96F32
+        let weight_fixed = U96F32::saturating_from_num(stored_weight);
 
         // Step 3: Normalize the weight by dividing by u64::MAX
         // This ensures the result is always between 0 and 1
-        weight_fixed.safe_div(I96F32::saturating_from_num(u64::MAX))
+        weight_fixed.safe_div(U96F32::saturating_from_num(u64::MAX))
     }
 
     /// Sets the global global weight in storage.
@@ -237,13 +242,13 @@ impl<T: Config> Pallet<T> {
     /// # Note
     /// This function uses saturating arithmetic to prevent overflows.
     pub fn get_tao_inherited_for_hotkey_on_subnet(hotkey: &T::AccountId, netuid: u16) -> u64 {
-        let initial_tao: I96F32 = I96F32::saturating_from_num(
+        let initial_tao: U96F32 = U96F32::saturating_from_num(
             Self::get_stake_for_hotkey_on_subnet(hotkey, Self::get_root_netuid()),
         );
 
         // Initialize variables to track alpha allocated to children and inherited from parents.
-        let mut tao_to_children: I96F32 = I96F32::saturating_from_num(0);
-        let mut tao_from_parents: I96F32 = I96F32::saturating_from_num(0);
+        let mut tao_to_children: U96F32 = U96F32::saturating_from_num(0);
+        let mut tao_from_parents: U96F32 = U96F32::saturating_from_num(0);
 
         // Step 2: Retrieve the lists of parents and children for the hotkey on the subnet.
         let parents: Vec<(u64, T::AccountId)> = Self::get_parents(hotkey, netuid);
@@ -264,16 +269,16 @@ impl<T: Config> Pallet<T> {
         // Step 3: Calculate the total tao allocated to children.
         for (proportion, _) in children {
             // Convert the proportion to a normalized value between 0 and 1.
-            let normalized_proportion: I96F32 = I96F32::saturating_from_num(proportion)
-                .safe_div(I96F32::saturating_from_num(u64::MAX));
+            let normalized_proportion: U96F32 = U96F32::saturating_from_num(proportion)
+                .safe_div(U96F32::saturating_from_num(u64::MAX));
             log::trace!(
                 "Normalized proportion for child: {:?}",
                 normalized_proportion
             );
 
             // Calculate the amount of tao to be allocated to this child.
-            let tao_proportion_to_child: I96F32 =
-                I96F32::saturating_from_num(initial_tao).saturating_mul(normalized_proportion);
+            let tao_proportion_to_child: U96F32 =
+                U96F32::saturating_from_num(initial_tao).saturating_mul(normalized_proportion);
             log::trace!("Tao proportion to child: {:?}", tao_proportion_to_child);
 
             // Add this child's allocation to the total tao allocated to children.
@@ -284,7 +289,7 @@ impl<T: Config> Pallet<T> {
         // Step 4: Calculate the total tao inherited from parents.
         for (proportion, parent) in parents {
             // Retrieve the parent's total stake on this subnet.
-            let parent_tao: I96F32 = I96F32::saturating_from_num(
+            let parent_tao: U96F32 = U96F32::saturating_from_num(
                 Self::get_stake_for_hotkey_on_subnet(&parent, Self::get_root_netuid()),
             );
             log::trace!(
@@ -295,16 +300,16 @@ impl<T: Config> Pallet<T> {
             );
 
             // Convert the proportion to a normalized value between 0 and 1.
-            let normalized_proportion: I96F32 = I96F32::saturating_from_num(proportion)
-                .safe_div(I96F32::saturating_from_num(u64::MAX));
+            let normalized_proportion: U96F32 = U96F32::saturating_from_num(proportion)
+                .safe_div(U96F32::saturating_from_num(u64::MAX));
             log::trace!(
                 "Normalized proportion from parent: {:?}",
                 normalized_proportion
             );
 
             // Calculate the amount of tao to be inherited from this parent.
-            let tao_proportion_from_parent: I96F32 =
-                I96F32::saturating_from_num(parent_tao).saturating_mul(normalized_proportion);
+            let tao_proportion_from_parent: U96F32 =
+                U96F32::saturating_from_num(parent_tao).saturating_mul(normalized_proportion);
             log::trace!(
                 "Tao proportion from parent: {:?}",
                 tao_proportion_from_parent
@@ -316,7 +321,7 @@ impl<T: Config> Pallet<T> {
         log::trace!("Total tao inherited from parents: {:?}", tao_from_parents);
 
         // Step 5: Calculate the final inherited tao for the hotkey.
-        let finalized_tao: I96F32 = initial_tao
+        let finalized_tao: U96F32 = initial_tao
             .saturating_sub(tao_to_children) // Subtract tao allocated to children
             .saturating_add(tao_from_parents); // Add tao inherited from parents
         log::trace!(
@@ -332,8 +337,8 @@ impl<T: Config> Pallet<T> {
 
     pub fn get_inherited_for_hotkey_on_subnet(hotkey: &T::AccountId, netuid: u16) -> u64 {
         // Step 1: Retrieve the initial total stake (alpha) for the hotkey on the specified subnet.
-        let initial_alpha: I96F32 =
-            I96F32::saturating_from_num(Self::get_stake_for_hotkey_on_subnet(hotkey, netuid));
+        let initial_alpha: U96F32 =
+            U96F32::saturating_from_num(Self::get_stake_for_hotkey_on_subnet(hotkey, netuid));
         log::debug!(
             "Initial alpha for hotkey {:?} on subnet {}: {:?}",
             hotkey,
@@ -345,8 +350,8 @@ impl<T: Config> Pallet<T> {
         }
 
         // Initialize variables to track alpha allocated to children and inherited from parents.
-        let mut alpha_to_children: I96F32 = I96F32::saturating_from_num(0);
-        let mut alpha_from_parents: I96F32 = I96F32::saturating_from_num(0);
+        let mut alpha_to_children: U96F32 = U96F32::saturating_from_num(0);
+        let mut alpha_from_parents: U96F32 = U96F32::saturating_from_num(0);
 
         // Step 2: Retrieve the lists of parents and children for the hotkey on the subnet.
         let parents: Vec<(u64, T::AccountId)> = Self::get_parents(hotkey, netuid);
@@ -367,16 +372,16 @@ impl<T: Config> Pallet<T> {
         // Step 3: Calculate the total alpha allocated to children.
         for (proportion, _) in children {
             // Convert the proportion to a normalized value between 0 and 1.
-            let normalized_proportion: I96F32 = I96F32::saturating_from_num(proportion)
-                .safe_div(I96F32::saturating_from_num(u64::MAX));
+            let normalized_proportion: U96F32 = U96F32::saturating_from_num(proportion)
+                .safe_div(U96F32::saturating_from_num(u64::MAX));
             log::trace!(
                 "Normalized proportion for child: {:?}",
                 normalized_proportion
             );
 
             // Calculate the amount of alpha to be allocated to this child.
-            let alpha_proportion_to_child: I96F32 =
-                I96F32::saturating_from_num(initial_alpha).saturating_mul(normalized_proportion);
+            let alpha_proportion_to_child: U96F32 =
+                U96F32::saturating_from_num(initial_alpha).saturating_mul(normalized_proportion);
             log::trace!("Alpha proportion to child: {:?}", alpha_proportion_to_child);
 
             // Add this child's allocation to the total alpha allocated to children.
@@ -387,8 +392,8 @@ impl<T: Config> Pallet<T> {
         // Step 4: Calculate the total alpha inherited from parents.
         for (proportion, parent) in parents {
             // Retrieve the parent's total stake on this subnet.
-            let parent_alpha: I96F32 =
-                I96F32::saturating_from_num(Self::get_stake_for_hotkey_on_subnet(&parent, netuid));
+            let parent_alpha: U96F32 =
+                U96F32::saturating_from_num(Self::get_stake_for_hotkey_on_subnet(&parent, netuid));
             log::trace!(
                 "Parent alpha for parent {:?} on subnet {}: {:?}",
                 parent,
@@ -397,16 +402,16 @@ impl<T: Config> Pallet<T> {
             );
 
             // Convert the proportion to a normalized value between 0 and 1.
-            let normalized_proportion: I96F32 = I96F32::saturating_from_num(proportion)
-                .safe_div(I96F32::saturating_from_num(u64::MAX));
+            let normalized_proportion: U96F32 = U96F32::saturating_from_num(proportion)
+                .safe_div(U96F32::saturating_from_num(u64::MAX));
             log::trace!(
                 "Normalized proportion from parent: {:?}",
                 normalized_proportion
             );
 
             // Calculate the amount of alpha to be inherited from this parent.
-            let alpha_proportion_from_parent: I96F32 =
-                I96F32::saturating_from_num(parent_alpha).saturating_mul(normalized_proportion);
+            let alpha_proportion_from_parent: U96F32 =
+                U96F32::saturating_from_num(parent_alpha).saturating_mul(normalized_proportion);
             log::trace!(
                 "Alpha proportion from parent: {:?}",
                 alpha_proportion_from_parent
@@ -421,7 +426,7 @@ impl<T: Config> Pallet<T> {
         );
 
         // Step 5: Calculate the final inherited alpha for the hotkey.
-        let finalized_alpha: I96F32 = initial_alpha
+        let finalized_alpha: U96F32 = initial_alpha
             .saturating_sub(alpha_to_children) // Subtract alpha allocated to children
             .saturating_add(alpha_from_parents); // Add alpha inherited from parents
         log::trace!(
@@ -620,15 +625,15 @@ impl<T: Config> Pallet<T> {
         // Step 2: Initialized vars.
         if mechanism_id == 1 {
             // Step 3.a.1: Dynamic mechanism calculations
-            let tao_reserves: I110F18 = I110F18::saturating_from_num(SubnetTAO::<T>::get(netuid));
-            let alpha_reserves: I110F18 =
-                I110F18::saturating_from_num(SubnetAlphaIn::<T>::get(netuid));
+            let tao_reserves: U110F18 = U110F18::saturating_from_num(SubnetTAO::<T>::get(netuid));
+            let alpha_reserves: U110F18 =
+                U110F18::saturating_from_num(SubnetAlphaIn::<T>::get(netuid));
             // Step 3.a.2: Compute constant product k = alpha * tao
-            let k: I110F18 = alpha_reserves.saturating_mul(tao_reserves);
+            let k: U110F18 = alpha_reserves.saturating_mul(tao_reserves);
 
             // Calculate new alpha reserve
-            let new_alpha_reserves: I110F18 =
-                k.safe_div(tao_reserves.saturating_add(I110F18::saturating_from_num(tao)));
+            let new_alpha_reserves: U110F18 =
+                k.safe_div(tao_reserves.saturating_add(U110F18::saturating_from_num(tao)));
 
             // Step 3.a.3: Calculate alpha staked using the constant product formula
             // alpha_stake_recieved = current_alpha - (k / (current_tao + new_tao))
@@ -659,16 +664,16 @@ impl<T: Config> Pallet<T> {
         // Step 2: Swap alpha and attain tao
         if mechanism_id == 1 {
             // Step 3.a.1: Dynamic mechanism calculations
-            let tao_reserves: I110F18 = I110F18::saturating_from_num(SubnetTAO::<T>::get(netuid));
-            let alpha_reserves: I110F18 =
-                I110F18::saturating_from_num(SubnetAlphaIn::<T>::get(netuid));
+            let tao_reserves: U110F18 = U110F18::saturating_from_num(SubnetTAO::<T>::get(netuid));
+            let alpha_reserves: U110F18 =
+                U110F18::saturating_from_num(SubnetAlphaIn::<T>::get(netuid));
             // Step 3.a.2: Compute constant product k = alpha * tao
-            let k: I110F18 = alpha_reserves.saturating_mul(tao_reserves);
+            let k: U110F18 = alpha_reserves.saturating_mul(tao_reserves);
 
             // Calculate new tao reserve
-            let new_tao_reserves: I110F18 = k
-                .checked_div(alpha_reserves.saturating_add(I110F18::saturating_from_num(alpha)))
-                .unwrap_or(I110F18::saturating_from_num(0));
+            let new_tao_reserves: U110F18 = k
+                .checked_div(alpha_reserves.saturating_add(U110F18::saturating_from_num(alpha)))
+                .unwrap_or(U110F18::saturating_from_num(0));
 
             // Step 3.a.3: Calculate alpha staked using the constant product formula
             // tao_recieved = tao_reserves - (k / (alpha_reserves + new_tao))
@@ -1081,7 +1086,7 @@ impl<T: Config> Pallet<T> {
         _origin_coldkey: &T::AccountId,
         destination: Option<(&T::AccountId, u16)>,
         _destination_coldkey: &T::AccountId,
-        alpha_estimate: I96F32,
+        alpha_estimate: U96F32,
     ) -> u64 {
         match origin {
             // If origin is defined, we are removing/moving stake
@@ -1103,11 +1108,11 @@ impl<T: Config> Pallet<T> {
                     // Otherwise, calculate the fee based on the alpha estimate
                     let mut fee = alpha_estimate
                         .saturating_mul(
-                            I96F32::saturating_from_num(AlphaDividendsPerSubnet::<T>::get(
+                            U96F32::saturating_from_num(AlphaDividendsPerSubnet::<T>::get(
                                 origin_netuid,
                                 &origin_hotkey,
                             ))
-                            .safe_div(I96F32::saturating_from_num(
+                            .safe_div(U96F32::saturating_from_num(
                                 TotalHotkeyAlpha::<T>::get(&origin_hotkey, origin_netuid),
                             )),
                         )
@@ -1116,7 +1121,7 @@ impl<T: Config> Pallet<T> {
 
                     // 0.005% per epoch matches to 44% annual in compound interest. Do not allow the fee
                     // to be lower than that. (1.00005^(365*20) ~= 1.44)
-                    let apr_20_percent = I96F32::saturating_from_num(0.00005);
+                    let apr_20_percent = U96F32::saturating_from_num(0.00005);
                     fee = fee.max(
                         alpha_estimate
                             .saturating_mul(apr_20_percent)

--- a/pallets/subtensor/src/tests/children.rs
+++ b/pallets/subtensor/src/tests/children.rs
@@ -4,7 +4,7 @@
 use super::mock::*;
 use approx::assert_abs_diff_eq;
 use frame_support::{assert_err, assert_noop, assert_ok};
-use substrate_fixed::types::{I64F64, I96F32};
+use substrate_fixed::types::{I64F64, I96F32, U96F32};
 
 use crate::{utils::rate_limiting::TransactionType, *};
 use sp_core::U256;
@@ -961,7 +961,7 @@ fn test_childkey_take_rate_limiting() {
                 last_block,
                 limit,
                 passes,
-                current_block.saturating_sub(last_block)
+                current_block - last_block
             );
         };
 
@@ -2764,9 +2764,7 @@ fn test_set_weights_no_parent() {
 
         // Set a minimum stake to set weights
         SubtensorModule::set_stake_threshold(
-            curr_stake_weight
-                .saturating_sub(I64F64::saturating_from_num(5))
-                .saturating_to_num::<u64>(),
+            (curr_stake_weight - I64F64::from_num(5)).to_num::<u64>(),
         );
 
         // Check if the stake for the hotkey is above
@@ -3029,7 +3027,7 @@ fn test_parent_child_chain_emission() {
         // Set the weight of root TAO to be 0%, so only alpha is effective.
         SubtensorModule::set_tao_weight(0);
 
-        let emission: I96F32 = I96F32::from_num(SubtensorModule::get_block_emission().unwrap_or(0));
+        let emission: U96F32 = U96F32::from_num(SubtensorModule::get_block_emission().unwrap_or(0));
 
         // Set pending emission to 0
         PendingEmission::<Test>::insert(netuid, 0);

--- a/pallets/subtensor/src/tests/delegate_info.rs
+++ b/pallets/subtensor/src/tests/delegate_info.rs
@@ -22,9 +22,8 @@ fn test_return_per_1000_tao() {
     // We expect 82 TAO per day with 10% of total_stake
     let expected_return_per_1000 = U64F64::from_num(82.0);
 
-    let diff_from_expected: f64 = (return_per_1000 / U64F64::from_num(1e9))
-        .saturating_sub(expected_return_per_1000)
-        .to_num::<f64>();
+    let diff_from_expected: f64 =
+        ((return_per_1000 / U64F64::from_num(1e9)) - expected_return_per_1000).to_num::<f64>();
 
     let eps: f64 = 0.0005e9; // Precision within 0.0005 TAO
     assert!(

--- a/pallets/subtensor/src/tests/emission.rs
+++ b/pallets/subtensor/src/tests/emission.rs
@@ -102,7 +102,7 @@ fn test_consecutive_blocks() {
         let mut last_result = SubtensorModule::blocks_until_next_epoch(netuid, tempo, 0);
         for i in 1..tempo - 1 {
             let current_result = SubtensorModule::blocks_until_next_epoch(netuid, tempo, i as u64);
-            assert_eq!(current_result, last_result.saturating_sub(1));
+            assert_eq!(current_result, last_result - 1);
             last_result = current_result;
         }
     });

--- a/pallets/subtensor/src/tests/move_stake.rs
+++ b/pallets/subtensor/src/tests/move_stake.rs
@@ -3,7 +3,7 @@ use crate::*;
 use approx::assert_abs_diff_eq;
 use frame_support::{assert_err, assert_noop, assert_ok};
 use sp_core::{Get, U256};
-use substrate_fixed::types::{I96F32, U64F64};
+use substrate_fixed::types::{U64F64, U96F32};
 
 // 1. test_do_move_success
 // Description: Test a successful move of stake between two hotkeys in the same subnet
@@ -112,9 +112,9 @@ fn test_do_move_different_subnets() {
             ),
             0
         );
-        let alpha_fee: I96F32 =
-            I96F32::from_num(fee) / SubtensorModule::get_alpha_price(destination_netuid);
-        let expected_value = I96F32::from_num(alpha)
+        let alpha_fee: U96F32 =
+            U96F32::from_num(fee) / SubtensorModule::get_alpha_price(destination_netuid);
+        let expected_value = U96F32::from_num(alpha)
             * SubtensorModule::get_alpha_price(origin_netuid)
             / SubtensorModule::get_alpha_price(destination_netuid);
         assert_abs_diff_eq!(
@@ -709,8 +709,8 @@ fn test_do_move_storage_updates() {
             0
         );
         let alpha_fee =
-            I96F32::from_num(fee) / SubtensorModule::get_alpha_price(destination_netuid);
-        let alpha2 = I96F32::from_num(alpha) * SubtensorModule::get_alpha_price(origin_netuid)
+            U96F32::from_num(fee) / SubtensorModule::get_alpha_price(destination_netuid);
+        let alpha2 = U96F32::from_num(alpha) * SubtensorModule::get_alpha_price(origin_netuid)
             / SubtensorModule::get_alpha_price(destination_netuid);
         assert_abs_diff_eq!(
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
@@ -1080,7 +1080,7 @@ fn test_do_transfer_different_subnets() {
             &destination_coldkey,
             destination_netuid,
         );
-        let expected_value = I96F32::from_num(stake_amount - fee)
+        let expected_value = U96F32::from_num(stake_amount - fee)
             / SubtensorModule::get_alpha_price(destination_netuid);
         assert_abs_diff_eq!(
             dest_stake,
@@ -1134,8 +1134,8 @@ fn test_do_swap_success() {
             destination_netuid,
         );
         let alpha_fee =
-            I96F32::from_num(fee) / SubtensorModule::get_alpha_price(destination_netuid);
-        let expected_value = I96F32::from_num(alpha_before)
+            U96F32::from_num(fee) / SubtensorModule::get_alpha_price(destination_netuid);
+        let expected_value = U96F32::from_num(alpha_before)
             * SubtensorModule::get_alpha_price(origin_netuid)
             / SubtensorModule::get_alpha_price(destination_netuid);
         assert_abs_diff_eq!(
@@ -1353,8 +1353,8 @@ fn test_do_swap_partial_stake() {
         );
 
         let alpha_fee =
-            I96F32::from_num(fee) / SubtensorModule::get_alpha_price(destination_netuid);
-        let expected_value = I96F32::from_num(swap_amount)
+            U96F32::from_num(fee) / SubtensorModule::get_alpha_price(destination_netuid);
+        let expected_value = U96F32::from_num(swap_amount)
             * SubtensorModule::get_alpha_price(origin_netuid)
             / SubtensorModule::get_alpha_price(destination_netuid);
         assert_abs_diff_eq!(
@@ -1408,8 +1408,8 @@ fn test_do_swap_storage_updates() {
         );
 
         let alpha_fee =
-            I96F32::from_num(fee) / SubtensorModule::get_alpha_price(destination_netuid);
-        let expected_value = I96F32::from_num(alpha)
+            U96F32::from_num(fee) / SubtensorModule::get_alpha_price(destination_netuid);
+        let expected_value = U96F32::from_num(alpha)
             * SubtensorModule::get_alpha_price(origin_netuid)
             / SubtensorModule::get_alpha_price(destination_netuid);
         assert_abs_diff_eq!(
@@ -1543,7 +1543,7 @@ fn test_swap_stake_limit_validate() {
         // Setup limit price so that it doesn't allow much slippage at all
         let limit_price = ((SubtensorModule::get_alpha_price(origin_netuid)
             / SubtensorModule::get_alpha_price(destination_netuid))
-            * I96F32::from_num(1_000_000_000))
+            * U96F32::from_num(1_000_000_000))
         .to_num::<u64>()
             - 1_u64;
 
@@ -1737,8 +1737,8 @@ fn test_move_stake_specific_stake_into_subnet_fail() {
             0
         );
         let fee = DefaultStakingFee::<Test>::get();
-        let alpha_fee: I96F32 = I96F32::from_num(fee) / SubtensorModule::get_alpha_price(netuid);
-        let expected_value = I96F32::from_num(alpha_to_move)
+        let alpha_fee: U96F32 = U96F32::from_num(fee) / SubtensorModule::get_alpha_price(netuid);
+        let expected_value = U96F32::from_num(alpha_to_move)
             * SubtensorModule::get_alpha_price(origin_netuid)
             / SubtensorModule::get_alpha_price(netuid);
         assert_abs_diff_eq!(

--- a/pallets/subtensor/src/tests/staking.rs
+++ b/pallets/subtensor/src/tests/staking.rs
@@ -387,7 +387,7 @@ fn test_remove_stake_ok_no_emission() {
 
         // Add subnet TAO for the equivalent amount added at price
         let amount_tao =
-            I96F32::saturating_from_num(amount) * SubtensorModule::get_alpha_price(netuid);
+            U96F32::saturating_from_num(amount) * SubtensorModule::get_alpha_price(netuid);
         SubnetTAO::<Test>::mutate(netuid, |v| *v += amount_tao.saturating_to_num::<u64>());
         TotalStake::<Test>::mutate(|v| *v += amount_tao.saturating_to_num::<u64>());
 
@@ -404,7 +404,7 @@ fn test_remove_stake_ok_no_emission() {
             &coldkey_account_id,
             None,
             &coldkey_account_id,
-            I96F32::saturating_from_num(amount),
+            U96F32::saturating_from_num(amount),
         );
 
         // we do not expect the exact amount due to slippage
@@ -568,7 +568,7 @@ fn test_remove_stake_total_balance_no_change() {
 
         // Add subnet TAO for the equivalent amount added at price
         let amount_tao =
-            I96F32::saturating_from_num(amount) * SubtensorModule::get_alpha_price(netuid);
+            U96F32::saturating_from_num(amount) * SubtensorModule::get_alpha_price(netuid);
         SubnetTAO::<Test>::mutate(netuid, |v| *v += amount_tao.saturating_to_num::<u64>());
         TotalStake::<Test>::mutate(|v| *v += amount_tao.saturating_to_num::<u64>());
 
@@ -585,7 +585,7 @@ fn test_remove_stake_total_balance_no_change() {
             &coldkey_account_id,
             None,
             &coldkey_account_id,
-            I96F32::saturating_from_num(amount),
+            U96F32::saturating_from_num(amount),
         );
         assert_abs_diff_eq!(
             SubtensorModule::get_coldkey_balance(&coldkey_account_id),
@@ -3526,8 +3526,11 @@ fn test_add_stake_limit_ok() {
         // Check that price has updated to ~24 = (150+450) / (100 - 75)
         let exp_price = U96F32::from_num(24.0);
         let current_price: U96F32 = U96F32::from_num(SubtensorModule::get_alpha_price(netuid));
-        assert!(exp_price.saturating_sub(current_price) < 0.0001);
-        assert!(current_price.saturating_sub(exp_price) < 0.0001);
+        assert_abs_diff_eq!(
+            exp_price.to_num::<f64>(),
+            current_price.to_num::<f64>(),
+            epsilon = 0.0001,
+        );
     });
 }
 

--- a/pallets/subtensor/src/tests/staking2.rs
+++ b/pallets/subtensor/src/tests/staking2.rs
@@ -6,7 +6,7 @@ use frame_support::{
     weights::Weight,
 };
 use sp_core::U256;
-use substrate_fixed::types::I96F32;
+use substrate_fixed::types::{I96F32, U96F32};
 
 // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --workspace --test staking2 -- test_swap_tao_for_alpha_dynamic_mechanism --exact --nocapture
 #[test]
@@ -673,7 +673,7 @@ fn test_stake_fee_api() {
             &coldkey1,
             Some((&hotkey1, netuid0)),
             &coldkey1,
-            I96F32::saturating_from_num(stake_amount),
+            U96F32::saturating_from_num(stake_amount),
         );
         assert_eq!(stake_fee_0, dynamic_fee_0);
 
@@ -690,7 +690,7 @@ fn test_stake_fee_api() {
             &coldkey1,
             None,
             &coldkey1,
-            I96F32::saturating_from_num(stake_amount),
+            U96F32::saturating_from_num(stake_amount),
         );
         assert_eq!(stake_fee_1, dynamic_fee_1);
 
@@ -707,7 +707,7 @@ fn test_stake_fee_api() {
             &coldkey1,
             Some((&hotkey1, netuid0)),
             &coldkey1,
-            I96F32::saturating_from_num(stake_amount),
+            U96F32::saturating_from_num(stake_amount),
         );
         assert_eq!(stake_fee_2, dynamic_fee_2);
 
@@ -724,7 +724,7 @@ fn test_stake_fee_api() {
             &coldkey1,
             Some((&hotkey2, root_netuid)),
             &coldkey1,
-            I96F32::saturating_from_num(stake_amount),
+            U96F32::saturating_from_num(stake_amount),
         );
         assert_eq!(stake_fee_3, dynamic_fee_3);
 
@@ -741,7 +741,7 @@ fn test_stake_fee_api() {
             &coldkey1,
             Some((&hotkey1, root_netuid)),
             &coldkey2,
-            I96F32::saturating_from_num(stake_amount),
+            U96F32::saturating_from_num(stake_amount),
         );
         assert_eq!(stake_fee_4, dynamic_fee_4);
 
@@ -758,7 +758,7 @@ fn test_stake_fee_api() {
             &coldkey1,
             Some((&hotkey1, root_netuid)),
             &coldkey1,
-            I96F32::saturating_from_num(stake_amount),
+            U96F32::saturating_from_num(stake_amount),
         );
         assert_eq!(stake_fee_5, dynamic_fee_5);
 
@@ -775,7 +775,7 @@ fn test_stake_fee_api() {
             &coldkey1,
             Some((&hotkey2, netuid0)),
             &coldkey1,
-            I96F32::saturating_from_num(stake_amount),
+            U96F32::saturating_from_num(stake_amount),
         );
         assert_eq!(stake_fee_6, dynamic_fee_6);
 
@@ -792,7 +792,7 @@ fn test_stake_fee_api() {
             &coldkey1,
             Some((&hotkey1, netuid0)),
             &coldkey2,
-            I96F32::saturating_from_num(stake_amount),
+            U96F32::saturating_from_num(stake_amount),
         );
         assert_eq!(stake_fee_7, dynamic_fee_7);
 
@@ -809,7 +809,7 @@ fn test_stake_fee_api() {
             &coldkey1,
             Some((&hotkey1, netuid1)),
             &coldkey1,
-            I96F32::saturating_from_num(stake_amount),
+            U96F32::saturating_from_num(stake_amount),
         );
         assert_eq!(stake_fee_8, dynamic_fee_8);
     });
@@ -861,7 +861,7 @@ fn test_stake_fee_calculation() {
             &coldkey1,
             Some((&hotkey1, netuid0)),
             &coldkey1,
-            I96F32::from_num(stake_amount),
+            U96F32::from_num(stake_amount),
         ); // Default for adding stake
         assert_eq!(stake_fee_0, default_fee);
 
@@ -871,7 +871,7 @@ fn test_stake_fee_calculation() {
             &coldkey1,
             None,
             &coldkey1,
-            I96F32::from_num(stake_amount),
+            U96F32::from_num(stake_amount),
         ); // Default for removing stake from root
         assert_eq!(stake_fee_1, default_fee);
 
@@ -881,7 +881,7 @@ fn test_stake_fee_calculation() {
             &coldkey1,
             Some((&hotkey1, netuid0)),
             &coldkey1,
-            I96F32::from_num(stake_amount),
+            U96F32::from_num(stake_amount),
         ); // Default for moving stake from root to non-root
         assert_eq!(stake_fee_2, default_fee);
 
@@ -891,7 +891,7 @@ fn test_stake_fee_calculation() {
             &coldkey1,
             Some((&hotkey2, root_netuid)),
             &coldkey1,
-            I96F32::from_num(stake_amount),
+            U96F32::from_num(stake_amount),
         ); // Default for moving stake between hotkeys on root
         assert_eq!(stake_fee_3, default_fee);
 
@@ -901,7 +901,7 @@ fn test_stake_fee_calculation() {
             &coldkey1,
             Some((&hotkey1, root_netuid)),
             &coldkey2,
-            I96F32::from_num(stake_amount),
+            U96F32::from_num(stake_amount),
         ); // Default for moving stake between coldkeys on root
         assert_eq!(stake_fee_4, default_fee);
 
@@ -911,7 +911,7 @@ fn test_stake_fee_calculation() {
             &coldkey1,
             Some((&hotkey1, root_netuid)),
             &coldkey1,
-            I96F32::from_num(stake_amount),
+            U96F32::from_num(stake_amount),
         ); // Charged a dynamic fee
         assert_ne!(stake_fee_5, default_fee);
 
@@ -921,7 +921,7 @@ fn test_stake_fee_calculation() {
             &coldkey1,
             Some((&hotkey2, netuid0)),
             &coldkey1,
-            I96F32::from_num(stake_amount),
+            U96F32::from_num(stake_amount),
         ); // Charge the default fee
         assert_eq!(stake_fee_6, default_fee);
 
@@ -931,7 +931,7 @@ fn test_stake_fee_calculation() {
             &coldkey1,
             Some((&hotkey1, netuid0)),
             &coldkey2,
-            I96F32::from_num(stake_amount),
+            U96F32::from_num(stake_amount),
         ); // Charge the default fee; stake did not leave the subnet.
         assert_eq!(stake_fee_7, default_fee);
 
@@ -941,7 +941,7 @@ fn test_stake_fee_calculation() {
             &coldkey1,
             Some((&hotkey1, netuid1)),
             &coldkey1,
-            I96F32::from_num(stake_amount),
+            U96F32::from_num(stake_amount),
         ); // Charged a dynamic fee
         assert_ne!(stake_fee_8, default_fee);
     });

--- a/pallets/subtensor/src/tests/swap_coldkey.rs
+++ b/pallets/subtensor/src/tests/swap_coldkey.rs
@@ -14,7 +14,7 @@ use frame_support::traits::schedule::DispatchTime;
 use frame_support::traits::schedule::v3::Named as ScheduleNamed;
 use sp_core::{Get, H256, U256};
 use sp_runtime::DispatchError;
-use substrate_fixed::types::I96F32;
+use substrate_fixed::types::U96F32;
 
 // // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test swap_coldkey -- test_swap_total_hotkey_coldkey_stakes_this_interval --exact --nocapture
 // #[test]
@@ -539,7 +539,7 @@ fn test_swap_concurrent_modifications() {
         let initial_stake = 1_000_000_000_000;
         let additional_stake = 500_000_000_000;
         let initial_stake_alpha =
-            I96F32::from(initial_stake).saturating_mul(SubtensorModule::get_alpha_price(netuid));
+            U96F32::from(initial_stake).saturating_mul(SubtensorModule::get_alpha_price(netuid));
         let fee = SubtensorModule::calculate_staking_fee(
             None,
             &new_coldkey,

--- a/pallets/subtensor/src/tests/weights.rs
+++ b/pallets/subtensor/src/tests/weights.rs
@@ -3110,7 +3110,7 @@ fn test_reveal_at_exact_block() {
             let current_block = SubtensorModule::get_current_block_as_u64();
             if current_block < reveal_epoch_start_block {
                 // Advance to one block before the reveal epoch starts
-                let blocks_to_advance = reveal_epoch_start_block.saturating_sub(current_block);
+                let blocks_to_advance = reveal_epoch_start_block - current_block;
                 if blocks_to_advance > 1 {
                     // Advance to one block before the reveal epoch
                     let new_block_number = current_block + blocks_to_advance - 1;
@@ -3181,9 +3181,7 @@ fn test_reveal_at_exact_block() {
             let commit_epoch = SubtensorModule::get_epoch_index(netuid, commit_block);
             let reveal_epoch = commit_epoch.saturating_add(reveal_period);
             let expiration_epoch = reveal_epoch.saturating_add(1);
-            let expiration_epoch_start_block = expiration_epoch
-                .saturating_mul(tempo_plus_one)
-                .saturating_sub(netuid_plus_one);
+            let expiration_epoch_start_block = expiration_epoch * tempo_plus_one - netuid_plus_one;
 
             let current_block = SubtensorModule::get_current_block_as_u64();
             if current_block < expiration_epoch_start_block {

--- a/pallets/subtensor/src/utils/misc.rs
+++ b/pallets/subtensor/src/utils/misc.rs
@@ -7,7 +7,7 @@ use safe_math::*;
 use sp_core::Get;
 use sp_core::U256;
 use sp_runtime::Saturating;
-use substrate_fixed::types::{I32F32, I96F32};
+use substrate_fixed::types::{I32F32, U96F32};
 
 impl<T: Config> Pallet<T> {
     pub fn ensure_subnet_owner_or_root(
@@ -598,9 +598,9 @@ impl<T: Config> Pallet<T> {
     pub fn get_subnet_owner_cut() -> u16 {
         SubnetOwnerCut::<T>::get()
     }
-    pub fn get_float_subnet_owner_cut() -> I96F32 {
-        I96F32::saturating_from_num(SubnetOwnerCut::<T>::get())
-            .safe_div(I96F32::saturating_from_num(u16::MAX))
+    pub fn get_float_subnet_owner_cut() -> U96F32 {
+        U96F32::saturating_from_num(SubnetOwnerCut::<T>::get())
+            .safe_div(U96F32::saturating_from_num(u16::MAX))
     }
     pub fn set_subnet_owner_cut(subnet_owner_cut: u16) {
         SubnetOwnerCut::<T>::set(subnet_owner_cut);

--- a/pallets/utility/src/tests.rs
+++ b/pallets/utility/src/tests.rs
@@ -18,6 +18,7 @@
 // Tests for Utility Pallet
 
 #![cfg(test)]
+#![allow(clippy::arithmetic_side_effects)]
 
 use super::*;
 
@@ -689,7 +690,7 @@ fn batch_all_handles_weight_refund() {
         assert_err_ignore_postinfo!(result, "The cake is a lie.");
         assert_eq!(
             extract_actual_weight(&result, &info),
-            info.weight.saturating_sub(diff.saturating_mul(batch_len))
+            info.weight - diff * batch_len
         );
 
         // Partial batch completion

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -207,7 +207,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 258,
+    spec_version: 259,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description

1. Get rid of I96F32 in run_coinbase.rs (use U96F32 instead)
2. Avoid using saturating_sub for signed types across code base

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

