### PR TITLE
Change `update_moving_price()` function

### DIFF
--- a/pallets/subtensor/src/tests/coinbase.rs
+++ b/pallets/subtensor/src/tests/coinbase.rs
@@ -190,7 +190,7 @@ fn test_coinbase_moving_prices() {
         SubnetAlphaIn::<Test>::insert(netuid, 1_000_000);
         SubnetMechanism::<Test>::insert(netuid, 1);
         SubnetMovingPrice::<Test>::insert(netuid, I96F32::from_num(1));
-        NetworkRegisteredAt::<Test>::insert(netuid, 1);
+        FirstEmissionBlockNumber::<Test>::insert(netuid, 1);
 
         // Updating the moving price keeps it the same.
         assert_eq!(
@@ -250,7 +250,7 @@ fn test_update_moving_price_initial() {
 
         // Registered recently
         System::set_block_number(510);
-        NetworkRegisteredAt::<Test>::insert(netuid, 500);
+        FirstEmissionBlockNumber::<Test>::insert(netuid, 500);
 
         SubtensorModule::update_moving_price(netuid);
 
@@ -275,7 +275,7 @@ fn test_update_moving_price_after_time() {
 
         // Registered long time ago
         System::set_block_number(144_000_500);
-        NetworkRegisteredAt::<Test>::insert(netuid, 500);
+        FirstEmissionBlockNumber::<Test>::insert(netuid, 500);
 
         SubtensorModule::update_moving_price(netuid);
 


### PR DESCRIPTION
## Description
We're changing `update_moving_price()` function to use `FirstEmissionBlockNumber` parameter instead of `NetworkRegisteredAt`. We need this change to take another block from the subnet lifecycle to calculate the moving price. Initially, we used the registration block, but the block of the invocation of `start_call()` function is more valid. `start_call()` sets `FirstEmissionBlockNumber` storage map and emits the related event. 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional Notes

The new code expects `start_call()` to be called before `update_moving_price()`; otherwise, the `first_emissions_block` defaults to zero. The block affecting the calculation is `FirstEmissionBlockNumber` minus one block because `start_block` sets FirstEmissionBlockNumber to the next block instead of the current one.