### PR TITLE
[fix] add remove validate to unstake_all

### DIFF
--- a/pallets/subtensor/src/staking/remove_stake.rs
+++ b/pallets/subtensor/src/staking/remove_stake.rs
@@ -134,6 +134,21 @@ impl<T: Config> Pallet<T> {
             // Ensure that the hotkey has enough stake to withdraw.
             let alpha_unstaked =
                 Self::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
+
+            if Self::validate_remove_stake(
+                &coldkey,
+                &hotkey,
+                netuid,
+                alpha_unstaked,
+                alpha_unstaked,
+                false,
+            )
+            .is_err()
+            {
+                // Don't unstake from this netuid
+                continue;
+            }
+
             let fee = Self::calculate_staking_fee(
                 Some((&hotkey, netuid)),
                 &coldkey,
@@ -211,6 +226,21 @@ impl<T: Config> Pallet<T> {
                 // Ensure that the hotkey has enough stake to withdraw.
                 let alpha_unstaked =
                     Self::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
+
+                if Self::validate_remove_stake(
+                    &coldkey,
+                    &hotkey,
+                    netuid,
+                    alpha_unstaked,
+                    alpha_unstaked,
+                    false,
+                )
+                .is_err()
+                {
+                    // Don't unstake from this netuid
+                    continue;
+                }
+
                 let fee = Self::calculate_staking_fee(
                     Some((&hotkey, netuid)),
                     &coldkey,


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
- Adds some validation to `unstake_all` and `unstake_all_alpha`
   - addresses the case where the unstake amount puts the pool below the minimum liquidity.
- also adds tests for this and success path

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.