### PR TITLE
Fix docker image overwrites by adding platform to image tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -66,8 +66,8 @@ jobs:
           push: true
           platforms: linux/amd64
           tags: |
-            ghcr.io/${{ github.repository }}:${{ env.tag }}
-            ${{ env.latest_tag == 'true' && format('ghcr.io/{0}:latest', github.repository) || '' }}
+            ghcr.io/${{ github.repository }}:${{ env.tag }}-amd64
+            ${{ env.latest_tag == 'true' && format('ghcr.io/{0}:latest-amd64', github.repository) || '' }}
   publish-arm:
     runs-on: SubtensorCI
 
@@ -112,5 +112,5 @@ jobs:
           push: true
           platforms: linux/arm64
           tags: |
-            ghcr.io/${{ github.repository }}:${{ env.tag }}
-            ${{ env.latest_tag == 'true' && format('ghcr.io/{0}:latest', github.repository) || '' }}
+            ghcr.io/${{ github.repository }}:${{ env.tag }}-arm64
+            ${{ env.latest_tag == 'true' && format('ghcr.io/{0}:latest-arm64', github.repository) || '' }}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -207,7 +207,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 260,
+    spec_version: 261,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
This PR alters the `docker.yml` by introducing additional tags related to the target platform when building docker images and pushing them to the repository.  The previous changes to the workflow split the multiplatform into two separate jobs; however, that caused image overwrites since the image tags were the same. The fix changes that and produces these results:

https://github.com/opentensor/subtensor/pkgs/container/subtensor/388517732?tag=ci-platform-fix-amd64
https://github.com/opentensor/subtensor/pkgs/container/subtensor/388656587?tag=ci-platform-fix-arm64

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (CI workflow fix):