### PR TITLE
Change update_moving_price() function

### DIFF
--- a/.github/workflows/try-runtime.yml
+++ b/.github/workflows/try-runtime.yml
@@ -9,6 +9,7 @@ env:
 jobs:
   check-devnet:
     name: check devnet
+    if: github.base_ref != 'main'
     runs-on: SubtensorCI
     steps:
       - name: Checkout sources
@@ -29,7 +30,7 @@ jobs:
 
   check-testnet:
     name: check testnet
-    # if: github.base_ref == 'testnet' || github.base_ref == 'devnet' || github.base_ref == 'main'
+    if: github.base_ref != 'main'
     runs-on: SubtensorCI
     steps:
       - name: Checkout sources

--- a/pallets/subtensor/src/tests/coinbase.rs
+++ b/pallets/subtensor/src/tests/coinbase.rs
@@ -191,7 +191,7 @@ fn test_coinbase_moving_prices() {
         SubnetAlphaIn::<Test>::insert(netuid, 1_000_000);
         SubnetMechanism::<Test>::insert(netuid, 1);
         SubnetMovingPrice::<Test>::insert(netuid, I96F32::from_num(1));
-        NetworkRegisteredAt::<Test>::insert(netuid, 1);
+        FirstEmissionBlockNumber::<Test>::insert(netuid, 1);
 
         // Updating the moving price keeps it the same.
         assert_eq!(
@@ -250,7 +250,7 @@ fn test_update_moving_price_initial() {
 
         // Registered recently
         System::set_block_number(510);
-        NetworkRegisteredAt::<Test>::insert(netuid, 500);
+        FirstEmissionBlockNumber::<Test>::insert(netuid, 500);
 
         SubtensorModule::update_moving_price(netuid);
 
@@ -275,7 +275,7 @@ fn test_update_moving_price_after_time() {
 
         // Registered long time ago
         System::set_block_number(144_000_500);
-        NetworkRegisteredAt::<Test>::insert(netuid, 500);
+        FirstEmissionBlockNumber::<Test>::insert(netuid, 500);
 
         SubtensorModule::update_moving_price(netuid);
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -207,7 +207,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 257,
+    spec_version: 258,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
change the function to use FirstEmissionBlockNumber parameter instead of NetworkRegisteredAt.

hotfix version of #1496 
