### PR TITLE
Added migration to remove total hk/ck stakes this interval

### DIFF
--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -87,7 +87,9 @@ mod hooks {
                 // Remove all zero value entries in TotalHotkeyAlpha
                 .saturating_add(migrations::migrate_remove_zero_total_hotkey_alpha::migrate_remove_zero_total_hotkey_alpha::<T>())
                 // Wipe existing items to prevent bad decoding for new type
-                .saturating_add(migrations::migrate_upgrade_revealed_commitments::migrate_upgrade_revealed_commitments::<T>());
+                .saturating_add(migrations::migrate_upgrade_revealed_commitments::migrate_upgrade_revealed_commitments::<T>())
+                // Remove all entries in TotalHotkeyColdkeyStakesThisInterval
+                .saturating_add(migrations::migrate_remove_total_hotkey_coldkey_stakes_this_interval::migrate_remove_total_hotkey_coldkey_stakes_this_interval::<T>());
             weight
         }
 

--- a/pallets/subtensor/src/migrations/migrate_remove_total_hotkey_coldkey_stakes_this_interval.rs
+++ b/pallets/subtensor/src/migrations/migrate_remove_total_hotkey_coldkey_stakes_this_interval.rs
@@ -1,0 +1,51 @@
+use super::*;
+use crate::HasMigrationRun;
+use frame_support::{traits::Get, weights::Weight};
+use sp_io::{KillStorageResult, hashing::twox_128, storage::clear_prefix};
+
+pub fn migrate_remove_total_hotkey_coldkey_stakes_this_interval<T: Config>() -> Weight {
+    let migration_name = "migrate_remove_total_hotkey_coldkey_stakes_this_interval";
+    let migration_name_bytes = migration_name.as_bytes().to_vec();
+
+    let mut weight = T::DbWeight::get().reads(1);
+    if HasMigrationRun::<T>::get(&migration_name_bytes) {
+        log::info!(
+            "Migration '{:?}' has already run. Skipping.",
+            migration_name
+        );
+        return weight;
+    }
+
+    log::info!("Running migration '{}'", migration_name);
+
+    let pallet_name = twox_128(b"SubtensorModule");
+    let storage_name = twox_128(b"TotalHotkeyColdkeyStakesThisInterval");
+    let prefix = [pallet_name, storage_name].concat();
+
+    // Try to remove all entries from the storage, if some entries are remaining,
+    // the migration will re-run again on next blocks until all entries are removed.
+    let removed_entries_count = match clear_prefix(&prefix, Some(u32::MAX)) {
+        KillStorageResult::AllRemoved(removed) => {
+            // Mark migration as completed
+            HasMigrationRun::<T>::insert(&migration_name_bytes, true);
+            weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+            log::info!(
+                "Migration '{:?}' completed successfully. {:?} entries removed.",
+                migration_name,
+                removed
+            );
+            removed
+        }
+        KillStorageResult::SomeRemaining(removed) => {
+            log::info!(
+                "Migration '{:?}' completed partially. {:?} entries removed.",
+                migration_name,
+                removed
+            );
+            removed
+        }
+    };
+
+    weight.saturating_add(T::DbWeight::get().writes(removed_entries_count as u64))
+}

--- a/pallets/subtensor/src/migrations/mod.rs
+++ b/pallets/subtensor/src/migrations/mod.rs
@@ -10,6 +10,7 @@ pub mod migrate_init_total_issuance;
 pub mod migrate_populate_owned_hotkeys;
 pub mod migrate_rao;
 pub mod migrate_remove_stake_map;
+pub mod migrate_remove_total_hotkey_coldkey_stakes_this_interval;
 pub mod migrate_remove_unused_maps_and_values;
 pub mod migrate_remove_zero_total_hotkey_alpha;
 pub mod migrate_set_first_emission_block_number;

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -555,3 +555,39 @@ fn test_migrate_revealed_commitments() {
         assert!(!weight.is_zero(), "Migration weight should be non-zero");
     });
 }
+
+#[test]
+fn test_migrate_remove_total_hotkey_coldkey_stakes_this_interval() {
+    new_test_ext(1).execute_with(|| {
+        const MIGRATION_NAME: &str = "migrate_remove_total_hotkey_coldkey_stakes_this_interval";
+
+        let pallet_name = twox_128(b"SubtensorModule");
+        let storage_name = twox_128(b"TotalHotkeyColdkeyStakesThisInterval");
+        let prefix = [pallet_name, storage_name].concat();
+
+        // Set up 200 000 entries to be deleted.
+        for i in 0..200_000{
+            let hotkey = U256::from(i as u64);
+            let coldkey = U256::from(i as u64);
+            let key = [prefix.clone(), hotkey.encode(), coldkey.encode()].concat();
+            let value = (100 + i, 200 + i);
+            put_raw(&key, &value.encode());
+        }
+
+        assert!(frame_support::storage::unhashed::contains_prefixed_key(&prefix), "Entries should exist before migration.");
+        assert!(
+            !HasMigrationRun::<Test>::get(MIGRATION_NAME.as_bytes().to_vec()),
+            "Migration should not have run yet."
+        );
+
+        // Run migration
+        let weight = crate::migrations::migrate_remove_total_hotkey_coldkey_stakes_this_interval::migrate_remove_total_hotkey_coldkey_stakes_this_interval::<Test>();
+
+        assert!(!frame_support::storage::unhashed::contains_prefixed_key(&prefix), "All entries should have been removed.");
+        assert!(
+            HasMigrationRun::<Test>::get(MIGRATION_NAME.as_bytes().to_vec()),
+            "Migration should be marked as run."
+        );
+        assert!(!weight.is_zero(),"Migration weight should be non-zero.");
+    });
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -207,7 +207,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 261,
+    spec_version: 262,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
The TotalHotkeyColdkeyStakesThisInterval storage item doesn't exist anymore, but it existed previously and no migrations has been done to clean the storage.

There are ~102,000 entries stored on chain.

## Related Issue(s)

- Closes #592 

## Type of Change
<!--
Please check the relevant options:
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.