### PR TITLE
Add missing benchmarks.

### DIFF
--- a/pallets/subtensor/src/benchmarks.rs
+++ b/pallets/subtensor/src/benchmarks.rs
@@ -192,6 +192,86 @@ benchmarks! {
     let amount_unstaked: u64 = u64_staked_amt - 1;
   }: remove_stake(RawOrigin::Signed( coldkey.clone() ), hotkey.clone(), netuid, amount_unstaked)
 
+  benchmark_remove_stake_limit_aggregate{
+    let caller: T::AccountId = whitelisted_caller::<AccountIdOf<T>>();
+    let caller_origin = <T as frame_system::Config>::RuntimeOrigin::from(RawOrigin::Signed(caller.clone()));
+    let netuid: u16 = 1;
+    let tempo: u16 = 1;
+    let modality: u16 = 0;
+    let seed : u32 = 1;
+
+    // Set our total stake to 1000 TAO
+    Subtensor::<T>::increase_total_stake(1_000_000_000_000);
+
+    Subtensor::<T>::init_new_network(netuid, tempo);
+    Subtensor::<T>::set_network_registration_allowed( netuid, true );
+
+    Subtensor::<T>::set_max_allowed_uids( netuid, 4096 );
+    assert_eq!(Subtensor::<T>::get_max_allowed_uids(netuid), 4096);
+
+    let coldkey: T::AccountId = account("Test", 0, seed);
+    let hotkey: T::AccountId = account("Alice", 0, seed);
+    Subtensor::<T>::set_burn(netuid, 1);
+
+    let limit: u64 = 1_000_000_000;
+    let tao_reserve = 150_000_000_000_u64;
+    let alpha_in = 100_000_000_000_u64;
+    SubnetTAO::<T>::insert(netuid, tao_reserve);
+    SubnetAlphaIn::<T>::insert(netuid, alpha_in);
+
+    let wallet_bal = 1000000u32.into();
+    Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), wallet_bal);
+
+    assert_ok!(Subtensor::<T>::do_burned_registration(RawOrigin::Signed(coldkey.clone()).into(), netuid, hotkey.clone()));
+
+    let u64_staked_amt = 100_000_000_000;
+    Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), u64_staked_amt);
+
+    assert_ok!(Subtensor::<T>::add_stake(RawOrigin::Signed( coldkey.clone() ).into() , hotkey.clone(), netuid, u64_staked_amt));
+
+    let amount_unstaked: u64 = 30_000_000_000;
+  }: remove_stake_limit_aggregate(RawOrigin::Signed( coldkey.clone() ), hotkey.clone(), netuid, amount_unstaked, limit, false)
+
+  benchmark_remove_stake_limit{
+    let caller: T::AccountId = whitelisted_caller::<AccountIdOf<T>>();
+    let caller_origin = <T as frame_system::Config>::RuntimeOrigin::from(RawOrigin::Signed(caller.clone()));
+    let netuid: u16 = 1;
+    let tempo: u16 = 1;
+    let modality: u16 = 0;
+    let seed : u32 = 1;
+
+    // Set our total stake to 1000 TAO
+    Subtensor::<T>::increase_total_stake(1_000_000_000_000);
+
+    Subtensor::<T>::init_new_network(netuid, tempo);
+    Subtensor::<T>::set_network_registration_allowed( netuid, true );
+
+    Subtensor::<T>::set_max_allowed_uids( netuid, 4096 );
+    assert_eq!(Subtensor::<T>::get_max_allowed_uids(netuid), 4096);
+
+    let coldkey: T::AccountId = account("Test", 0, seed);
+    let hotkey: T::AccountId = account("Alice", 0, seed);
+    Subtensor::<T>::set_burn(netuid, 1);
+
+    let limit: u64 = 1_000_000_000;
+    let tao_reserve = 150_000_000_000_u64;
+    let alpha_in = 100_000_000_000_u64;
+    SubnetTAO::<T>::insert(netuid, tao_reserve);
+    SubnetAlphaIn::<T>::insert(netuid, alpha_in);
+
+    let wallet_bal = 1000000u32.into();
+    Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), wallet_bal);
+
+    assert_ok!(Subtensor::<T>::do_burned_registration(RawOrigin::Signed(coldkey.clone()).into(), netuid, hotkey.clone()));
+
+    let u64_staked_amt = 100_000_000_000;
+    Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), u64_staked_amt);
+
+    assert_ok!(Subtensor::<T>::add_stake(RawOrigin::Signed( coldkey.clone() ).into() , hotkey.clone(), netuid, u64_staked_amt));
+
+    let amount_unstaked: u64 = 30_000_000_000;
+  }: remove_stake_limit(RawOrigin::Signed( coldkey.clone() ), hotkey.clone(), netuid, amount_unstaked, limit, false)
+
   benchmark_remove_stake_aggregate{
     let caller: T::AccountId = whitelisted_caller::<AccountIdOf<T>>();
     let caller_origin = <T as frame_system::Config>::RuntimeOrigin::from(RawOrigin::Signed(caller.clone()));
@@ -227,6 +307,65 @@ benchmarks! {
 
     let amount_unstaked: u64 = 600000;
   }: remove_stake_aggregate(RawOrigin::Signed( coldkey.clone() ), hotkey.clone(), netuid, amount_unstaked)
+
+  benchmark_add_stake_limit {
+    let caller: T::AccountId = whitelisted_caller::<AccountIdOf<T>>();
+    let caller_origin = <T as frame_system::Config>::RuntimeOrigin::from(RawOrigin::Signed(caller.clone()));
+    let netuid: u16 = 1;
+    let tempo: u16 = 1;
+    let modality: u16 = 0;
+    let seed : u32 = 1;
+
+    Subtensor::<T>::init_new_network(netuid, tempo);
+    Subtensor::<T>::set_burn(netuid, 1);
+    Subtensor::<T>::set_network_registration_allowed( netuid, true );
+    Subtensor::<T>::set_max_allowed_uids( netuid, 4096 );
+
+    let coldkey: T::AccountId = account("Test", 0, seed);
+    let hotkey: T::AccountId = account("Alice", 0, seed);
+
+    let amount = 900_000_000_000;
+    let limit: u64 = 6_000_000_000;
+    let amount_to_be_staked = 440_000_000_000;
+    Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), amount);
+
+    let tao_reserve = 150_000_000_000_u64;
+    let alpha_in = 100_000_000_000_u64;
+    SubnetTAO::<T>::insert(netuid, tao_reserve);
+    SubnetAlphaIn::<T>::insert(netuid, alpha_in);
+
+    assert_ok!(Subtensor::<T>::do_burned_registration(RawOrigin::Signed(coldkey.clone()).into(), netuid, hotkey.clone()));
+  }: add_stake_limit(RawOrigin::Signed( coldkey.clone() ), hotkey, netuid, amount_to_be_staked, limit, false)
+
+  benchmark_add_stake_limit_aggregate {
+    let caller: T::AccountId = whitelisted_caller::<AccountIdOf<T>>();
+    let caller_origin = <T as frame_system::Config>::RuntimeOrigin::from(RawOrigin::Signed(caller.clone()));
+    let netuid: u16 = 1;
+    let tempo: u16 = 1;
+    let modality: u16 = 0;
+    let seed : u32 = 1;
+
+    Subtensor::<T>::init_new_network(netuid, tempo);
+    Subtensor::<T>::set_burn(netuid, 1);
+    Subtensor::<T>::set_network_registration_allowed( netuid, true );
+    Subtensor::<T>::set_max_allowed_uids( netuid, 4096 );
+
+    let coldkey: T::AccountId = account("Test", 0, seed);
+    let hotkey: T::AccountId = account("Alice", 0, seed);
+
+    let amount = 900_000_000_000;
+    let limit: u64 = 6_000_000_000;
+    let amount_to_be_staked = 440_000_000_000;
+    Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), amount);
+
+    let tao_reserve = 150_000_000_000_u64;
+    let alpha_in = 100_000_000_000_u64;
+    SubnetTAO::<T>::insert(netuid, tao_reserve);
+    SubnetAlphaIn::<T>::insert(netuid, alpha_in);
+
+    assert_ok!(Subtensor::<T>::do_burned_registration(RawOrigin::Signed(coldkey.clone()).into(), netuid, hotkey.clone()));
+  }: add_stake_limit_aggregate(RawOrigin::Signed( coldkey.clone() ), hotkey, netuid, amount_to_be_staked, limit, false)
+
 
   benchmark_serve_axon{
     let caller: T::AccountId = whitelisted_caller::<AccountIdOf<T>>();


### PR DESCRIPTION
## Description
This PR adds missing benchmarks for staking extrinsics:
- benchmark_add_stake_limit
- benchmark_remove_stake_limit
- benchmark_add_stake_limit_aggregate
- benchmark_remove_stake_limit_aggregate

This is a subtask for https://github.com/opentensor/subtensor/pull/1525

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please describe): add benchmarks for existing code

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
