### PR TITLE
Improve EVM test stability in CI

### DIFF
--- a/evm-tests/package.json
+++ b/evm-tests/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "test": "mocha --timeout 999999 --file src/setup.ts --require ts-node/register test/*test.ts"
+    "test": "mocha --timeout 999999 --retries 3 --file src/setup.ts --require ts-node/register test/*test.ts"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Description
The PR to improve the evm test stability by

- add retries in mocha test
- add check for start call extrinsic 
- add sleep time for most frequent extrinsic like burn register and force set balance

The solution is verified via PR https://github.com/opentensor/subtensor/pull/1543


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.