### PR TITLE
Delay aggregated staking jobs.

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -891,8 +891,15 @@ pub mod pallet {
         StorageValue<_, u64, ValueQuery, DefaultSenateRequiredStakePercentage<T>>;
 
     #[pallet::storage]
-    pub type StakeJobs<T: Config> =
-        StorageMap<_, Blake2_128Concat, u64, StakeJob<T::AccountId>, OptionQuery>;
+    pub type StakeJobs<T: Config> = StorageDoubleMap<
+        _,
+        Blake2_128Concat,
+        BlockNumberFor<T>, // first key: current block number
+        Twox64Concat,
+        u64, // second key: unique job ID
+        StakeJob<T::AccountId>,
+        OptionQuery,
+    >;
 
     #[pallet::storage]
     /// Ensures unique IDs for StakeJobs storage map

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2032,7 +2032,7 @@ mod dispatches {
         /// price, the staking order may execute only partially or not execute
         /// at all.
         ///
-        /// The operation will be delayed until the end of the block.
+        /// The operation will be delayed.
         ///
         /// # Args:
         ///  * 'origin': (<T as frame_system::Config>Origin):
@@ -2086,7 +2086,7 @@ mod dispatches {
         /// price, the staking order may execute only partially or not execute
         /// at all.
         ///
-        /// The operation will be delayed until the end of the block.
+        /// The operation will be delayed.
         ///
         /// # Args:
         /// * 'origin': (<T as frame_system::Config>Origin):
@@ -2140,7 +2140,7 @@ mod dispatches {
         /// price, the staking order may execute only partially or not execute
         /// at all.
         ///
-        /// The operation will be delayed until the end of the block.
+        /// The operation will be delayed.
         ///
         /// # Args:
         ///  * 'origin': (<T as frame_system::Config>Origin):
@@ -2203,7 +2203,7 @@ mod dispatches {
         /// price, the staking order may execute only partially or not execute
         /// at all.
         ///
-        /// The operation will be delayed until the end of the block.
+        /// The operation will be delayed.
         ///
         /// # Args:
         /// * 'origin': (<T as frame_system::Config>Origin):
@@ -2260,7 +2260,7 @@ mod dispatches {
 
         /// ---- The implementation for the extrinsic unstake_all_aggregate: Removes all stake from a hotkey account across all subnets and adds it onto a coldkey.
         ///
-        /// The operation will be delayed until the end of the block.
+        /// The operation will be delayed.
         ///
         /// # Args:
         /// * `origin` - (<T as frame_system::Config>::Origin):
@@ -2293,7 +2293,7 @@ mod dispatches {
 
         /// ---- The implementation for the extrinsic unstake_all_alpha_aggregate: Removes all stake from a hotkey account across all subnets and adds it onto a coldkey.
         ///
-        /// The operation will be delayed until the end of the block.
+        /// The operation will be delayed.
         ///
         /// # Args:
         /// * `origin` - (<T as frame_system::Config>::Origin):

--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -39,8 +39,8 @@ mod hooks {
         // # Args:
         // 	* 'n': (BlockNumberFor<T>):
         // 		- The number of the block we are finalizing.
-        fn on_finalize(_block_number: BlockNumberFor<T>) {
-            Self::do_on_finalize();
+        fn on_finalize(block_number: BlockNumberFor<T>) {
+            Self::do_on_finalize(block_number);
         }
 
         fn on_runtime_upgrade() -> frame_support::weights::Weight {

--- a/pallets/subtensor/src/staking/add_stake.rs
+++ b/pallets/subtensor/src/staking/add_stake.rs
@@ -135,8 +135,9 @@ impl<T: Config> Pallet<T> {
         };
 
         let stake_job_id = NextStakeJobId::<T>::get();
+        let current_blocknumber = <frame_system::Pallet<T>>::block_number();
 
-        StakeJobs::<T>::insert(stake_job_id, stake_job);
+        StakeJobs::<T>::insert(current_blocknumber, stake_job_id, stake_job);
         NextStakeJobId::<T>::set(stake_job_id.saturating_add(1));
 
         Ok(())
@@ -211,8 +212,9 @@ impl<T: Config> Pallet<T> {
         };
 
         let stake_job_id = NextStakeJobId::<T>::get();
+        let current_blocknumber = <frame_system::Pallet<T>>::block_number();
 
-        StakeJobs::<T>::insert(stake_job_id, stake_job);
+        StakeJobs::<T>::insert(current_blocknumber, stake_job_id, stake_job);
         NextStakeJobId::<T>::set(stake_job_id.saturating_add(1));
 
         Ok(())

--- a/pallets/subtensor/src/staking/remove_stake.rs
+++ b/pallets/subtensor/src/staking/remove_stake.rs
@@ -144,8 +144,9 @@ impl<T: Config> Pallet<T> {
         };
 
         let stake_job_id = NextStakeJobId::<T>::get();
+        let current_blocknumber = <frame_system::Pallet<T>>::block_number();
 
-        StakeJobs::<T>::insert(stake_job_id, stake_job);
+        StakeJobs::<T>::insert(current_blocknumber, stake_job_id, stake_job);
         NextStakeJobId::<T>::set(stake_job_id.saturating_add(1));
 
         Ok(())
@@ -270,8 +271,9 @@ impl<T: Config> Pallet<T> {
         let stake_job = StakeJob::UnstakeAll { hotkey, coldkey };
 
         let stake_job_id = NextStakeJobId::<T>::get();
+        let current_blocknumber = <frame_system::Pallet<T>>::block_number();
 
-        StakeJobs::<T>::insert(stake_job_id, stake_job);
+        StakeJobs::<T>::insert(current_blocknumber, stake_job_id, stake_job);
         NextStakeJobId::<T>::set(stake_job_id.saturating_add(1));
 
         Ok(())
@@ -409,8 +411,9 @@ impl<T: Config> Pallet<T> {
         let stake_job = StakeJob::UnstakeAllAlpha { hotkey, coldkey };
 
         let stake_job_id = NextStakeJobId::<T>::get();
+        let current_blocknumber = <frame_system::Pallet<T>>::block_number();
 
-        StakeJobs::<T>::insert(stake_job_id, stake_job);
+        StakeJobs::<T>::insert(current_blocknumber, stake_job_id, stake_job);
         NextStakeJobId::<T>::set(stake_job_id.saturating_add(1));
 
         Ok(())
@@ -589,8 +592,9 @@ impl<T: Config> Pallet<T> {
         };
 
         let stake_job_id = NextStakeJobId::<T>::get();
+        let current_blocknumber = <frame_system::Pallet<T>>::block_number();
 
-        StakeJobs::<T>::insert(stake_job_id, stake_job);
+        StakeJobs::<T>::insert(current_blocknumber, stake_job_id, stake_job);
         NextStakeJobId::<T>::set(stake_job_id.saturating_add(1));
 
         // Done and ok.

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -1,6 +1,8 @@
 use super::*;
+use frame_system::pallet_prelude::BlockNumberFor;
 use safe_math::*;
 use share_pool::{SharePool, SharePoolDataOperations};
+use sp_runtime::Saturating;
 use sp_std::ops::Neg;
 use substrate_fixed::types::{I64F64, I96F32, U64F64, U96F32, U110F18};
 
@@ -1158,8 +1160,12 @@ impl<T: Config> Pallet<T> {
     }
 
     // Process staking job for on_finalize() hook.
-    pub(crate) fn do_on_finalize() {
-        let stake_jobs = StakeJobs::<T>::drain().collect::<Vec<_>>();
+    pub(crate) fn do_on_finalize(current_block_number: BlockNumberFor<T>) {
+        // We delay job execution
+        const DELAY_IN_BLOCKS: u32 = 1u32;
+        let actual_block_with_delay = current_block_number.saturating_sub(DELAY_IN_BLOCKS.into());
+
+        let stake_jobs = StakeJobs::<T>::drain_prefix(actual_block_with_delay).collect::<Vec<_>>();
 
         // Sort jobs by job type
         let mut add_stake = vec![];
@@ -1179,6 +1185,12 @@ impl<T: Config> Pallet<T> {
                 StakeJob::UnstakeAllAlpha { .. } => unstake_all_aplha.push(job),
             }
         }
+        // Reorder jobs based on the previous block hash
+        let previous_block_hash = <frame_system::Pallet<T>>::parent_hash();
+        let hash_bytes = previous_block_hash.as_ref();
+        let first_byte = hash_bytes.first().expect("hash operation is infallible");
+        // Extract the first bit
+        let altered_order = (first_byte & 0b10000000) != 0;
 
         // Ascending sort by coldkey
         remove_stake_limit.sort_by(|a, b| match (a, b) {
@@ -1186,7 +1198,13 @@ impl<T: Config> Pallet<T> {
                 StakeJob::RemoveStakeLimit { coldkey: a_key, .. },
                 StakeJob::RemoveStakeLimit { coldkey: b_key, .. },
             ) => {
-                a_key.cmp(b_key) // ascending
+                let direct_order = a_key.cmp(b_key); // ascending
+
+                if altered_order {
+                    direct_order.reverse()
+                } else {
+                    direct_order
+                }
             }
             _ => sp_std::cmp::Ordering::Equal, // unreachable
         });
@@ -1196,7 +1214,13 @@ impl<T: Config> Pallet<T> {
                 StakeJob::RemoveStake { coldkey: a_key, .. },
                 StakeJob::RemoveStake { coldkey: b_key, .. },
             ) => {
-                a_key.cmp(b_key) // ascending
+                let direct_order = a_key.cmp(b_key); // ascending
+
+                if altered_order {
+                    direct_order.reverse()
+                } else {
+                    direct_order
+                }
             }
             _ => sp_std::cmp::Ordering::Equal, // unreachable
         });
@@ -1206,7 +1230,13 @@ impl<T: Config> Pallet<T> {
                 StakeJob::UnstakeAll { coldkey: a_key, .. },
                 StakeJob::UnstakeAll { coldkey: b_key, .. },
             ) => {
-                a_key.cmp(b_key) // ascending
+                let direct_order = a_key.cmp(b_key); // ascending
+
+                if altered_order {
+                    direct_order.reverse()
+                } else {
+                    direct_order
+                }
             }
             _ => sp_std::cmp::Ordering::Equal, // unreachable
         });
@@ -1216,7 +1246,13 @@ impl<T: Config> Pallet<T> {
                 StakeJob::UnstakeAllAlpha { coldkey: a_key, .. },
                 StakeJob::UnstakeAllAlpha { coldkey: b_key, .. },
             ) => {
-                a_key.cmp(b_key) // ascending
+                let direct_order = a_key.cmp(b_key); // ascending
+
+                if altered_order {
+                    direct_order.reverse()
+                } else {
+                    direct_order
+                }
             }
             _ => sp_std::cmp::Ordering::Equal, // unreachable
         });
@@ -1227,7 +1263,13 @@ impl<T: Config> Pallet<T> {
                 StakeJob::AddStakeLimit { coldkey: a_key, .. },
                 StakeJob::AddStakeLimit { coldkey: b_key, .. },
             ) => {
-                b_key.cmp(a_key) // descending
+                let direct_order = b_key.cmp(a_key); // descending
+
+                if altered_order {
+                    direct_order.reverse()
+                } else {
+                    direct_order
+                }
             }
             _ => sp_std::cmp::Ordering::Equal, // unreachable
         });
@@ -1237,239 +1279,243 @@ impl<T: Config> Pallet<T> {
                 StakeJob::AddStake { coldkey: a_key, .. },
                 StakeJob::AddStake { coldkey: b_key, .. },
             ) => {
-                b_key.cmp(a_key) // descending
+                let direct_order = b_key.cmp(a_key); // descending
+
+                if altered_order {
+                    direct_order.reverse()
+                } else {
+                    direct_order
+                }
             }
             _ => sp_std::cmp::Ordering::Equal, // unreachable
         });
 
-        // Process RemoveStakeLimit job (priority 1)
-        for job in remove_stake_limit.into_iter() {
-            if let StakeJob::RemoveStakeLimit {
-                hotkey,
-                coldkey,
-                netuid,
-                alpha_unstaked,
-                limit_price,
-                allow_partial,
-            } = job
-            {
-                let result = Self::do_remove_stake_limit(
-                    dispatch::RawOrigin::Signed(coldkey.clone()).into(),
-                    hotkey.clone(),
-                    netuid,
-                    alpha_unstaked,
-                    limit_price,
-                    allow_partial,
-                );
-
-                if let Err(err) = result {
-                    log::debug!(
-                        "Failed to remove aggregated limited stake: {:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}",
-                        coldkey,
-                        hotkey,
-                        netuid,
-                        alpha_unstaked,
-                        limit_price,
-                        allow_partial,
-                        err
-                    );
-                    Self::deposit_event(Event::FailedToRemoveAggregatedLimitedStake(
-                        coldkey,
-                        hotkey,
-                        netuid,
-                        alpha_unstaked,
-                        limit_price,
-                        allow_partial,
-                    ));
-                } else {
-                    Self::deposit_event(Event::AggregatedLimitedStakeRemoved(
-                        coldkey,
-                        hotkey,
-                        netuid,
-                        alpha_unstaked,
-                        limit_price,
-                        allow_partial,
-                    ));
-                }
-            }
+        // direct job order
+        let mut job_batches = vec![
+            remove_stake_limit,
+            remove_stake,
+            unstake_all,
+            unstake_all_aplha,
+            add_stake_limit,
+            add_stake,
+        ];
+        if altered_order {
+            job_batches.reverse();
         }
 
-        // Process RemoveStake job (priority 2)
-        for job in remove_stake.into_iter() {
-            if let StakeJob::RemoveStake {
-                coldkey,
-                hotkey,
-                netuid,
-                alpha_unstaked,
-            } = job
-            {
-                let result = Self::do_remove_stake(
-                    dispatch::RawOrigin::Signed(coldkey.clone()).into(),
-                    hotkey.clone(),
-                    netuid,
-                    alpha_unstaked,
-                );
+        for jobs in job_batches.into_iter() {
+            for job in jobs.into_iter() {
+                match job {
+                    StakeJob::RemoveStakeLimit {
+                        hotkey,
+                        coldkey,
+                        netuid,
+                        alpha_unstaked,
+                        limit_price,
+                        allow_partial,
+                    } => {
+                        let result = Self::do_remove_stake_limit(
+                            dispatch::RawOrigin::Signed(coldkey.clone()).into(),
+                            hotkey.clone(),
+                            netuid,
+                            alpha_unstaked,
+                            limit_price,
+                            allow_partial,
+                        );
 
-                if let Err(err) = result {
-                    log::debug!(
-                        "Failed to remove aggregated stake: {:?}, {:?}, {:?}, {:?}, {:?}",
+                        if let Err(err) = result {
+                            log::debug!(
+                                "Failed to remove aggregated limited stake: {:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}",
+                                coldkey,
+                                hotkey,
+                                netuid,
+                                alpha_unstaked,
+                                limit_price,
+                                allow_partial,
+                                err
+                            );
+                            Self::deposit_event(Event::FailedToRemoveAggregatedLimitedStake(
+                                coldkey,
+                                hotkey,
+                                netuid,
+                                alpha_unstaked,
+                                limit_price,
+                                allow_partial,
+                            ));
+                        } else {
+                            Self::deposit_event(Event::AggregatedLimitedStakeRemoved(
+                                coldkey,
+                                hotkey,
+                                netuid,
+                                alpha_unstaked,
+                                limit_price,
+                                allow_partial,
+                            ));
+                        }
+                    }
+                    StakeJob::RemoveStake {
                         coldkey,
                         hotkey,
                         netuid,
                         alpha_unstaked,
-                        err
-                    );
-                    Self::deposit_event(Event::FailedToRemoveAggregatedStake(
-                        coldkey,
+                    } => {
+                        let result = Self::do_remove_stake(
+                            dispatch::RawOrigin::Signed(coldkey.clone()).into(),
+                            hotkey.clone(),
+                            netuid,
+                            alpha_unstaked,
+                        );
+
+                        if let Err(err) = result {
+                            log::debug!(
+                                "Failed to remove aggregated stake: {:?}, {:?}, {:?}, {:?}, {:?}",
+                                coldkey,
+                                hotkey,
+                                netuid,
+                                alpha_unstaked,
+                                err
+                            );
+                            Self::deposit_event(Event::FailedToRemoveAggregatedStake(
+                                coldkey,
+                                hotkey,
+                                netuid,
+                                alpha_unstaked,
+                            ));
+                        } else {
+                            Self::deposit_event(Event::AggregatedStakeRemoved(
+                                coldkey,
+                                hotkey,
+                                netuid,
+                                alpha_unstaked,
+                            ));
+                        }
+                    }
+                    StakeJob::UnstakeAll { hotkey, coldkey } => {
+                        let result = Self::do_unstake_all(
+                            dispatch::RawOrigin::Signed(coldkey.clone()).into(),
+                            hotkey.clone(),
+                        );
+
+                        if let Err(err) = result {
+                            log::debug!(
+                                "Failed to unstake all: {:?}, {:?}, {:?}",
+                                coldkey,
+                                hotkey,
+                                err
+                            );
+                            Self::deposit_event(Event::AggregatedUnstakeAllFailed(coldkey, hotkey));
+                        } else {
+                            Self::deposit_event(Event::AggregatedUnstakeAllSucceeded(
+                                coldkey, hotkey,
+                            ));
+                        }
+                    }
+                    StakeJob::UnstakeAllAlpha { hotkey, coldkey } => {
+                        let result = Self::do_unstake_all_alpha(
+                            dispatch::RawOrigin::Signed(coldkey.clone()).into(),
+                            hotkey.clone(),
+                        );
+
+                        if let Err(err) = result {
+                            log::debug!(
+                                "Failed to unstake all alpha: {:?}, {:?}, {:?}",
+                                coldkey,
+                                hotkey,
+                                err
+                            );
+                            Self::deposit_event(Event::AggregatedUnstakeAllAlphaFailed(
+                                coldkey, hotkey,
+                            ));
+                        } else {
+                            Self::deposit_event(Event::AggregatedUnstakeAllAlphaSucceeded(
+                                coldkey, hotkey,
+                            ));
+                        }
+                    }
+                    StakeJob::AddStakeLimit {
                         hotkey,
-                        netuid,
-                        alpha_unstaked,
-                    ));
-                } else {
-                    Self::deposit_event(Event::AggregatedStakeRemoved(
                         coldkey,
-                        hotkey,
-                        netuid,
-                        alpha_unstaked,
-                    ));
-                }
-            }
-        }
-
-        // Process UnstakeAll job (priority 3)
-        for job in unstake_all.into_iter() {
-            if let StakeJob::UnstakeAll { hotkey, coldkey } = job {
-                let result = Self::do_unstake_all(
-                    dispatch::RawOrigin::Signed(coldkey.clone()).into(),
-                    hotkey.clone(),
-                );
-
-                if let Err(err) = result {
-                    log::debug!(
-                        "Failed to unstake all: {:?}, {:?}, {:?}",
-                        coldkey,
-                        hotkey,
-                        err
-                    );
-                    Self::deposit_event(Event::AggregatedUnstakeAllFailed(coldkey, hotkey));
-                } else {
-                    Self::deposit_event(Event::AggregatedUnstakeAllSucceeded(coldkey, hotkey));
-                }
-            }
-        }
-
-        // Process UnstakeAll job (priority 4)
-        for job in unstake_all_aplha.into_iter() {
-            if let StakeJob::UnstakeAllAlpha { hotkey, coldkey } = job {
-                let result = Self::do_unstake_all_alpha(
-                    dispatch::RawOrigin::Signed(coldkey.clone()).into(),
-                    hotkey.clone(),
-                );
-
-                if let Err(err) = result {
-                    log::debug!(
-                        "Failed to unstake all alpha: {:?}, {:?}, {:?}",
-                        coldkey,
-                        hotkey,
-                        err
-                    );
-                    Self::deposit_event(Event::AggregatedUnstakeAllAlphaFailed(coldkey, hotkey));
-                } else {
-                    Self::deposit_event(Event::AggregatedUnstakeAllAlphaSucceeded(coldkey, hotkey));
-                }
-            }
-        }
-
-        // Process AddStakeLimit job (priority 5)
-        for job in add_stake_limit.into_iter() {
-            if let StakeJob::AddStakeLimit {
-                hotkey,
-                coldkey,
-                netuid,
-                stake_to_be_added,
-                limit_price,
-                allow_partial,
-            } = job
-            {
-                let result = Self::do_add_stake_limit(
-                    dispatch::RawOrigin::Signed(coldkey.clone()).into(),
-                    hotkey.clone(),
-                    netuid,
-                    stake_to_be_added,
-                    limit_price,
-                    allow_partial,
-                );
-
-                if let Err(err) = result {
-                    log::debug!(
-                        "Failed to add aggregated limited stake: {:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}",
-                        coldkey,
-                        hotkey,
                         netuid,
                         stake_to_be_added,
                         limit_price,
                         allow_partial,
-                        err
-                    );
-                    Self::deposit_event(Event::FailedToAddAggregatedLimitedStake(
-                        coldkey,
-                        hotkey,
-                        netuid,
-                        stake_to_be_added,
-                        limit_price,
-                        allow_partial,
-                    ));
-                } else {
-                    Self::deposit_event(Event::AggregatedLimitedStakeAdded(
-                        coldkey,
-                        hotkey,
-                        netuid,
-                        stake_to_be_added,
-                        limit_price,
-                        allow_partial,
-                    ));
-                }
-            }
-        }
+                    } => {
+                        let result = Self::do_add_stake_limit(
+                            dispatch::RawOrigin::Signed(coldkey.clone()).into(),
+                            hotkey.clone(),
+                            netuid,
+                            stake_to_be_added,
+                            limit_price,
+                            allow_partial,
+                        );
 
-        // Process AddStake job (priority 6)
-        for job in add_stake.into_iter() {
-            if let StakeJob::AddStake {
-                hotkey,
-                coldkey,
-                netuid,
-                stake_to_be_added,
-            } = job
-            {
-                let result = Self::do_add_stake(
-                    dispatch::RawOrigin::Signed(coldkey.clone()).into(),
-                    hotkey.clone(),
-                    netuid,
-                    stake_to_be_added,
-                );
+                        if let Err(err) = result {
+                            log::debug!(
+                                "Failed to add aggregated limited stake: {:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}",
+                                coldkey,
+                                hotkey,
+                                netuid,
+                                stake_to_be_added,
+                                limit_price,
+                                allow_partial,
+                                err
+                            );
+                            Self::deposit_event(Event::FailedToAddAggregatedLimitedStake(
+                                coldkey,
+                                hotkey,
+                                netuid,
+                                stake_to_be_added,
+                                limit_price,
+                                allow_partial,
+                            ));
+                        } else {
+                            Self::deposit_event(Event::AggregatedLimitedStakeAdded(
+                                coldkey,
+                                hotkey,
+                                netuid,
+                                stake_to_be_added,
+                                limit_price,
+                                allow_partial,
+                            ));
+                        }
+                    }
+                    StakeJob::AddStake {
+                        hotkey,
+                        coldkey,
+                        netuid,
+                        stake_to_be_added,
+                    } => {
+                        let result = Self::do_add_stake(
+                            dispatch::RawOrigin::Signed(coldkey.clone()).into(),
+                            hotkey.clone(),
+                            netuid,
+                            stake_to_be_added,
+                        );
 
-                if let Err(err) = result {
-                    log::debug!(
-                        "Failed to add aggregated stake: {:?}, {:?}, {:?}, {:?}, {:?}",
-                        coldkey,
-                        hotkey,
-                        netuid,
-                        stake_to_be_added,
-                        err
-                    );
-                    Self::deposit_event(Event::FailedToAddAggregatedStake(
-                        coldkey,
-                        hotkey,
-                        netuid,
-                        stake_to_be_added,
-                    ));
-                } else {
-                    Self::deposit_event(Event::AggregatedStakeAdded(
-                        coldkey,
-                        hotkey,
-                        netuid,
-                        stake_to_be_added,
-                    ));
+                        if let Err(err) = result {
+                            log::debug!(
+                                "Failed to add aggregated stake: {:?}, {:?}, {:?}, {:?}, {:?}",
+                                coldkey,
+                                hotkey,
+                                netuid,
+                                stake_to_be_added,
+                                err
+                            );
+                            Self::deposit_event(Event::FailedToAddAggregatedStake(
+                                coldkey,
+                                hotkey,
+                                netuid,
+                                stake_to_be_added,
+                            ));
+                        } else {
+                            Self::deposit_event(Event::AggregatedStakeAdded(
+                                coldkey,
+                                hotkey,
+                                netuid,
+                                stake_to_be_added,
+                            ));
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR adds execution delay for the previously aggregated staking jobs. Additionally, we change the sort order based on the previous block hash. 

This is a subtask for https://github.com/opentensor/subtensor/pull/1525

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules