### PR TITLE
Add the migration to remove deprecated map values for root subnet

### DIFF
--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -91,7 +91,9 @@ mod hooks {
                 // Set subtoken enabled for all existed subnets
                 .saturating_add(migrations::migrate_set_subtoken_enabled::migrate_set_subtoken_enabled::<T>())
                 // Remove all entries in TotalHotkeyColdkeyStakesThisInterval
-                .saturating_add(migrations::migrate_remove_total_hotkey_coldkey_stakes_this_interval::migrate_remove_total_hotkey_coldkey_stakes_this_interval::<T>());
+                .saturating_add(migrations::migrate_remove_total_hotkey_coldkey_stakes_this_interval::migrate_remove_total_hotkey_coldkey_stakes_this_interval::<T>())
+                // Remove unused root values from yuma maps
+                .saturating_add(migrations::migrate_remove_unused_root_values::migrate_remove_unused_root_values::<T>());
             weight
         }
 

--- a/pallets/subtensor/src/migrations/migrate_remove_unused_root_values.rs
+++ b/pallets/subtensor/src/migrations/migrate_remove_unused_root_values.rs
@@ -1,0 +1,47 @@
+use super::*;
+use crate::HasMigrationRun;
+use frame_support::{traits::Get, weights::Weight};
+use scale_info::prelude::string::String;
+
+pub fn migrate_remove_unused_root_values<T: Config>() -> Weight {
+    let migration_name = b"migrate_remove_unused_root_values".to_vec();
+    let mut weight = T::DbWeight::get().reads(1);
+
+    if HasMigrationRun::<T>::get(&migration_name) {
+        log::info!(
+            "Migration '{:?}' has already run. Skipping.",
+            migration_name
+        );
+        return weight;
+    }
+
+    log::info!(
+        "Running migration '{}'",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    let netuid = 0;
+
+    Incentive::<T>::remove(netuid);
+    Dividends::<T>::remove(netuid);
+    Rank::<T>::remove(netuid);
+    Trust::<T>::remove(netuid);
+    ValidatorTrust::<T>::remove(netuid);
+    ValidatorPermit::<T>::remove(netuid);
+    Consensus::<T>::remove(netuid);
+    StakeWeight::<T>::remove(netuid);
+    Active::<T>::remove(netuid);
+    Emission::<T>::remove(netuid);
+    PruningScores::<T>::remove(netuid);
+
+    // Mark Migration as Completed
+    HasMigrationRun::<T>::insert(&migration_name, true);
+    weight = weight.saturating_add(T::DbWeight::get().writes(12));
+
+    log::info!(
+        "Migration '{:?}' completed successfully.",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    weight
+}

--- a/pallets/subtensor/src/migrations/mod.rs
+++ b/pallets/subtensor/src/migrations/mod.rs
@@ -12,6 +12,7 @@ pub mod migrate_rao;
 pub mod migrate_remove_stake_map;
 pub mod migrate_remove_total_hotkey_coldkey_stakes_this_interval;
 pub mod migrate_remove_unused_maps_and_values;
+pub mod migrate_remove_unused_root_values;
 pub mod migrate_remove_zero_total_hotkey_alpha;
 pub mod migrate_set_first_emission_block_number;
 pub mod migrate_set_min_burn;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -207,7 +207,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 262,
+    spec_version: 263,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description

The added migration is for cleaning up root subnet state. The epoch is no more executed for root and state variables such as Incentive, Rank, etc. are no longer relevant for root network.

## Related Issue(s)

- Closes #939 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please describe): State cleanup

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
