### PR TITLE
add check before sending burned register

### DIFF
--- a/evm-tests/src/subtensor.ts
+++ b/evm-tests/src/subtensor.ts
@@ -139,6 +139,13 @@ export async function disableWhiteListCheck(api: TypedApi<typeof devnet>, disabl
 }
 
 export async function burnedRegister(api: TypedApi<typeof devnet>, netuid: number, ss58Address: string, keypair: KeyPair) {
+    const registered = await api.query.SubtensorModule.Uids.getValue(netuid, ss58Address);
+    // just return if already registered
+    if (registered !== undefined) {
+        console.log("hotkey ", ss58Address, " already registered in netuid ", netuid)
+        return;
+    }
+
     await new Promise((resolve) => setTimeout(resolve, 1000));
     const uids = await api.query.SubtensorModule.SubnetworkN.getValue(netuid)
     const signer = getSignerFromKeypair(keypair)


### PR DESCRIPTION
## Description
check if the hotkey already registered in the subnet before sending burned register extinsic.


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.