### PR TITLE
fix: command execution

### DIFF
--- a/scripts/localnet.sh
+++ b/scripts/localnet.sh
@@ -117,8 +117,8 @@ if [ $BUILD_ONLY -eq 0 ]; then
   trap 'pkill -P $$' EXIT SIGINT SIGTERM
 
   (
-    ("${alice_start[@]}" 2>&1) &
-    ("${bob_start[@]}" 2>&1)
+    "${alice_start[@]}" 2>&1 &
+    "${bob_start[@]}" 2>&1 &
     wait
   )
 fi


### PR DESCRIPTION
## Description

Turns out the script was grouping commands instead of just running them because of how parentheses were used. Tweaked it so everything runs like it should now.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
