### PR TITLE
[fix] add to StakingHotkeys on inc stake

### DIFF
--- a/pallets/subtensor/src/tests/staking.rs
+++ b/pallets/subtensor/src/tests/staking.rs
@@ -6111,3 +6111,50 @@ fn test_unstake_all_aggregate_fails() {
         }));
     });
 }
+
+#[test]
+fn test_increase_stake_for_hotkey_and_coldkey_on_subnet_adds_to_staking_hotkeys_map() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let coldkey1 = U256::from(2);
+        let hotkey = U256::from(3);
+
+        let netuid = 1;
+        let stake_amount = 100_000_000_000;
+
+        // Check no entry in the staking hotkeys map
+        assert!(!StakingHotkeys::<Test>::contains_key(coldkey));
+        // insert manually
+        StakingHotkeys::<Test>::insert(coldkey, Vec::<U256>::new());
+        // check entry has no hotkey
+        assert!(!StakingHotkeys::<Test>::get(coldkey).contains(&hotkey));
+
+        SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey,
+            &coldkey,
+            netuid,
+            stake_amount,
+        );
+
+        // Check entry exists in the staking hotkeys map
+        assert!(StakingHotkeys::<Test>::contains_key(coldkey));
+        // check entry has hotkey
+        assert!(StakingHotkeys::<Test>::get(coldkey).contains(&hotkey));
+
+        // Check no entry in the staking hotkeys map for coldkey1
+        assert!(!StakingHotkeys::<Test>::contains_key(coldkey1));
+
+        // Run increase stake for hotkey and coldkey1 on subnet
+        SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey,
+            &coldkey1,
+            netuid,
+            stake_amount,
+        );
+
+        // Check entry exists in the staking hotkeys map for coldkey1
+        assert!(StakingHotkeys::<Test>::contains_key(coldkey1));
+        // check entry has hotkey
+        assert!(StakingHotkeys::<Test>::get(coldkey1).contains(&hotkey));
+    });
+}


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
Fixes an issue with listing stake on hotkeys that are miners only, because they are not listed in `StakingHotkeys`.

It's possible that there are some runtime considerations for this change. But I feel the extra read is probably minimal.

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.