### PR TITLE
Ensure we only reset BondsMovingAverage to 975000 only if it exceeds

### DIFF
--- a/pallets/subtensor/src/migrations/migrate_reset_bonds_moving_average.rs
+++ b/pallets/subtensor/src/migrations/migrate_reset_bonds_moving_average.rs
@@ -24,14 +24,14 @@ pub fn migrate_reset_bonds_moving_average<T: Config>() -> Weight {
     );
 
     // ------------------------------
-    // Step 1: Reset all subnet's BondsMovingAverage to 975000
+    // Step 1: Reset all subnet's BondsMovingAverage to 975000 if the value exceeds 975000
     // ------------------------------
 
     let mut reset_entries_count = 0u64;
 
     for netuid in BondsMovingAverage::<T>::iter_keys() {
         BondsMovingAverage::<T>::mutate(netuid, |average| {
-            *average = 975000;
+            *average = average.min(975000);
         });
         reset_entries_count = reset_entries_count.saturating_add(1);
     }

--- a/pallets/subtensor/src/migrations/migrate_reset_bonds_moving_average.rs
+++ b/pallets/subtensor/src/migrations/migrate_reset_bonds_moving_average.rs
@@ -31,7 +31,7 @@ pub fn migrate_reset_bonds_moving_average<T: Config>() -> Weight {
 
     for netuid in BondsMovingAverage::<T>::iter_keys() {
         BondsMovingAverage::<T>::mutate(netuid, |average| {
-            *average = average.min(975000);
+            *average = (*average).min(975000);
         });
         reset_entries_count = reset_entries_count.saturating_add(1);
     }

--- a/pallets/subtensor/src/migrations/migrate_reset_max_burn.rs
+++ b/pallets/subtensor/src/migrations/migrate_reset_max_burn.rs
@@ -40,7 +40,7 @@ pub fn migrate_reset_max_burn<T: Config>() -> Weight {
         .saturating_add(T::DbWeight::get().reads_writes(reset_entries_count, reset_entries_count));
 
     log::info!(
-        "Reset {} subnets from BondsMovingAverage.",
+        "Reset {} subnets from MaxBurn.",
         reset_entries_count
     );
 

--- a/pallets/subtensor/src/migrations/migrate_reset_max_burn.rs
+++ b/pallets/subtensor/src/migrations/migrate_reset_max_burn.rs
@@ -39,10 +39,7 @@ pub fn migrate_reset_max_burn<T: Config>() -> Weight {
     weight = weight
         .saturating_add(T::DbWeight::get().reads_writes(reset_entries_count, reset_entries_count));
 
-    log::info!(
-        "Reset {} subnets from MaxBurn.",
-        reset_entries_count
-    );
+    log::info!("Reset {} subnets from MaxBurn.", reset_entries_count);
 
     // ------------------------------
     // Step 2: Mark Migration as Completed


### PR DESCRIPTION
This fixes one of the migrations introduced in #1573, ensuring that we only reset the `BondsMovingAverage` to 975000 only if the existing value already exceeds that amount.