### PR TITLE
only rerun on `skip-validate-benchmarks`

### DIFF
--- a/.github/workflows/label-triggers.yml
+++ b/.github/workflows/label-triggers.yml
@@ -31,34 +31,38 @@ jobs:
 
   cancel_benchmarks:
     runs-on: ubuntu-latest
-    if: github.event.action == 'labeled' && github.event.label.name == 'skip-validate-benchmarks'
+    if: >
+      github.event.action == 'labeled' &&
+      github.event.label.name == 'skip-validate-benchmarks'
     steps:
       - name: Cancel in-progress Validate-Benchmarks runs
         uses: actions/github-script@v6
         with:
           script: |
             const runs = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+              owner:       context.repo.owner,
+              repo:        context.repo.repo,
               workflow_id: 'benchmarks.yml',
-              branch: context.payload.pull_request.head.ref,
-              status: 'in_progress'
+              branch:      context.payload.pull_request.head.ref,
+              status:      'in_progress'
             });
             for (const run of runs.data.workflow_runs) {
               await github.rest.actions.cancelWorkflowRun({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
+                owner:  context.repo.owner,
+                repo:   context.repo.repo,
                 run_id: run.id
               });
             }
 
   dispatch_benchmarks:
     runs-on: ubuntu-latest
-    if: github.event.action == 'unlabeled' && github.event.label.name == 'skip-validate-benchmarks'
+    if: >
+      github.event.action == 'unlabeled' &&
+      github.event.label.name == 'skip-validate-benchmarks'
     steps:
       - name: Re-trigger Validate-Benchmarks
         uses: peter-evans/workflow-dispatch@v2
         with:
           workflow: benchmarks.yml
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref:      ${{ context.payload.pull_request.head.sha }}
 

--- a/.github/workflows/label-triggers.yml
+++ b/.github/workflows/label-triggers.yml
@@ -26,3 +26,16 @@ jobs:
               repo: context.repo.repo,
               body: '@opentensor/cerebrum / @opentensor/gyrus / @opentensor/cortex breaking change detected! Please prepare accordingly!'
             })
+
+  dispatch_benchmarks:
+    needs: comment_on_breaking_change
+    runs-on: ubuntu-latest
+    if: >
+      github.event.action == 'unlabeled' &&
+      github.event.label.name == 'skip-validate-benchmarks'
+    steps:
+      - name: Re-trigger Validate-Benchmarks
+        uses: peter-evans/workflow-dispatch@v2
+        with:
+          workflow: benchmarks.yml
+          ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/label-triggers.yml
+++ b/.github/workflows/label-triggers.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   issues: write
   pull-requests: write
+  workflows: write
 
 jobs:
   comment_on_breaking_change:

--- a/.github/workflows/label-triggers.yml
+++ b/.github/workflows/label-triggers.yml
@@ -54,7 +54,7 @@ jobs:
             }
 
   dispatch_benchmarks:
-    needs: cancel_benchmarks
+    needs: comment_on_breaking_change
     runs-on: ubuntu-latest
     if: github.event.action == 'unlabeled' && github.event.label.name == 'skip-validate-benchmarks'
     steps:

--- a/.github/workflows/label-triggers.yml
+++ b/.github/workflows/label-triggers.yml
@@ -10,7 +10,6 @@ on:
 permissions:
   issues: write
   pull-requests: write
-  workflows: write
 
 jobs:
   comment_on_breaking_change:
@@ -27,16 +26,3 @@ jobs:
               repo: context.repo.repo,
               body: '@opentensor/cerebrum / @opentensor/gyrus / @opentensor/cortex breaking change detected! Please prepare accordingly!'
             })
-
-  dispatch_benchmarks:
-    needs: comment_on_breaking_change
-    runs-on: ubuntu-latest
-    if: >
-      github.event.action == 'unlabeled' &&
-      github.event.label.name == 'skip-validate-benchmarks'
-    steps:
-      - name: Re-trigger Validate-Benchmarks
-        uses: peter-evans/workflow-dispatch@v2
-        with:
-          workflow: benchmarks.yml
-          ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/label-triggers.yml
+++ b/.github/workflows/label-triggers.yml
@@ -10,6 +10,8 @@ on:
 permissions:
   issues: write
   pull-requests: write
+  actions: write
+  workflows: write
 
 jobs:
   comment_on_breaking_change:

--- a/.github/workflows/label-triggers.yml
+++ b/.github/workflows/label-triggers.yml
@@ -30,7 +30,6 @@ jobs:
             })
 
   cancel_benchmarks:
-    needs: comment_on_breaking_change
     runs-on: ubuntu-latest
     if: github.event.action == 'labeled' && github.event.label.name == 'skip-validate-benchmarks'
     steps:
@@ -54,7 +53,6 @@ jobs:
             }
 
   dispatch_benchmarks:
-    needs: comment_on_breaking_change
     runs-on: ubuntu-latest
     if: github.event.action == 'unlabeled' && github.event.label.name == 'skip-validate-benchmarks'
     steps:

--- a/.github/workflows/label-triggers.yml
+++ b/.github/workflows/label-triggers.yml
@@ -26,3 +26,39 @@ jobs:
               repo: context.repo.repo,
               body: '@opentensor/cerebrum / @opentensor/gyrus / @opentensor/cortex breaking change detected! Please prepare accordingly!'
             })
+
+  cancel_benchmarks:
+    needs: comment_on_breaking_change
+    runs-on: ubuntu-latest
+    if: github.event.action == 'labeled' && github.event.label.name == 'skip-validate-benchmarks'
+    steps:
+      - name: Cancel in-progress Validate-Benchmarks runs
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'benchmarks.yml',
+              branch: context.payload.pull_request.head.ref,
+              status: 'in_progress'
+            });
+            for (const run of runs.data.workflow_runs) {
+              await github.rest.actions.cancelWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id
+              });
+            }
+
+  dispatch_benchmarks:
+    needs: cancel_benchmarks
+    runs-on: ubuntu-latest
+    if: github.event.action == 'unlabeled' && github.event.label.name == 'skip-validate-benchmarks'
+    steps:
+      - name: Re-trigger Validate-Benchmarks
+        uses: peter-evans/workflow-dispatch@v2
+        with:
+          workflow: benchmarks.yml
+          ref: ${{ github.event.pull_request.head.sha }}
+

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -18,10 +18,13 @@ jobs:
 
     if: >
       (
-        github.event.action == 'opened'      ||
+        github.event.action == 'opened' ||
         github.event.action == 'synchronize' ||
-        github.event.action == 'labeled'     ||
-        github.event.action == 'unlabeled'
+        (
+          (github.event.action == 'labeled' || github.event.action == 'unlabeled')
+          &&
+          github.event.label.name == 'skip-validate-benchmarks'
+        )
       )
       &&
       !contains(github.event.pull_request.labels.*.name, 'skip-validate-benchmarks')

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -2,16 +2,17 @@
 name: Validate-Benchmarks
 
 on:
+  workflow_dispatch:
+
   pull_request:
     types:
+      - opened
+      - synchronize
       - labeled
       - unlabeled
-      - synchronize
-      - opened
-  workflow_dispatch:
-    push:
-      paths:
-        - .github/workflows/benchmarks.yml
+  push:
+    paths:
+      - .github/workflows/benchmarks.yml
 
 concurrency:
   group: run-benchmarks-${{ github.ref }}
@@ -20,12 +21,15 @@ concurrency:
 jobs:
   validate-benchmarks:
     if: ${{ 
-      !contains(github.event.pull_request.labels.*.name, 'skip-validate-benchmarks') &&
+      github.event_name == 'push' ||
       (
-        github.event.action == 'opened' ||
-        github.event.action == 'synchronize' ||
-        (github.event.action == 'labeled' && github.event.label.name == 'validate-benchmarks') ||
-        (github.event.action == 'unlabeled' && github.event.label.name == 'validate-benchmarks')
+        !contains(github.event.pull_request.labels.*.name, 'skip-validate-benchmarks') &&
+        (
+          github.event.action == 'opened'       ||
+          github.event.action == 'synchronize'  ||
+          (github.event.action == 'labeled'   && github.event.label.name == 'validate-benchmarks') ||
+          (github.event.action == 'unlabeled' && github.event.label.name == 'validate-benchmarks')
+        )
       )
     }}
     runs-on: Benchmarking

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -16,7 +16,15 @@ concurrency:
 
 jobs:
   validate-benchmarks:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-validate-benchmarks') }}
+    if: >
+      github.event_name == 'pull_request' &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-validate-benchmarks') &&
+      (
+        github.event.action == 'opened' ||
+        github.event.action == 'synchronize' ||
+        (github.event.action == 'labeled' and github.event.label.name == 'validate-benchmarks') ||
+        (github.event.action == 'unlabeled' and github.event.label.name == 'validate-benchmarks')
+      )
     runs-on: Benchmarking
     steps:
       - name: Checkout PR branch

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -9,6 +9,9 @@ on:
       - synchronize
       - opened
   workflow_dispatch:
+    push:
+      paths:
+        - .github/workflows/benchmarks.yml
 
 concurrency:
   group: run-benchmarks-${{ github.ref }}

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -17,7 +17,6 @@ concurrency:
 jobs:
   validate-benchmarks:
     if: ${{ 
-      github.event_name == 'pull_request' &&
       !contains(github.event.pull_request.labels.*.name, 'skip-validate-benchmarks') &&
       (
         github.event.action == 'opened' ||

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -1,4 +1,4 @@
-# .github/workflows/benchmarks.yml
+# .github/workflows/run-benchmarks.yml
 name: Validate-Benchmarks
 
 on:
@@ -6,38 +6,22 @@ on:
     types:
       - opened
       - synchronize
-      - labeled
-      - unlabeled
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   validate-benchmarks:
+    if: >
+      github.event_name == 'workflow_dispatch'
+      ||
+      !contains(github.event.pull_request.labels.*.name, 'skip-validate-benchmarks')
+
     runs-on: Benchmarking
     concurrency:
       group: run-benchmarks-${{ github.ref }}
       cancel-in-progress: true
-
-    # 1) Always run on manual dispatch.
-    # 2) Otherwise, run only if the PR DOES NOT have the skip-validate-benchmarks label,
-    #    AND it’s either:
-    #      • a PR open event,
-    #      • a PR sync event, OR
-    #      • a label/unlabel event where the label touched is exactly skip-validate-benchmarks.
-    if: >
-      github.event_name == 'workflow_dispatch'
-      ||
-      (
-        !contains(github.event.pull_request.labels.*.name, 'skip-validate-benchmarks')
-        &&
-        (
-          github.event.action == 'opened'
-          || github.event.action == 'synchronize'
-          || (
-            (github.event.action == 'labeled' || github.event.action == 'unlabeled')
-            && github.event.label.name == 'skip-validate-benchmarks'
-          )
-        )
-      )
 
     steps:
       - name: Checkout PR branch

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -16,15 +16,16 @@ concurrency:
 
 jobs:
   validate-benchmarks:
-    if: >
+    if: ${{ 
       github.event_name == 'pull_request' &&
       !contains(github.event.pull_request.labels.*.name, 'skip-validate-benchmarks') &&
       (
         github.event.action == 'opened' ||
         github.event.action == 'synchronize' ||
-        (github.event.action == 'labeled' and github.event.label.name == 'validate-benchmarks') ||
-        (github.event.action == 'unlabeled' and github.event.label.name == 'validate-benchmarks')
+        (github.event.action == 'labeled' && github.event.label.name == 'validate-benchmarks') ||
+        (github.event.action == 'unlabeled' && github.event.label.name == 'validate-benchmarks')
       )
+    }}
     runs-on: Benchmarking
     steps:
       - name: Checkout PR branch

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -18,16 +18,10 @@ jobs:
 
     if: >
       (
-        github.event.action == 'opened' ||
+        github.event.action == 'opened'      ||
         github.event.action == 'synchronize' ||
-        (
-          github.event.action == 'labeled'   &&
-          github.event.label.name == 'skip-validate-benchmarks'
-        ) ||
-        (
-          github.event.action == 'unlabeled' &&
-          github.event.label.name == 'skip-validate-benchmarks'
-        )
+        github.event.action == 'labeled'     ||
+        github.event.action == 'unlabeled'
       )
       &&
       !contains(github.event.pull_request.labels.*.name, 'skip-validate-benchmarks')

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -2,17 +2,13 @@
 name: Validate-Benchmarks
 
 on:
-  workflow_dispatch:
-
   pull_request:
     types:
       - opened
       - synchronize
       - labeled
       - unlabeled
-  push:
-    paths:
-      - .github/workflows/benchmarks.yml
+  workflow_dispatch:
 
 concurrency:
   group: run-benchmarks-${{ github.ref }}
@@ -20,18 +16,21 @@ concurrency:
 
 jobs:
   validate-benchmarks:
-    if: ${{ 
-      github.event_name == 'push' ||
+    if: >
       (
-        !contains(github.event.pull_request.labels.*.name, 'skip-validate-benchmarks') &&
+        github.event.action == 'opened' ||
+        github.event.action == 'synchronize' ||
         (
-          github.event.action == 'opened'       ||
-          github.event.action == 'synchronize'  ||
-          (github.event.action == 'labeled'   && github.event.label.name == 'validate-benchmarks') ||
-          (github.event.action == 'unlabeled' && github.event.label.name == 'validate-benchmarks')
+          github.event.action == 'labeled'   &&
+          github.event.label.name == 'skip-validate-benchmarks'
+        ) ||
+        (
+          github.event.action == 'unlabeled' &&
+          github.event.label.name == 'skip-validate-benchmarks'
         )
       )
-    }}
+      &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-validate-benchmarks')
     runs-on: Benchmarking
     steps:
       - name: Checkout PR branch

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -10,6 +10,10 @@ on:
 
 jobs:
   validate-benchmarks:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      !contains(github.event.pull_request.labels.*.name, 'skip-validate-benchmarks')
+
     runs-on: Benchmarking
     concurrency:
       group: run-benchmarks-${{ github.ref }}

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -6,18 +6,38 @@ on:
     types:
       - opened
       - synchronize
+      - labeled
+      - unlabeled
   workflow_dispatch:
 
 jobs:
   validate-benchmarks:
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      !contains(github.event.pull_request.labels.*.name, 'skip-validate-benchmarks')
-
     runs-on: Benchmarking
     concurrency:
       group: run-benchmarks-${{ github.ref }}
       cancel-in-progress: true
+
+    # 1) Always run on manual dispatch.
+    # 2) Otherwise, run only if the PR DOES NOT have the skip-validate-benchmarks label,
+    #    AND it’s either:
+    #      • a PR open event,
+    #      • a PR sync event, OR
+    #      • a label/unlabel event where the label touched is exactly skip-validate-benchmarks.
+    if: >
+      github.event_name == 'workflow_dispatch'
+      ||
+      (
+        !contains(github.event.pull_request.labels.*.name, 'skip-validate-benchmarks')
+        &&
+        (
+          github.event.action == 'opened'
+          || github.event.action == 'synchronize'
+          || (
+            (github.event.action == 'labeled' || github.event.action == 'unlabeled')
+            && github.event.label.name == 'skip-validate-benchmarks'
+          )
+        )
+      )
 
     steps:
       - name: Checkout PR branch

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -10,12 +10,12 @@ on:
       - unlabeled
   workflow_dispatch:
 
-concurrency:
-  group: run-benchmarks-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   validate-benchmarks:
+    concurrency:
+      group: run-benchmarks-${{ github.ref }}
+      cancel-in-progress: true
+
     if: >
       (
         github.event.action == 'opened' ||

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -6,29 +6,15 @@ on:
     types:
       - opened
       - synchronize
-      - labeled
-      - unlabeled
   workflow_dispatch:
 
 jobs:
   validate-benchmarks:
+    runs-on: Benchmarking
     concurrency:
       group: run-benchmarks-${{ github.ref }}
       cancel-in-progress: true
 
-    if: >
-      (
-        github.event.action == 'opened' ||
-        github.event.action == 'synchronize' ||
-        (
-          (github.event.action == 'labeled' || github.event.action == 'unlabeled')
-          &&
-          github.event.label.name == 'skip-validate-benchmarks'
-        )
-      )
-      &&
-      !contains(github.event.pull_request.labels.*.name, 'skip-validate-benchmarks')
-    runs-on: Benchmarking
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description
Rerun benchmarks only on `skip-validate-benchmarks` label instead of every one. 

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):
