### PR TITLE
`Validate-benchmarks` Job Only Respects `skip-validate-benchmarks`

### DIFF
--- a/.github/workflows/label-triggers.yml
+++ b/.github/workflows/label-triggers.yml
@@ -1,6 +1,6 @@
 name: Label Triggers
 on:
-  pull_request_target:
+  pull_request:
     types:
       - labeled
       - unlabeled
@@ -37,6 +37,7 @@ jobs:
       - name: Trigger Benchmarks workflow_dispatch
         uses: actions/github-script@v6
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,

--- a/.github/workflows/label-triggers.yml
+++ b/.github/workflows/label-triggers.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   issues: write
   pull-requests: write
+  contents: write 
 
 jobs:
   comment_on_breaking_change:
@@ -25,4 +26,20 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: '@opentensor/cerebrum / @opentensor/gyrus / @opentensor/cortex breaking change detected! Please prepare accordingly!'
+            })
+
+  re_run_validate_benchmarks:
+    name: "Re-run Validate-Benchmarks if skip-validate-benchmarks is removed"
+    runs-on: ubuntu-latest
+    if: github.event.action == 'unlabeled' && github.event.label.name == 'skip-validate-benchmarks'
+    steps:
+      - name: Trigger Benchmarks workflow_dispatch
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'run-benchmarks.yml',
+              ref: context.payload.pull_request.head.ref
             })

--- a/.github/workflows/label-triggers.yml
+++ b/.github/workflows/label-triggers.yml
@@ -1,6 +1,6 @@
 name: Label Triggers
 on:
-  pull_request_target:
+  pull_request:
     types:
       - labeled
       - unlabeled
@@ -10,8 +10,8 @@ on:
 permissions:
   issues: write
   pull-requests: write
-  contents: write 
-  actions: write 
+  contents: write
+  actions: write
 
 jobs:
   comment_on_breaking_change:

--- a/.github/workflows/label-triggers.yml
+++ b/.github/workflows/label-triggers.yml
@@ -1,6 +1,6 @@
 name: Label Triggers
 on:
-  pull_request:
+  pull_request_target::
     types:
       - labeled
       - unlabeled

--- a/.github/workflows/label-triggers.yml
+++ b/.github/workflows/label-triggers.yml
@@ -1,6 +1,6 @@
 name: Label Triggers
 on:
-  pull_request:
+  pull_request_target:
     types:
       - labeled
       - unlabeled
@@ -11,6 +11,7 @@ permissions:
   issues: write
   pull-requests: write
   contents: write 
+  actions: write 
 
 jobs:
   comment_on_breaking_change:

--- a/.github/workflows/label-triggers.yml
+++ b/.github/workflows/label-triggers.yml
@@ -1,6 +1,6 @@
 name: Label Triggers
 on:
-  pull_request_target::
+  pull_request_target:
     types:
       - labeled
       - unlabeled

--- a/.github/workflows/label-triggers.yml
+++ b/.github/workflows/label-triggers.yml
@@ -10,8 +10,6 @@ on:
 permissions:
   issues: write
   pull-requests: write
-  contents: write
-  actions: write
 
 jobs:
   comment_on_breaking_change:
@@ -27,21 +25,4 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: '@opentensor/cerebrum / @opentensor/gyrus / @opentensor/cortex breaking change detected! Please prepare accordingly!'
-            })
-
-  re_run_validate_benchmarks:
-    name: "Re-run Validate-Benchmarks if skip-validate-benchmarks is removed"
-    runs-on: ubuntu-latest
-    if: github.event.action == 'unlabeled' && github.event.label.name == 'skip-validate-benchmarks'
-    steps:
-      - name: Trigger Benchmarks workflow_dispatch
-        uses: actions/github-script@v6
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'run-benchmarks.yml',
-              ref: context.payload.pull_request.head.ref
             })

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -27,6 +27,13 @@ jobs:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
+      - name: Install GitHub CLI
+        if: ${{ env.SKIP_BENCHMARKS != '1' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gh
+          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+
       - name: Check skip label
         if: ${{ env.SKIP_BENCHMARKS != '1' }}
         run: |

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -4,10 +4,8 @@ name: Validate-Benchmarks
 on:
   pull_request:
     types:
-      - labeled
-      - unlabeled
-      - synchronize
       - opened
+      - synchronize
   workflow_dispatch:
 
 concurrency:
@@ -25,10 +23,32 @@ jobs:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
+      - name: Install GitHub CLI
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gh
+          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+
+      - name: Check skip label
+        run: |
+          labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
+          if echo "$labels" | grep -q "skip-validate-benchmarks"; then
+            echo "Skip label found - stopping."
+            exit 0
+          fi
+
       - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
+
+      - name: Check skip label
+        run: |
+          labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
+          if echo "$labels" | grep -q "skip-validate-benchmarks"; then
+            echo "Skip label found - stopping."
+            exit 0
+          fi
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -36,14 +56,38 @@ jobs:
           profile: minimal
           toolchain: stable
 
+      - name: Check skip label
+        run: |
+          labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
+          if echo "$labels" | grep -q "skip-validate-benchmarks"; then
+            echo "Skip label found - stopping."
+            exit 0
+          fi
+
       - name: Cache Rust build
         uses: Swatinem/rust-cache@v2
         with:
           key: bench-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Check skip label
+        run: |
+          labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
+          if echo "$labels" | grep -q "skip-validate-benchmarks"; then
+            echo "Skip label found - stopping."
+            exit 0
+          fi
+
       - name: Build node with benchmarks
         run: |
           cargo build --profile production -p node-subtensor --features runtime-benchmarks
+
+      - name: Check skip label
+        run: |
+          labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
+          if echo "$labels" | grep -q "skip-validate-benchmarks"; then
+            echo "Skip label found - stopping."
+            exit 0
+          fi
 
       - name: Run & validate benchmarks
         run: |

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -28,13 +28,6 @@ jobs:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
-      - name: Install GitHub CLI
-        if: ${{ env.SKIP_BENCHMARKS != '1' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gh
-          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
-
       - name: Check skip label
         if: ${{ env.SKIP_BENCHMARKS != '1' }}
         run: |

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -50,7 +50,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
 
-      - name: Check skip label again
+      - name: Check skip label
         if: ${{ env.SKIP_BENCHMARKS != '1' }}
         run: |
           labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
@@ -66,7 +66,7 @@ jobs:
           profile: minimal
           toolchain: stable
 
-      - name: Check skip label again
+      - name: Check skip label
         if: ${{ env.SKIP_BENCHMARKS != '1' }}
         run: |
           labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
@@ -81,7 +81,7 @@ jobs:
         with:
           key: bench-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Check skip label again
+      - name: Check skip label
         if: ${{ env.SKIP_BENCHMARKS != '1' }}
         run: |
           labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
@@ -95,7 +95,7 @@ jobs:
         run: |
           cargo build --profile production -p node-subtensor --features runtime-benchmarks
 
-      - name: Check skip label again
+      - name: Check skip label
         if: ${{ env.SKIP_BENCHMARKS != '1' }}
         run: |
           labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -34,7 +34,7 @@ jobs:
           labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
           if echo "$labels" | grep -q "skip-validate-benchmarks"; then
             echo "Skip label found - stopping."
-            exit 0
+            exit 1
           fi
 
       - name: Install system dependencies
@@ -47,7 +47,7 @@ jobs:
           labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
           if echo "$labels" | grep -q "skip-validate-benchmarks"; then
             echo "Skip label found - stopping."
-            exit 0
+            exit 1
           fi
 
       - name: Install Rust toolchain
@@ -61,7 +61,7 @@ jobs:
           labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
           if echo "$labels" | grep -q "skip-validate-benchmarks"; then
             echo "Skip label found - stopping."
-            exit 0
+            exit 1
           fi
 
       - name: Cache Rust build
@@ -74,7 +74,7 @@ jobs:
           labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
           if echo "$labels" | grep -q "skip-validate-benchmarks"; then
             echo "Skip label found - stopping."
-            exit 0
+            exit 1
           fi
 
       - name: Build node with benchmarks
@@ -86,7 +86,7 @@ jobs:
           labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
           if echo "$labels" | grep -q "skip-validate-benchmarks"; then
             echo "Skip label found - stopping."
-            exit 0
+            exit 1
           fi
 
       - name: Run & validate benchmarks

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -116,4 +116,3 @@ jobs:
           labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
           if echo "$labels" | grep -q "skip-validate-benchmarks"; then
             echo "skip-validate-benchmarks label was found — but benchmarks already ran."
-            # Nothing else to skip now, but you can do something else if desired.

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -14,7 +14,6 @@ concurrency:
 
 jobs:
   validate-benchmarks:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-validate-benchmarks') }}
     runs-on: Benchmarking
 
     env:
@@ -27,13 +26,6 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
-
-      - name: Install GitHub CLI
-        if: ${{ env.SKIP_BENCHMARKS != '1' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gh
-          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
 
       - name: Check skip label
         if: ${{ env.SKIP_BENCHMARKS != '1' }}

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -116,3 +116,4 @@ jobs:
           labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
           if echo "$labels" | grep -q "skip-validate-benchmarks"; then
             echo "skip-validate-benchmarks label was found — but benchmarks already ran."
+          fi

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -16,80 +16,104 @@ jobs:
   validate-benchmarks:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-validate-benchmarks') }}
     runs-on: Benchmarking
+
+    env:
+      SKIP_BENCHMARKS: '0'
+
     steps:
-      - name: Checkout PR branch
+      - name: Check out PR branch
+        if: ${{ env.SKIP_BENCHMARKS != '1' }}
         uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - name: Install GitHub CLI
+        if: ${{ env.SKIP_BENCHMARKS != '1' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y gh
           echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
 
       - name: Check skip label
+        if: ${{ env.SKIP_BENCHMARKS != '1' }}
         run: |
           labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
           if echo "$labels" | grep -q "skip-validate-benchmarks"; then
-            echo "Skip label found - stopping."
-            exit 1
+            echo "skip-validate-benchmarks label found — skipping benchmarks."
+            echo "SKIP_BENCHMARKS=1" >> "$GITHUB_ENV"
           fi
 
       - name: Install system dependencies
+        if: ${{ env.SKIP_BENCHMARKS != '1' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
 
-      - name: Check skip label
+      - name: Check skip label again
+        if: ${{ env.SKIP_BENCHMARKS != '1' }}
         run: |
           labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
           if echo "$labels" | grep -q "skip-validate-benchmarks"; then
-            echo "Skip label found - stopping."
-            exit 1
+            echo "skip-validate-benchmarks label found — skipping benchmarks."
+            echo "SKIP_BENCHMARKS=1" >> "$GITHUB_ENV"
           fi
 
       - name: Install Rust toolchain
+        if: ${{ env.SKIP_BENCHMARKS != '1' }}
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
 
-      - name: Check skip label
+      - name: Check skip label again
+        if: ${{ env.SKIP_BENCHMARKS != '1' }}
         run: |
           labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
           if echo "$labels" | grep -q "skip-validate-benchmarks"; then
-            echo "Skip label found - stopping."
-            exit 1
+            echo "skip-validate-benchmarks label found — skipping benchmarks."
+            echo "SKIP_BENCHMARKS=1" >> "$GITHUB_ENV"
           fi
 
       - name: Cache Rust build
+        if: ${{ env.SKIP_BENCHMARKS != '1' }}
         uses: Swatinem/rust-cache@v2
         with:
           key: bench-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Check skip label
+      - name: Check skip label again
+        if: ${{ env.SKIP_BENCHMARKS != '1' }}
         run: |
           labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
           if echo "$labels" | grep -q "skip-validate-benchmarks"; then
-            echo "Skip label found - stopping."
-            exit 1
+            echo "skip-validate-benchmarks label found — skipping benchmarks."
+            echo "SKIP_BENCHMARKS=1" >> "$GITHUB_ENV"
           fi
 
       - name: Build node with benchmarks
+        if: ${{ env.SKIP_BENCHMARKS != '1' }}
         run: |
           cargo build --profile production -p node-subtensor --features runtime-benchmarks
 
-      - name: Check skip label
+      - name: Check skip label again
+        if: ${{ env.SKIP_BENCHMARKS != '1' }}
         run: |
           labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
           if echo "$labels" | grep -q "skip-validate-benchmarks"; then
-            echo "Skip label found - stopping."
-            exit 1
+            echo "skip-validate-benchmarks label found — skipping benchmarks."
+            echo "SKIP_BENCHMARKS=1" >> "$GITHUB_ENV"
           fi
 
       - name: Run & validate benchmarks
+        if: ${{ env.SKIP_BENCHMARKS != '1' }}
         run: |
           chmod +x scripts/benchmark_action.sh
           ./scripts/benchmark_action.sh
+
+      - name: Check skip label after run
+        if: ${{ env.SKIP_BENCHMARKS != '1' }}
+        run: |
+          labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
+          if echo "$labels" | grep -q "skip-validate-benchmarks"; then
+            echo "skip-validate-benchmarks label was found — but benchmarks already ran."
+            # Nothing else to skip now, but you can do something else if desired.

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -28,6 +28,13 @@ jobs:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
+      - name: Install GitHub CLI
+        if: ${{ env.SKIP_BENCHMARKS != '1' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gh
+          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+
       - name: Check skip label
         if: ${{ env.SKIP_BENCHMARKS != '1' }}
         run: |


### PR DESCRIPTION
## Description
This PR fixes a bug where the `validate-benchmarks` job will re-run on any label change. 


## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):
