### PR TITLE
remove the duplicated variant from the type info

### DIFF
--- a/pallets/commitments/src/types.rs
+++ b/pallets/commitments/src/types.rs
@@ -163,9 +163,7 @@ impl TypeInfo for Data {
     type Identity = Self;
 
     fn type_info() -> Type {
-        let variants = Variants::new()
-            .variant("None", |v| v.index(0))
-            .variant("ResetBondsFlag", |v| v.index(135));
+        let variants = Variants::new().variant("None", |v| v.index(0));
 
         // create a variant for all sizes of Raw data from 0-32
         let variants = data_raw_variants!(


### PR DESCRIPTION
## Description
Fix the PolkadotJS bug caused by the double registration of the variant in the `type_info` of the `Data` structure of the commitments pallet.


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.