### PR TITLE
Clean small values from Alpha map.

### DIFF
--- a/pallets/subtensor/src/coinbase/block_step.rs
+++ b/pallets/subtensor/src/coinbase/block_step.rs
@@ -18,7 +18,10 @@ impl<T: Config + pallet_drand::Config> Pallet<T> {
         Self::run_coinbase(block_emission);
         // --- 4. Set pending children on the epoch; but only after the coinbase has been run.
         Self::try_set_pending_children(block_number);
-        // Return ok.
+
+        // Clear small batch of Alpha map entries if they are insignificant
+        Self::clear_small_nominations_batch();
+
         Ok(())
     }
 

--- a/pallets/subtensor/src/staking/helpers.rs
+++ b/pallets/subtensor/src/staking/helpers.rs
@@ -196,6 +196,54 @@ impl<T: Config> Pallet<T> {
         }
     }
 
+    /// The function clears Alpha map in batches. Each run will check ALPHA_MAP_CLEAN_BATCH_SIZE
+    /// alphas. It keeps the alpha value stored when it's >= than MIN_ALPHA.
+    /// The function uses AlphaMapCleanLastKey as a storage for key iterator between runs.
+    pub fn clear_small_nominations_batch() {
+        // Get starting key for the batch. Get the first key if we restart the process.
+        let mut starting_raw_key = AlphaMapCleanLastKey::<T>::get();
+        let mut starting_key = None;
+        if starting_raw_key.is_none() {
+            starting_key = Alpha::<T>::iter_keys().next();
+            starting_raw_key = starting_key.as_ref().map(Alpha::<T>::hashed_key_for);
+        }
+
+        if let Some(starting_raw_key) = starting_raw_key {
+            // Get the key batch
+            let mut keys = Alpha::<T>::iter_keys_from(starting_raw_key)
+                .take(ALPHA_MAP_CLEAN_BATCH_SIZE)
+                .collect::<Vec<_>>();
+
+            // New iteration: insert the starting key in the batch if it's a new iteration
+            // iter_keys_from() skips the starting key
+            if let Some(starting_key) = starting_key {
+                if keys.len() == ALPHA_MAP_CLEAN_BATCH_SIZE {
+                    keys.remove(keys.len().saturating_sub(1));
+                }
+                keys.insert(0, starting_key);
+            }
+
+            let mut new_starting_key = None;
+            let new_iteration = keys.len() < ALPHA_MAP_CLEAN_BATCH_SIZE;
+
+            // Check and remove alphas if necessary
+            for key in keys {
+                let alpha = Alpha::<T>::get(&key);
+                if alpha < U64F64::saturating_from_num(MIN_ALPHA) {
+                    Alpha::<T>::remove(&key);
+                }
+                new_starting_key = Some(Alpha::<T>::hashed_key_for(key));
+            }
+
+            // Restart the process if it's the last batch
+            if new_iteration {
+                new_starting_key = None;
+            }
+
+            AlphaMapCleanLastKey::<T>::put(new_starting_key);
+        }
+    }
+
     pub fn add_balance_to_coldkey_account(
         coldkey: &T::AccountId,
         amount: <<T as Config>::Currency as fungible::Inspect<<T as system::Config>::AccountId>>::Balance,

--- a/pallets/subtensor/src/tests/staking.rs
+++ b/pallets/subtensor/src/tests/staking.rs
@@ -2404,6 +2404,113 @@ fn test_faucet_ok() {
     });
 }
 
+#[test]
+fn test_clear_small_nominations_batches() {
+    new_test_ext(0).execute_with(|| {
+        let cold = U256::from(3);
+        let netuid: u16 = 1;
+        let low_amount = U64F64::saturating_from_num(MIN_ALPHA.saturating_sub(1));
+        let enough_amount = U64F64::saturating_from_num(MIN_ALPHA);
+
+        // Set alpha to clear
+        for i in 0..ALPHA_MAP_CLEAN_BATCH_SIZE + 1 {
+            let hot = U256::from(i);
+            let key = (hot, cold, netuid);
+            Alpha::<Test>::insert(key, low_amount);
+        }
+
+        let keys = Alpha::<Test>::iter_keys().collect::<Vec<_>>();
+        assert_eq!(keys.len(), ALPHA_MAP_CLEAN_BATCH_SIZE + 1);
+        assert!(AlphaMapCleanLastKey::<Test>::get().is_none());
+
+        SubtensorModule::clear_small_nominations_batch();
+
+        let keys = Alpha::<Test>::iter_keys().collect::<Vec<_>>();
+        // First batch cleared
+        assert_eq!(keys.len(), 1);
+        // Pagination set
+        assert!(AlphaMapCleanLastKey::<Test>::get().is_some());
+
+        SubtensorModule::clear_small_nominations_batch();
+
+        let keys = Alpha::<Test>::iter_keys().collect::<Vec<_>>();
+        // Last batch cleared
+        assert_eq!(keys.len(), 0);
+        // Pagination removed (start over)
+        assert!(AlphaMapCleanLastKey::<Test>::get().is_none());
+
+        // Set alpha to keep
+        for i in 0..ALPHA_MAP_CLEAN_BATCH_SIZE + 1 {
+            let hot = U256::from(i);
+            let key = (hot, cold, netuid);
+            Alpha::<Test>::insert(key, enough_amount);
+        }
+
+        let keys = Alpha::<Test>::iter_keys().collect::<Vec<_>>();
+        assert_eq!(keys.len(), ALPHA_MAP_CLEAN_BATCH_SIZE + 1);
+        assert!(AlphaMapCleanLastKey::<Test>::get().is_none());
+
+        SubtensorModule::clear_small_nominations_batch();
+
+        let keys = Alpha::<Test>::iter_keys().collect::<Vec<_>>();
+        // First batch kept
+        assert_eq!(keys.len(), ALPHA_MAP_CLEAN_BATCH_SIZE + 1);
+        // Pagination set
+        assert!(AlphaMapCleanLastKey::<Test>::get().is_some());
+
+        SubtensorModule::clear_small_nominations_batch();
+
+        let keys = Alpha::<Test>::iter_keys().collect::<Vec<_>>();
+        // Last batch kept
+        assert_eq!(keys.len(), ALPHA_MAP_CLEAN_BATCH_SIZE + 1);
+        // Pagination removed (start over)
+        assert!(AlphaMapCleanLastKey::<Test>::get().is_none());
+    });
+}
+
+#[test]
+fn test_clear_small_nominations_batches_by_blocks() {
+    new_test_ext(0).execute_with(|| {
+        let cold = U256::from(3);
+        let netuid: u16 = 1;
+        let low_amount = U64F64::saturating_from_num(MIN_ALPHA.saturating_sub(1));
+        let enough_amount = U64F64::saturating_from_num(MIN_ALPHA);
+
+        // Set alpha to keep and to remove
+        let extra = 5usize;
+        for i in 1..=(ALPHA_MAP_CLEAN_BATCH_SIZE * 2) {
+            let hot1 = U256::from(i);
+            let hot2 = U256::from(i * 100);
+            let key1 = (hot1, cold, netuid);
+            let key2 = (hot2, cold, netuid);
+            Alpha::<Test>::insert(key1, low_amount);
+            Alpha::<Test>::insert(key2, enough_amount);
+        }
+
+        for i in 1..=extra {
+            let hot = U256::from(i * 100000);
+            let key = (hot, cold, netuid);
+            Alpha::<Test>::insert(key, enough_amount);
+        }
+
+        // Check preconditions
+        let keys = Alpha::<Test>::iter_keys().collect::<Vec<_>>();
+        assert_eq!(keys.len(), ALPHA_MAP_CLEAN_BATCH_SIZE * 4 + extra);
+        assert!(AlphaMapCleanLastKey::<Test>::get().is_none());
+
+        run_to_block(4);
+        assert!(AlphaMapCleanLastKey::<Test>::get().is_some());
+        run_to_block(5);
+
+        let keys = Alpha::<Test>::iter_keys().collect::<Vec<_>>();
+        assert_eq!(keys.len(), 2 * ALPHA_MAP_CLEAN_BATCH_SIZE + extra);
+        assert!(AlphaMapCleanLastKey::<Test>::get().is_none());
+
+        run_to_block(6);
+        assert!(AlphaMapCleanLastKey::<Test>::get().is_some());
+    });
+}
+
 /// This test ensures that the clear_small_nominations function works as expected.
 /// It creates a network with two hotkeys and two coldkeys, and then registers a nominator account for each hotkey.
 /// When we call set_nominator_min_required_stake, it should clear all small nominations that are below the minimum required stake.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -209,7 +209,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 268,
+    spec_version: 269,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
This PR adds a process that iterates through small number (10) of Alpha map entries each block and cleans values less than 10 RAO.

## Related Issue(s)

- Closes https://github.com/opentensor/subtensor/issues/1567

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

This PR clears alpha stake values. We need to be sure that we chose the constants correctly.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules