### PR TITLE
Add `BigRaw` Commitments Variant

### DIFF
--- a/pallets/commitments/src/lib.rs
+++ b/pallets/commitments/src/lib.rs
@@ -47,7 +47,7 @@ pub mod pallet {
         /// Because this pallet emits events, it depends on the runtime's definition of an event.
         type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
-        /// Currency type that will be used to place deposits on neurons
+        ///Currency type that will be used to reserve deposits for commitments
         type Currency: ReservableCurrency<Self::AccountId> + Send + Sync;
 
         /// Weight information for extrinsics in this pallet.
@@ -71,11 +71,11 @@ pub mod pallet {
         #[pallet::constant]
         type FieldDeposit: Get<BalanceOf<Self>>;
 
-        /// Used to retreive the given subnet's tempo
+        /// Used to retrieve the given subnet's tempo
         type TempoInterface: GetTempoInterface;
     }
 
-    /// Used to retreive the given subnet's tempo
+    /// Used to retrieve the given subnet's tempo
     pub trait GetTempoInterface {
         /// Used to retreive the epoch index for the given subnet.
         fn get_epoch_index(netuid: u16, cur_block: u64) -> u64;
@@ -113,7 +113,7 @@ pub mod pallet {
     pub enum Error<T> {
         /// Account passed too many additional fields to their commitment
         TooManyFieldsInCommitmentInfo,
-        /// Account is not allow to make commitments to the chain
+        /// Account is not allowed to make commitments to the chain
         AccountNotAllowedCommit,
         /// Space Limit Exceeded for the current interval
         SpaceLimitExceeded,

--- a/pallets/commitments/src/tests.rs
+++ b/pallets/commitments/src/tests.rs
@@ -35,6 +35,7 @@ fn manual_data_type_info() {
             Data::Raw(bytes) => format!("Raw{}", bytes.len()),
             Data::TimelockEncrypted { .. } => "TimelockEncrypted".to_string(),
             Data::ResetBondsFlag => "ResetBondsFlag".to_string(),
+            Data::BigRaw(_) => "BigRaw".to_string(),
         };
         if let scale_info::TypeDef::Variant(variant) = &type_info.type_def {
             let variant = variant
@@ -50,7 +51,8 @@ fn manual_data_type_info() {
             if !variant.fields.is_empty() {
                 let expected_len = match data {
                     Data::None => 0,
-                    Data::Raw(bytes) => bytes.len() as u32,
+                    Data::Raw(bytes)
+                    | Data::BigRaw(bytes) => bytes.len() as u32,
                     Data::BlakeTwo256(_)
                     | Data::Sha256(_)
                     | Data::Keccak256(_)

--- a/pallets/commitments/src/tests.rs
+++ b/pallets/commitments/src/tests.rs
@@ -51,8 +51,7 @@ fn manual_data_type_info() {
             if !variant.fields.is_empty() {
                 let expected_len = match data {
                     Data::None => 0,
-                    Data::Raw(bytes)
-                    | Data::BigRaw(bytes) => bytes.len() as u32,
+                    Data::Raw(bytes) | Data::BigRaw(bytes) => bytes.len() as u32,
                     Data::BlakeTwo256(_)
                     | Data::Sha256(_)
                     | Data::Keccak256(_)

--- a/pallets/commitments/src/tests.rs
+++ b/pallets/commitments/src/tests.rs
@@ -51,7 +51,8 @@ fn manual_data_type_info() {
             if !variant.fields.is_empty() {
                 let expected_len = match data {
                     Data::None => 0,
-                    Data::Raw(bytes) | Data::BigRaw(bytes) => bytes.len() as u32,
+                    Data::Raw(bytes) => bytes.len() as u32,
+                    Data::BigRaw(bytes) => bytes.len() as u32,
                     Data::BlakeTwo256(_)
                     | Data::Sha256(_)
                     | Data::Keccak256(_)

--- a/pallets/commitments/src/types.rs
+++ b/pallets/commitments/src/types.rs
@@ -40,7 +40,7 @@ pub enum Data {
     /// No data here.
     None,
     /// The data is stored directly.
-    Raw(BoundedVec<u8, ConstU32<512>>),
+    Raw(BoundedVec<u8, ConstU32<128>>),
     /// Only the Blake2 hash of the data is stored. The preimage of the hash may be retrieved
     /// through some hash-lookup service.
     BlakeTwo256([u8; 32]),
@@ -60,6 +60,9 @@ pub enum Data {
     },
     /// Flag to trigger bonds reset for subnet
     ResetBondsFlag,
+
+    /// A "larger" raw blob, up to 512 bytes, encoded via standard SCALE in this arm.
+    BigRaw(BoundedVec<u8, ConstU32<MAX_BIGRAW_COMMITMENT_SIZE_BYTES>>),
 }
 
 impl Data {
@@ -82,6 +85,7 @@ impl Data {
             | Data::ShaThree256(arr) => arr.len() as u64,
             Data::TimelockEncrypted { encrypted, .. } => encrypted.len() as u64,
             Data::ResetBondsFlag => 0,
+            Data::BigRaw(bytes) => bytes.len() as u64,
         }
     }
 }
@@ -112,6 +116,10 @@ impl Decode for Data {
                 }
             }
             135 => Data::ResetBondsFlag,
+            136 => {
+                let bigvec = BoundedVec::<u8, ConstU32<MAX_BIGRAW_COMMITMENT_SIZE_BYTES>>::decode(input)?;
+                Data::BigRaw(bigvec)
+            }
             _ => return Err(codec::Error::from("invalid leading byte")),
         })
     }
@@ -141,6 +149,11 @@ impl Encode for Data {
                 r
             }
             Data::ResetBondsFlag => vec![135],
+            Data::BigRaw(bigvec) => {
+                let mut r = vec![136];
+                r.extend_from_slice(&bigvec.encode());
+                r
+            }
         }
     }
 }
@@ -327,7 +340,11 @@ impl TypeInfo for Data {
                         .field(|f| f.name("reveal_round").ty::<u64>()),
                 )
             })
-            .variant("ResetBondsFlag", |v| v.index(135));
+            .variant("ResetBondsFlag", |v| v.index(135))
+            .variant("BigRaw", |v| {
+                v.index(136)
+                 .fields(Fields::unnamed().field(|f| f.ty::<BoundedVec<u8, ConstU32<MAX_BIGRAW_COMMITMENT_SIZE_BYTES>>>()))
+            });
 
         Type::builder()
             .path(Path::new("Data", module_path!()))
@@ -354,6 +371,7 @@ pub struct CommitmentInfo<FieldLimit: Get<u32>> {
 
 /// Maximum size of the serialized timelock commitment in bytes
 pub const MAX_TIMELOCK_COMMITMENT_SIZE_BYTES: u32 = 1024;
+pub const MAX_BIGRAW_COMMITMENT_SIZE_BYTES: u32 = 512;
 
 /// Contains the decrypted data of a revealed commitment.
 #[freeze_struct("bf575857b57f9bef")]

--- a/pallets/commitments/src/types.rs
+++ b/pallets/commitments/src/types.rs
@@ -37,7 +37,7 @@ use subtensor_macros::freeze_struct;
 /// - A cryptographic hash (BlakeTwo256, Sha256, Keccak256, ShaThree256)
 /// - A timelock-encrypted blob with a reveal round
 /// - A reset flag (`ResetBondsFlag`)
-/// Can also be `None`.
+///   Can also be `None`.
 #[derive(Clone, Eq, PartialEq, RuntimeDebug, MaxEncodedLen)]
 pub enum Data {
     /// No data here.

--- a/pallets/commitments/src/types.rs
+++ b/pallets/commitments/src/types.rs
@@ -31,15 +31,18 @@ use sp_runtime::{
 use sp_std::{fmt::Debug, iter::once, prelude::*};
 use subtensor_macros::freeze_struct;
 
-/// Either underlying data blob if it is at most 32 bytes, or a hash of it. If the data is greater
-/// than 32-bytes then it will be truncated when encoding.
-///
+/// Represents stored data which can be:
+/// - `Raw`: a direct blob up to 128 bytes
+/// - `BigRaw`: a larger blob up to 512 bytes
+/// - A cryptographic hash (BlakeTwo256, Sha256, Keccak256, ShaThree256)
+/// - A timelock-encrypted blob with a reveal round
+/// - A reset flag (`ResetBondsFlag`)
 /// Can also be `None`.
 #[derive(Clone, Eq, PartialEq, RuntimeDebug, MaxEncodedLen)]
 pub enum Data {
     /// No data here.
     None,
-    /// The data is stored directly.
+    /// The data is stored directly (up to 128 bytes).
     Raw(BoundedVec<u8, ConstU32<128>>),
     /// Only the Blake2 hash of the data is stored. The preimage of the hash may be retrieved
     /// through some hash-lookup service.
@@ -60,8 +63,7 @@ pub enum Data {
     },
     /// Flag to trigger bonds reset for subnet
     ResetBondsFlag,
-
-    /// A "larger" raw blob, up to 512 bytes, encoded via standard SCALE in this arm.
+    /// The data is stored directly (up to 512 bytes).
     BigRaw(BoundedVec<u8, ConstU32<MAX_BIGRAW_COMMITMENT_SIZE_BYTES>>),
 }
 

--- a/pallets/commitments/src/types.rs
+++ b/pallets/commitments/src/types.rs
@@ -117,7 +117,8 @@ impl Decode for Data {
             }
             135 => Data::ResetBondsFlag,
             136 => {
-                let bigvec = BoundedVec::<u8, ConstU32<MAX_BIGRAW_COMMITMENT_SIZE_BYTES>>::decode(input)?;
+                let bigvec =
+                    BoundedVec::<u8, ConstU32<MAX_BIGRAW_COMMITMENT_SIZE_BYTES>>::decode(input)?;
                 Data::BigRaw(bigvec)
             }
             _ => return Err(codec::Error::from("invalid leading byte")),
@@ -342,8 +343,9 @@ impl TypeInfo for Data {
             })
             .variant("ResetBondsFlag", |v| v.index(135))
             .variant("BigRaw", |v| {
-                v.index(136)
-                 .fields(Fields::unnamed().field(|f| f.ty::<BoundedVec<u8, ConstU32<MAX_BIGRAW_COMMITMENT_SIZE_BYTES>>>()))
+                v.index(136).fields(Fields::unnamed().field(|f| {
+                    f.ty::<BoundedVec<u8, ConstU32<MAX_BIGRAW_COMMITMENT_SIZE_BYTES>>>()
+                }))
             });
 
         Type::builder()


### PR DESCRIPTION
## Description
This PR adds a new commitments type `BigRaw` which stored a maximum of 512 bytes. 