### PR TITLE
[Fix] [testnet] allow burn reg with SN token enabled == false

### DIFF
--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -925,7 +925,7 @@ mod dispatches {
         /// User register a new subnetwork via burning token
         #[pallet::call_index(7)]
         #[pallet::weight((Weight::from_parts(219_400_000, 0)
-		.saturating_add(T::DbWeight::get().reads(34))
+		.saturating_add(T::DbWeight::get().reads(33))
 		.saturating_add(T::DbWeight::get().writes(29)), DispatchClass::Normal, Pays::No))]
         pub fn burned_register(
             origin: OriginFor<T>,

--- a/pallets/subtensor/src/subnets/registration.rs
+++ b/pallets/subtensor/src/subnets/registration.rs
@@ -86,8 +86,6 @@ impl<T: Config> Pallet<T> {
             Error::<T>::SubNetworkDoesNotExist
         );
 
-        Self::ensure_subtoken_enabled(netuid)?;
-
         // --- 3. Ensure the passed network allows registrations.
         ensure!(
             Self::get_network_registration_allowed(netuid),

--- a/pallets/subtensor/src/tests/subnet.rs
+++ b/pallets/subtensor/src/tests/subnet.rs
@@ -253,6 +253,13 @@ fn test_subtoken_enable_reject_trading_before_enable() {
 
         add_network_disable_subtoken(netuid, 10, 0);
         add_network_disable_subtoken(netuid2, 10, 0);
+
+        // Register so staking *could* work
+        register_ok_neuron(netuid, hotkey_account_id, coldkey_account_id, 0);
+        register_ok_neuron(netuid2, hotkey_account_id, coldkey_account_id, 100);
+        register_ok_neuron(netuid, hotkey_account_2_id, coldkey_account_id, 0);
+        register_ok_neuron(netuid2, hotkey_account_2_id, coldkey_account_id, 100);
+
         SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, 10_000);
 
         // all trading extrinsic should be rejected.
@@ -349,6 +356,12 @@ fn test_subtoken_enable_trading_ok_with_enable() {
 
         add_network(netuid, 10, 0);
         add_network(netuid2, 10, 0);
+        // Register so staking works
+        register_ok_neuron(netuid, hotkey_account_id, coldkey_account_id, 0);
+        register_ok_neuron(netuid2, hotkey_account_id, coldkey_account_id, 100);
+        register_ok_neuron(netuid, hotkey_account_2_id, coldkey_account_id, 0);
+        register_ok_neuron(netuid2, hotkey_account_2_id, coldkey_account_id, 100);
+
         SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, stake_amount * 10);
 
         // all trading extrinsic should be possible now that subtoken is enabled.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -209,7 +209,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 270,
+    spec_version: 271,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
We should be allowing burned registrations while the `subtoken_enabled` toggle if `false`.
This PR removes the check for this in the burn register extrinsic, fixes the tests, and adds a new test to ensure this behaviour.

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.