### PR TITLE
Clear epoch values for root subnets.

### DIFF
--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -115,7 +115,9 @@ mod hooks {
                 // Reset max burn
                 .saturating_add(migrations::migrate_reset_max_burn::migrate_reset_max_burn::<T>())
                 // Migrate ColdkeySwapScheduled structure to new format
-                .saturating_add(migrations::migrate_coldkey_swap_scheduled::migrate_coldkey_swap_scheduled::<T>());
+                .saturating_add(migrations::migrate_coldkey_swap_scheduled::migrate_coldkey_swap_scheduled::<T>())
+                // Clear epoch storage values for root netuid
+                .saturating_add(migrations::migrate_clear_root_epoch_values::migrate_clear_root_epoch_values::<T>());
             weight
         }
 

--- a/pallets/subtensor/src/migrations/migrate_clear_root_epoch_values.rs
+++ b/pallets/subtensor/src/migrations/migrate_clear_root_epoch_values.rs
@@ -4,17 +4,11 @@ use alloc::string::String;
 use frame_support::{traits::Get, weights::Weight};
 
 // List of cleared maps for root netuid:
-// - SubnetworkN
-// - Tempo
 // - ActivityCutoff
 // - Bonds
-// - Keys
-// - MaxAllowedValidators
-// - SubnetOwnerHotkey
 // - Kappa
 // - BondsPenalty
 // - Yuma3On
-// - BlockAtRegistration
 // - Rank
 // - Trust
 // - Active
@@ -47,42 +41,30 @@ pub fn migrate_clear_root_epoch_values<T: Config>() -> Weight {
     // Clear root epoch values
     let root_netuid = Subtensor::<T>::get_root_netuid();
 
-    crate::SubnetworkN::<T>::remove(root_netuid);
-    crate::Tempo::<T>::remove(root_netuid);
     crate::ActivityCutoff::<T>::remove(root_netuid);
-    crate::MaxAllowedValidators::<T>::remove(root_netuid);
-    crate::SubnetOwnerHotkey::<T>::remove(root_netuid);
-
     crate::Kappa::<T>::remove(root_netuid);
     crate::BondsPenalty::<T>::remove(root_netuid);
     crate::Yuma3On::<T>::remove(root_netuid);
     crate::Rank::<T>::remove(root_netuid);
     crate::Trust::<T>::remove(root_netuid);
-
     crate::Active::<T>::remove(root_netuid);
     crate::Emission::<T>::remove(root_netuid);
     crate::Consensus::<T>::remove(root_netuid);
     crate::Incentive::<T>::remove(root_netuid);
     crate::Dividends::<T>::remove(root_netuid);
-
     crate::LastUpdate::<T>::remove(root_netuid);
     crate::PruningScores::<T>::remove(root_netuid);
     crate::ValidatorTrust::<T>::remove(root_netuid);
     crate::ValidatorPermit::<T>::remove(root_netuid);
     crate::StakeWeight::<T>::remove(root_netuid);
 
-    let total_simple_removals = 20u64;
+    let total_simple_removals = 16u64;
 
     let mut total_db_operations = total_simple_removals;
 
     let bonds_removal_res = crate::Bonds::<T>::clear_prefix(root_netuid, u32::MAX, None);
-    let keys_removal_res = crate::Keys::<T>::clear_prefix(root_netuid, u32::MAX, None);
-    let regblocks_removal_res =
-        crate::BlockAtRegistration::<T>::clear_prefix(root_netuid, u32::MAX, None);
 
     total_db_operations = total_db_operations.saturating_add(bonds_removal_res.backend.into());
-    total_db_operations = total_db_operations.saturating_add(keys_removal_res.backend.into());
-    total_db_operations = total_db_operations.saturating_add(regblocks_removal_res.backend.into());
     weight = weight.saturating_add(T::DbWeight::get().writes(total_db_operations));
 
     // Mark Migration as Completed

--- a/pallets/subtensor/src/migrations/migrate_clear_root_epoch_values.rs
+++ b/pallets/subtensor/src/migrations/migrate_clear_root_epoch_values.rs
@@ -1,0 +1,98 @@
+use crate::Pallet as Subtensor;
+use crate::{Config, HasMigrationRun};
+use alloc::string::String;
+use frame_support::{traits::Get, weights::Weight};
+
+// List of cleared maps for root netuid:
+// - SubnetworkN
+// - Tempo
+// - ActivityCutoff
+// - Bonds
+// - Keys
+// - MaxAllowedValidators
+// - SubnetOwnerHotkey
+// - Kappa
+// - BondsPenalty
+// - Yuma3On
+// - BlockAtRegistration
+// - Rank
+// - Trust
+// - Active
+// - Emission
+// - Consensus
+// - Incentive
+// - Dividends
+// - LastUpdate
+// - PruningScores
+// - ValidatorTrust
+// - ValidatorPermit
+// - StakeWeight
+pub fn migrate_clear_root_epoch_values<T: Config>() -> Weight {
+    let migration_name = b"migrate_clear_root_epoch_values".to_vec();
+    let mut weight = T::DbWeight::get().reads(1);
+
+    if HasMigrationRun::<T>::get(&migration_name) {
+        log::info!(
+            "Migration '{:?}' has already run. Skipping.",
+            migration_name
+        );
+        return weight;
+    }
+
+    log::info!(
+        "Running migration '{}'",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    // Clear root epoch values
+    let root_netuid = Subtensor::<T>::get_root_netuid();
+
+    crate::SubnetworkN::<T>::remove(root_netuid);
+    crate::Tempo::<T>::remove(root_netuid);
+    crate::ActivityCutoff::<T>::remove(root_netuid);
+    crate::MaxAllowedValidators::<T>::remove(root_netuid);
+    crate::SubnetOwnerHotkey::<T>::remove(root_netuid);
+
+    crate::Kappa::<T>::remove(root_netuid);
+    crate::BondsPenalty::<T>::remove(root_netuid);
+    crate::Yuma3On::<T>::remove(root_netuid);
+    crate::Rank::<T>::remove(root_netuid);
+    crate::Trust::<T>::remove(root_netuid);
+
+    crate::Active::<T>::remove(root_netuid);
+    crate::Emission::<T>::remove(root_netuid);
+    crate::Consensus::<T>::remove(root_netuid);
+    crate::Incentive::<T>::remove(root_netuid);
+    crate::Dividends::<T>::remove(root_netuid);
+
+    crate::LastUpdate::<T>::remove(root_netuid);
+    crate::PruningScores::<T>::remove(root_netuid);
+    crate::ValidatorTrust::<T>::remove(root_netuid);
+    crate::ValidatorPermit::<T>::remove(root_netuid);
+    crate::StakeWeight::<T>::remove(root_netuid);
+
+    let total_simple_removals = 20u64;
+
+    let mut total_db_operations = total_simple_removals;
+
+    let bonds_removal_res = crate::Bonds::<T>::clear_prefix(root_netuid, u32::MAX, None);
+    let keys_removal_res = crate::Keys::<T>::clear_prefix(root_netuid, u32::MAX, None);
+    let regblocks_removal_res =
+        crate::BlockAtRegistration::<T>::clear_prefix(root_netuid, u32::MAX, None);
+
+    total_db_operations = total_db_operations.saturating_add(bonds_removal_res.backend.into());
+    total_db_operations = total_db_operations.saturating_add(keys_removal_res.backend.into());
+    total_db_operations = total_db_operations.saturating_add(regblocks_removal_res.backend.into());
+    weight = weight.saturating_add(T::DbWeight::get().writes(total_db_operations));
+
+    // Mark Migration as Completed
+    HasMigrationRun::<T>::insert(&migration_name, true);
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+    log::info!(
+        "Migration '{:?}' completed successfully.",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    weight
+}

--- a/pallets/subtensor/src/migrations/mod.rs
+++ b/pallets/subtensor/src/migrations/mod.rs
@@ -4,6 +4,7 @@ use sp_io::KillStorageResult;
 use sp_io::hashing::twox_128;
 use sp_io::storage::clear_prefix;
 pub mod migrate_chain_identity;
+pub mod migrate_clear_root_epoch_values;
 pub mod migrate_coldkey_swap_scheduled;
 pub mod migrate_commit_reveal_v2;
 pub mod migrate_create_root_network;

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -864,33 +864,23 @@ fn test_migrate_clear_root_epoch_values() {
             "Migration should not have run yet"
         );
 
-        assert!(SubnetworkN::<Test>::contains_key(root_netuid));
-        assert!(Tempo::<Test>::contains_key(root_netuid));
         assert!(ActivityCutoff::<Test>::contains_key(root_netuid));
-        assert!(MaxAllowedValidators::<Test>::contains_key(root_netuid));
-        assert!(SubnetOwnerHotkey::<Test>::contains_key(root_netuid));
-
         assert!(Kappa::<Test>::contains_key(root_netuid));
         assert!(BondsPenalty::<Test>::contains_key(root_netuid));
         assert!(Yuma3On::<Test>::contains_key(root_netuid));
         assert!(Rank::<Test>::contains_key(root_netuid));
         assert!(Trust::<Test>::contains_key(root_netuid));
-
         assert!(Active::<Test>::contains_key(root_netuid));
         assert!(Emission::<Test>::contains_key(root_netuid));
         assert!(Consensus::<Test>::contains_key(root_netuid));
         assert!(Incentive::<Test>::contains_key(root_netuid));
         assert!(Dividends::<Test>::contains_key(root_netuid));
-
         assert!(LastUpdate::<Test>::contains_key(root_netuid));
         assert!(PruningScores::<Test>::contains_key(root_netuid));
         assert!(ValidatorTrust::<Test>::contains_key(root_netuid));
         assert!(ValidatorPermit::<Test>::contains_key(root_netuid));
         assert!(StakeWeight::<Test>::contains_key(root_netuid));
-
         assert!(Bonds::<Test>::contains_prefix(root_netuid));
-        assert!(Keys::<Test>::contains_prefix(root_netuid));
-        assert!(BlockAtRegistration::<Test>::contains_prefix(root_netuid));
 
         // ------------------------------
         // Step 2: Run the Migration
@@ -908,33 +898,23 @@ fn test_migrate_clear_root_epoch_values() {
         // ------------------------------
         // Step 3: Verify Migration Effects
         // ------------------------------
-        assert!(!SubnetworkN::<Test>::contains_key(root_netuid));
-        assert!(!Tempo::<Test>::contains_key(root_netuid));
         assert!(!ActivityCutoff::<Test>::contains_key(root_netuid));
-        assert!(!MaxAllowedValidators::<Test>::contains_key(root_netuid));
-        assert!(!SubnetOwnerHotkey::<Test>::contains_key(root_netuid));
-
         assert!(!Kappa::<Test>::contains_key(root_netuid));
         assert!(!BondsPenalty::<Test>::contains_key(root_netuid));
         assert!(!Yuma3On::<Test>::contains_key(root_netuid));
         assert!(!Rank::<Test>::contains_key(root_netuid));
         assert!(!Trust::<Test>::contains_key(root_netuid));
-
         assert!(!Active::<Test>::contains_key(root_netuid));
         assert!(!Emission::<Test>::contains_key(root_netuid));
         assert!(!Consensus::<Test>::contains_key(root_netuid));
         assert!(!Incentive::<Test>::contains_key(root_netuid));
         assert!(!Dividends::<Test>::contains_key(root_netuid));
-
         assert!(!LastUpdate::<Test>::contains_key(root_netuid));
         assert!(!PruningScores::<Test>::contains_key(root_netuid));
         assert!(!ValidatorTrust::<Test>::contains_key(root_netuid));
         assert!(!ValidatorPermit::<Test>::contains_key(root_netuid));
         assert!(!StakeWeight::<Test>::contains_key(root_netuid));
-
         assert!(!Bonds::<Test>::contains_prefix(root_netuid));
-        assert!(!Keys::<Test>::contains_prefix(root_netuid));
-        assert!(!BlockAtRegistration::<Test>::contains_prefix(root_netuid));
 
         assert!(!weight.is_zero(), "Migration weight should be non-zero");
     });

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -209,7 +209,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 270,
+    spec_version: 272,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
This PR removes values for root subnets from the following storage item list:

- SubnetworkN
- Tempo
- ActivityCutoff
- Bonds
- Keys
- MaxAllowedValidators
- SubnetOwnerHotkey
- Kappa
- BondsPenalty
- Yuma3On
- BlockAtRegistration
- Rank
- Trust
- Active
- Emission
- Consensus
- Incentive
- Dividends
- LastUpdate
- PruningScores
- ValidatorTrust
- ValidatorPermit
- StakeWeight


## Related Issue(s)

- Closes https://github.com/opentensor/subtensor/issues/939

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules