### PR TITLE
Add stake locks

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -825,6 +825,12 @@ pub mod pallet {
         50400
     }
 
+    #[pallet::type_value]
+    /// Default value for block number
+    pub fn DefaultBlockNumber<T: Config>() -> BlockNumberFor<T> {
+        0u32.into()
+    }
+
     #[pallet::storage]
     pub type MinActivityCutoff<T: Config> =
         StorageValue<_, u16, ValueQuery, DefaultMinActivityCutoff<T>>;
@@ -1101,6 +1107,20 @@ pub mod pallet {
     #[pallet::storage] // --- MAP ( netuid ) --> token_symbol | Returns the token symbol for a subnet.
     pub type TokenSymbol<T: Config> =
         StorageMap<_, Identity, u16, Vec<u8>, ValueQuery, DefaultUnicodeVecU8<T>>;
+
+    #[pallet::storage]
+    /// DMAP ( hot, netuid ) --> lock until block number | Returns the block number of the stake lock
+    pub type StakeLocks<T: Config> = StorageNMap<
+        _,
+        (
+            NMapKey<Blake2_128Concat, T::AccountId>, // hot
+            NMapKey<Blake2_128Concat, T::AccountId>, // cold
+            NMapKey<Identity, u16>,                  // subnet
+        ),
+        BlockNumberFor<T>,
+        ValueQuery,
+        DefaultBlockNumber<T>,
+    >;
 
     /// ============================
     /// ==== Global Parameters =====

--- a/pallets/subtensor/src/macros/errors.rs
+++ b/pallets/subtensor/src/macros/errors.rs
@@ -218,5 +218,7 @@ mod errors {
         ZeroMaxStakeAmount,
         /// Invalid netuid duplication
         SameNetuid,
+        /// Stake is locked
+        StakeLocked,
     }
 }

--- a/pallets/subtensor/src/staking/add_stake.rs
+++ b/pallets/subtensor/src/staking/add_stake.rs
@@ -76,6 +76,7 @@ impl<T: Config> Pallet<T> {
             netuid,
             tao_staked.saturating_to_num::<u64>(),
             T::SwapInterface::max_price(),
+            true,
         )?;
 
         // Ok and return.
@@ -167,7 +168,7 @@ impl<T: Config> Pallet<T> {
 
         // 6. Swap the stake into alpha on the subnet and increase counters.
         // Emit the staking event.
-        Self::stake_into_subnet(&hotkey, &coldkey, netuid, tao_staked, limit_price)?;
+        Self::stake_into_subnet(&hotkey, &coldkey, netuid, tao_staked, limit_price, true)?;
 
         // Ok and return.
         Ok(())

--- a/pallets/subtensor/src/staking/move_stake.rs
+++ b/pallets/subtensor/src/staking/move_stake.rs
@@ -49,6 +49,7 @@ impl<T: Config> Pallet<T> {
             None,
             None,
             false,
+            true,
         )?;
 
         // Log the event.
@@ -119,6 +120,9 @@ impl<T: Config> Pallet<T> {
         // Ensure the extrinsic is signed by the origin_coldkey.
         let coldkey = ensure_signed(origin)?;
 
+        // Prevent DoS attacks
+        let set_lock = coldkey == destination_coldkey;
+
         // Validate input and move stake
         let tao_moved = Self::transition_stake_internal(
             &coldkey,
@@ -131,6 +135,7 @@ impl<T: Config> Pallet<T> {
             None,
             None,
             true,
+            set_lock,
         )?;
 
         // 9. Emit an event for logging/monitoring.
@@ -201,6 +206,7 @@ impl<T: Config> Pallet<T> {
             None,
             None,
             false,
+            true,
         )?;
 
         // Emit an event for logging.
@@ -273,6 +279,7 @@ impl<T: Config> Pallet<T> {
             Some(limit_price),
             Some(allow_partial),
             false,
+            true,
         )?;
 
         // Emit an event for logging.
@@ -309,6 +316,7 @@ impl<T: Config> Pallet<T> {
         maybe_limit_price: Option<u64>,
         maybe_allow_partial: Option<bool>,
         check_transfer_toggle: bool,
+        set_lock: bool,
     ) -> Result<u64, DispatchError> {
         // Calculate the maximum amount that can be executed
         let max_amount = if let Some(limit_price) = maybe_limit_price {
@@ -361,6 +369,7 @@ impl<T: Config> Pallet<T> {
                 destination_netuid,
                 tao_unstaked,
                 T::SwapInterface::max_price(),
+                set_lock,
             )?;
         }
 

--- a/pallets/subtensor/src/staking/remove_stake.rs
+++ b/pallets/subtensor/src/staking/remove_stake.rs
@@ -274,6 +274,7 @@ impl<T: Config> Pallet<T> {
             Self::get_root_netuid(),
             total_tao_unstaked,
             T::SwapInterface::max_price(),
+            false,
         )?;
 
         // 5. Done and ok.

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -1053,6 +1053,8 @@ impl<T: Config> Pallet<T> {
             ensure!(origin_netuid != destination_netuid, Error::<T>::SameNetuid);
         }
 
+        Self::ensure_stake_is_unlocked(origin_hotkey, origin_coldkey, origin_netuid)?;
+
         // Ensure that both subnets exist.
         ensure!(
             Self::if_subnet_exist(origin_netuid),

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -876,6 +876,8 @@ impl<T: Config> Pallet<T> {
 
         ensure!(current_block_number > stake_lock, Error::<T>::StakeLocked);
 
+        StakeLocks::<T>::remove((hotkey, coldkey, netuid));
+
         Ok(())
     }
 

--- a/pallets/subtensor/src/tests/children.rs
+++ b/pallets/subtensor/src/tests/children.rs
@@ -2245,6 +2245,8 @@ fn test_do_remove_stake_clears_pending_childkeys() {
         assert!(!pending_before.0.is_empty());
         assert!(pending_before.1 > 0);
 
+        remove_stake_lock_for_tests(&hotkey, &coldkey, netuid);
+
         // Remove stake
         assert_ok!(SubtensorModule::do_remove_stake(
             RuntimeOrigin::signed(coldkey),

--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -890,8 +890,13 @@ pub fn increase_stake_on_coldkey_hotkey_account(
         netuid,
         tao_staked,
         <Test as Config>::SwapInterface::max_price(),
+        false,
     )
     .unwrap();
+}
+
+pub(crate) fn remove_stake_lock_for_tests(hotkey: &U256, coldkey: &U256, netuid: u16) {
+    StakeLocks::<Test>::remove((hotkey, coldkey, netuid));
 }
 
 /// Increases the stake on the hotkey account under its owning coldkey.

--- a/pallets/subtensor/src/tests/move_stake.rs
+++ b/pallets/subtensor/src/tests/move_stake.rs
@@ -33,6 +33,7 @@ fn test_do_move_success() {
             netuid.into(),
             stake_amount,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
         let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
@@ -101,6 +102,7 @@ fn test_do_move_different_subnets() {
             origin_netuid,
             stake_amount,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
         let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
@@ -167,6 +169,7 @@ fn test_do_move_nonexistent_subnet() {
             origin_netuid,
             stake_amount,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
         let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
@@ -269,6 +272,7 @@ fn test_do_move_nonexistent_destination_hotkey() {
             netuid,
             stake_amount,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
 
@@ -330,6 +334,7 @@ fn test_do_move_all_stake() {
             netuid,
             stake_amount,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
         let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
@@ -391,6 +396,7 @@ fn test_do_move_half_stake() {
             netuid,
             stake_amount,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
         let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
@@ -455,6 +461,7 @@ fn test_do_move_partial_stake() {
             netuid,
             total_stake,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
         let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
@@ -521,12 +528,14 @@ fn test_do_move_multiple_times() {
             netuid,
             initial_stake,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
 
         // Move stake multiple times
         let mut expected_alpha: u64 = 0;
         for _ in 0..3 {
+            remove_stake_lock_for_tests(&hotkey1, &coldkey, netuid);
             let alpha1 = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
                 &hotkey1, &coldkey, netuid,
             );
@@ -538,6 +547,8 @@ fn test_do_move_multiple_times() {
                 netuid,
                 alpha1,
             ));
+            remove_stake_lock_for_tests(&hotkey2, &coldkey, netuid);
+
             let alpha2 = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
                 &hotkey2, &coldkey, netuid,
             );
@@ -590,6 +601,7 @@ fn test_do_move_wrong_origin() {
             netuid,
             stake_amount,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
         let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
@@ -655,6 +667,7 @@ fn test_do_move_same_hotkey_fails() {
             netuid,
             stake_amount,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
         let alpha =
@@ -704,6 +717,7 @@ fn test_do_move_event_emission() {
             netuid,
             stake_amount,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
         let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
@@ -761,6 +775,7 @@ fn test_do_move_storage_updates() {
             origin_netuid,
             stake_amount,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
 
@@ -834,6 +849,7 @@ fn test_do_move_max_values() {
             netuid,
             max_stake,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
         let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
@@ -900,6 +916,8 @@ fn test_moving_too_little_unstakes() {
             amount + fee
         ));
 
+        remove_stake_lock_for_tests(&hotkey_account_id, &coldkey_account_id, netuid);
+
         assert_err!(
             SubtensorModule::move_stake(
                 RuntimeOrigin::signed(coldkey_account_id),
@@ -937,6 +955,7 @@ fn test_do_transfer_success() {
             netuid,
             stake_amount,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
         let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
@@ -1045,6 +1064,7 @@ fn test_do_transfer_insufficient_stake() {
             netuid,
             stake_amount,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
 
@@ -1085,6 +1105,7 @@ fn test_do_transfer_wrong_origin() {
             netuid,
             stake_amount,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
 
@@ -1121,6 +1142,7 @@ fn test_do_transfer_minimum_stake_check() {
             netuid,
             stake_amount,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
 
@@ -1167,6 +1189,7 @@ fn test_do_transfer_different_subnets() {
             origin_netuid,
             stake_amount,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
 
@@ -1231,6 +1254,7 @@ fn test_do_swap_success() {
             origin_netuid,
             stake_amount,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
         let alpha_before = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
@@ -1337,6 +1361,7 @@ fn test_do_swap_insufficient_stake() {
             netuid1,
             stake_amount,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
 
@@ -1373,6 +1398,7 @@ fn test_do_swap_wrong_origin() {
             netuid1,
             stake_amount,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
 
@@ -1409,6 +1435,7 @@ fn test_do_swap_minimum_stake_check() {
             netuid1,
             total_stake,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
 
@@ -1443,6 +1470,7 @@ fn test_do_swap_same_subnet() {
             netuid,
             stake_amount,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
 
@@ -1485,6 +1513,7 @@ fn test_do_swap_partial_stake() {
             origin_netuid,
             total_stake,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
 
@@ -1530,6 +1559,7 @@ fn test_do_swap_storage_updates() {
             origin_netuid,
             stake_amount,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
 
@@ -1588,11 +1618,13 @@ fn test_do_swap_multiple_times() {
             netuid1,
             initial_stake,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
 
         let mut expected_alpha: u64 = 0;
         for _ in 0..3 {
+            remove_stake_lock_for_tests(&hotkey, &coldkey, netuid1);
             let alpha1 = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
                 &hotkey, &coldkey, netuid1,
             );
@@ -1605,6 +1637,8 @@ fn test_do_swap_multiple_times() {
                     alpha1
                 ));
             }
+
+            remove_stake_lock_for_tests(&hotkey, &coldkey, netuid2);
             let alpha2 = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
                 &hotkey, &coldkey, netuid2,
             );
@@ -1655,6 +1689,7 @@ fn test_do_swap_allows_non_owned_hotkey() {
             origin_netuid,
             stake_amount,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
         let alpha_before = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
@@ -1700,6 +1735,7 @@ fn test_swap_stake_limit_validate() {
             origin_netuid,
             stake_amount,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
 
@@ -1763,6 +1799,7 @@ fn test_stake_transfers_disabled_validate() {
             origin_netuid,
             stake_amount,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
 
@@ -1888,6 +1925,8 @@ fn test_move_stake_specific_stake_into_subnet_fail() {
             &coldkey_account_id,
             origin_netuid,
         );
+
+        remove_stake_lock_for_tests(&hotkey_account_id, &coldkey_account_id, origin_netuid);
 
         // Move stake to destination subnet
         let (tao_equivalent, _) = mock::swap_alpha_to_tao(origin_netuid, alpha_to_move);

--- a/pallets/subtensor/src/tests/staking.rs
+++ b/pallets/subtensor/src/tests/staking.rs
@@ -671,6 +671,7 @@ fn test_remove_stake_insufficient_liquidity() {
             netuid,
             amount_staked,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
 
@@ -749,6 +750,8 @@ fn test_remove_stake_total_issuance_no_change() {
             &coldkey_account_id,
             netuid,
         );
+
+        remove_stake_lock_for_tests(&hotkey_account_id, &coldkey_account_id, netuid);
 
         let total_fee = mock::swap_alpha_to_tao(netuid, stake).1 + fee;
 
@@ -845,6 +848,8 @@ fn test_remove_prev_epoch_stake() {
                 &coldkey_account_id,
                 netuid,
             );
+
+            remove_stake_lock_for_tests(&hotkey_account_id, &coldkey_account_id, netuid);
 
             let fee = mock::swap_alpha_to_tao(netuid, stake).1 + fee;
             assert_ok!(SubtensorModule::remove_stake(
@@ -1430,6 +1435,9 @@ fn test_clear_small_nominations() {
             netuid,
             amount + fee
         ));
+
+        remove_stake_lock_for_tests(&hot1, &cold1, netuid);
+
         assert_ok!(SubtensorModule::remove_stake(
             RuntimeOrigin::signed(cold1),
             hot1,
@@ -1450,6 +1458,7 @@ fn test_clear_small_nominations() {
             netuid,
             amount + fee
         ));
+        remove_stake_lock_for_tests(&hot1, &cold2, netuid);
         assert_ok!(SubtensorModule::remove_stake(
             RuntimeOrigin::signed(cold2),
             hot1,
@@ -1470,6 +1479,7 @@ fn test_clear_small_nominations() {
             netuid,
             amount + fee
         ));
+        remove_stake_lock_for_tests(&hot2, &cold1, netuid);
         assert_ok!(SubtensorModule::remove_stake(
             RuntimeOrigin::signed(cold1),
             hot2,
@@ -1491,6 +1501,8 @@ fn test_clear_small_nominations() {
             netuid,
             amount + fee
         ));
+
+        remove_stake_lock_for_tests(&hot2, &cold2, netuid);
         assert_ok!(SubtensorModule::remove_stake(
             RuntimeOrigin::signed(cold2),
             hot2,
@@ -1989,6 +2001,8 @@ fn test_get_total_delegated_stake_after_unstaking() {
             initial_stake - existential_deposit - fee,
             epsilon = initial_stake / 1000,
         );
+
+        remove_stake_lock_for_tests(&delegate_hotkey, &delegator, netuid);
 
         // Unstake part of the delegation
         assert_ok!(SubtensorModule::remove_stake(
@@ -2798,6 +2812,7 @@ fn test_unstake_low_liquidity_validate() {
             netuid,
             amount_staked,
             <Test as Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
 
@@ -2853,6 +2868,7 @@ fn test_unstake_all_validate() {
             netuid,
             amount_staked,
             <Test as pallet::Config>::SwapInterface::max_price(),
+            false,
         )
         .unwrap();
 
@@ -3955,6 +3971,8 @@ fn test_remove_stake_limit_ok() {
         let expected_alpha_reduction = (0.00138 * alpha_in.to_num::<f64>()) as u64;
         let fee: u64 = (expected_alpha_reduction as f64 * 0.003) as u64;
 
+        remove_stake_lock_for_tests(&hotkey_account_id, &coldkey_account_id, netuid);
+
         // Remove stake with slippage safety
         assert_ok!(SubtensorModule::remove_stake_limit(
             RuntimeOrigin::signed(coldkey_account_id),
@@ -4140,6 +4158,8 @@ fn test_remove_99_9991_per_cent_stake_removes_all() {
             amount
         ));
 
+        remove_stake_lock_for_tests(&hotkey_account_id, &coldkey_account_id, netuid);
+
         // Remove 99.9991% stake
         let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
             &hotkey_account_id,
@@ -4198,6 +4218,8 @@ fn test_remove_99_9989_per_cent_stake_leaves_a_little() {
             netuid,
             amount
         ));
+
+        remove_stake_lock_for_tests(&hotkey_account_id, &coldkey_account_id, netuid);
 
         // Remove 99.9989% stake
         let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
@@ -4422,6 +4444,8 @@ fn test_unstake_all_alpha_works() {
             stake_amount
         ));
 
+        remove_stake_lock_for_tests(&hotkey, &coldkey, netuid);
+
         // Setup the pool so that removing all the TAO will keep liq above min
         mock::setup_reserves(netuid, stake_amount * 10, stake_amount * 100);
 
@@ -4464,6 +4488,8 @@ fn test_unstake_all_works() {
             netuid,
             stake_amount
         ));
+
+        remove_stake_lock_for_tests(&hotkey, &coldkey, netuid);
 
         // Setup the pool so that removing all the TAO will keep liq above min
         mock::setup_reserves(netuid, stake_amount * 10, stake_amount * 100);
@@ -4518,6 +4544,7 @@ fn test_stake_into_subnet_ok() {
             netuid,
             amount,
             u64::MAX,
+            false,
         ));
         let expected_stake = (amount as f64) * 0.997 / current_price;
 
@@ -4567,6 +4594,7 @@ fn test_stake_into_subnet_low_amount() {
             netuid,
             amount,
             u64::MAX,
+            false,
         ));
         let expected_stake = ((amount as f64) * 0.997 / current_price) as u64;
 
@@ -4613,6 +4641,7 @@ fn test_unstake_from_subnet_low_amount() {
             netuid,
             amount,
             u64::MAX,
+            false,
         ));
 
         // Remove stake
@@ -4722,6 +4751,7 @@ fn test_unstake_from_subnet_prohibitive_limit() {
             netuid,
             amount,
             u64::MAX,
+            false,
         ));
 
         // Remove stake
@@ -4795,6 +4825,7 @@ fn test_unstake_full_amount() {
             netuid,
             amount,
             u64::MAX,
+            false,
         ));
 
         // Remove stake
@@ -4931,6 +4962,8 @@ fn test_swap_fees_tao_correctness() {
         ));
         fees += (fee_rate * amount as f64) as u64;
 
+        remove_stake_lock_for_tests(&owner_hotkey, &coldkey, netuid);
+
         let user_alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
             &owner_hotkey,
             &coldkey,
@@ -5041,6 +5074,8 @@ fn test_default_min_stake_sufficiency() {
         let fee_stake = (fee_rate * amount as f64) as u64;
         let current_price_after_stake =
             <Test as pallet::Config>::SwapInterface::current_alpha_price(netuid.into());
+
+        remove_stake_lock_for_tests(&owner_hotkey, &coldkey, netuid);
 
         let user_alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
             &owner_hotkey,

--- a/pallets/subtensor/src/tests/staking.rs
+++ b/pallets/subtensor/src/tests/staking.rs
@@ -5296,3 +5296,35 @@ fn test_large_swap() {
         ));
     });
 }
+
+#[test]
+fn test_stake_locks() {
+    new_test_ext(0).execute_with(|| {
+        // Create subnet and accounts.
+        let subnet_owner_coldkey = U256::from(10);
+        let subnet_owner_hotkey = U256::from(20);
+        let hot1 = U256::from(1);
+        let cold1 = U256::from(3);
+        let netuid: u16 = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
+        let amount = DefaultMinStake::<Test>::get() * 10;
+        let fee: u64 = DefaultMinStake::<Test>::get();
+        let init_balance = amount + fee + ExistentialDeposit::get();
+
+        register_ok_neuron(netuid, hot1, cold1, 0);
+        Delegates::<Test>::insert(hot1, SubtensorModule::get_min_delegate_take());
+        assert_eq!(SubtensorModule::get_owning_coldkey_for_hotkey(&hot1), cold1);
+
+        SubtensorModule::add_balance_to_coldkey_account(&cold1, init_balance);
+        assert_ok!(SubtensorModule::add_stake(
+            RuntimeOrigin::signed(cold1),
+            hot1,
+            netuid,
+            amount + fee
+        ));
+
+        assert_err!(
+            SubtensorModule::remove_stake(RuntimeOrigin::signed(cold1), hot1, netuid, amount),
+            Error::<Test>::StakeLocked
+        );
+    });
+}

--- a/pallets/subtensor/src/tests/subnet.rs
+++ b/pallets/subtensor/src/tests/subnet.rs
@@ -433,6 +433,8 @@ fn test_subtoken_enable_trading_ok_with_enable() {
             stake_amount
         ));
 
+        remove_stake_lock_for_tests(&hotkey_account_id, &coldkey_account_id, netuid);
+
         assert_ok!(SubtensorModule::remove_stake(
             RuntimeOrigin::signed(coldkey_account_id),
             hotkey_account_id,
@@ -462,6 +464,8 @@ fn test_subtoken_enable_trading_ok_with_enable() {
             netuid2,
             unstake_amount,
         ));
+
+        remove_stake_lock_for_tests(&hotkey_account_2_id, &coldkey_account_id, netuid);
 
         assert_ok!(SubtensorModule::transfer_stake(
             RuntimeOrigin::signed(coldkey_account_id),

--- a/pallets/subtensor/src/tests/swap_coldkey.rs
+++ b/pallets/subtensor/src/tests/swap_coldkey.rs
@@ -2402,6 +2402,8 @@ fn test_coldkey_in_swap_schedule_prevents_funds_usage() {
             ))
         );
 
+        remove_stake_lock_for_tests(&hotkey, &coldkey, netuid);
+
         // Remove stake
         let call = RuntimeCall::SubtensorModule(SubtensorCall::remove_stake {
             hotkey,


### PR DESCRIPTION
## Description

This PR introduces stake locks. 

This PR addresses the stake manipulation problem by introducing a stake lock after each stake deposit operation (like add_stake or add_stake_limit). The lock is the block number after which stake removal is allowed. It calculates as "current_block + subnet tempo".

This PR relates to both MEV and "stake delta" problems.

Affected extrinsics:
- add_stake
- add_stake_limit
- remove_stake
- remove_stake_limit
- unstake_all
- unstake_all_alpha
- move_stake
- swap_stake
- swap_stake_limit
- transfer_stake

All extrinsics that add stake to the destination netuid lock tuple (hotkey, coldkey, netuid) for the tempo period of the subnet. All extrinsics that remove stake check the stake lock first and fail with the `StakeLocked` error if the lock is active. The only exception is `transfer_stake` when the destination coldkey is different from the origin (to prevent putting locks on others).


## Related Issue(s)

- https://github.com/opentensor/subtensor/issues/1509
- https://github.com/opentensor/subtensor/issues/1558

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

The code that removes the stake immediately will stop working.

## Checklist


- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional Notes

The additional weights fix commit will be likely required and added after the initial code review. 