### PR TITLE
fix: replace `pure` with `create_pure` in comments

### DIFF
--- a/pallets/proxy/src/lib.rs
+++ b/pallets/proxy/src/lib.rs
@@ -266,7 +266,7 @@ pub mod pallet {
         ///
         /// The dispatch origin for this call must be _Signed_.
         ///
-        /// WARNING: This may be called on accounts created by `pure`, however if done, then
+        /// WARNING: This may be called on accounts created by `create_pure`, however if done, then
         /// the unreserved fees will be inaccessible. **All access to this account will be lost.**
         #[pallet::call_index(3)]
         #[pallet::weight(T::WeightInfo::remove_proxies(T::MaxProxies::get()))]
@@ -336,16 +336,16 @@ pub mod pallet {
         /// inaccessible.
         ///
         /// Requires a `Signed` origin, and the sender account must have been created by a call to
-        /// `pure` with corresponding parameters.
+        /// `create_pure` with corresponding parameters.
         ///
-        /// - `spawner`: The account that originally called `pure` to create this account.
-        /// - `index`: The disambiguation index originally passed to `pure`. Probably `0`.
-        /// - `proxy_type`: The proxy type originally passed to `pure`.
-        /// - `height`: The height of the chain when the call to `pure` was processed.
-        /// - `ext_index`: The extrinsic index in which the call to `pure` was processed.
+        /// - `spawner`: The account that originally called `create_pure` to create this account.
+        /// - `index`: The disambiguation index originally passed to `create_pure`. Probably `0`.
+        /// - `proxy_type`: The proxy type originally passed to `create_pure`.
+        /// - `height`: The height of the chain when the call to `create_pure` was processed.
+        /// - `ext_index`: The extrinsic index in which the call to `create_pure` was processed.
         ///
         /// Fails with `NoPermission` in case the caller is not a previously created pure
-        /// account whose `pure` call has corresponding parameters.
+        /// account whose `create_pure` call has corresponding parameters.
         #[pallet::call_index(5)]
         #[pallet::weight(T::WeightInfo::kill_pure(T::MaxProxies::get()))]
         pub fn kill_pure(


### PR DESCRIPTION
## Description

This PR is to update the comments - replace `pure` with `create_pure` in the documenation.

PR merged in `polkadot-sdk` https://github.com/paritytech/polkadot-sdk/pull/8892

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Other (please describe):

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

