### PR TITLE
fix: map to hotkey not uid

### DIFF
--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -121,8 +121,8 @@ pub mod pallet {
         Metagraph,
         /// Enum for neuron precompile
         Neuron,
-        /// Enum for UID lookup precompile
-        UidLookup,
+        /// Enum for hotkey lookup precompile
+        HotkeyLookup,
         /// Enum for alpha precompile
         Alpha,
     }

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1675,9 +1675,9 @@ pub mod pallet {
     /// ==== EVM related storage ====
     /// =============================
     #[pallet::storage]
-    /// --- DMAP (netuid, uid) --> (H160, last_block_where_ownership_was_proven)
+    /// --- DMAP (netuid, hotkey) --> (H160, last_block_where_ownership_was_proven)
     pub type AssociatedEvmAddress<T: Config> =
-        StorageDoubleMap<_, Twox64Concat, NetUid, Twox64Concat, u16, (H160, u64), OptionQuery>;
+        StorageDoubleMap<_, Twox64Concat, NetUid, Twox64Concat, T::AccountId, (H160, u64), OptionQuery>;
 
     /// ==================
     /// ==== Genesis =====

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1676,8 +1676,15 @@ pub mod pallet {
     /// =============================
     #[pallet::storage]
     /// --- DMAP (netuid, hotkey) --> (H160, last_block_where_ownership_was_proven)
-    pub type AssociatedEvmAddress<T: Config> =
-        StorageDoubleMap<_, Twox64Concat, NetUid, Twox64Concat, T::AccountId, (H160, u64), OptionQuery>;
+    pub type AssociatedEvmAddress<T: Config> = StorageDoubleMap<
+        _,
+        Twox64Concat,
+        NetUid,
+        Twox64Concat,
+        T::AccountId,
+        (H160, u64),
+        OptionQuery,
+    >;
 
     /// ==================
     /// ==== Genesis =====

--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -117,7 +117,9 @@ mod hooks {
                 // Reset max burn
                 .saturating_add(migrations::migrate_reset_max_burn::migrate_reset_max_burn::<T>())
                 // Migrate ColdkeySwapScheduled structure to new format
-                .saturating_add(migrations::migrate_coldkey_swap_scheduled::migrate_coldkey_swap_scheduled::<T>());
+                .saturating_add(migrations::migrate_coldkey_swap_scheduled::migrate_coldkey_swap_scheduled::<T>())
+                // Migrate AssociatedEvmAddress from UID to Hotkey
+                .saturating_add(migrations::migrate_evm_address_to_hotkey::migrate_evm_address_to_hotkey::<T>());
             weight
         }
 

--- a/pallets/subtensor/src/migrations/migrate_evm_address_to_hotkey.rs
+++ b/pallets/subtensor/src/migrations/migrate_evm_address_to_hotkey.rs
@@ -1,0 +1,103 @@
+use super::*;
+use frame_support::{
+    pallet_prelude::{Twox64Concat, OptionQuery},
+    storage_alias,
+    traits::Get,
+    weights::Weight,
+};
+use log::info;
+use sp_core::H160;
+
+const LOG_TARGET: &str = "migrate_evm_address_to_hotkey";
+
+/// Module containing deprecated storage format for AssociatedEvmAddress
+pub mod deprecated_evm_address_format {
+    use super::*;
+
+    #[storage_alias]
+    pub(super) type AssociatedEvmAddress<T: Config> =
+        StorageDoubleMap<Pallet<T>, Twox64Concat, u16, Twox64Concat, u16, (H160, u64), OptionQuery>;
+}
+
+/// Migrate AssociatedEvmAddress from (netuid, uid) -> (evm_address, block) to (netuid, hotkey) -> (evm_address, block)
+pub fn migrate_evm_address_to_hotkey<T: Config>() -> Weight {
+    let mut weight = T::DbWeight::get().reads(1);
+    let migration_name = "Migrate AssociatedEvmAddress from UID to Hotkey";
+    let migration_name_bytes = migration_name.as_bytes().to_vec();
+
+    // Check if migration has already run
+    if HasMigrationRun::<T>::get(&migration_name_bytes) {
+        info!(
+            target: LOG_TARGET,
+            "Migration '{}' has already run. Skipping.",
+            migration_name
+        );
+        return Weight::zero();
+    }
+
+    info!(target: LOG_TARGET, ">>> Starting Migration: {}", migration_name);
+
+    let mut migrated_count: u64 = 0;
+    let mut orphaned_count: u64 = 0;
+    let mut storage_reads: u64 = 0;
+    let mut storage_writes: u64 = 0;
+
+    // Create a vector to store the old entries
+    let mut old_entries = Vec::new();
+
+    // Read all old entries
+    deprecated_evm_address_format::AssociatedEvmAddress::<T>::iter().for_each(|(netuid, uid, (evm_address, block))| {
+        old_entries.push((netuid, uid, evm_address, block));
+        storage_reads = storage_reads.saturating_add(1);
+    });
+
+    weight = weight.saturating_add(T::DbWeight::get().reads(old_entries.len() as u64));
+
+    // Clear the old storage
+    let _ = deprecated_evm_address_format::AssociatedEvmAddress::<T>::clear(u32::MAX, None);
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+    // Migrate each entry
+    for (netuid, uid, evm_address, block) in old_entries {
+        // Look up the hotkey for this uid on this subnet
+        if let Ok(hotkey) = Keys::<T>::try_get(netuid, uid) {
+            storage_reads = storage_reads.saturating_add(1);
+            
+            // Store with the new format using hotkey
+            AssociatedEvmAddress::<T>::insert(netuid, &hotkey, (evm_address, block));
+            storage_writes = storage_writes.saturating_add(1);
+            migrated_count = migrated_count.saturating_add(1);
+            
+            weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
+            
+            info!(
+                target: LOG_TARGET,
+                "Migrated EVM address {} from UID {} to hotkey {:?} on subnet {}",
+                evm_address, uid, hotkey, netuid
+            );
+        } else {
+            // No hotkey found for this UID - the neuron may have been deregistered
+            orphaned_count = orphaned_count.saturating_add(1);
+            weight = weight.saturating_add(T::DbWeight::get().reads(1));
+            
+            info!(
+                target: LOG_TARGET,
+                "WARNING: Orphaned EVM address {} for UID {} on subnet {} - no hotkey found",
+                evm_address, uid, netuid
+            );
+        }
+    }
+
+    // Mark migration as complete
+    HasMigrationRun::<T>::insert(&migration_name_bytes, true);
+    storage_writes = storage_writes.saturating_add(1);
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+    info!(
+        target: LOG_TARGET,
+        "Migration {} finished. Migrated: {}, Orphaned: {}, Storage reads: {}, Storage writes: {}",
+        migration_name, migrated_count, orphaned_count, storage_reads, storage_writes
+    );
+
+    weight
+}

--- a/pallets/subtensor/src/migrations/mod.rs
+++ b/pallets/subtensor/src/migrations/mod.rs
@@ -34,6 +34,7 @@ pub mod migrate_to_v2_fixed_total_stake;
 pub mod migrate_total_issuance;
 pub mod migrate_transfer_ownership_to_foundation;
 pub mod migrate_upgrade_revealed_commitments;
+pub mod migrate_evm_address_to_hotkey;
 
 pub(crate) fn migrate_storage<T: Config>(
     migration_name: &'static str,

--- a/pallets/subtensor/src/migrations/mod.rs
+++ b/pallets/subtensor/src/migrations/mod.rs
@@ -9,6 +9,7 @@ pub mod migrate_commit_reveal_v2;
 pub mod migrate_create_root_network;
 pub mod migrate_delete_subnet_21;
 pub mod migrate_delete_subnet_3;
+pub mod migrate_evm_address_to_hotkey;
 pub mod migrate_fix_is_network_member;
 pub mod migrate_identities_v2;
 pub mod migrate_init_total_issuance;
@@ -34,7 +35,6 @@ pub mod migrate_to_v2_fixed_total_stake;
 pub mod migrate_total_issuance;
 pub mod migrate_transfer_ownership_to_foundation;
 pub mod migrate_upgrade_revealed_commitments;
-pub mod migrate_evm_address_to_hotkey;
 
 pub(crate) fn migrate_storage<T: Config>(
     migration_name: &'static str,

--- a/precompiles/src/hotkey_lookup.rs
+++ b/precompiles/src/hotkey_lookup.rs
@@ -5,12 +5,13 @@ use pallet_evm::PrecompileHandle;
 use precompile_utils::{EvmResult, prelude::Address};
 use sp_runtime::traits::{Dispatchable, StaticLookup};
 use sp_std::vec::Vec;
+use parity_scale_codec::Encode;
 
 use crate::PrecompileExt;
 
-pub(crate) struct UidLookupPrecompile<R>(PhantomData<R>);
+pub(crate) struct HotkeyLookupPrecompile<R>(PhantomData<R>);
 
-impl<R> PrecompileExt<R::AccountId> for UidLookupPrecompile<R>
+impl<R> PrecompileExt<R::AccountId> for HotkeyLookupPrecompile<R>
 where
     R: frame_system::Config + pallet_subtensor::Config + pallet_evm::Config,
     R::AccountId: From<[u8; 32]>,
@@ -25,7 +26,7 @@ where
 }
 
 #[precompile_utils::precompile]
-impl<R> UidLookupPrecompile<R>
+impl<R> HotkeyLookupPrecompile<R>
 where
     R: frame_system::Config + pallet_subtensor::Config + pallet_evm::Config,
     R::AccountId: From<[u8; 32]>,
@@ -36,18 +37,28 @@ where
         + Dispatchable<PostInfo = PostDispatchInfo>,
     <<R as frame_system::Config>::Lookup as StaticLookup>::Source: From<R::AccountId>,
 {
-    #[precompile::public("uidLookup(uint16,address,uint16)")]
+    #[precompile::public("hotkeyLookup(uint16,address,uint16)")]
     #[precompile::view]
-    fn uid_lookup(
+    fn hotkey_lookup(
         _handle: &mut impl PrecompileHandle,
         netuid: u16,
         evm_address: Address,
         limit: u16,
-    ) -> EvmResult<Vec<(u16, u64)>> {
-        Ok(pallet_subtensor::Pallet::<R>::uid_lookup(
+    ) -> EvmResult<Vec<(Address, u64)>> {
+        let results = pallet_subtensor::Pallet::<R>::hotkey_lookup(
             netuid.into(),
             evm_address.0,
             limit,
-        ))
+        );
+        
+        // Convert AccountId to Address for EVM compatibility
+        Ok(results.into_iter()
+            .map(|(account_id, block)| {
+                let mut bytes = [0u8; 20];
+                let account_bytes = account_id.encode();
+                bytes.copy_from_slice(&account_bytes[..20.min(account_bytes.len())]);
+                (Address::from(bytes), block)
+            })
+            .collect())
     }
 }

--- a/precompiles/src/hotkey_lookup.rs
+++ b/precompiles/src/hotkey_lookup.rs
@@ -2,10 +2,10 @@ use core::marker::PhantomData;
 
 use frame_support::dispatch::{GetDispatchInfo, PostDispatchInfo};
 use pallet_evm::PrecompileHandle;
+use parity_scale_codec::Encode;
 use precompile_utils::{EvmResult, prelude::Address};
 use sp_runtime::traits::{Dispatchable, StaticLookup};
 use sp_std::vec::Vec;
-use parity_scale_codec::Encode;
 
 use crate::PrecompileExt;
 
@@ -45,14 +45,12 @@ where
         evm_address: Address,
         limit: u16,
     ) -> EvmResult<Vec<(Address, u64)>> {
-        let results = pallet_subtensor::Pallet::<R>::hotkey_lookup(
-            netuid.into(),
-            evm_address.0,
-            limit,
-        );
-        
+        let results =
+            pallet_subtensor::Pallet::<R>::hotkey_lookup(netuid.into(), evm_address.0, limit);
+
         // Convert AccountId to Address for EVM compatibility
-        Ok(results.into_iter()
+        Ok(results
+            .into_iter()
             .map(|(account_id, block)| {
                 let mut bytes = [0u8; 20];
                 let account_bytes = account_id.encode();

--- a/precompiles/src/lib.rs
+++ b/precompiles/src/lib.rs
@@ -28,25 +28,25 @@ use crate::alpha::*;
 use crate::balance_transfer::*;
 use crate::ed25519::*;
 use crate::extensions::*;
+use crate::hotkey_lookup::*;
 use crate::metagraph::*;
 use crate::neuron::*;
 use crate::sr25519::*;
 use crate::staking::*;
 use crate::storage_query::*;
 use crate::subnet::*;
-use crate::hotkey_lookup::*;
 
 mod alpha;
 mod balance_transfer;
 mod ed25519;
 mod extensions;
+mod hotkey_lookup;
 mod metagraph;
 mod neuron;
 mod sr25519;
 mod staking;
 mod storage_query;
 mod subnet;
-mod hotkey_lookup;
 pub struct Precompiles<R>(PhantomData<R>);
 
 impl<R> Default for Precompiles<R>

--- a/precompiles/src/lib.rs
+++ b/precompiles/src/lib.rs
@@ -34,7 +34,7 @@ use crate::sr25519::*;
 use crate::staking::*;
 use crate::storage_query::*;
 use crate::subnet::*;
-use crate::uid_lookup::*;
+use crate::hotkey_lookup::*;
 
 mod alpha;
 mod balance_transfer;
@@ -46,7 +46,7 @@ mod sr25519;
 mod staking;
 mod storage_query;
 mod subnet;
-mod uid_lookup;
+mod hotkey_lookup;
 pub struct Precompiles<R>(PhantomData<R>);
 
 impl<R> Default for Precompiles<R>
@@ -117,7 +117,7 @@ where
             hash(NeuronPrecompile::<R>::INDEX),
             hash(StakingPrecompileV2::<R>::INDEX),
             hash(StorageQueryPrecompile::<R>::INDEX),
-            hash(UidLookupPrecompile::<R>::INDEX),
+            hash(HotkeyLookupPrecompile::<R>::INDEX),
             hash(AlphaPrecompile::<R>::INDEX),
         ]
     }
@@ -185,8 +185,8 @@ where
             a if a == hash(NeuronPrecompile::<R>::INDEX) => {
                 NeuronPrecompile::<R>::try_execute::<R>(handle, PrecompileEnum::Neuron)
             }
-            a if a == hash(UidLookupPrecompile::<R>::INDEX) => {
-                UidLookupPrecompile::<R>::try_execute::<R>(handle, PrecompileEnum::UidLookup)
+            a if a == hash(HotkeyLookupPrecompile::<R>::INDEX) => {
+                HotkeyLookupPrecompile::<R>::try_execute::<R>(handle, PrecompileEnum::HotkeyLookup)
             }
             a if a == hash(StorageQueryPrecompile::<R>::INDEX) => {
                 Some(StorageQueryPrecompile::<R>::execute(handle))


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
This PR improves the user experience and data integrity of EVM address associations by changing the storage from UID-based to hotkey-based. Since UIDs can be recycled when neurons are deregistered and re-registered, the current implementation leads to confusing UX where querying by UID might return EVM associations from previous neuron owners.

## Problem

The current implementation stores EVM address associations using the storage map:
```rust
StorageDoubleMap<_, _, NetUid, _, u16, (H160, u64)>  // (netuid, uid) -> (evm_address, block)
```

Additionally, the association logic already requires signing with the hotkey, making it more logical to store the association by hotkey rather than by UID.


This creates a suboptimal user experience:
1. User A registers a neuron, gets UID 5, and associates their EVM address
2. User A deregisters their neuron
3. User B registers a new neuron and gets the recycled UID 5
4. Querying UID 5's EVM association now incorrectly returns User A's EVM address

## Solution

This PR changes the storage to use hotkeys instead of UIDs:
```rust
StorageDoubleMap<_, _, NetUid, _, T::AccountId, (H160, u64)>  // (netuid, hotkey) -> (evm_address, block)
```

Hotkeys are permanent and unique to each account, preventing any inheritance issues.

## Changes Made

### 1. Storage Map Update
- **File**: `pallets/subtensor/src/lib.rs`
- Changed `AssociatedEvmAddress` to map from `(netuid, uid: u16)` to `(netuid, hotkey: T::AccountId)`

### 2. Core Function Updates
- **File**: `pallets/subtensor/src/utils/evm.rs`
  - Updated `do_associate_evm_key` to store by hotkey instead of uid
  - Removed unnecessary UID lookup since we're storing directly by hotkey
  - Renamed `uid_lookup` to `hotkey_lookup` with updated return type

### 3. Precompile Updates
- **Files**: `precompiles/src/hotkey_lookup.rs` (renamed from `uid_lookup.rs`), `precompiles/src/lib.rs`
  - Renamed `UidLookupPrecompile` to `HotkeyLookupPrecompile`
  - Updated function signature to return hotkey addresses instead of UIDs
  - Updated precompile registration and enum values

### 4. Admin Utils Update
- **File**: `pallets/admin-utils/src/lib.rs`
  - Updated `PrecompileEnum::UidLookup` to `PrecompileEnum::HotkeyLookup`

### 5. Migration Implementation
- **Files**: `pallets/subtensor/src/migrations/migrate_evm_address_to_hotkey.rs`, `pallets/subtensor/src/migrations/mod.rs`, `pallets/subtensor/src/macros/hooks.rs`
  - Created migration to convert existing storage entries from uid-based to hotkey-based
  - Added migration to the runtime upgrade hook
  - Handles orphaned entries where neurons have been deregistered

## Breaking Changes

This is a **breaking change** that affects:
1. **Storage Migration Required**: Existing EVM address associations need to be migrated from UID-based to hotkey-based storage
2. **API Changes**: 
   - The `uid_lookup` function is now `hotkey_lookup` and returns hotkeys instead of UIDs
   - Precompile function changed from `uidLookup` to `hotkeyLookup`
3. **Client Updates**: Any clients querying `AssociatedEvmAddress` storage will need to update their code to use hotkeys instead of UIDs

## Testing

- [ ] Verify `do_associate_evm_key` correctly stores by hotkey
- [ ] Test `hotkey_lookup` returns correct hotkeys for given EVM addresses
- [ ] Verify precompile works correctly with new signature
- [ ] Test that deregistering and re-registering neurons doesn't inherit EVM associations
- [ ] Ensure storage migration correctly converts existing data

## Migration Plan

A storage migration has been implemented in `migrate_evm_address_to_hotkey.rs` that:
1. Reads all existing `(netuid, uid) -> (evm_address, block)` entries
2. Looks up the hotkey for each uid using the `Keys` storage map
3. Stores the data in the new format `(netuid, hotkey) -> (evm_address, block)`
4. Handles orphaned entries where the neuron has been deregistered
5. Logs migration statistics including migrated and orphaned counts

The migration is automatically executed during runtime upgrade.

## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.