### PR TITLE
Fix root subnet tao mismatch

### DIFF
--- a/pallets/crowdloan/src/migrations/migrate_add_contributors_count.rs
+++ b/pallets/crowdloan/src/migrations/migrate_add_contributors_count.rs
@@ -30,7 +30,7 @@ pub fn migrate_add_contributors_count<T: Config>() -> Weight {
     if HasMigrationRun::<T>::get(&migration_name) {
         log::info!(
             "Migration '{:?}' has already run. Skipping.",
-            migration_name
+            String::from_utf8_lossy(&migration_name)
         );
         return weight;
     }

--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -492,7 +492,7 @@ impl<T: Config> Pallet<T> {
             root_tao = root_tao.saturating_sub(tao_take);
             // Give the validator their take.
             log::debug!("hotkey: {:?} tao_take: {:?}", hotkey, tao_take);
-            Self::increase_stake_for_hotkey_and_coldkey_on_subnet(
+            let validator_stake = Self::increase_stake_for_hotkey_and_coldkey_on_subnet(
                 &hotkey,
                 &Owner::<T>::get(hotkey.clone()),
                 NetUid::ROOT,
@@ -504,6 +504,12 @@ impl<T: Config> Pallet<T> {
             // Record root dividends for this validator on this subnet.
             TaoDividendsPerSubnet::<T>::mutate(netuid, hotkey.clone(), |divs| {
                 *divs = divs.saturating_add(tou64!(root_tao));
+            });
+            // Add the stakes to the total TAO on the subnet.
+            SubnetTAO::<T>::mutate(NetUid::ROOT, |total| {
+                *total = total
+                    .saturating_add(validator_stake)
+                    .saturating_add(tou64!(root_tao));
             });
         }
     }

--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -505,7 +505,7 @@ impl<T: Config> Pallet<T> {
             TaoDividendsPerSubnet::<T>::mutate(netuid, hotkey.clone(), |divs| {
                 *divs = divs.saturating_add(tou64!(root_tao));
             });
-            // Add the stakes to the total TAO on the subnet.
+            // Update the total TAO on the subnet with root tao dividends.
             SubnetTAO::<T>::mutate(NetUid::ROOT, |total| {
                 *total = total
                     .saturating_add(validator_stake)

--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -117,7 +117,9 @@ mod hooks {
                 // Reset max burn
                 .saturating_add(migrations::migrate_reset_max_burn::migrate_reset_max_burn::<T>())
                 // Migrate ColdkeySwapScheduled structure to new format
-                .saturating_add(migrations::migrate_coldkey_swap_scheduled::migrate_coldkey_swap_scheduled::<T>());
+                .saturating_add(migrations::migrate_coldkey_swap_scheduled::migrate_coldkey_swap_scheduled::<T>())
+                // Fix the root subnet TAO storage value
+                .saturating_add(migrations::migrate_fix_root_subnet_tao::migrate_fix_root_subnet_tao::<T>());
             weight
         }
 

--- a/pallets/subtensor/src/migrations/migrate_chain_identity.rs
+++ b/pallets/subtensor/src/migrations/migrate_chain_identity.rs
@@ -40,7 +40,7 @@ pub fn migrate_set_hotkey_identities<T: Config>() -> Weight {
     if HasMigrationRun::<T>::get(&migration_name) {
         log::info!(
             "Migration '{:?}' has already run. Skipping.",
-            migration_name
+            String::from_utf8_lossy(&migration_name)
         );
         return weight;
     }

--- a/pallets/subtensor/src/migrations/migrate_coldkey_swap_scheduled.rs
+++ b/pallets/subtensor/src/migrations/migrate_coldkey_swap_scheduled.rs
@@ -27,7 +27,7 @@ pub fn migrate_coldkey_swap_scheduled<T: Config>() -> Weight {
     if HasMigrationRun::<T>::get(&migration_name) {
         log::info!(
             "Migration '{:?}' has already run. Skipping.",
-            migration_name
+            String::from_utf8_lossy(&migration_name)
         );
         return weight;
     }

--- a/pallets/subtensor/src/migrations/migrate_commit_reveal_v2.rs
+++ b/pallets/subtensor/src/migrations/migrate_commit_reveal_v2.rs
@@ -11,7 +11,7 @@ pub fn migrate_commit_reveal_2<T: Config>() -> Weight {
     if HasMigrationRun::<T>::get(&migration_name) {
         log::info!(
             "Migration '{:?}' has already run. Skipping.",
-            migration_name
+            String::from_utf8_lossy(&migration_name)
         );
         return weight;
     }

--- a/pallets/subtensor/src/migrations/migrate_fix_is_network_member.rs
+++ b/pallets/subtensor/src/migrations/migrate_fix_is_network_member.rs
@@ -13,7 +13,7 @@ pub fn migrate_fix_is_network_member<T: Config>() -> Weight {
     if HasMigrationRun::<T>::get(&migration_name) {
         log::info!(
             "Migration '{:?}' has already run. Skipping.",
-            migration_name
+            String::from_utf8_lossy(&migration_name)
         );
         return weight;
     }

--- a/pallets/subtensor/src/migrations/migrate_fix_root_subnet_tao.rs
+++ b/pallets/subtensor/src/migrations/migrate_fix_root_subnet_tao.rs
@@ -1,5 +1,6 @@
 use super::*;
 use alloc::string::String;
+use super::migrate_init_total_issuance::migrate_init_total_issuance;
 
 pub fn migrate_fix_root_subnet_tao<T: Config>() -> Weight {
     let migration_name = b"migrate_fix_root_subnet_tao".to_vec();
@@ -48,5 +49,7 @@ pub fn migrate_fix_root_subnet_tao<T: Config>() -> Weight {
         String::from_utf8_lossy(&migration_name)
     );
 
-    weight
+    // We need to run the total issuance migration to update the total issuance
+    // when the root subnet TAO has been updated.
+    migrate_init_total_issuance::<T>().saturating_add(weight)
 }

--- a/pallets/subtensor/src/migrations/migrate_fix_root_subnet_tao.rs
+++ b/pallets/subtensor/src/migrations/migrate_fix_root_subnet_tao.rs
@@ -1,0 +1,46 @@
+use super::*;
+use alloc::string::String;
+
+pub fn migrate_fix_root_subnet_tao<T: Config>() -> Weight {
+    let migration_name = b"migrate_fix_root_subnet_tao".to_vec();
+    let mut weight = T::DbWeight::get().reads(1);
+
+    if HasMigrationRun::<T>::get(&migration_name) {
+        log::info!(
+            "Migration '{:?}' has already run. Skipping.",
+            String::from_utf8_lossy(&migration_name)
+        );
+        return weight;
+    }
+
+    log::info!(
+        target: "runtime",
+        "Running migration '{}'",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    let mut total_stake: u64 = 0;
+    let mut hotkey_count: u64 = 0;
+    // We accumulate the total stake for all hotkeys on the root subnet.
+    for hotkey in Owner::<T>::iter_keys() {
+        let hotkey_stake = TotalHotkeyAlpha::<T>::get(&hotkey, NetUid::ROOT);
+        total_stake = total_stake.saturating_add(hotkey_stake);
+        hotkey_count = hotkey_count.saturating_add(1);
+    }
+    weight = weight.saturating_add(T::DbWeight::get().reads(hotkey_count).saturating_mul(2));
+
+    // We set the root subnet TAO to the total stake.
+    SubnetTAO::<T>::insert(NetUid::ROOT, total_stake);
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+    HasMigrationRun::<T>::insert(&migration_name, true);
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+    log::info!(
+        target: "runtime",
+        "Migration '{}' completed successfully.",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    weight
+}

--- a/pallets/subtensor/src/migrations/migrate_fix_root_subnet_tao.rs
+++ b/pallets/subtensor/src/migrations/migrate_fix_root_subnet_tao.rs
@@ -1,6 +1,6 @@
+use super::migrate_init_total_issuance::migrate_init_total_issuance;
 use super::*;
 use alloc::string::String;
-use super::migrate_init_total_issuance::migrate_init_total_issuance;
 
 pub fn migrate_fix_root_subnet_tao<T: Config>() -> Weight {
     let migration_name = b"migrate_fix_root_subnet_tao".to_vec();

--- a/pallets/subtensor/src/migrations/migrate_fix_root_subnet_tao.rs
+++ b/pallets/subtensor/src/migrations/migrate_fix_root_subnet_tao.rs
@@ -14,7 +14,6 @@ pub fn migrate_fix_root_subnet_tao<T: Config>() -> Weight {
     }
 
     log::info!(
-        target: "runtime",
         "Running migration '{}'",
         String::from_utf8_lossy(&migration_name)
     );
@@ -27,6 +26,13 @@ pub fn migrate_fix_root_subnet_tao<T: Config>() -> Weight {
         total_stake = total_stake.saturating_add(hotkey_stake);
         hotkey_count = hotkey_count.saturating_add(1);
     }
+
+    log::info!(
+        "Total stake: {}, hotkey count: {}",
+        total_stake,
+        hotkey_count
+    );
+
     weight = weight.saturating_add(T::DbWeight::get().reads(hotkey_count).saturating_mul(2));
 
     // We set the root subnet TAO to the total stake.

--- a/pallets/subtensor/src/migrations/migrate_rao.rs
+++ b/pallets/subtensor/src/migrations/migrate_rao.rs
@@ -15,7 +15,7 @@ pub fn migrate_rao<T: Config>() -> Weight {
     if HasMigrationRun::<T>::get(&migration_name) {
         log::info!(
             "Migration '{:?}' has already run. Skipping.",
-            migration_name
+            String::from_utf8_lossy(&migration_name)
         );
         return weight;
     }

--- a/pallets/subtensor/src/migrations/migrate_remove_commitments_rate_limit.rs
+++ b/pallets/subtensor/src/migrations/migrate_remove_commitments_rate_limit.rs
@@ -10,7 +10,7 @@ pub fn migrate_remove_commitments_rate_limit<T: Config>() -> Weight {
     if HasMigrationRun::<T>::get(&migration_name) {
         log::info!(
             "Migration '{:?}' has already run. Skipping.",
-            migration_name
+            String::from_utf8_lossy(&migration_name)
         );
         return weight;
     }

--- a/pallets/subtensor/src/migrations/migrate_remove_stake_map.rs
+++ b/pallets/subtensor/src/migrations/migrate_remove_stake_map.rs
@@ -11,7 +11,7 @@ pub fn migrate_remove_stake_map<T: Config>() -> Weight {
     if HasMigrationRun::<T>::get(&migration_name) {
         log::info!(
             "Migration '{:?}' has already run. Skipping.",
-            migration_name
+            String::from_utf8_lossy(&migration_name)
         );
         return weight;
     }

--- a/pallets/subtensor/src/migrations/migrate_remove_unused_maps_and_values.rs
+++ b/pallets/subtensor/src/migrations/migrate_remove_unused_maps_and_values.rs
@@ -39,7 +39,7 @@ pub fn migrate_remove_unused_maps_and_values<T: Config>() -> Weight {
     if HasMigrationRun::<T>::get(&migration_name) {
         log::info!(
             "Migration '{:?}' has already run. Skipping.",
-            migration_name
+            String::from_utf8_lossy(&migration_name)
         );
         return weight;
     }

--- a/pallets/subtensor/src/migrations/migrate_remove_zero_total_hotkey_alpha.rs
+++ b/pallets/subtensor/src/migrations/migrate_remove_zero_total_hotkey_alpha.rs
@@ -13,7 +13,7 @@ pub fn migrate_remove_zero_total_hotkey_alpha<T: Config>() -> Weight {
     if HasMigrationRun::<T>::get(&migration_name) {
         log::info!(
             "Migration '{:?}' has already run. Skipping.",
-            migration_name
+            String::from_utf8_lossy(&migration_name)
         );
         return weight;
     }

--- a/pallets/subtensor/src/migrations/migrate_reset_bonds_moving_average.rs
+++ b/pallets/subtensor/src/migrations/migrate_reset_bonds_moving_average.rs
@@ -13,7 +13,7 @@ pub fn migrate_reset_bonds_moving_average<T: Config>() -> Weight {
     if HasMigrationRun::<T>::get(&migration_name) {
         log::info!(
             "Migration '{:?}' has already run. Skipping.",
-            migration_name
+            String::from_utf8_lossy(&migration_name)
         );
         return weight;
     }

--- a/pallets/subtensor/src/migrations/migrate_reset_max_burn.rs
+++ b/pallets/subtensor/src/migrations/migrate_reset_max_burn.rs
@@ -13,7 +13,7 @@ pub fn migrate_reset_max_burn<T: Config>() -> Weight {
     if HasMigrationRun::<T>::get(&migration_name) {
         log::info!(
             "Migration '{:?}' has already run. Skipping.",
-            migration_name
+            String::from_utf8_lossy(&migration_name)
         );
         return weight;
     }

--- a/pallets/subtensor/src/migrations/migrate_set_min_burn.rs
+++ b/pallets/subtensor/src/migrations/migrate_set_min_burn.rs
@@ -15,7 +15,7 @@ pub fn migrate_set_min_burn<T: Config>() -> Weight {
     if HasMigrationRun::<T>::get(&migration_name) {
         log::info!(
             "Migration '{:?}' has already run. Skipping.",
-            migration_name
+            String::from_utf8_lossy(&migration_name)
         );
         return weight;
     }

--- a/pallets/subtensor/src/migrations/migrate_set_min_difficulty.rs
+++ b/pallets/subtensor/src/migrations/migrate_set_min_difficulty.rs
@@ -15,7 +15,7 @@ pub fn migrate_set_min_difficulty<T: Config>() -> Weight {
     if HasMigrationRun::<T>::get(&migration_name) {
         log::info!(
             "Migration '{:?}' has already run. Skipping.",
-            migration_name
+            String::from_utf8_lossy(&migration_name)
         );
         return weight;
     }

--- a/pallets/subtensor/src/migrations/migrate_stake_threshold.rs
+++ b/pallets/subtensor/src/migrations/migrate_stake_threshold.rs
@@ -20,7 +20,7 @@ pub fn migrate_stake_threshold<T: Config>() -> Weight {
     if HasMigrationRun::<T>::get(&migration_name) {
         log::info!(
             "Migration '{:?}' has already run. Skipping.",
-            migration_name
+            String::from_utf8_lossy(&migration_name)
         );
         return weight;
     }

--- a/pallets/subtensor/src/migrations/migrate_subnet_volume.rs
+++ b/pallets/subtensor/src/migrations/migrate_subnet_volume.rs
@@ -12,7 +12,7 @@ pub fn migrate_subnet_volume<T: Config>() -> Weight {
     if HasMigrationRun::<T>::get(&migration_name) {
         log::info!(
             "Migration '{:?}' has already run. Skipping.",
-            migration_name
+            String::from_utf8_lossy(&migration_name)
         );
         return weight;
     }

--- a/pallets/subtensor/src/migrations/migrate_upgrade_revealed_commitments.rs
+++ b/pallets/subtensor/src/migrations/migrate_upgrade_revealed_commitments.rs
@@ -11,7 +11,7 @@ pub fn migrate_upgrade_revealed_commitments<T: Config>() -> Weight {
     if HasMigrationRun::<T>::get(&migration_name) {
         log::info!(
             "Migration '{:?}' has already run. Skipping.",
-            migration_name
+            String::from_utf8_lossy(&migration_name)
         );
         return weight;
     }

--- a/pallets/subtensor/src/migrations/mod.rs
+++ b/pallets/subtensor/src/migrations/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use alloc::string::String;
 use frame_support::pallet_prelude::Weight;
 use sp_io::KillStorageResult;
 use sp_io::hashing::twox_128;
@@ -10,6 +11,7 @@ pub mod migrate_create_root_network;
 pub mod migrate_delete_subnet_21;
 pub mod migrate_delete_subnet_3;
 pub mod migrate_fix_is_network_member;
+pub mod migrate_fix_root_subnet_tao;
 pub mod migrate_identities_v2;
 pub mod migrate_init_total_issuance;
 pub mod migrate_orphaned_storage_items;
@@ -46,7 +48,7 @@ pub(crate) fn migrate_storage<T: Config>(
     if HasMigrationRun::<T>::get(&migration_name_bytes) {
         log::info!(
             "Migration '{:?}' has already run. Skipping.",
-            migration_name
+            String::from_utf8_lossy(&migration_name_bytes)
         );
         return weight;
     }

--- a/pallets/subtensor/src/tests/coinbase.rs
+++ b/pallets/subtensor/src/tests/coinbase.rs
@@ -757,7 +757,11 @@ fn test_drain_base_with_subnet_with_two_stakers_registered_and_root_different_am
         let expected_root2 = I96F32::from_num(stake_before)
             + I96F32::from_num(pending_tao) * I96F32::from_num(1.0 / 3.0);
         assert_abs_diff_eq!(expected_root2.to_num::<u64>(), root_after2, epsilon = 10); // Registered gets 1/3 tao emission
-        assert_abs_diff_eq!(SubnetTAO::<Test>::get(NetUid::ROOT), pending_tao, epsilon = 10);
+        assert_abs_diff_eq!(
+            SubnetTAO::<Test>::get(NetUid::ROOT),
+            pending_tao,
+            epsilon = 10
+        );
     });
 }
 
@@ -833,7 +837,11 @@ fn test_drain_base_with_subnet_with_two_stakers_registered_and_root_different_am
         let expected_root2 = I96F32::from_num(stake_before)
             + I96F32::from_num(pending_tao) * I96F32::from_num(1.0 / 3.0);
         assert_abs_diff_eq!(expected_root2.to_num::<u64>(), root_after2, epsilon = 10);
-        assert_abs_diff_eq!(SubnetTAO::<Test>::get(NetUid::ROOT), pending_tao, epsilon = 10);
+        assert_abs_diff_eq!(
+            SubnetTAO::<Test>::get(NetUid::ROOT),
+            pending_tao,
+            epsilon = 10
+        );
     });
 }
 
@@ -1105,7 +1113,7 @@ fn test_get_root_children_drain() {
             SubtensorModule::get_stake_for_hotkey_on_subnet(&bob, NetUid::ROOT),
             bob_root_stake + pending_root1 / 2
         );
-        
+
         // The pending root dividends should be present in root subnet.
         assert_eq!(SubnetTAO::<Test>::get(NetUid::ROOT), pending_root1);
 
@@ -1116,7 +1124,7 @@ fn test_get_root_children_drain() {
         let pending_alpha: u64 = 1_000_000_000;
         let pending_root2: u64 = 1_000_000_000;
         SubtensorModule::drain_pending_emission(alpha, pending_alpha, pending_root2, 0, 0);
-        
+
         // Alice makes nothing
         assert_eq!(AlphaDividendsPerSubnet::<Test>::get(alpha, alice), 0);
         assert_eq!(TaoDividendsPerSubnet::<Test>::get(alpha, alice), 0);
@@ -1126,9 +1134,15 @@ fn test_get_root_children_drain() {
             pending_alpha,
             epsilon = 1
         );
-        assert_eq!(TaoDividendsPerSubnet::<Test>::get(alpha, bob), pending_root2);
+        assert_eq!(
+            TaoDividendsPerSubnet::<Test>::get(alpha, bob),
+            pending_root2
+        );
         // The pending root dividends should be present in root subnet.
-        assert_eq!(SubnetTAO::<Test>::get(NetUid::ROOT), pending_root1 + pending_root2);
+        assert_eq!(
+            SubnetTAO::<Test>::get(NetUid::ROOT),
+            pending_root1 + pending_root2
+        );
     });
 }
 

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -829,10 +829,7 @@ fn test_migrate_fix_root_subnet_tao() {
         let mut expected_total_stake = 0;
         // Seed some hotkeys with some fake stake.
         for i in 0..100_000 {
-            Owner::<Test>::insert(
-                U256::from(U256::from(i)),
-                U256::from(i + 1_000_000),
-            );
+            Owner::<Test>::insert(U256::from(U256::from(i)), U256::from(i + 1_000_000));
             let stake = i + 1_000_000;
             TotalHotkeyAlpha::<Test>::insert(U256::from(U256::from(i)), NetUid::ROOT, stake);
             expected_total_stake += stake;

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -830,11 +830,11 @@ fn test_migrate_fix_root_subnet_tao() {
         // Seed some hotkeys with some fake stake.
         for i in 0..100_000 {
             Owner::<Test>::insert(
-                U256::from(U256::from(i as u64)),
-                U256::from((i + 1_000_000) as u64),
+                U256::from(U256::from(i)),
+                U256::from(i + 1_000_000),
             );
             let stake = i + 1_000_000;
-            TotalHotkeyAlpha::<Test>::insert(U256::from(U256::from(i as u64)), NetUid::ROOT, stake);
+            TotalHotkeyAlpha::<Test>::insert(U256::from(U256::from(i)), NetUid::ROOT, stake);
             expected_total_stake += stake;
         }
 

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -820,3 +820,40 @@ fn test_migrate_remove_commitments_rate_limit() {
         assert!(!weight.is_zero(), "Migration weight should be non-zero");
     });
 }
+
+#[test]
+fn test_migrate_fix_root_subnet_tao() {
+    new_test_ext(1).execute_with(|| {
+        const MIGRATION_NAME: &str = "migrate_fix_root_subnet_tao";
+
+        let mut expected_total_stake = 0;
+        // Seed some hotkeys with some fake stake.
+        for i in 0..100_000 {
+            Owner::<Test>::insert(
+                U256::from(U256::from(i as u64)),
+                U256::from((i + 1_000_000) as u64),
+            );
+            let stake = i + 1_000_000;
+            TotalHotkeyAlpha::<Test>::insert(U256::from(U256::from(i as u64)), NetUid::ROOT, stake);
+            expected_total_stake += stake;
+        }
+
+        assert_eq!(SubnetTAO::<Test>::get(NetUid::ROOT), 0);
+        assert!(
+            !HasMigrationRun::<Test>::get(MIGRATION_NAME.as_bytes().to_vec()),
+            "Migration should not have run yet"
+        );
+
+        // Run the migration
+        let weight =
+            crate::migrations::migrate_fix_root_subnet_tao::migrate_fix_root_subnet_tao::<Test>();
+
+        // Verify the migration ran correctly
+        assert!(
+            HasMigrationRun::<Test>::get(MIGRATION_NAME.as_bytes().to_vec()),
+            "Migration should be marked as run"
+        );
+        assert!(!weight.is_zero(), "Migration weight should be non-zero");
+        assert_eq!(SubnetTAO::<Test>::get(NetUid::ROOT), expected_total_stake);
+    });
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -217,7 +217,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 281,
+    spec_version: 282,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description

- Account for the TAO in SubnetTAO when distributing root divs in run_coinbase.
- Migration to fix the mismatch between accumulated stakes and the actual SubnetTAO value for root.
- Fix migrations logging that display a u8 vector instead of the name as a string.




## Related Issue(s)


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.