### PR TITLE
fix: only remove delta when modifying a position

### DIFF
--- a/pallets/swap/src/pallet/impls.rs
+++ b/pallets/swap/src/pallet/impls.rs
@@ -964,8 +964,8 @@ impl<T: Config> Pallet<T> {
             position.liquidity = position.liquidity.saturating_add(delta_liquidity_abs);
         } else {
             // Remove liquidity at tick
-            Self::remove_liquidity_at_index(netuid, position.tick_low, position.liquidity, false);
-            Self::remove_liquidity_at_index(netuid, position.tick_high, position.liquidity, true);
+            Self::remove_liquidity_at_index(netuid, position.tick_low, delta_liquidity_abs, false);
+            Self::remove_liquidity_at_index(netuid, position.tick_high, delta_liquidity_abs, true);
 
             // Remove liquidity from user position
             position.liquidity = position.liquidity.saturating_sub(delta_liquidity_abs);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -217,7 +217,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 280,
+    spec_version: 281,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description

Fixes do_momdify_position by only removing the delta rather than the whole position's liquidity

## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.