### PR TITLE
Revert publish jobs separation for multiple platforms in docler.yml workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ permissions:
   security-events: write
 
 jobs:
-  publish-x86:
+  publish:
     runs-on: SubtensorCI
 
     steps:
@@ -64,53 +64,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/${{ github.repository }}:${{ env.tag }}-amd64
-            ${{ env.latest_tag == 'true' && format('ghcr.io/{0}:latest-amd64', github.repository) || '' }}
-  publish-arm:
-    runs-on: SubtensorCI
-
-    steps:
-      - name: Determine Docker tag and ref
-        id: tag
-        run: |
-          branch_or_tag="${{ github.event.inputs.branch-or-tag || github.ref_name }}"
-          echo "Determined branch or tag: $branch_or_tag"
-          echo "tag=$branch_or_tag" >> $GITHUB_ENV
-          echo "ref=$branch_or_tag" >> $GITHUB_ENV
-
-          # Check if this is a tagged release (not devnet-ready/devnet/testnet)
-          if [[ "${{ github.event_name }}" == "release" && "$branch_or_tag" != "devnet-ready" && "$branch_or_tag" != "devnet" && "$branch_or_tag" != "testnet" ]]; then
-            echo "latest_tag=true" >> $GITHUB_ENV
-          else
-            echo "latest_tag=false" >> $GITHUB_ENV
-          fi
-
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.ref }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          platforms: linux/arm64
-          tags: |
-            ghcr.io/${{ github.repository }}:${{ env.tag }}-arm64
-            ${{ env.latest_tag == 'true' && format('ghcr.io/{0}:latest-arm64', github.repository) || '' }}
+            ghcr.io/${{ github.repository }}:${{ env.tag }}
+            ${{ env.latest_tag == 'true' && format('ghcr.io/{0}:latest', github.repository) || '' }}


### PR DESCRIPTION
## Description
This PR reverts `docker.yml` CI workfow to a single multiplatform publish job while keeping the updated action versions. 


## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
