### PR TITLE
Fix double fees, set default min stake to 0.02 TAO, fix tick range check

### DIFF
--- a/pallets/subtensor/src/benchmarks.rs
+++ b/pallets/subtensor/src/benchmarks.rs
@@ -741,7 +741,7 @@ mod pallet_benchmarks {
         Subtensor::<T>::init_new_network(netuid, 1);
 
         let burn_fee = Subtensor::<T>::get_burn_as_u64(netuid);
-        let stake_tao: u64 = 1_000_000;
+        let stake_tao: u64 = DefaultMinStake::<T>::get();
         let deposit = burn_fee.saturating_mul(2).saturating_add(stake_tao);
         Subtensor::<T>::add_balance_to_coldkey_account(&coldkey, deposit);
 
@@ -919,7 +919,7 @@ mod pallet_benchmarks {
         Subtensor::<T>::init_new_network(netuid, 1);
 
         let reg_fee = Subtensor::<T>::get_burn_as_u64(netuid);
-        let stake_tao: u64 = 1_000_000;
+        let stake_tao: u64 = DefaultMinStake::<T>::get();
         let deposit = reg_fee.saturating_mul(2).saturating_add(stake_tao);
         Subtensor::<T>::add_balance_to_coldkey_account(&coldkey, deposit);
 
@@ -974,7 +974,7 @@ mod pallet_benchmarks {
         Subtensor::<T>::init_new_network(netuid2, 1);
 
         let reg_fee = Subtensor::<T>::get_burn_as_u64(netuid1);
-        let stake_tao: u64 = 1_000_000;
+        let stake_tao: u64 = DefaultMinStake::<T>::get();
         let deposit = reg_fee.saturating_mul(2).saturating_add(stake_tao);
         Subtensor::<T>::add_balance_to_coldkey_account(&coldkey, deposit);
 

--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -194,11 +194,12 @@ impl<T: Config> Pallet<T> {
             // Get pending alpha as original alpha_out - root_alpha.
             let pending_alpha: U96F32 = alpha_out_i.saturating_sub(root_alpha);
             log::debug!("pending_alpha: {:?}", pending_alpha);
-            // Sell root emission through the pool.
+            // Sell root emission through the pool (do not pay fees)
             let swap_result = Self::swap_alpha_for_tao(
                 *netuid_i,
                 tou64!(root_alpha),
                 T::SwapInterface::min_price(),
+                true,
             );
             if let Ok(ok_result) = swap_result {
                 let root_tao: u64 = ok_result.amount_paid_out;

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -801,7 +801,7 @@ pub mod pallet {
     #[pallet::type_value]
     /// Default minimum stake.
     pub fn DefaultMinStake<T: Config>() -> u64 {
-        500_000
+        20_000_000
     }
 
     #[pallet::type_value]

--- a/pallets/subtensor/src/staking/add_stake.rs
+++ b/pallets/subtensor/src/staking/add_stake.rs
@@ -188,10 +188,16 @@ impl<T: Config> Pallet<T> {
         }
 
         // Use reverting swap to estimate max limit amount
-        let result =
-            T::SwapInterface::swap(netuid.into(), OrderType::Buy, u64::MAX, limit_price, true)
-                .map(|r| r.amount_paid_in.saturating_add(r.fee_paid))
-                .map_err(|_| Error::ZeroMaxStakeAmount)?;
+        let result = T::SwapInterface::swap(
+            netuid.into(),
+            OrderType::Buy,
+            u64::MAX,
+            limit_price,
+            false,
+            true,
+        )
+        .map(|r| r.amount_paid_in.saturating_add(r.fee_paid))
+        .map_err(|_| Error::ZeroMaxStakeAmount)?;
 
         if result != 0 {
             Ok(result)

--- a/pallets/subtensor/src/staking/helpers.rs
+++ b/pallets/subtensor/src/staking/helpers.rs
@@ -193,6 +193,7 @@ impl<T: Config> Pallet<T> {
                     netuid,
                     stake,
                     T::SwapInterface::min_price(),
+                    false,
                 );
 
                 if let Ok(cleared_stake) = maybe_cleared_stake {

--- a/pallets/subtensor/src/staking/move_stake.rs
+++ b/pallets/subtensor/src/staking/move_stake.rs
@@ -351,12 +351,14 @@ impl<T: Config> Pallet<T> {
             max_amount
         };
 
+        // do not pay fees to avoid double fees in moves transactions
         let tao_unstaked = Self::unstake_from_subnet(
             origin_hotkey,
             origin_coldkey,
             origin_netuid,
             move_amount,
             T::SwapInterface::min_price(),
+            true,
         )?;
 
         // Stake the unstaked amount into the destination.

--- a/pallets/subtensor/src/staking/remove_stake.rs
+++ b/pallets/subtensor/src/staking/remove_stake.rs
@@ -64,13 +64,14 @@ impl<T: Config> Pallet<T> {
             false,
         )?;
 
-        // 3. Swap the alpba to tao and update counters for this subnet.
+        // 3. Swap the alpha to tao and update counters for this subnet.
         let tao_unstaked: u64 = Self::unstake_from_subnet(
             &hotkey,
             &coldkey,
             netuid,
             alpha_unstaked,
             T::SwapInterface::min_price(),
+            false,
         )?;
 
         // 4. We add the balance to the coldkey. If the above fails we will not credit this coldkey.
@@ -165,6 +166,7 @@ impl<T: Config> Pallet<T> {
                     netuid,
                     alpha_unstaked,
                     T::SwapInterface::min_price(),
+                    false,
                 )?;
 
                 // Add the balance to the coldkey. If the above fails we will not credit this coldkey.
@@ -257,6 +259,7 @@ impl<T: Config> Pallet<T> {
                         netuid,
                         alpha_unstaked,
                         T::SwapInterface::min_price(),
+                        false,
                     )?;
 
                     // Increment total
@@ -358,8 +361,14 @@ impl<T: Config> Pallet<T> {
         )?;
 
         // 4. Swap the alpha to tao and update counters for this subnet.
-        let tao_unstaked =
-            Self::unstake_from_subnet(&hotkey, &coldkey, netuid, possible_alpha, limit_price)?;
+        let tao_unstaked = Self::unstake_from_subnet(
+            &hotkey,
+            &coldkey,
+            netuid,
+            possible_alpha,
+            limit_price,
+            false,
+        )?;
 
         // 5. We add the balance to the coldkey. If the above fails we will not credit this coldkey.
         Self::add_balance_to_coldkey_account(&coldkey, tao_unstaked);
@@ -392,10 +401,16 @@ impl<T: Config> Pallet<T> {
         }
 
         // Use reverting swap to estimate max limit amount
-        let result =
-            T::SwapInterface::swap(netuid.into(), OrderType::Sell, u64::MAX, limit_price, true)
-                .map(|r| r.amount_paid_in.saturating_add(r.fee_paid))
-                .map_err(|_| Error::ZeroMaxStakeAmount)?;
+        let result = T::SwapInterface::swap(
+            netuid.into(),
+            OrderType::Sell,
+            u64::MAX,
+            limit_price,
+            false,
+            true,
+        )
+        .map(|r| r.amount_paid_in.saturating_add(r.fee_paid))
+        .map_err(|_| Error::ZeroMaxStakeAmount)?;
 
         if result != 0 {
             Ok(result)

--- a/pallets/subtensor/src/subnets/leasing.rs
+++ b/pallets/subtensor/src/subnets/leasing.rs
@@ -293,6 +293,7 @@ impl<T: Config> Pallet<T> {
             lease.netuid,
             total_contributors_cut_alpha,
             T::SwapInterface::min_price(),
+            false,
         ) {
             Ok(tao_unstaked) => tao_unstaked,
             Err(err) => {

--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -934,6 +934,7 @@ pub(crate) fn swap_tao_to_alpha(netuid: NetUid, tao: u64) -> (u64, u64) {
         OrderType::Buy,
         tao,
         <Test as pallet::Config>::SwapInterface::max_price(),
+        false,
         true,
     );
 
@@ -947,7 +948,7 @@ pub(crate) fn swap_tao_to_alpha(netuid: NetUid, tao: u64) -> (u64, u64) {
     (result.amount_paid_out, result.fee_paid)
 }
 
-pub(crate) fn swap_alpha_to_tao(netuid: NetUid, alpha: u64) -> (u64, u64) {
+pub(crate) fn swap_alpha_to_tao_ext(netuid: NetUid, alpha: u64, drop_fees: bool) -> (u64, u64) {
     if netuid.is_root() {
         return (alpha, 0);
     }
@@ -962,6 +963,7 @@ pub(crate) fn swap_alpha_to_tao(netuid: NetUid, alpha: u64) -> (u64, u64) {
         OrderType::Sell,
         alpha,
         <Test as pallet::Config>::SwapInterface::min_price(),
+        drop_fees,
         true,
     );
 
@@ -973,4 +975,8 @@ pub(crate) fn swap_alpha_to_tao(netuid: NetUid, alpha: u64) -> (u64, u64) {
     assert!(result.amount_paid_out > 0);
 
     (result.amount_paid_out, result.fee_paid)
+}
+
+pub(crate) fn swap_alpha_to_tao(netuid: NetUid, alpha: u64) -> (u64, u64) {
+    swap_alpha_to_tao_ext(netuid, alpha, false)
 }

--- a/pallets/subtensor/src/tests/move_stake.rs
+++ b/pallets/subtensor/src/tests/move_stake.rs
@@ -44,8 +44,7 @@ fn test_do_move_success() {
         );
 
         // Perform the move
-        let (tao_equivalent, _) = mock::swap_alpha_to_tao(netuid, alpha);
-        let (expected_alpha, _) = mock::swap_tao_to_alpha(netuid, tao_equivalent);
+        let expected_alpha = alpha * 997 / 1000;
         assert_ok!(SubtensorModule::do_move_stake(
             RuntimeOrigin::signed(coldkey),
             origin_hotkey,
@@ -71,7 +70,7 @@ fn test_do_move_success() {
                 netuid
             ),
             expected_alpha,
-            epsilon = 1000
+            epsilon = expected_alpha / 1000
         );
     });
 }
@@ -138,7 +137,7 @@ fn test_do_move_different_subnets() {
                 &coldkey,
                 destination_netuid
             ),
-            alpha - (2 * fee),
+            alpha - fee,
             epsilon = alpha / 1000
         );
     });
@@ -309,200 +308,78 @@ fn test_do_move_nonexistent_destination_hotkey() {
     });
 }
 
-// 8. test_do_move_all_stake
-// Description: Test moving all stake from one hotkey to another
-// SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test move -- test_do_move_all_stake --exact --nocapture
-#[test]
-fn test_do_move_all_stake() {
-    new_test_ext(1).execute_with(|| {
-        let subnet_owner_coldkey = U256::from(1001);
-        let subnet_owner_hotkey = U256::from(1002);
-        let netuid = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
-        let coldkey = U256::from(1);
-        let origin_hotkey = U256::from(2);
-        let destination_hotkey = U256::from(3);
-        let stake_amount = DefaultMinStake::<Test>::get() * 10;
-
-        mock::setup_reserves(netuid, stake_amount * 10, stake_amount * 10);
-
-        // Set up initial stake
-        SubtensorModule::stake_into_subnet(
-            &origin_hotkey,
-            &coldkey,
-            netuid,
-            stake_amount,
-            <Test as Config>::SwapInterface::max_price(),
-        )
-        .unwrap();
-        let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
-            &origin_hotkey,
-            &coldkey,
-            netuid,
-        );
-
-        // Move all stake
-        SubtensorModule::create_account_if_non_existent(&coldkey, &origin_hotkey);
-        SubtensorModule::create_account_if_non_existent(&coldkey, &destination_hotkey);
-        assert_ok!(SubtensorModule::do_move_stake(
-            RuntimeOrigin::signed(coldkey),
-            origin_hotkey,
-            destination_hotkey,
-            netuid,
-            netuid,
-            alpha,
-        ));
-
-        // Check that all stake was moved
-        assert_eq!(
-            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
-                &origin_hotkey,
-                &coldkey,
-                netuid
-            ),
-            0
-        );
-        let fee = <Test as Config>::SwapInterface::approx_fee_amount(netuid.into(), alpha);
-        assert_abs_diff_eq!(
-            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
-                &destination_hotkey,
-                &coldkey,
-                netuid
-            ),
-            alpha - (2 * fee),
-            epsilon = alpha / 1000
-        );
-    });
-}
-
-#[test]
-fn test_do_move_half_stake() {
-    new_test_ext(1).execute_with(|| {
-        let subnet_owner_coldkey = U256::from(1001);
-        let subnet_owner_hotkey = U256::from(1002);
-        let netuid = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
-        let coldkey = U256::from(1);
-        let origin_hotkey = U256::from(2);
-        let destination_hotkey = U256::from(3);
-        let stake_amount = DefaultMinStake::<Test>::get() * 10;
-        mock::setup_reserves(netuid, stake_amount * 100, stake_amount * 100);
-
-        // Set up initial stake
-        SubtensorModule::stake_into_subnet(
-            &origin_hotkey,
-            &coldkey,
-            netuid,
-            stake_amount,
-            <Test as Config>::SwapInterface::max_price(),
-        )
-        .unwrap();
-        let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
-            &origin_hotkey,
-            &coldkey,
-            netuid,
-        );
-
-        // Move all stake
-        SubtensorModule::create_account_if_non_existent(&coldkey, &origin_hotkey);
-        SubtensorModule::create_account_if_non_existent(&coldkey, &destination_hotkey);
-        assert_ok!(SubtensorModule::do_move_stake(
-            RuntimeOrigin::signed(coldkey),
-            origin_hotkey,
-            destination_hotkey,
-            netuid,
-            netuid,
-            alpha / 2,
-        ));
-
-        // Check that all stake was moved
-        assert_abs_diff_eq!(
-            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
-                &origin_hotkey,
-                &coldkey,
-                netuid
-            ),
-            alpha / 2,
-            epsilon = alpha / 1000
-        );
-        let fee = <Test as Config>::SwapInterface::approx_fee_amount(netuid.into(), alpha);
-        assert_abs_diff_eq!(
-            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
-                &destination_hotkey,
-                &coldkey,
-                netuid
-            ),
-            alpha / 2 - fee,
-            epsilon = alpha / 1000
-        );
-    });
-}
-
-// 9. test_do_move_partial_stake
+// 9. test_do_move_partial_stake (replaces "move half" and "move all" tests)
 // Description: Test moving a portion of stake from one hotkey to another
 // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test move -- test_do_move_partial_stake --exact --nocapture
 #[test]
 fn test_do_move_partial_stake() {
-    new_test_ext(1).execute_with(|| {
-        let subnet_owner_coldkey = U256::from(1001);
-        let subnet_owner_hotkey = U256::from(1002);
-        let netuid = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
-        let coldkey = U256::from(1);
-        let origin_hotkey = U256::from(2);
-        let destination_hotkey = U256::from(3);
-        let total_stake = DefaultMinStake::<Test>::get() * 10;
+    // Test case: portion of stake to move (in tenths)
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        .into_iter()
+        .for_each(|portion_moved| {
+            new_test_ext(1).execute_with(|| {
+                let subnet_owner_coldkey = U256::from(1001);
+                let subnet_owner_hotkey = U256::from(1002);
+                let netuid = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
+                let coldkey = U256::from(1);
+                let origin_hotkey = U256::from(2);
+                let destination_hotkey = U256::from(3);
+                let total_stake = DefaultMinStake::<Test>::get() * 20;
 
-        // Set up initial stake
-        SubtensorModule::stake_into_subnet(
-            &origin_hotkey,
-            &coldkey,
-            netuid,
-            total_stake,
-            <Test as Config>::SwapInterface::max_price(),
-        )
-        .unwrap();
-        let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
-            &origin_hotkey,
-            &coldkey,
-            netuid,
-        );
+                // Set up initial stake
+                SubtensorModule::stake_into_subnet(
+                    &origin_hotkey,
+                    &coldkey,
+                    netuid,
+                    total_stake,
+                    <Test as Config>::SwapInterface::max_price(),
+                )
+                .unwrap();
+                let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+                    &origin_hotkey,
+                    &coldkey,
+                    netuid,
+                );
 
-        // Move partial stake
-        let (tao_equivalent, _) = mock::swap_alpha_to_tao(netuid, alpha);
-        let (expected_alpha, _) = mock::swap_tao_to_alpha(netuid, tao_equivalent);
-        SubtensorModule::create_account_if_non_existent(&coldkey, &origin_hotkey);
-        SubtensorModule::create_account_if_non_existent(&coldkey, &destination_hotkey);
-        assert_ok!(SubtensorModule::do_move_stake(
-            RuntimeOrigin::signed(coldkey),
-            origin_hotkey,
-            destination_hotkey,
-            netuid,
-            netuid,
-            alpha,
-        ));
+                // Move partial stake
+                let alpha_moved = alpha * portion_moved / 10;
+                SubtensorModule::create_account_if_non_existent(&coldkey, &origin_hotkey);
+                SubtensorModule::create_account_if_non_existent(&coldkey, &destination_hotkey);
+                assert_ok!(SubtensorModule::do_move_stake(
+                    RuntimeOrigin::signed(coldkey),
+                    origin_hotkey,
+                    destination_hotkey,
+                    netuid,
+                    netuid,
+                    alpha_moved,
+                ));
 
-        // Check that the correct amount of stake was moved
-        assert_eq!(
-            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
-                &origin_hotkey,
-                &coldkey,
-                netuid
-            ),
-            0
-        );
-        assert_abs_diff_eq!(
-            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
-                &destination_hotkey,
-                &coldkey,
-                netuid
-            ),
-            expected_alpha,
-            epsilon = 1000
-        );
-    });
+                // Check that the correct amount of stake was moved
+                assert_abs_diff_eq!(
+                    SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+                        &origin_hotkey,
+                        &coldkey,
+                        netuid
+                    ),
+                    alpha - alpha_moved,
+                    epsilon = 10
+                );
+                assert_abs_diff_eq!(
+                    SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+                        &destination_hotkey,
+                        &coldkey,
+                        netuid
+                    ),
+                    alpha_moved * 997 / 1000,
+                    epsilon = 10_000
+                );
+            });
+        });
 }
 
 // 10. test_do_move_multiple_times
 // Description: Test moving stake multiple times between the same hotkeys
-// SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test move -- test_do_move_multiple_times --exact --nocapture
+// SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --package pallet-subtensor --lib -- tests::move_stake::test_do_move_multiple_times --exact --show-output
 #[test]
 fn test_do_move_multiple_times() {
     new_test_ext(1).execute_with(|| {
@@ -525,9 +402,11 @@ fn test_do_move_multiple_times() {
             <Test as Config>::SwapInterface::max_price(),
         )
         .unwrap();
+        let alpha =
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey1, &coldkey, netuid);
 
         // Move stake multiple times
-        let mut expected_alpha: u64 = 0;
+        let mut expected_alpha: u64 = alpha;
         for _ in 0..3 {
             let alpha1 = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
                 &hotkey1, &coldkey, netuid,
@@ -543,9 +422,6 @@ fn test_do_move_multiple_times() {
             let alpha2 = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
                 &hotkey2, &coldkey, netuid,
             );
-            let (tao_equivalent, _) = mock::swap_alpha_to_tao(netuid, alpha2);
-            // we need expected_alpha before the last move, so we call it within the loop
-            expected_alpha = mock::swap_tao_to_alpha(netuid, tao_equivalent).0;
             assert_ok!(SubtensorModule::do_move_stake(
                 RuntimeOrigin::signed(coldkey),
                 hotkey2,
@@ -554,13 +430,16 @@ fn test_do_move_multiple_times() {
                 netuid,
                 alpha2,
             ));
+
+            // Reduce by fees x2
+            expected_alpha -= expected_alpha * 6 / 1000;
         }
 
         // Check final stake distribution
         assert_abs_diff_eq!(
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey1, &coldkey, netuid),
             expected_alpha,
-            epsilon = 1000,
+            epsilon = expected_alpha / 1000,
         );
         assert_eq!(
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey2, &coldkey, netuid),
@@ -716,7 +595,7 @@ fn test_do_move_event_emission() {
 
         // Move stake and capture events
         System::reset_events();
-        let (tao_equivalent, _) = mock::swap_alpha_to_tao(netuid, alpha);
+        let (tao_equivalent, _) = mock::swap_alpha_to_tao_ext(netuid, alpha, true);
         assert_ok!(SubtensorModule::do_move_stake(
             RuntimeOrigin::signed(coldkey),
             origin_hotkey,
@@ -775,7 +654,7 @@ fn test_do_move_storage_updates() {
             origin_netuid,
         );
 
-        let (tao_equivalent, _) = mock::swap_alpha_to_tao(origin_netuid, alpha);
+        let (tao_equivalent, _) = mock::swap_alpha_to_tao_ext(origin_netuid, alpha, true);
         let (alpha2, _) = mock::swap_tao_to_alpha(destination_netuid, tao_equivalent);
         assert_ok!(SubtensorModule::do_move_stake(
             RuntimeOrigin::signed(coldkey),
@@ -845,7 +724,7 @@ fn test_do_move_max_values() {
         );
 
         // Move maximum stake
-        let (_, fee) = mock::swap_alpha_to_tao(netuid, alpha);
+        let (_, fee) = mock::swap_alpha_to_tao_ext(netuid, alpha, true);
         assert_ok!(SubtensorModule::do_move_stake(
             RuntimeOrigin::signed(coldkey),
             origin_hotkey,
@@ -948,8 +827,7 @@ fn test_do_transfer_success() {
         );
 
         // 4. Transfer the entire stake to the destination coldkey on the same subnet (netuid, netuid).
-        let (tao_equivalent, _) = mock::swap_alpha_to_tao(netuid, alpha);
-        let (expected_alpha, _) = mock::swap_tao_to_alpha(netuid, tao_equivalent);
+        let expected_alpha = alpha * 997 / 1000;
         assert_ok!(SubtensorModule::do_transfer_stake(
             RuntimeOrigin::signed(origin_coldkey),
             destination_coldkey,
@@ -975,7 +853,7 @@ fn test_do_transfer_success() {
                 netuid
             ),
             expected_alpha,
-            epsilon = 1000
+            epsilon = expected_alpha / 1000
         );
     });
 }
@@ -1179,7 +1057,7 @@ fn test_do_transfer_different_subnets() {
             origin_netuid,
         );
 
-        let (tao_equivalent, _) = mock::swap_alpha_to_tao(origin_netuid, alpha);
+        let (tao_equivalent, _) = mock::swap_alpha_to_tao_ext(origin_netuid, alpha, true);
         let (expected_alpha, _) = mock::swap_tao_to_alpha(destination_netuid, tao_equivalent);
 
         assert_ok!(SubtensorModule::do_transfer_stake(
@@ -1241,7 +1119,7 @@ fn test_do_swap_success() {
             origin_netuid,
         );
 
-        let (tao_equivalent, _) = mock::swap_alpha_to_tao(origin_netuid, alpha_before);
+        let (tao_equivalent, _) = mock::swap_alpha_to_tao_ext(origin_netuid, alpha_before, true);
         let (expected_alpha, _) = mock::swap_tao_to_alpha(destination_netuid, tao_equivalent);
         assert_ok!(SubtensorModule::do_swap_stake(
             RuntimeOrigin::signed(coldkey),
@@ -1468,6 +1346,7 @@ fn test_do_swap_same_subnet() {
     });
 }
 
+// cargo test --package pallet-subtensor --lib -- tests::move_stake::test_do_swap_partial_stake --exact --show-output
 #[test]
 fn test_do_swap_partial_stake() {
     new_test_ext(1).execute_with(|| {
@@ -1478,20 +1357,25 @@ fn test_do_swap_partial_stake() {
 
         let coldkey = U256::from(1);
         let hotkey = U256::from(2);
-        let total_stake = DefaultMinStake::<Test>::get() * 10;
+        let total_stake_tao = DefaultMinStake::<Test>::get() * 10;
 
         SubtensorModule::create_account_if_non_existent(&coldkey, &hotkey);
         SubtensorModule::stake_into_subnet(
             &hotkey,
             &coldkey,
             origin_netuid,
-            total_stake,
+            total_stake_tao,
             <Test as Config>::SwapInterface::max_price(),
         )
         .unwrap();
+        let total_stake_alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey,
+            &coldkey,
+            origin_netuid,
+        );
 
-        let swap_amount = total_stake / 2;
-        let (tao_equivalent, _) = mock::swap_alpha_to_tao(origin_netuid, swap_amount);
+        let swap_amount = total_stake_alpha / 2;
+        let (tao_equivalent, _) = mock::swap_alpha_to_tao_ext(origin_netuid, swap_amount, true);
         let (expected_alpha, _) = mock::swap_tao_to_alpha(destination_netuid, tao_equivalent);
         assert_ok!(SubtensorModule::do_swap_stake(
             RuntimeOrigin::signed(coldkey),
@@ -1505,7 +1389,7 @@ fn test_do_swap_partial_stake() {
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
                 &hotkey,
                 &coldkey,
-                origin_netuid
+                destination_netuid
             ),
             expected_alpha,
             epsilon = 1000
@@ -1540,7 +1424,7 @@ fn test_do_swap_storage_updates() {
             &coldkey,
             origin_netuid,
         );
-        let (tao_equivalent, _) = mock::swap_alpha_to_tao(origin_netuid, alpha);
+        let (tao_equivalent, _) = mock::swap_alpha_to_tao_ext(origin_netuid, alpha, true);
         let (expected_alpha, _) = mock::swap_tao_to_alpha(destination_netuid, tao_equivalent);
         assert_ok!(SubtensorModule::do_swap_stake(
             RuntimeOrigin::signed(coldkey),
@@ -1611,7 +1495,7 @@ fn test_do_swap_multiple_times() {
                 &hotkey, &coldkey, netuid2,
             );
             if alpha2 > 0 {
-                let (tao_equivalent, _) = mock::swap_alpha_to_tao(netuid2, alpha2);
+                let (tao_equivalent, _) = mock::swap_alpha_to_tao_ext(netuid2, alpha2, true);
                 // we do this in the loop, because we need the value before the swap
                 expected_alpha = mock::swap_tao_to_alpha(netuid1, tao_equivalent).0;
                 assert_ok!(SubtensorModule::do_swap_stake(
@@ -1918,7 +1802,7 @@ fn test_move_stake_specific_stake_into_subnet_fail() {
         );
 
         // Move stake to destination subnet
-        let (tao_equivalent, _) = mock::swap_alpha_to_tao(origin_netuid, alpha_to_move);
+        let (tao_equivalent, _) = mock::swap_alpha_to_tao_ext(origin_netuid, alpha_to_move, true);
         let (expected_value, _) = mock::swap_tao_to_alpha(netuid, tao_equivalent);
         assert_ok!(SubtensorModule::move_stake(
             RuntimeOrigin::signed(coldkey_account_id),

--- a/pallets/subtensor/src/tests/move_stake.rs
+++ b/pallets/subtensor/src/tests/move_stake.rs
@@ -337,7 +337,7 @@ fn test_do_move_partial_stake() {
                     netuid,
                     total_stake,
                     <Test as Config>::SwapInterface::max_price(),
-                    false,                    
+                    false,
                 )
                 .unwrap();
                 let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
@@ -429,6 +429,7 @@ fn test_do_move_multiple_times() {
             let alpha2 = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
                 &hotkey2, &coldkey, netuid,
             );
+            remove_stake_rate_limit_for_tests(&hotkey2, &coldkey, netuid);
             assert_ok!(SubtensorModule::do_move_stake(
                 RuntimeOrigin::signed(coldkey),
                 hotkey2,
@@ -438,7 +439,7 @@ fn test_do_move_multiple_times() {
                 alpha2,
             ));
 
-            // Reduce by fees x2
+            // Reduce expected_alpha by fees x2
             expected_alpha -= expected_alpha * 6 / 1000;
         }
 

--- a/pallets/subtensor/src/tests/swap_coldkey.rs
+++ b/pallets/subtensor/src/tests/swap_coldkey.rs
@@ -2465,7 +2465,7 @@ fn test_coldkey_in_swap_schedule_prevents_funds_usage() {
         let call = RuntimeCall::SubtensorModule(SubtensorCall::remove_stake {
             hotkey,
             netuid,
-            amount_unstaked: 1_000_000,
+            amount_unstaked: DefaultMinStake::<Test>::get() * 2,
         });
         let result = extension.validate(
             RawOrigin::Signed(who).into(),
@@ -2483,7 +2483,7 @@ fn test_coldkey_in_swap_schedule_prevents_funds_usage() {
         let call = RuntimeCall::SubtensorModule(SubtensorCall::remove_stake_limit {
             hotkey,
             netuid,
-            amount_unstaked: 1_000_000,
+            amount_unstaked: DefaultMinStake::<Test>::get() * 2,
             limit_price: 123456789, // should be low enough
             allow_partial: true,
         });

--- a/pallets/subtensor/src/tests/swap_hotkey_with_subnet.rs
+++ b/pallets/subtensor/src/tests/swap_hotkey_with_subnet.rs
@@ -90,7 +90,7 @@ fn test_swap_total_hotkey_stake() {
         assert_abs_diff_eq!(
             SubtensorModule::get_total_stake_for_hotkey(&old_hotkey),
             amount - fee,
-            epsilon = amount / 1000,
+            epsilon = amount / 100,
         );
         assert_abs_diff_eq!(
             SubtensorModule::get_total_stake_for_hotkey(&new_hotkey),
@@ -116,7 +116,7 @@ fn test_swap_total_hotkey_stake() {
         assert_abs_diff_eq!(
             SubtensorModule::get_total_stake_for_hotkey(&new_hotkey),
             amount - fee,
-            epsilon = amount / 1000,
+            epsilon = amount / 100,
         );
     });
 }

--- a/pallets/swap-interface/src/lib.rs
+++ b/pallets/swap-interface/src/lib.rs
@@ -16,6 +16,7 @@ pub trait SwapHandler<AccountId> {
         order_t: OrderType,
         amount: u64,
         price_limit: u64,
+        drop_fees: bool,
         should_rollback: bool,
     ) -> Result<SwapResult, DispatchError>;
     fn sim_swap(

--- a/pallets/swap/src/pallet/tests.rs
+++ b/pallets/swap/src/pallet/tests.rs
@@ -367,6 +367,18 @@ fn test_add_liquidity_out_of_bounds() {
                 TickIndex::new_unchecked(TickIndex::MAX.get() + 100),
                 1_000_000_000_u64,
             ),
+            // Inverted ticks: high < low
+            (
+                TickIndex::new_unchecked(-900),
+                TickIndex::new_unchecked(-1000),
+                1_000_000_000_u64,
+            ),
+            // Equal ticks: high == low
+            (
+                TickIndex::new_unchecked(-10_000),
+                TickIndex::new_unchecked(-10_000),
+                1_000_000_000_u64,
+            ),
         ]
         .into_iter()
         .enumerate()
@@ -619,6 +631,7 @@ fn test_modify_position_basic() {
                 liquidity / 10,
                 sqrt_limit_price,
                 false,
+                false,
             )
             .unwrap();
 
@@ -724,9 +737,15 @@ fn test_swap_basic() {
 
                 // Swap
                 let sqrt_limit_price = SqrtPrice::from_num((limit_price).sqrt());
-                let swap_result =
-                    Pallet::<Test>::do_swap(netuid, order_type, liquidity, sqrt_limit_price, false)
-                        .unwrap();
+                let swap_result = Pallet::<Test>::do_swap(
+                    netuid,
+                    order_type,
+                    liquidity,
+                    sqrt_limit_price,
+                    false,
+                    false,
+                )
+                .unwrap();
                 assert_abs_diff_eq!(
                     swap_result.amount_paid_out,
                     output_amount,
@@ -970,6 +989,7 @@ fn test_swap_single_position() {
                         order_liquidity as u64,
                         sqrt_limit_price,
                         false,
+                        false,
                     )
                     .unwrap();
                     assert_abs_diff_eq!(
@@ -1193,6 +1213,7 @@ fn test_swap_multiple_positions() {
                 order_liquidity,
                 sqrt_limit_price,
                 false,
+                false,
             )
             .unwrap();
             assert_abs_diff_eq!(
@@ -1262,7 +1283,8 @@ fn test_swap_precision_edge_case() {
 
         // Swap
         let swap_result =
-            Pallet::<Test>::do_swap(netuid, order_type, liquidity, sqrt_limit_price, true).unwrap();
+            Pallet::<Test>::do_swap(netuid, order_type, liquidity, sqrt_limit_price, false, true)
+                .unwrap();
 
         assert!(swap_result.amount_paid_out > 0);
     });
@@ -1467,10 +1489,18 @@ fn test_swap_fee_correctness() {
             liquidity / 10,
             u64::MAX.into(),
             false,
+            false,
         )
         .unwrap();
-        Pallet::<Test>::do_swap(netuid, OrderType::Sell, liquidity / 10, 0_u64.into(), false)
-            .unwrap();
+        Pallet::<Test>::do_swap(
+            netuid,
+            OrderType::Sell,
+            liquidity / 10,
+            0_u64.into(),
+            false,
+            false,
+        )
+        .unwrap();
 
         // Get user position
         let mut position =
@@ -1560,10 +1590,24 @@ fn test_rollback_works() {
         let netuid = NetUid::from(1);
 
         assert_eq!(
-            Pallet::<Test>::do_swap(netuid, OrderType::Buy, 1_000_000, u64::MAX.into(), true)
-                .unwrap(),
-            Pallet::<Test>::do_swap(netuid, OrderType::Buy, 1_000_000, u64::MAX.into(), false)
-                .unwrap()
+            Pallet::<Test>::do_swap(
+                netuid,
+                OrderType::Buy,
+                1_000_000,
+                u64::MAX.into(),
+                false,
+                true
+            )
+            .unwrap(),
+            Pallet::<Test>::do_swap(
+                netuid,
+                OrderType::Buy,
+                1_000_000,
+                u64::MAX.into(),
+                false,
+                false
+            )
+            .unwrap()
         );
     })
 }
@@ -1606,10 +1650,18 @@ fn test_new_lp_doesnt_get_old_fees() {
             liquidity / 10,
             u64::MAX.into(),
             false,
+            false,
         )
         .unwrap();
-        Pallet::<Test>::do_swap(netuid, OrderType::Sell, liquidity / 10, 0_u64.into(), false)
-            .unwrap();
+        Pallet::<Test>::do_swap(
+            netuid,
+            OrderType::Sell,
+            liquidity / 10,
+            0_u64.into(),
+            false,
+            false,
+        )
+        .unwrap();
 
         // Add liquidity from a different user to a new tick
         let (position_id_2, _tao, _alpha) = Pallet::<Test>::do_add_liquidity(
@@ -1678,7 +1730,8 @@ fn test_wrapping_fees() {
         let swap_amt = 800_000_000_u64;
         let order_type = OrderType::Sell;
         let sqrt_limit_price = SqrtPrice::from_num(0.000001);
-        Pallet::<Test>::do_swap(netuid, order_type, swap_amt, sqrt_limit_price, false).unwrap();
+        Pallet::<Test>::do_swap(netuid, order_type, swap_amt, sqrt_limit_price, false, false)
+            .unwrap();
 
         let swap_amt = 1_850_000_000_u64;
         let order_type = OrderType::Buy;
@@ -1686,7 +1739,8 @@ fn test_wrapping_fees() {
 
         print_current_price(netuid);
 
-        Pallet::<Test>::do_swap(netuid, order_type, swap_amt, sqrt_limit_price, false).unwrap();
+        Pallet::<Test>::do_swap(netuid, order_type, swap_amt, sqrt_limit_price, false, false)
+            .unwrap();
 
         print_current_price(netuid);
 
@@ -1705,7 +1759,8 @@ fn test_wrapping_fees() {
         let sqrt_limit_price = SqrtPrice::from_num(0.000001);
 
         let initial_sqrt_price = Pallet::<Test>::current_price_sqrt(netuid);
-        Pallet::<Test>::do_swap(netuid, order_type, swap_amt, sqrt_limit_price, false).unwrap();
+        Pallet::<Test>::do_swap(netuid, order_type, swap_amt, sqrt_limit_price, false, false)
+            .unwrap();
         let final_sqrt_price = Pallet::<Test>::current_price_sqrt(netuid);
 
         print_current_price(netuid);
@@ -1754,5 +1809,90 @@ fn test_wrapping_fees() {
 
         assert_abs_diff_eq!(fee_tao, expected_fee_tao, epsilon = 1);
         assert_abs_diff_eq!(fee_alpha, expected_fee_alpha, epsilon = 1);
+    });
+}
+
+/// Test that price moves less with provided liquidity
+/// cargo test --package pallet-subtensor-swap --lib -- pallet::tests::test_less_price_movement --exact --show-output
+#[test]
+fn test_less_price_movement() {
+    let netuid = NetUid::from(1);
+    let mut last_end_price = U96F32::from_num(0);
+    let initial_stake_liquidity = 1_000_000_000;
+    let swapped_liquidity = 1_000_000;
+
+    // Test case is (order_type, provided_liquidity)
+    // Testing algorithm:
+    //   - Stake initial_stake_liquidity
+    //   - Provide liquidity if iteration provides lq
+    //   - Buy or sell
+    //   - Save end price if iteration doesn't provide lq
+    [
+        (OrderType::Buy, 0_u64),
+        (OrderType::Buy, 1_000_000_000_000_u64),
+        (OrderType::Sell, 0_u64),
+        (OrderType::Sell, 1_000_000_000_000_u64),
+    ]
+    .into_iter()
+    .for_each(|(order_type, provided_liquidity)| {
+        new_test_ext().execute_with(|| {
+            // Setup swap
+            assert_ok!(Pallet::<Test>::maybe_initialize_v3(netuid));
+
+            // Buy Alpha
+            assert_ok!(Pallet::<Test>::do_swap(
+                netuid,
+                OrderType::Buy,
+                initial_stake_liquidity,
+                SqrtPrice::from_num(10_000_000_000_u64),
+                false,
+                false
+            ));
+
+            // Get current price
+            let start_price = Pallet::<Test>::current_price(netuid);
+
+            // Add liquidity if this test iteration provides
+            if provided_liquidity > 0 {
+                let tick_low = price_to_tick(start_price.to_num::<f64>() * 0.5);
+                let tick_high = price_to_tick(start_price.to_num::<f64>() * 1.5);
+                assert_ok!(Pallet::<Test>::do_add_liquidity(
+                    netuid,
+                    &OK_COLDKEY_ACCOUNT_ID,
+                    &OK_HOTKEY_ACCOUNT_ID,
+                    tick_low,
+                    tick_high,
+                    provided_liquidity,
+                ));
+            }
+
+            // Swap
+            let sqrt_limit_price = if order_type == OrderType::Buy {
+                SqrtPrice::from_num(1000.)
+            } else {
+                SqrtPrice::from_num(0.001)
+            };
+            assert_ok!(Pallet::<Test>::do_swap(
+                netuid,
+                order_type,
+                swapped_liquidity,
+                sqrt_limit_price,
+                false,
+                false
+            ));
+
+            let end_price = Pallet::<Test>::current_price(netuid);
+
+            // Save end price if iteration doesn't provide or compare with previous end price if it does
+            if provided_liquidity > 0 {
+                if order_type == OrderType::Buy {
+                    assert!(end_price < last_end_price);
+                } else {
+                    assert!(end_price > last_end_price);
+                }
+            } else {
+                last_end_price = end_price;
+            }
+        });
     });
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -218,7 +218,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 285,
+    spec_version: 286,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description

1. Fix double fees on move transactions
2. Set `DefaultMinStake` to 0.02 TAO
3. Fix check for tick_low < tick_high
4. Additional check for limit price in swap

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
