### PR TITLE
fix yuma3 inactive neurons bonds computation

### DIFF
--- a/pallets/subtensor/src/epoch/math.rs
+++ b/pallets/subtensor/src/epoch/math.rs
@@ -565,6 +565,22 @@ pub fn inplace_mask_rows(mask: &[bool], matrix: &mut [Vec<I32F32>]) {
         });
 }
 
+// Apply row mask to sparse matrix, mask=true will set the values on that row to to 0
+#[allow(dead_code)]
+pub fn inplace_mask_rows_sparse(mask: &[bool], sparse_matrix: &mut [Vec<(u16, I32F32)>]) {
+    assert_eq!(sparse_matrix.len(), mask.len());
+    sparse_matrix
+        .iter_mut()
+        .zip(mask)
+        .for_each(|(sparse_row, mask_row)| {
+            if *mask_row {
+                sparse_row.iter_mut().for_each(|(_j, value)| {
+                    *value = I32F32::saturating_from_num(0);
+                });
+            }
+        });
+}
+
 // Apply column mask to matrix, mask=true will mask out, i.e. set to 0.
 // Assumes each column has the same length.
 #[allow(dead_code)]

--- a/pallets/subtensor/src/epoch/run_epoch.rs
+++ b/pallets/subtensor/src/epoch/run_epoch.rs
@@ -212,7 +212,7 @@ impl<T: Config> Pallet<T> {
         // Calculate weights for bonds, apply bonds penalty to weights.
         // bonds_penalty = 0: weights_for_bonds = weights.clone()
         // bonds_penalty = 1: weights_for_bonds = clipped_weights.clone()
-        let weights_for_bonds: Vec<Vec<I32F32>> =
+        let mut weights_for_bonds: Vec<Vec<I32F32>> =
             interpolate(&weights, &clipped_weights, bonds_penalty);
 
         let mut dividends: Vec<I32F32>;
@@ -222,6 +222,13 @@ impl<T: Config> Pallet<T> {
             let mut bonds: Vec<Vec<I32F32>> = Self::get_bonds_fixed_proportion(netuid);
             inplace_mask_cols(&recently_registered, &mut bonds); // mask outdated bonds
             log::trace!("B: {:?}", &bonds);
+
+            // Inactive neurons bonds are computed assuming 0 weights.
+            inplace_mask_rows(&inactive, &mut weights_for_bonds);
+            log::trace!(
+                "Weights for bonds (active neurons): {:?}",
+                &weights_for_bonds
+            );
 
             // Compute the Exponential Moving Average (EMA) of bonds.
             ema_bonds = Self::compute_bonds(netuid, &weights_for_bonds, &bonds, &consensus);
@@ -628,7 +635,7 @@ impl<T: Config> Pallet<T> {
         // Calculate weights for bonds, apply bonds penalty to weights.
         // bonds_penalty = 0: weights_for_bonds = weights.clone()
         // bonds_penalty = 1: weights_for_bonds = clipped_weights.clone()
-        let weights_for_bonds: Vec<Vec<(u16, I32F32)>> =
+        let mut weights_for_bonds: Vec<Vec<(u16, I32F32)>> =
             interpolate_sparse(&weights, &clipped_weights, n, bonds_penalty);
 
         let mut dividends: Vec<I32F32>;
@@ -650,8 +657,16 @@ impl<T: Config> Pallet<T> {
             );
             log::trace!("Bonds: (mask) {:?}", &bonds);
 
-            // Compute the Exponential Moving Average (EMA) of bonds.
+            // Inactive neurons bonds are computed assuming 0 weights.
+            // for this is necessary to keep (index, 0) entries in the sparse matrix.
             log::trace!("weights_for_bonds: {:?}", &weights_for_bonds);
+            inplace_mask_rows_sparse(&inactive, &mut weights_for_bonds);
+            log::trace!(
+                "Weights for bonds (active neurons): {:?}",
+                &weights_for_bonds
+            );
+
+            // Compute the Exponential Moving Average (EMA) of bonds.
             ema_bonds = Self::compute_bonds_sparse(netuid, &weights_for_bonds, &bonds, &consensus);
             log::trace!("emaB: {:?}", &ema_bonds);
 

--- a/pallets/subtensor/src/tests/epoch.rs
+++ b/pallets/subtensor/src/tests/epoch.rs
@@ -2757,6 +2757,75 @@ fn set_yuma_3_weights(netuid: NetUid, weights: Vec<Vec<u16>>, indices: Vec<u16>)
 }
 
 #[test]
+fn test_yuma_3_inactive_bonds() {
+    // Test how bonds change over epochs for active vs inactive validators
+    for sparse in [true, false].iter() {
+        new_test_ext(1).execute_with(|| {
+            let n: u16 = 4; // 2 validators, 2 servers
+            let netuid = NetUid::from(1);
+            let max_stake: u64 = 8;
+            let stakes: Vec<u64> = vec![5, 5, 0, 0];
+            let weights_to_set: Vec<u16> = vec![u16::MAX, 0];
+            let miner_indices: Vec<u16> = vec![2, 3];
+
+            setup_yuma_3_scenario(netuid, n, *sparse, max_stake, stakes);
+
+            // at epoch 4 validator will go inactive if weights not set
+            SubtensorModule::set_activity_cutoff(netuid, 3);
+
+            // set initial weights
+            set_yuma_3_weights(
+                netuid,
+                vec![weights_to_set.clone(); 2],
+                miner_indices.clone(),
+            );
+
+            let all_targets_bonds = [
+                vec![vec![0.101319, 0.0000], vec![0.101319, 0.0000]],
+                vec![vec![0.192370, 0.0000], vec![0.192370, 0.0000]],
+                vec![vec![0.274204, 0.0000], vec![0.274204, 0.0000]],
+                vec![vec![0.241580, 0.0000], vec![0.347737, 0.0000]],
+                vec![vec![0.214023, 0.0000], vec![0.413824, 0.0000]],
+                vec![vec![0.293659, 0.0000], vec![0.473212, 0.0000]],
+                vec![vec![0.365224, 0.0000], vec![0.526588, 0.0000]],
+                vec![vec![0.429541, 0.0000], vec![0.574547, 0.0000]],
+            ];
+
+            for (epoch, target_bonds) in all_targets_bonds.iter().enumerate() {
+                if epoch == 2 {
+                    // Set weight only on validator 1 and let the other become inactive
+                    assert_ok!(SubtensorModule::set_weights(
+                        RuntimeOrigin::signed(U256::from(1)),
+                        netuid,
+                        miner_indices.clone(),
+                        weights_to_set.clone(),
+                        0
+                    ));
+                }
+                if epoch == 5 {
+                    // all 2 validators are active again
+                    set_yuma_3_weights(
+                        netuid,
+                        vec![weights_to_set.clone(); 2],
+                        miner_indices.clone(),
+                    );
+                }
+                run_epoch(netuid, *sparse);
+
+                // Check bonds values
+                let bonds = SubtensorModule::get_bonds_fixed_proportion(netuid);
+                for (bond, target_bond) in bonds.iter().zip(target_bonds.iter()) {
+                    // skip the 2 validators bonds 0 values
+                    for (b, t) in bond.iter().skip(2).zip(target_bond) {
+                        assert_approx_eq(*b, fixed(*t), I32F32::from_num(1e-3));
+                    }
+                }
+            }
+        });
+    }
+}
+
+#[test]
 fn test_yuma_3_kappa_moves_first() {
     for sparse in [true, false].iter() {
         new_test_ext(1).execute_with(|| {

--- a/pallets/subtensor/src/tests/math.rs
+++ b/pallets/subtensor/src/tests/math.rs
@@ -419,6 +419,15 @@ fn vec_to_sparse_mat_fixed(
     rows: usize,
     transpose: bool,
 ) -> Vec<Vec<(u16, I32F32)>> {
+    _vec_to_sparse_mat_fixed(vector, rows, transpose, true)
+}
+
+fn _vec_to_sparse_mat_fixed(
+    vector: &[f32],
+    rows: usize,
+    transpose: bool,
+    filter_zeros: bool,
+) -> Vec<Vec<(u16, I32F32)>> {
     assert!(
         vector.len() % rows == 0,
         "Vector of len {:?} cannot reshape to {rows} rows.",
@@ -430,7 +439,7 @@ fn vec_to_sparse_mat_fixed(
         for col in 0..cols {
             let mut row_vec: Vec<(u16, I32F32)> = vec![];
             for row in 0..rows {
-                if vector[row * cols + col] > 0. {
+                if !filter_zeros || vector[row * cols + col] > 0. {
                     row_vec.push((row as u16, I32F32::from_num(vector[row * cols + col])));
                 }
             }
@@ -440,7 +449,7 @@ fn vec_to_sparse_mat_fixed(
         for row in 0..rows {
             let mut row_vec: Vec<(u16, I32F32)> = vec![];
             for col in 0..cols {
-                if vector[row * cols + col] > 0. {
+                if !filter_zeros || vector[row * cols + col] > 0. {
                     row_vec.push((col as u16, I32F32::from_num(vector[row * cols + col])));
                 }
             }
@@ -1023,6 +1032,48 @@ fn test_math_inplace_mask_rows() {
     assert_mat_compare(
         &mat,
         &vec_to_mat_fixed(&target, 3, false),
+        I32F32::from_num(0),
+    );
+}
+
+#[test]
+fn test_math_inplace_mask_rows_sparse() {
+    let input: Vec<f32> = vec![1., 2., 3., 4., 5., 6., 7., 8., 9.];
+    let mask: Vec<bool> = vec![false, false, false];
+    let target: Vec<f32> = vec![1., 2., 3., 4., 5., 6., 7., 8., 9.];
+    let mut mat = _vec_to_sparse_mat_fixed(&input, 3, false, false);
+    inplace_mask_rows_sparse(&mask, &mut mat);
+    assert_sparse_mat_compare(
+        &mat,
+        &_vec_to_sparse_mat_fixed(&target, 3, false, false),
+        I32F32::from_num(0),
+    );
+    let mask: Vec<bool> = vec![true, true, true];
+    let target: Vec<f32> = vec![0., 0., 0., 0., 0., 0., 0., 0., 0.];
+    let mut mat = _vec_to_sparse_mat_fixed(&input, 3, false, false);
+    inplace_mask_rows_sparse(&mask, &mut mat);
+    assert_sparse_mat_compare(
+        &mat,
+        &_vec_to_sparse_mat_fixed(&target, 3, false, false),
+        I32F32::from_num(0),
+    );
+    let mask: Vec<bool> = vec![true, false, true];
+    let target: Vec<f32> = vec![0., 0., 0., 4., 5., 6., 0., 0., 0.];
+    let mut mat = _vec_to_sparse_mat_fixed(&input, 3, false, false);
+    inplace_mask_rows_sparse(&mask, &mut mat);
+    assert_sparse_mat_compare(
+        &mat,
+        &_vec_to_sparse_mat_fixed(&target, 3, false, false),
+        I32F32::from_num(0),
+    );
+    let input: Vec<f32> = vec![0., 0., 0., 0., 0., 0., 0., 0., 0.];
+    let mut mat = _vec_to_sparse_mat_fixed(&input, 3, false, false);
+    let mask: Vec<bool> = vec![false, false, false];
+    let target: Vec<f32> = vec![0., 0., 0., 0., 0., 0., 0., 0., 0.];
+    inplace_mask_rows_sparse(&mask, &mut mat);
+    assert_sparse_mat_compare(
+        &mat,
+        &_vec_to_sparse_mat_fixed(&target, 3, false, false),
         I32F32::from_num(0),
     );
 }


### PR DESCRIPTION
## Description
fix yuma3 bonds calculation so that it takes into account inactive neurons. This is done by computing bonds based on weights set to 0 for inactive neurons.


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
