### PR TITLE
[feat] add Subnet ID and symbol to Owner proxytype

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -750,13 +750,21 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
                 _ => false,
             },
             ProxyType::Owner => {
-                matches!(c, RuntimeCall::AdminUtils(..))
-                    && !matches!(
-                        c,
-                        RuntimeCall::AdminUtils(
-                            pallet_admin_utils::Call::sudo_set_sn_owner_hotkey { .. }
+                matches!(
+                    c,
+                    RuntimeCall::AdminUtils(..)
+                        | RuntimeCall::SubtensorModule(
+                            pallet_subtensor::Call::set_subnet_identity { .. }
                         )
+                        | RuntimeCall::SubtensorModule(
+                            pallet_subtensor::Call::update_symbol { .. }
+                        )
+                ) && !matches!(
+                    c,
+                    RuntimeCall::AdminUtils(
+                        pallet_admin_utils::Call::sudo_set_sn_owner_hotkey { .. }
                     )
+                )
             }
             ProxyType::NonCritical => !matches!(
                 c,

--- a/runtime/tests/pallet_proxy.rs
+++ b/runtime/tests/pallet_proxy.rs
@@ -77,6 +77,31 @@ fn call_sn_owner_hotkey() -> RuntimeCall {
     })
 }
 
+// set subnet identity call
+fn call_set_subnet_identity() -> RuntimeCall {
+    let netuid = NetUid::from(1);
+    RuntimeCall::SubtensorModule(pallet_subtensor::Call::set_subnet_identity {
+        netuid,
+        subnet_name: vec![],
+        github_repo: vec![],
+        subnet_contact: vec![],
+        subnet_url: vec![],
+        discord: vec![],
+        description: vec![],
+        logo_url: vec![],
+        additional: vec![],
+    })
+}
+
+// update symbol call
+fn call_update_symbol() -> RuntimeCall {
+    let netuid = NetUid::from(1);
+    RuntimeCall::SubtensorModule(pallet_subtensor::Call::update_symbol {
+        netuid,
+        symbol: vec![],
+    })
+}
+
 // critical call for Subtensor
 fn call_propose() -> RuntimeCall {
     let proposal = call_remark();
@@ -264,5 +289,20 @@ fn test_owner_type_cannot_set_sn_owner_hotkey() {
             }
             .into(),
         );
+    });
+}
+
+#[test]
+fn test_owner_type_can_set_subnet_identity_and_update_symbol() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(Proxy::add_proxy(
+            RuntimeOrigin::signed(AccountId::from(ACCOUNT)),
+            AccountId::from(DELEGATE).into(),
+            ProxyType::Owner,
+            0
+        ));
+
+        verify_call_with_proxy_type(&ProxyType::Owner, &call_set_subnet_identity());
+        verify_call_with_proxy_type(&ProxyType::Owner, &call_update_symbol());
     });
 }


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
Allow `proxyType::Owner` to set the subnet identity and the symbol

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.