### PR TITLE
Fix issues around DefaultMinStake and NominatorMinRequiredStake

### DIFF
--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -9,7 +9,7 @@ use pallet_subtensor::{Error as SubtensorError, SubnetOwner, Tempo, WeightsVersi
 // use pallet_subtensor::{migrations, Event};
 use pallet_subtensor::Event;
 use sp_consensus_grandpa::AuthorityId as GrandpaId;
-use sp_core::{Pair, U256, ed25519};
+use sp_core::{Get, Pair, U256, ed25519};
 use substrate_fixed::types::I96F32;
 use subtensor_runtime_common::NetUid;
 
@@ -1032,13 +1032,20 @@ mod sudo_set_nominator_min_required_stake {
                 <<Test as Config>::RuntimeOrigin>::root(),
                 10u64
             ));
-            assert_eq!(SubtensorModule::get_nominator_min_required_stake(), 10u64);
+            let default_min_stake = pallet_subtensor::DefaultMinStake::<Test>::get();
+            assert_eq!(
+                SubtensorModule::get_nominator_min_required_stake(),
+                10_u64 * default_min_stake / 1_000_000_u64
+            );
 
             assert_ok!(AdminUtils::sudo_set_nominator_min_required_stake(
                 <<Test as Config>::RuntimeOrigin>::root(),
                 5u64
             ));
-            assert_eq!(SubtensorModule::get_nominator_min_required_stake(), 5u64);
+            assert_eq!(
+                SubtensorModule::get_nominator_min_required_stake(),
+                5_u64 * default_min_stake / 1_000_000_u64
+            );
         });
     }
 
@@ -1046,13 +1053,14 @@ mod sudo_set_nominator_min_required_stake {
     fn sets_a_higher_value() {
         new_test_ext().execute_with(|| {
             let to_be_set: u64 = SubtensorModule::get_nominator_min_required_stake() + 5_u64;
+            let default_min_stake = pallet_subtensor::DefaultMinStake::<Test>::get();
             assert_ok!(AdminUtils::sudo_set_nominator_min_required_stake(
                 <<Test as Config>::RuntimeOrigin>::root(),
                 to_be_set
             ));
             assert_eq!(
                 SubtensorModule::get_nominator_min_required_stake(),
-                to_be_set
+                to_be_set * default_min_stake / 1_000_000_u64
             );
         });
     }
@@ -1631,13 +1639,14 @@ fn test_sets_a_lower_value_clears_small_nominations() {
         // Register a neuron
         register_ok_neuron(netuid, hotkey, owner_coldkey, 0);
 
+        let default_min_stake = pallet_subtensor::DefaultMinStake::<Test>::get();
         assert_ok!(AdminUtils::sudo_set_nominator_min_required_stake(
             RuntimeOrigin::root(),
             initial_nominator_min_required_stake
         ));
         assert_eq!(
             SubtensorModule::get_nominator_min_required_stake(),
-            initial_nominator_min_required_stake
+            initial_nominator_min_required_stake * default_min_stake / 1_000_000_u64
         );
 
         // Stake to the hotkey as staker_coldkey
@@ -1648,13 +1657,14 @@ fn test_sets_a_lower_value_clears_small_nominations() {
             to_stake,
         );
 
+        let default_min_stake = pallet_subtensor::DefaultMinStake::<Test>::get();
         assert_ok!(AdminUtils::sudo_set_nominator_min_required_stake(
             RuntimeOrigin::root(),
             nominator_min_required_stake_0
         ));
         assert_eq!(
             SubtensorModule::get_nominator_min_required_stake(),
-            nominator_min_required_stake_0
+            nominator_min_required_stake_0 * default_min_stake / 1_000_000_u64
         );
 
         // Check this nomination is not cleared
@@ -1672,7 +1682,7 @@ fn test_sets_a_lower_value_clears_small_nominations() {
         ));
         assert_eq!(
             SubtensorModule::get_nominator_min_required_stake(),
-            nominator_min_required_stake_1
+            nominator_min_required_stake_1 * default_min_stake / 1_000_000_u64
         );
 
         // Check this nomination is cleared

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -803,7 +803,7 @@ pub mod pallet {
     #[pallet::type_value]
     /// Default minimum stake.
     pub fn DefaultMinStake<T: Config>() -> u64 {
-        20_000_000
+        2_000_000
     }
 
     #[pallet::type_value]
@@ -1170,7 +1170,8 @@ pub mod pallet {
     #[pallet::storage]
     /// ITEM( network_rate_limit )
     pub type NetworkRateLimit<T> = StorageValue<_, u64, ValueQuery, DefaultNetworkRateLimit<T>>;
-    #[pallet::storage] // --- ITEM( nominator_min_required_stake )
+    #[pallet::storage]
+    /// --- ITEM( nominator_min_required_stake ) --- Factor of DefaultMinStake in per-mill format.
     pub type NominatorMinRequiredStake<T> = StorageValue<_, u64, ValueQuery, DefaultZeroU64<T>>;
     #[pallet::storage]
     /// ITEM( weights_version_key_rate_limit ) --- Rate limit in tempos.

--- a/pallets/subtensor/src/migrations/migrate_set_nominator_min_stake.rs
+++ b/pallets/subtensor/src/migrations/migrate_set_nominator_min_stake.rs
@@ -1,0 +1,39 @@
+use super::*;
+use alloc::string::String;
+use frame_support::{traits::Get, weights::Weight};
+
+pub fn migrate_set_nominator_min_stake<T: Config>() -> Weight {
+    let migration_name = b"migrate_set_nominator_min_stake".to_vec();
+
+    // Initialize the weight with one read operation.
+    let mut weight = T::DbWeight::get().reads(1);
+
+    // Check if the migration has already run
+    if HasMigrationRun::<T>::get(&migration_name) {
+        log::info!(
+            "Migration '{:?}' has already run. Skipping.",
+            String::from_utf8_lossy(&migration_name)
+        );
+        return weight;
+    }
+    log::info!(
+        "Running migration '{}'",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    // Set nominator min stake to 10 in per-mill format
+    Pallet::<T>::set_nominator_min_required_stake(10_000_000);
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+    // Mark the migration as completed
+    HasMigrationRun::<T>::insert(&migration_name, true);
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+    log::info!(
+        "Migration '{:?}' completed.",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    // Return the migration weight.
+    weight
+}

--- a/pallets/subtensor/src/migrations/mod.rs
+++ b/pallets/subtensor/src/migrations/mod.rs
@@ -27,6 +27,7 @@ pub mod migrate_reset_max_burn;
 pub mod migrate_set_first_emission_block_number;
 pub mod migrate_set_min_burn;
 pub mod migrate_set_min_difficulty;
+pub mod migrate_set_nominator_min_stake;
 pub mod migrate_set_registration_enable;
 pub mod migrate_set_subtoken_enabled;
 pub mod migrate_stake_threshold;

--- a/pallets/subtensor/src/staking/helpers.rs
+++ b/pallets/subtensor/src/staking/helpers.rs
@@ -180,9 +180,13 @@ impl<T: Config> Pallet<T> {
         if !Self::coldkey_owns_hotkey(coldkey, hotkey) {
             // If the stake is below the minimum required, it's considered a small nomination and needs to be cleared.
             // Log if the stake is below the minimum required
-            let stake: u64 =
+            let alpha_stake: u64 =
                 Self::get_stake_for_hotkey_and_coldkey_on_subnet(hotkey, coldkey, netuid);
-            if stake < Self::get_nominator_min_required_stake() {
+            let min_alpha_stake =
+                U96F32::saturating_from_num(Self::get_nominator_min_required_stake())
+                    .safe_div(T::SwapInterface::current_alpha_price(netuid))
+                    .saturating_to_num::<u64>();
+            if alpha_stake < min_alpha_stake {
                 // Log the clearing of a small nomination
                 // Remove the stake from the nominator account. (this is a more forceful unstake operation which )
                 // Actually deletes the staking account.
@@ -191,7 +195,7 @@ impl<T: Config> Pallet<T> {
                     hotkey,
                     coldkey,
                     netuid,
-                    stake,
+                    alpha_stake,
                     T::SwapInterface::min_price(),
                     false,
                 );

--- a/pallets/subtensor/src/staking/recycle_alpha.rs
+++ b/pallets/subtensor/src/staking/recycle_alpha.rs
@@ -42,10 +42,7 @@ impl<T: Config> Pallet<T> {
         );
 
         // Ensure that the hotkey has enough stake to withdraw.
-        ensure!(
-            Self::has_enough_stake_on_subnet(&hotkey, &coldkey, netuid, amount),
-            Error::<T>::NotEnoughStakeToWithdraw
-        );
+        Self::calculate_reduced_stake_on_subnet(&hotkey, &coldkey, netuid, amount)?;
 
         ensure!(
             SubnetAlphaOut::<T>::get(netuid) >= amount,
@@ -111,10 +108,7 @@ impl<T: Config> Pallet<T> {
         );
 
         // Ensure that the hotkey has enough stake to withdraw.
-        ensure!(
-            Self::has_enough_stake_on_subnet(&hotkey, &coldkey, netuid, amount),
-            Error::<T>::NotEnoughStakeToWithdraw
-        );
+        Self::calculate_reduced_stake_on_subnet(&hotkey, &coldkey, netuid, amount)?;
 
         ensure!(
             SubnetAlphaOut::<T>::get(netuid) >= amount,

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -953,3 +953,40 @@ fn test_migrate_set_registration_enable() {
         assert!(!weight.is_zero(), "Migration weight should be non-zero");
     });
 }
+
+#[test]
+fn test_migrate_set_nominator_min_stake() {
+    new_test_ext(1).execute_with(|| {
+        const MIGRATION_NAME: &str = "migrate_set_nominator_min_stake";
+
+        let min_nomination_initial = 100_000_000;
+        let min_nomination_migrated = 10_000_000;
+        NominatorMinRequiredStake::<Test>::set(min_nomination_initial);
+
+        assert_eq!(
+            NominatorMinRequiredStake::<Test>::get(),
+            min_nomination_initial
+        );
+        assert!(
+            !HasMigrationRun::<Test>::get(MIGRATION_NAME.as_bytes().to_vec()),
+            "Migration should not have run yet"
+        );
+
+        // Run the migration
+        let weight =
+            crate::migrations::migrate_set_nominator_min_stake::migrate_set_nominator_min_stake::<
+                Test,
+            >();
+
+        // Verify the migration ran correctly
+        assert!(
+            HasMigrationRun::<Test>::get(MIGRATION_NAME.as_bytes().to_vec()),
+            "Migration should be marked as run"
+        );
+        assert!(!weight.is_zero(), "Migration weight should be non-zero");
+        assert_eq!(
+            NominatorMinRequiredStake::<Test>::get(),
+            min_nomination_migrated
+        );
+    });
+}

--- a/pallets/subtensor/src/utils/misc.rs
+++ b/pallets/subtensor/src/utils/misc.rs
@@ -667,8 +667,19 @@ impl<T: Config> Pallet<T> {
         SubnetOwner::<T>::iter_values().any(|owner| *address == owner)
     }
 
+    /// The NominatorMinRequiredStake is the factor by which we multiply
+    /// the DefaultMinStake to get nominator minimum stake. With DefaulMinStake
+    /// of 0.001 TAO and NominatorMinRequiredStake of 100_000_000, the
+    /// minimum nomination stake will be 0.1 TAO.
     pub fn get_nominator_min_required_stake() -> u64 {
-        NominatorMinRequiredStake::<T>::get()
+        // Get the factor (It is stored in per-million format)
+        let factor = NominatorMinRequiredStake::<T>::get();
+
+        // Return the default minimum stake multiplied by factor
+        // 21M * 10^9 * 10^6 fits u64, hence no need for fixed type usage here
+        DefaultMinStake::<T>::get()
+            .saturating_mul(factor)
+            .safe_div(1_000_000)
     }
 
     pub fn set_nominator_min_required_stake(min_stake: u64) {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -218,7 +218,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 291,
+    spec_version: 292,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description

- Reduce DefaultMinStake to 0.002 TAO.
- Make NominatorMinRequiredStake to be the factor of DefaultMinStake instead of plain value.
- Bypass minimum check in remove_stake... extrinsics if full amount is being unstaked.
- Error out remove_stake... extrinsics if 0 amount is being unstaked.

## Related Issue(s)

- Closes #1833 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
