### PR TITLE
[fix] don't remove EVM association on Hotkey Swap

### DIFF
--- a/pallets/subtensor/src/swap/swap_hotkey.rs
+++ b/pallets/subtensor/src/swap/swap_hotkey.rs
@@ -379,7 +379,6 @@ impl<T: Config> Pallet<T> {
             // 3.2.1 Swap the UIDS
             if let Ok(old_uid) = Uids::<T>::try_get(netuid, old_hotkey) {
                 Uids::<T>::remove(netuid, old_hotkey);
-                AssociatedEvmAddress::<T>::remove(netuid, old_uid);
                 Uids::<T>::insert(netuid, new_hotkey, old_uid);
                 weight.saturating_accrue(T::DbWeight::get().reads_writes(1, 2));
 

--- a/pallets/subtensor/src/tests/swap_hotkey.rs
+++ b/pallets/subtensor/src/tests/swap_hotkey.rs
@@ -1432,30 +1432,3 @@ fn test_swap_hotkey_swap_rate_limits() {
         );
     });
 }
-
-// SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test swap_hotkey -- test_swap_hotkey_with_associated_evm_address --exact --nocapture
-#[test]
-fn test_swap_hotkey_with_associated_evm_address() {
-    new_test_ext(1).execute_with(|| {
-        let old_hotkey = U256::from(1);
-        let new_hotkey = U256::from(2);
-        let coldkey = U256::from(3);
-        let mut weight = Weight::zero();
-        let netuid = add_dynamic_network(&old_hotkey, &coldkey);
-        let uid = Uids::<Test>::get(netuid, old_hotkey).unwrap();
-        let evm_address = H160::from_slice(&[1_u8; 20]);
-        AssociatedEvmAddress::<Test>::insert(netuid, uid, (evm_address, 1));
-
-        Owner::<Test>::insert(old_hotkey, coldkey);
-        assert_ok!(SubtensorModule::perform_hotkey_swap_on_all_subnets(
-            &old_hotkey,
-            &new_hotkey,
-            &coldkey,
-            &mut weight
-        ));
-
-        assert_eq!(AssociatedEvmAddress::<Test>::get(netuid, uid), None);
-        assert!(!Owner::<Test>::contains_key(old_hotkey));
-        assert_eq!(Owner::<Test>::get(new_hotkey), coldkey);
-    });
-}

--- a/pallets/subtensor/src/tests/swap_hotkey_with_subnet.rs
+++ b/pallets/subtensor/src/tests/swap_hotkey_with_subnet.rs
@@ -1556,31 +1556,3 @@ fn test_swap_hotkey_registered_on_other_subnet() {
         );
     });
 }
-
-// SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test swap_hotkey_with_subnet -- test_swap_hotkey_with_associated_evm_address --exact --nocapture
-#[test]
-fn test_swap_hotkey_with_associated_evm_address() {
-    new_test_ext(1).execute_with(|| {
-        let old_hotkey = U256::from(1);
-        let new_hotkey = U256::from(2);
-        let coldkey = U256::from(3);
-
-        let netuid = add_dynamic_network(&old_hotkey, &coldkey);
-        let uid = Uids::<Test>::get(netuid, old_hotkey).unwrap();
-        let evm_address = H160::from_slice(&[1_u8; 20]);
-        AssociatedEvmAddress::<Test>::insert(netuid, uid, (evm_address, 1));
-        SubtensorModule::add_balance_to_coldkey_account(&coldkey, u64::MAX);
-        Owner::<Test>::insert(old_hotkey, coldkey);
-        System::set_block_number(System::block_number() + HotkeySwapOnSubnetInterval::get());
-        assert_ok!(SubtensorModule::do_swap_hotkey(
-            RuntimeOrigin::signed(coldkey),
-            &old_hotkey,
-            &new_hotkey,
-            Some(netuid)
-        ));
-
-        assert_eq!(AssociatedEvmAddress::<Test>::get(netuid, uid), None);
-        assert_eq!(Owner::<Test>::get(old_hotkey), coldkey);
-        assert_eq!(Owner::<Test>::get(new_hotkey), coldkey);
-    });
-}


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
We shouldn't remove the EVM association after a hotkey swap.
This reverts part of #1801

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
