### PR TITLE
Disallow staking below minimum amount when partial flag is set

### DIFF
--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -939,7 +939,10 @@ impl<T: Config> Pallet<T> {
                 .map_err(|_| Error::<T>::InsufficientLiquidity)?;
 
         // Check that actual withdrawn TAO amount is not lower than the minimum stake
-        ensure!(swap_result.amount_paid_in >= min_stake, Error::<T>::AmountTooLow);
+        ensure!(
+            swap_result.amount_paid_in >= min_stake,
+            Error::<T>::AmountTooLow
+        );
 
         ensure!(
             swap_result.amount_paid_out > 0,

--- a/pallets/subtensor/src/tests/epoch.rs
+++ b/pallets/subtensor/src/tests/epoch.rs
@@ -1314,7 +1314,7 @@ fn test_set_alpha_disabled() {
             signer.clone(),
             hotkey,
             netuid,
-            DefaultMinStake::<Test>::get() + fee
+            5 * DefaultMinStake::<Test>::get() + fee
         ));
         // Only owner can set alpha values
         assert_ok!(SubtensorModule::register_network(signer.clone(), hotkey));
@@ -2233,6 +2233,7 @@ fn test_validator_permits() {
     }
 }
 
+/// cargo test --package pallet-subtensor --lib -- tests::epoch::test_get_set_alpha --exact --show-output 
 #[test]
 fn test_get_set_alpha() {
     new_test_ext(1).execute_with(|| {
@@ -2268,7 +2269,7 @@ fn test_get_set_alpha() {
             signer.clone(),
             hotkey,
             netuid,
-            DefaultMinStake::<Test>::get() + fee
+            DefaultMinStake::<Test>::get() + fee * 2
         ));
 
         assert_ok!(SubtensorModule::do_set_alpha_values(

--- a/pallets/subtensor/src/tests/epoch.rs
+++ b/pallets/subtensor/src/tests/epoch.rs
@@ -2233,7 +2233,7 @@ fn test_validator_permits() {
     }
 }
 
-/// cargo test --package pallet-subtensor --lib -- tests::epoch::test_get_set_alpha --exact --show-output 
+/// cargo test --package pallet-subtensor --lib -- tests::epoch::test_get_set_alpha --exact --show-output
 #[test]
 fn test_get_set_alpha() {
     new_test_ext(1).execute_with(|| {

--- a/pallets/subtensor/src/tests/move_stake.rs
+++ b/pallets/subtensor/src/tests/move_stake.rs
@@ -785,13 +785,13 @@ fn test_moving_too_little_unstakes() {
 
         let (_, fee) = mock::swap_tao_to_alpha(netuid, amount);
 
-        SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, amount + fee);
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, amount + fee * 2);
 
         assert_ok!(SubtensorModule::add_stake(
             RuntimeOrigin::signed(coldkey_account_id),
             hotkey_account_id,
             netuid,
-            amount + fee
+            amount + fee * 2
         ));
 
         remove_stake_rate_limit_for_tests(&hotkey_account_id, &coldkey_account_id, netuid);

--- a/pallets/subtensor/src/tests/staking.rs
+++ b/pallets/subtensor/src/tests/staking.rs
@@ -555,7 +555,10 @@ fn test_add_stake_partial_below_min_stake_fails() {
         // Stake TAO amount is above min stake
         let min_stake = DefaultMinStake::<Test>::get();
         let amount = min_stake * 2;
-        SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, amount + ExistentialDeposit::get());
+        SubtensorModule::add_balance_to_coldkey_account(
+            &coldkey_account_id,
+            amount + ExistentialDeposit::get(),
+        );
 
         // Setup reserves so that price is 1.0 and init swap
         mock::setup_reserves(netuid, amount * 10, amount * 10);
@@ -2602,8 +2605,7 @@ fn test_stake_below_min_validate() {
         // Increase the stake to be equal to the minimum, but leave the balance low
         let amount_staked = {
             let min_stake = DefaultMinStake::<Test>::get();
-            let fee =
-                <Test as Config>::SwapInterface::approx_fee_amount(netuid.into(), min_stake);
+            let fee = <Test as Config>::SwapInterface::approx_fee_amount(netuid.into(), min_stake);
 
             min_stake + fee * 2
         };
@@ -2700,8 +2702,7 @@ fn test_stake_below_min_can_unstake() {
         // Increase the stake to be equal to the minimum, but leave the balance low
         let amount_staked = {
             let min_stake = DefaultMinStake::<Test>::get();
-            let fee =
-                <Test as Config>::SwapInterface::approx_fee_amount(netuid.into(), min_stake);
+            let fee = <Test as Config>::SwapInterface::approx_fee_amount(netuid.into(), min_stake);
 
             min_stake + fee * 2
         };


### PR DESCRIPTION
## Description

Disallow staking below minimum amount when partial flag is set

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
