### PR TITLE
turn on automatic const fns clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ resolver = "2"
 edition = "2024"
 
 [workspace.lints.clippy]
+missing_const_for_fn = "warn"
 arithmetic-side-effects = "deny"
 indexing-slicing = "deny"
 manual_inspect = "allow"

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -63,15 +63,15 @@ impl NetUid {
         *self == Self::ROOT
     }
 
-    pub fn next(&self) -> NetUid {
+    pub const fn next(&self) -> NetUid {
         Self(self.0.saturating_add(1))
     }
 
-    pub fn prev(&self) -> NetUid {
+    pub const fn prev(&self) -> NetUid {
         Self(self.0.saturating_sub(1))
     }
 
-    pub fn inner(&self) -> u16 {
+    pub const fn inner(&self) -> u16 {
         self.0
     }
 }

--- a/node/src/benchmarking.rs
+++ b/node/src/benchmarking.rs
@@ -27,7 +27,7 @@ pub struct RemarkBuilder {
 
 impl RemarkBuilder {
     // Creates a new [`Self`] from the given client.
-    pub fn new(client: Arc<FullClient>) -> Self {
+    pub const fn new(client: Arc<FullClient>) -> Self {
         Self { client }
     }
 }
@@ -66,7 +66,7 @@ pub struct TransferKeepAliveBuilder {
 
 impl TransferKeepAliveBuilder {
     // Creates a new [`Self`] from the given client.
-    pub fn new(client: Arc<FullClient>, dest: AccountId, value: Balance) -> Self {
+    pub const fn new(client: Arc<FullClient>, dest: AccountId, value: Balance) -> Self {
         Self {
             client,
             dest,

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -233,7 +233,7 @@ where
     F: BlockImport<B>,
     F::Error: Into<ConsensusError>,
 {
-    pub fn new(inner: I, frontier_block_import: F) -> Self {
+    pub const fn new(inner: I, frontier_block_import: F) -> Self {
         Self {
             inner,
             frontier_block_import,

--- a/pallets/collective/src/lib.rs
+++ b/pallets/collective/src/lib.rs
@@ -678,7 +678,7 @@ use frame_system::pallet_prelude::BlockNumberFor;
 /// Return the weight of a dispatch call result as an `Option`.
 ///
 /// Will return the weight regardless of what the state of the result is.
-fn get_result_weight(result: DispatchResultWithPostInfo) -> Option<Weight> {
+const fn get_result_weight(result: DispatchResultWithPostInfo) -> Option<Weight> {
     match result {
         Ok(post_info) => post_info.actual_weight,
         Err(err) => err.post_info.actual_weight,

--- a/pallets/registry/src/types.rs
+++ b/pallets/registry/src/types.rs
@@ -390,7 +390,7 @@ impl<
     MaxAdditionalFields: Get<u32>,
 > Registration<Balance, MaxAdditionalFields>
 {
-    pub(crate) fn total_deposit(&self) -> Balance {
+    pub(crate) const fn total_deposit(&self) -> Balance {
         self.deposit
     }
 }

--- a/precompiles/src/subnet.rs
+++ b/precompiles/src/subnet.rs
@@ -252,7 +252,7 @@ where
 
     #[precompile::public("setWeightsSetRateLimit(uint16,uint64)")]
     #[precompile::payable]
-    fn set_weights_set_rate_limit(
+    const fn set_weights_set_rate_limit(
         _handle: &mut impl PrecompileHandle,
         _netuid: u16,
         _weights_set_rate_limit: u64,
@@ -521,7 +521,7 @@ where
 
     #[precompile::public("setMinBurn(uint16,uint64)")]
     #[precompile::payable]
-    fn set_min_burn(
+    const fn set_min_burn(
         _handle: &mut impl PrecompileHandle,
         _netuid: u16,
         _min_burn: u64,
@@ -538,7 +538,7 @@ where
 
     #[precompile::public("setMaxBurn(uint16,uint64)")]
     #[precompile::payable]
-    fn set_max_burn(
+    const fn set_max_burn(
         _handle: &mut impl PrecompileHandle,
         _netuid: u16,
         _max_burn: u64,

--- a/primitives/share-pool/src/lib.rs
+++ b/primitives/share-pool/src/lib.rs
@@ -39,7 +39,7 @@ where
     K: Eq,
     Ops: SharePoolDataOperations<K>,
 {
-    pub fn new(ops: Ops) -> Self {
+    pub const fn new(ops: Ops) -> Self {
         SharePool {
             state_ops: ops,
             phantom_key: marker::PhantomData,

--- a/runtime/src/check_nonce.rs
+++ b/runtime/src/check_nonce.rs
@@ -41,7 +41,7 @@ pub struct CheckNonce<T: Config>(#[codec(compact)] pub T::Nonce);
 
 impl<T: Config> CheckNonce<T> {
     /// utility constructor. Used only in client/factory code.
-    pub fn from(nonce: T::Nonce) -> Self {
+    pub const fn from(nonce: T::Nonce) -> Self {
         Self(nonce)
     }
 }

--- a/support/macros/src/visitor.rs
+++ b/support/macros/src/visitor.rs
@@ -4,7 +4,7 @@ use syn::{parse_quote, visit_mut::VisitMut};
 pub struct CleanDocComments;
 
 impl CleanDocComments {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 }


### PR DESCRIPTION
Makes it so any function that _could_ be a const fn, clippy will try to make it into a const fn. Should be a good performance optimization in certain places.