### PR TITLE
Stake locks

### DIFF
--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -12,7 +12,7 @@ use pallet_subtensor::Event;
 use sp_consensus_grandpa::AuthorityId as GrandpaId;
 use sp_core::{Get, Pair, U256, ed25519};
 use substrate_fixed::types::I96F32;
-use subtensor_runtime_common::NetUid;
+use subtensor_runtime_common::{AlphaCurrency, NetUid};
 
 use crate::Error;
 use crate::pallet::PrecompileEnable;
@@ -2013,7 +2013,7 @@ fn test_sudo_set_lock_interval_blocks_effect_on_existing_locks() {
         let netuid = NetUid::from(1);
         let coldkey = U256::from(1);
         let hotkey = U256::from(2);
-        let lock_amount = 1_000_000;
+        let lock_amount = AlphaCurrency::from(1_000_000);
         let initial_lock_interval = 7200;
         let new_lock_interval = 14400;
 

--- a/pallets/subtensor/src/coinbase/block_step.rs
+++ b/pallets/subtensor/src/coinbase/block_step.rs
@@ -10,13 +10,15 @@ impl<T: Config + pallet_drand::Config> Pallet<T> {
         log::debug!("block_step for block: {:?} ", block_number);
         // --- 1. Adjust difficulties.
         Self::adjust_registration_terms_for_networks();
-        // --- 2. Get the current coinbase emission.
+        // --- 2. Update subnet lock EMAs and owners.
+        Self::update_stake_locks(block_number);
+        // --- 3. Get the current coinbase emission.
         let block_emission: U96F32 =
             U96F32::saturating_from_num(Self::get_block_emission().unwrap_or(0));
         log::debug!("Block emission: {:?}", block_emission);
-        // --- 3. Run emission through network.
+        // --- 4. Run emission through network.
         Self::run_coinbase(block_emission);
-        // --- 4. Set pending children on the epoch; but only after the coinbase has been run.
+        // --- 5. Set pending children on the epoch; but only after the coinbase has been run.
         Self::try_set_pending_children(block_number);
         // Return ok.
         Ok(())

--- a/pallets/subtensor/src/coinbase/root.rs
+++ b/pallets/subtensor/src/coinbase/root.rs
@@ -425,9 +425,9 @@ impl<T: Config> Pallet<T> {
     /// This function does not emit any events, nor does it raise any errors. It silently
     /// returns if any internal checks fail.
     pub fn remove_network(netuid: NetUid) {
-        // --- 1. Return balance to subnet owner.
-        let owner_coldkey: T::AccountId = SubnetOwner::<T>::get(netuid);
-        let reserved_amount: u64 = Self::get_subnet_locked_balance(netuid);
+        // --- 1. Return balance to subnet owner - DEPRECATED
+        // let owner_coldkey: T::AccountId = SubnetOwner::<T>::get(netuid);
+        // let reserved_amount = Self::get_subnet_locked_balance(netuid);
 
         // --- 2. Remove network count.
         SubnetworkN::<T>::remove(netuid);
@@ -502,8 +502,10 @@ impl<T: Config> Pallet<T> {
         BurnRegistrationsThisInterval::<T>::remove(netuid);
 
         // --- 12. Add the balance back to the owner.
-        Self::add_balance_to_coldkey_account(&owner_coldkey, reserved_amount);
-        Self::set_subnet_locked_balance(netuid, 0);
+        // Subnets don't have locked TAO balance on Finney anymore (all zeroes are currently in block #6,018,471)
+        // And SubnetLocked is repurposed to store locked Alpha, not TAO
+        // Self::add_balance_to_coldkey_account(&owner_coldkey, reserved_amount);
+        Self::set_subnet_locked_balance(netuid, 0.into());
         SubnetOwner::<T>::remove(netuid);
 
         // --- 13. Remove subnet identity if it exists.

--- a/pallets/subtensor/src/epoch/math.rs
+++ b/pallets/subtensor/src/epoch/math.rs
@@ -9,7 +9,7 @@ use sp_std::cmp::Ordering;
 
 use sp_std::vec;
 use substrate_fixed::transcendental::{exp, ln};
-use substrate_fixed::types::{I32F32, I64F64, I96F32};
+use substrate_fixed::types::{I32F32, I64F64};
 
 // TODO: figure out what cfg gate this needs to not be a warning in rustc
 #[allow(unused)]
@@ -211,33 +211,6 @@ pub fn exp_safe(input: I32F32) -> I32F32 {
                 output = I32F32::saturating_from_num(0);
             } else {
                 output = I32F32::max_value();
-            }
-        }
-    }
-    output
-}
-
-// Exp safe function with I32F32 output of I32F32 input.
-#[allow(dead_code)]
-pub fn exp_safe_f96(input: I96F32) -> I96F32 {
-    let min_input: I96F32 = I96F32::from_num(-20); // <= 1/exp(-20) = 485 165 195,4097903
-    let max_input: I96F32 = I96F32::from_num(20); // <= exp(20) = 485 165 195,4097903
-    let mut safe_input: I96F32 = input;
-    if input < min_input {
-        safe_input = min_input;
-    } else if max_input < input {
-        safe_input = max_input;
-    }
-    let output: I96F32;
-    match exp(safe_input) {
-        Ok(val) => {
-            output = val;
-        }
-        Err(_err) => {
-            if safe_input <= 0 {
-                output = I96F32::from_num(0);
-            } else {
-                output = I96F32::max_value();
             }
         }
     }

--- a/pallets/subtensor/src/epoch/math.rs
+++ b/pallets/subtensor/src/epoch/math.rs
@@ -9,7 +9,7 @@ use sp_std::cmp::Ordering;
 
 use sp_std::vec;
 use substrate_fixed::transcendental::{exp, ln};
-use substrate_fixed::types::{I32F32, I64F64};
+use substrate_fixed::types::{I32F32, I64F64, I96F32};
 
 // TODO: figure out what cfg gate this needs to not be a warning in rustc
 #[allow(unused)]
@@ -211,6 +211,33 @@ pub fn exp_safe(input: I32F32) -> I32F32 {
                 output = I32F32::saturating_from_num(0);
             } else {
                 output = I32F32::max_value();
+            }
+        }
+    }
+    output
+}
+
+// Exp safe function with I32F32 output of I32F32 input.
+#[allow(dead_code)]
+pub fn exp_safe_f96(input: I96F32) -> I96F32 {
+    let min_input: I96F32 = I96F32::from_num(-20); // <= 1/exp(-20) = 485 165 195,4097903
+    let max_input: I96F32 = I96F32::from_num(20); // <= exp(20) = 485 165 195,4097903
+    let mut safe_input: I96F32 = input;
+    if input < min_input {
+        safe_input = min_input;
+    } else if max_input < input {
+        safe_input = max_input;
+    }
+    let output: I96F32;
+    match exp(safe_input) {
+        Ok(val) => {
+            output = val;
+        }
+        Err(_err) => {
+            if safe_input <= 0 {
+                output = I96F32::from_num(0);
+            } else {
+                output = I96F32::max_value();
             }
         }
     }

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1764,7 +1764,7 @@ pub mod pallet {
             NMapKey<Blake2_128Concat, T::AccountId>, // hot
             NMapKey<Blake2_128Concat, T::AccountId>, // cold
         ),
-        u64,
+        AlphaCurrency,
         ValueQuery,
     >;
 

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1734,7 +1734,7 @@ pub mod pallet {
     /// ======================
 
     #[pallet::storage]
-    /// --- ITEM ( lock_interval_blocks ) | Stake lock half-life factor
+    /// --- ITEM ( lock_interval_blocks ) | Stake lock EMA half-life factor
     pub type LockIntervalBlocks<T: Config> =
         StorageValue<_, u64, ValueQuery, DefaultLockIntervalBlocks<T>>;
 

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1207,7 +1207,7 @@ pub mod pallet {
         StorageMap<_, Identity, NetUid, bool, ValueQuery, DefaultTrue<T>>;
     #[pallet::storage] // --- MAP ( netuid ) --> total_subnet_locked
     pub type SubnetLocked<T: Config> =
-        StorageMap<_, Identity, NetUid, u64, ValueQuery, DefaultZeroU64<T>>;
+        StorageMap<_, Identity, NetUid, AlphaCurrency, ValueQuery, DefaultZeroAlpha<T>>;
     #[pallet::storage] // --- MAP ( netuid ) --> largest_locked
     pub type LargestLocked<T: Config> =
         StorageMap<_, Identity, NetUid, u64, ValueQuery, DefaultZeroU64<T>>;

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -856,6 +856,12 @@ pub mod pallet {
         50400
     }
 
+    #[pallet::type_value]
+    /// Default value for lock interval blocks.
+    pub fn DefaultLockIntervalBlocks<T: Config>() -> u64 {
+        7200 * 180 // 180 days.
+    }
+
     #[pallet::storage]
     pub type MinActivityCutoff<T: Config> =
         StorageValue<_, u16, ValueQuery, DefaultMinActivityCutoff<T>>;
@@ -1722,6 +1728,28 @@ pub mod pallet {
     pub type AccumulatedLeaseDividends<T: Config> =
         StorageMap<_, Twox64Concat, LeaseId, u64, ValueQuery, ConstU64<0>>;
 
+    /// ======================
+    /// ==== Stake locks =====
+    /// ======================
+
+    #[pallet::storage]
+    /// --- ITEM ( lock_interval_blocks ) | Stake lock half-life factor
+    pub type LockIntervalBlocks<T: Config> = StorageValue<_, u64, ValueQuery, ConstU64<0>>;
+
+    #[pallet::storage]
+    /// --- NMAP ( hot, cold, netuid ) --> alpha locked | Returns the alpha shares for a hotkey, coldkey, netuid triplet.
+    pub type Locks<T: Config> = StorageNMap<
+        _,
+        (
+            NMapKey<Blake2_128Concat, T::AccountId>, // hot
+            NMapKey<Blake2_128Concat, T::AccountId>, // cold
+            NMapKey<Identity, NetUid>,               // subnet
+        ),
+        U64F64, // Shares
+        ValueQuery,
+    >;
+
+    
     /// ==================
     /// ==== Genesis =====
     /// ==================

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -813,6 +813,12 @@ pub mod pallet {
     }
 
     #[pallet::type_value]
+    /// Default minimum lock duration.
+    pub fn DefaultMinLockDuration<T: Config>() -> u64 {
+        7_200
+    }
+
+    #[pallet::type_value]
     /// Default unicode vector for tau symbol.
     pub fn DefaultUnicodeVecU8<T: Config>() -> Vec<u8> {
         b"\xF0\x9D\x9C\x8F".to_vec() // Unicode for tau (𝜏)

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2175,5 +2175,41 @@ mod dispatches {
             Self::deposit_event(Event::SymbolUpdated { netuid, symbol });
             Ok(())
         }
+
+        /// Locks a specified amount of alpha for a given hotkey on a specific subnet.
+        ///
+        /// This function allows a user to lock a certain amount of alpha (stake) for a hotkey
+        /// on a particular subnet. Locking alpha can be used to increase the influence or
+        /// participation of the hotkey in the subnet's operations.
+        ///
+        /// # Arguments
+        ///
+        /// * `origin` - The origin of the call, typically representing the account initiating the lock.
+        /// * `hotkey` - The account ID of the hotkey for which alpha is being locked.
+        /// * `netuid` - The unique identifier of the subnet where the alpha is being locked.
+        /// * `alpha_locked` - The amount of alpha to be locked, represented as a u64.
+        ///
+        /// # Returns
+        ///
+        /// Returns a `DispatchResult` indicating success or failure of the operation.
+        ///
+        /// # Weight
+        ///
+        /// - Base Weight: 124,000,000 + 10 DB Reads + 7 DB Writes
+        /// - Dispatch Class: Normal
+        /// - Pays Fee: No
+        #[pallet::call_index(113)]
+        #[pallet::weight((Weight::from_parts(124_000_000, 0)
+		.saturating_add(T::DbWeight::get().reads(10))
+		.saturating_add(T::DbWeight::get().writes(7)), DispatchClass::Normal, Pays::Yes))]
+        pub fn lock_stake(
+            origin: OriginFor<T>,
+            hotkey: T::AccountId,
+            netuid: NetUid,
+            duration: u64,
+            alpha_locked: u64,
+        ) -> DispatchResult {
+            Self::do_lock(origin, hotkey, netuid, duration, alpha_locked)
+        }
     }
 }

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -693,7 +693,7 @@ mod dispatches {
         /// 	- Attempting to set prometheus information withing the rate limit min.
         ///
         #[pallet::call_index(4)]
-        #[pallet::weight((Weight::from_parts(49_840_000, 0)
+        #[pallet::weight((Weight::from_parts(34_640_000, 0)
 		.saturating_add(T::DbWeight::get().reads(4))
 		.saturating_add(T::DbWeight::get().writes(1)), DispatchClass::Normal, Pays::No))]
         pub fn serve_axon(
@@ -1012,7 +1012,7 @@ mod dispatches {
         ///
         #[pallet::call_index(75)]
         #[pallet::weight((
-            Weight::from_parts(62_970_000, 0)
+            Weight::from_parts(48_100_000, 0)
             .saturating_add(T::DbWeight::get().reads(5))
             .saturating_add(T::DbWeight::get().writes(2)),
     DispatchClass::Normal,

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -693,7 +693,7 @@ mod dispatches {
         /// 	- Attempting to set prometheus information withing the rate limit min.
         ///
         #[pallet::call_index(4)]
-        #[pallet::weight((Weight::from_parts(35_670_000, 0)
+        #[pallet::weight((Weight::from_parts(49_840_000, 0)
 		.saturating_add(T::DbWeight::get().reads(4))
 		.saturating_add(T::DbWeight::get().writes(1)), DispatchClass::Normal, Pays::No))]
         pub fn serve_axon(
@@ -1012,7 +1012,7 @@ mod dispatches {
         ///
         #[pallet::call_index(75)]
         #[pallet::weight((
-            Weight::from_parts(46_330_000, 0)
+            Weight::from_parts(62_970_000, 0)
             .saturating_add(T::DbWeight::get().reads(5))
             .saturating_add(T::DbWeight::get().writes(2)),
     DispatchClass::Normal,
@@ -1638,7 +1638,7 @@ mod dispatches {
         ///
         #[pallet::call_index(85)]
         #[pallet::weight((Weight::from_parts(157_100_000, 0)
-        .saturating_add(T::DbWeight::get().reads(15_u64))
+        .saturating_add(T::DbWeight::get().reads(16_u64))
         .saturating_add(T::DbWeight::get().writes(7_u64)), DispatchClass::Operational, Pays::Yes))]
         pub fn move_stake(
             origin: T::RuntimeOrigin,
@@ -1681,7 +1681,7 @@ mod dispatches {
         /// May emit a `StakeTransferred` event on success.
         #[pallet::call_index(86)]
         #[pallet::weight((Weight::from_parts(154_800_000, 0)
-        .saturating_add(T::DbWeight::get().reads(13_u64))
+        .saturating_add(T::DbWeight::get().reads(14_u64))
         .saturating_add(T::DbWeight::get().writes(6_u64)), DispatchClass::Operational, Pays::Yes))]
         pub fn transfer_stake(
             origin: T::RuntimeOrigin,
@@ -1723,7 +1723,7 @@ mod dispatches {
         #[pallet::call_index(87)]
         #[pallet::weight((
             Weight::from_parts(351_300_000, 0)
-            .saturating_add(T::DbWeight::get().reads(32))
+            .saturating_add(T::DbWeight::get().reads(33_u64))
             .saturating_add(T::DbWeight::get().writes(17)),
             DispatchClass::Operational,
             Pays::Yes
@@ -1852,7 +1852,7 @@ mod dispatches {
         ///
         #[pallet::call_index(89)]
         #[pallet::weight((Weight::from_parts(403_800_000, 0)
-		.saturating_add(T::DbWeight::get().reads(30))
+		.saturating_add(T::DbWeight::get().reads(31_u64))
 		.saturating_add(T::DbWeight::get().writes(14)), DispatchClass::Normal, Pays::Yes))]
         pub fn remove_stake_limit(
             origin: OriginFor<T>,
@@ -1896,7 +1896,7 @@ mod dispatches {
         #[pallet::call_index(90)]
         #[pallet::weight((
             Weight::from_parts(426_500_000, 0)
-            .saturating_add(T::DbWeight::get().reads(32))
+            .saturating_add(T::DbWeight::get().reads(33_u64))
             .saturating_add(T::DbWeight::get().writes(17)),
             DispatchClass::Operational,
             Pays::Yes
@@ -2076,7 +2076,7 @@ mod dispatches {
         /// Without limit_price it remove all the stake similar to `remove_stake` extrinsic
         #[pallet::call_index(103)]
         #[pallet::weight((Weight::from_parts(398_000_000, 10142)
-			.saturating_add(T::DbWeight::get().reads(30_u64))
+			.saturating_add(T::DbWeight::get().reads(31_u64))
 			.saturating_add(T::DbWeight::get().writes(14_u64)), DispatchClass::Normal, Pays::Yes))]
         pub fn remove_stake_full_limit(
             origin: T::RuntimeOrigin,

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -611,7 +611,7 @@ mod dispatches {
         /// * 'netuid' (u16):
         ///     - Subnetwork UID
         ///
-        /// * 'amount_unstaked' (u64):
+        /// * 'amount_unstaked' (AlphaCurrency):
         /// 	- The amount of stake to be added to the hotkey staking account.
         ///
         /// # Event:
@@ -2207,7 +2207,7 @@ mod dispatches {
             hotkey: T::AccountId,
             netuid: NetUid,
             duration: u64,
-            alpha_locked: u64,
+            alpha_locked: AlphaCurrency,
         ) -> DispatchResult {
             Self::do_lock(origin, hotkey, netuid, duration, alpha_locked)
         }

--- a/pallets/subtensor/src/macros/errors.rs
+++ b/pallets/subtensor/src/macros/errors.rs
@@ -242,5 +242,7 @@ mod errors {
         SymbolDoesNotExist,
         /// Symbol already in use.
         SymbolAlreadyInUse,
+        /// Duration is too short.
+        DurationTooShort,
     }
 }

--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -397,7 +397,7 @@ mod events {
             /// Subnet ID
             netuid: NetUid,
             /// Amount of alpha locked
-            alpha_locked: u64,
+            alpha_locked: AlphaCurrency,
         },
     }
 }

--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -381,5 +381,23 @@ mod events {
             /// The symbol that has been updated.
             symbol: Vec<u8>,
         },
+
+        /// The new stake lock interval half-life factor was set
+        LockIntervalSet {
+            /// New interval value (in blocks)
+            new_interval: u64
+        },
+
+        /// Stake lock has increased
+        LockIncreased {
+            /// The owner coldkey of the stake
+            coldkey: T::AccountId,
+            /// The hotkey the stake is made to
+            hotkey: T::AccountId,
+            /// Subnet ID
+            netuid: NetUid,
+            /// Amount of alpha locked
+            alpha_locked: u64,
+        },
     }
 }

--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -385,7 +385,7 @@ mod events {
         /// The new stake lock interval half-life factor was set
         LockIntervalSet {
             /// New interval value (in blocks)
-            new_interval: u64
+            new_interval: u64,
         },
 
         /// Stake lock has increased

--- a/pallets/subtensor/src/macros/genesis.rs
+++ b/pallets/subtensor/src/macros/genesis.rs
@@ -63,7 +63,7 @@ mod genesis {
             Tempo::<T>::insert(netuid, 100);
             NetworkRegistrationAllowed::<T>::insert(netuid, true);
             SubnetOwner::<T>::insert(netuid, hotkey.clone());
-            SubnetLocked::<T>::insert(netuid, 1);
+            SubnetLocked::<T>::insert(netuid, AlphaCurrency::from(1));
             LargestLocked::<T>::insert(netuid, 1);
             Alpha::<T>::insert(
                 // Lock the initial funds making this key the owner.

--- a/pallets/subtensor/src/migrations/migrate_rao.rs
+++ b/pallets/subtensor/src/migrations/migrate_rao.rs
@@ -71,7 +71,7 @@ pub fn migrate_rao<T: Config>() -> Weight {
             continue;
         }
         let owner = SubnetOwner::<T>::get(netuid);
-        let lock = SubnetLocked::<T>::get(netuid);
+        let lock = u64::from(SubnetLocked::<T>::get(netuid));
 
         // Put initial TAO from lock into subnet TAO and produce numerically equal amount of Alpha
         // The initial TAO is the locked amount, with a minimum of 1 RAO and a cap of 100 TAO.
@@ -92,7 +92,7 @@ pub fn migrate_rao<T: Config>() -> Weight {
         //         .unwrap_or(I96F32::from_num(0.0)),
         // );
         Pallet::<T>::add_balance_to_coldkey_account(&owner, remaining_lock);
-        SubnetLocked::<T>::insert(netuid, 0); // Clear lock amount.
+        SubnetLocked::<T>::insert(netuid, AlphaCurrency::from(0)); // Clear lock amount.
         SubnetTAO::<T>::insert(netuid, pool_initial_tao);
         TotalStake::<T>::mutate(|total| {
             *total = total.saturating_add(pool_initial_tao);

--- a/pallets/subtensor/src/migrations/migrate_total_issuance.rs
+++ b/pallets/subtensor/src/migrations/migrate_total_issuance.rs
@@ -51,9 +51,6 @@ pub fn migrate_total_issuance<T: Config>(test: bool) -> Weight {
             T::DbWeight::get().reads((Owner::<T>::iter().count() as u64).saturating_mul(2)),
         );
 
-        // Calculate the sum of all locked subnet values
-        let locked_sum: u64 =
-            SubnetLocked::<T>::iter().fold(0, |acc, (_, locked)| acc.saturating_add(locked));
         // Add weight for reading all subnet locked entries
         weight = weight
             .saturating_add(T::DbWeight::get().reads(SubnetLocked::<T>::iter().count() as u64));
@@ -67,9 +64,7 @@ pub fn migrate_total_issuance<T: Config>(test: bool) -> Weight {
         match TryInto::<u64>::try_into(total_balance) {
             Ok(total_balance_sum) => {
                 // Compute the total issuance value
-                let total_issuance_value: u64 = stake_sum
-                    .saturating_add(total_balance_sum)
-                    .saturating_add(locked_sum);
+                let total_issuance_value: u64 = stake_sum.saturating_add(total_balance_sum);
 
                 // Update the total issuance in storage
                 TotalIssuance::<T>::put(total_issuance_value);

--- a/pallets/subtensor/src/rpc_info/stake_info.rs
+++ b/pallets/subtensor/src/rpc_info/stake_info.rs
@@ -44,7 +44,7 @@ impl<T: Config> Pallet<T> {
                     }
                     let emission = AlphaDividendsPerSubnet::<T>::get(*netuid_i, &hotkey_i);
                     let tao_emission: u64 = TaoDividendsPerSubnet::<T>::get(*netuid_i, &hotkey_i);
-                    let conviction: u64 = Self::get_conviction_for_hotkey_and_coldkey_on_subnet(
+                    let conviction = Self::get_conviction_for_hotkey_and_coldkey_on_subnet(
                         hotkey_i, coldkey_i, *netuid_i,
                     );
                     let is_registered: bool =
@@ -54,7 +54,7 @@ impl<T: Config> Pallet<T> {
                         coldkey: coldkey_i.clone(),
                         netuid: (*netuid_i).into(),
                         stake: alpha.into(),
-                        locked: conviction.into(),
+                        locked: u64::from(conviction).into(),
                         emission: emission.into(),
                         tao_emission: tao_emission.into(),
                         drain: 0.into(),

--- a/pallets/subtensor/src/rpc_info/stake_info.rs
+++ b/pallets/subtensor/src/rpc_info/stake_info.rs
@@ -44,6 +44,9 @@ impl<T: Config> Pallet<T> {
                     }
                     let emission: u64 = AlphaDividendsPerSubnet::<T>::get(*netuid_i, &hotkey_i);
                     let tao_emission: u64 = TaoDividendsPerSubnet::<T>::get(*netuid_i, &hotkey_i);
+                    let conviction: u64 = Self::get_conviction_for_hotkey_and_coldkey_on_subnet(
+                        hotkey_i, coldkey_i, *netuid_i,
+                    );
                     let is_registered: bool =
                         Self::is_hotkey_registered_on_network(*netuid_i, hotkey_i);
                     stake_info_for_coldkey.push(StakeInfo {
@@ -51,7 +54,7 @@ impl<T: Config> Pallet<T> {
                         coldkey: coldkey_i.clone(),
                         netuid: (*netuid_i).into(),
                         stake: alpha.into(),
-                        locked: 0.into(),
+                        locked: conviction.into(),
                         emission: emission.into(),
                         tao_emission: tao_emission.into(),
                         drain: 0.into(),

--- a/pallets/subtensor/src/staking/lock.rs
+++ b/pallets/subtensor/src/staking/lock.rs
@@ -1,0 +1,580 @@
+use super::*;
+use crate::epoch::math::*;
+use alloc::collections::BTreeMap;
+use substrate_fixed::types::I96F32;
+
+impl<T: Config> Pallet<T> {
+    /// Sets the lock interval in blocks.
+    ///
+    /// This function updates the minimum duration for which stakes can be locked.
+    ///
+    /// # Arguments
+    ///
+    /// * `new_interval` - The new lock interval in blocks.
+    ///
+    /// # Events
+    ///
+    /// Emits a `LockIntervalSet` event with the new interval value.
+    pub fn set_lock_interval_blocks(new_interval: u64) {
+        // Update the lock interval storage
+        LockIntervalBlocks::<T>::put(new_interval);
+
+        // Emit an event for the new lock interval
+        Self::deposit_event(Event::LockIntervalSet(new_interval));
+    }
+
+    /// Gets the current lock interval in blocks.
+    ///
+    /// This function retrieves the current value of the lock interval.
+    ///
+    /// # Returns
+    ///
+    /// * `u64` - The current lock interval in blocks.
+    pub fn get_lock_interval_blocks() -> u64 {
+        LockIntervalBlocks::<T>::get()
+    }
+
+    /// Retrieves the amount of locked stake for a specific hotkey and coldkey pair on a given subnet.
+    ///
+    /// This function queries the `Locks` storage to get the locked stake amount for the specified
+    /// hotkey and coldkey combination on the given subnet.
+    ///
+    /// # Arguments
+    ///
+    /// * `hotkey` - The hotkey account ID.
+    /// * `coldkey` - The coldkey account ID.
+    /// * `netuid` - The subnet ID.
+    ///
+    /// # Returns
+    ///
+    /// * `u64` - The amount of locked stake. Returns the first element of the lock tuple,
+    ///           which represents the locked amount.
+    pub fn get_locked_for_hotkey_and_coldkey_on_subnet(
+        hotkey: &T::AccountId,
+        coldkey: &T::AccountId,
+        netuid: u16,
+    ) -> u64 {
+        Locks::<T>::get((netuid, hotkey.clone(), coldkey.clone())).0
+    }
+
+    /// Calculates the conviction score for a specific hotkey and coldkey pair on a given subnet.
+    ///
+    /// This function retrieves the locked stake amount from the `Locks` storage and calculates
+    /// the conviction score based on the locked amount and the lock duration.
+    ///
+    /// # Arguments
+    ///
+    /// * `hotkey` - The hotkey account ID.
+    /// * `coldkey` - The coldkey account ID.
+    /// * `netuid` - The subnet ID.
+    ///
+    /// # Returns
+    ///
+    /// * `u64` - The conviction score calculated from the locked stake.
+    pub fn get_conviction_for_hotkey_and_coldkey_on_subnet(
+        hotkey: &T::AccountId,
+        coldkey: &T::AccountId,
+        netuid: u16,
+    ) -> u64 {
+        let (locked, _, end) = Locks::<T>::get((netuid, hotkey.clone(), coldkey.clone()));
+        
+        Self::calculate_conviction(locked, end, Self::get_current_block_as_u64())
+    }
+
+    /// Locks a specified amount of stake for a given duration on a subnet.
+    ///
+    /// This function allows a user to lock their stake, increasing their conviction score.
+    /// The locked stake cannot be withdrawn until the lock period expires, and the new lock
+    /// must not decrease the current conviction score.
+    ///
+    /// # Arguments
+    ///
+    /// * `origin` - The origin of the call, must be signed by the coldkey.
+    /// * `hotkey` - The hotkey associated with the stake to be locked.
+    /// * `netuid` - The ID of the subnet where the stake is locked.
+    /// * `duration` - The duration (in blocks) for which the stake will be locked.
+    /// * `alpha_locked` - The amount of stake to be locked.
+    ///
+    /// # Returns
+    ///
+    /// * `DispatchResult` - The result of the lock operation.
+    ///
+    /// # Errors
+    ///
+    /// * `SubnetNotExists` - If the specified subnet does not exist.
+    /// * `HotKeyAccountNotExists` - If the hotkey account does not exist.
+    /// * `HotKeyNotRegisteredInSubNet` - If the hotkey is not registered on the specified subnet.
+    /// * `NotEnoughStakeToWithdraw` - If the user doesn't have enough stake to lock, or if the new lock would decrease the current conviction.
+    ///
+    /// # Events
+    ///
+    /// * `LockIncreased` - Emitted when the lock is successfully increased.
+    ///
+    /// # TODO
+    ///
+    /// * Consider implementing a maximum lock duration to prevent excessively long locks.
+    /// * Implement a mechanism to partially unlock stakes as the lock period progresses.
+    /// * Add more granular error handling for different failure scenarios.
+    pub fn do_lock(
+        origin: T::RuntimeOrigin,
+        hotkey: T::AccountId,
+        netuid: u16,
+        duration: u64,
+        alpha_locked: u64,
+    ) -> dispatch::DispatchResult {
+        // Step 1: Validate inputs and check conditions
+        // Ensure the origin is valid.
+        let coldkey = ensure_signed(origin)?;
+
+        // Ensure that the subnet exists.
+        ensure!(Self::if_subnet_exist(netuid), Error::<T>::SubnetNotExists);
+
+        // Ensure that the hotkey account exists.
+        ensure!(
+            Self::hotkey_account_exists(&hotkey),
+            Error::<T>::HotKeyAccountNotExists
+        );
+
+        // Ensure the hotkey is registered on this subnet.
+        // DEPRECATED.
+        // ensure!(
+        //     Self::is_hotkey_registered_on_network(netuid, &hotkey),
+        //     Error::<T>::HotKeyNotRegisteredInSubNet
+        // );
+
+        // Ensure the the lock is above zero.
+        ensure!(alpha_locked > 0, Error::<T>::NotEnoughStakeToWithdraw);
+
+        // Get the lockers current stake.
+        let current_alpha_stake =
+            Self::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
+
+        // Ensure that the caller has enough stake to lock.
+        ensure!(
+            alpha_locked <= current_alpha_stake,
+            Error::<T>::NotEnoughStakeToWithdraw
+        );
+
+        // Step 2: Calculate and compare convictions
+        // Get the current block.
+        let current_block = Self::get_current_block_as_u64();
+        let new_end_block = current_block.saturating_add(duration);
+
+        // Check that we are not decreasing the current conviction.
+        if Locks::<T>::contains_key((netuid, hotkey.clone(), coldkey.clone())) {
+            // Get the current lock.
+            let (current_locked, _current_start, current_end) =
+                Locks::<T>::get((netuid, hotkey.clone(), coldkey.clone()));
+
+            // Calculate the current conviction.
+            let current_conviction =
+                Self::calculate_conviction(current_locked, current_end, current_block);
+
+            // Calculate the new conviction.
+            let new_conviction =
+                Self::calculate_conviction(alpha_locked, new_end_block, current_block);
+
+            // Ensure the new lock does not decrease the current conviction
+            ensure!(
+                new_conviction >= current_conviction,
+                Error::<T>::NotEnoughStakeToWithdraw
+            );
+        }
+
+        // Step 3: Set the new lock
+        Locks::<T>::insert(
+            (netuid, hotkey.clone(), coldkey.clone()),
+            (
+                alpha_locked,
+                current_block,
+                current_block.saturating_add(duration),
+            ),
+        );
+
+        // Step 4: Emit event and return
+        // Lock increased event.
+        log::info!(
+            "LockIncreased( coldkey:{:?}, hotkey:{:?}, netuid:{:?}, alpha_locked:{:?} )",
+            coldkey.clone(),
+            hotkey.clone(),
+            netuid,
+            alpha_locked
+        );
+        Self::deposit_event(Event::LockIncreased(
+            coldkey.clone(),
+            hotkey.clone(),
+            netuid,
+            alpha_locked,
+        ));
+
+        // Ok and return.
+        Ok(())
+    }
+
+    /// Calculates the "lion's share" distribution for a given set of convictions.
+    ///
+    /// This function applies an exponential function to create a sharp drop-off in the
+    /// distribution, favoring higher conviction scores more heavily.
+    ///
+    /// # Arguments
+    ///
+    /// * `convictions` - A vector of conviction scores.
+    /// * `sharpness` - The sharpness parameter for the exponential function (default: 20).
+    ///
+    /// # Returns
+    ///
+    /// * `Vec<I96F32>` - A vector of shares, represented as fixed-point numbers with 96 integer bits and 32 fractional bits.
+    pub fn calculate_lions_share(convictions: Vec<u64>, sharpness: u32) -> Vec<I96F32> {
+        // Handle empty convictions vector
+        if convictions.is_empty() {
+            return Vec::new();
+        }
+
+        // For a single conviction, return a vector with a single element of value 1
+        if convictions.len() == 1 {
+            return vec![I96F32::from_num(1)];
+        }
+
+        // Find the maximum conviction
+        let max_conviction = convictions.iter().max().cloned().unwrap_or(1);
+        // If the maximum conviction is zero, return a vector of zeros
+        if max_conviction == 0 {
+            return vec![I96F32::from_num(0); convictions.len()];
+        }
+
+        // Normalize convictions and apply exponential function
+        let mut powered_convictions: Vec<I96F32> = Vec::with_capacity(convictions.len());
+        for c in convictions.iter() {
+            let normalized = I96F32::from_num(*c) / I96F32::from_num(max_conviction);
+            // Use checked_mul to prevent overflow in exponentiation
+            let powered = exp_safe_f96(
+                I96F32::from_num(sharpness).saturating_mul(normalized - I96F32::from_num(1)),
+            );
+            powered_convictions.push(powered);
+        }
+
+        // Calculate total powered conviction
+        let total_powered: I96F32 = powered_convictions.iter().sum();
+
+        // Handle case where total_powered is zero to avoid division by zero
+        if total_powered == I96F32::from_num(0) {
+            return vec![I96F32::from_num(0); convictions.len()];
+        }
+
+        // Calculate shares
+        let shares: Vec<I96F32> = powered_convictions
+            .into_iter()
+            .map(|pc| pc / total_powered)
+            .collect();
+
+        shares
+    }
+
+    /// Distributes the owner payment among hotkeys based on their conviction scores.
+    ///
+    /// This function calculates the conviction scores for all locked hotkeys in a subnet,
+    /// and then distributes the payment proportionally based on these scores.
+    ///
+    /// # Arguments
+    ///
+    /// * `netuid` - The network ID of the subnet.
+    /// * `amount` - The total amount of payment to distribute.
+    ///
+    /// # Effects
+    ///
+    /// * Calculates conviction scores for all locked hotkeys in the subnet.
+    /// * Distributes the payment proportionally based on conviction scores.
+    /// * Adds the distributed share to each hotkey's balance.
+    /// * Emits an `OwnerPaymentDistributed` event for each distribution.
+    pub fn distribute_owner_cut(netuid: u16, amount: u64) -> u64 {
+        // Get the current block number
+        let current_block = Self::get_current_block_as_u64();
+
+        // Initialize variables to track total conviction and individual hotkey convictions
+        let mut total_conviction: u64 = 0;
+        let mut hotkey_convictions: BTreeMap<T::AccountId, u64> = BTreeMap::new();
+
+        // Calculate total conviction and individual hotkey convictions
+        for ((iter_netuid, hotkey, _), (lock_amount, _, end_block)) in Locks::<T>::iter() {
+            if iter_netuid != netuid {
+                continue;
+            }
+            // Calculate conviction for each lock
+            let conviction = Self::calculate_conviction(lock_amount, end_block, current_block);
+            // Add conviction to the hotkey's total
+            *hotkey_convictions.entry(hotkey.clone()).or_default() += conviction;
+            // Add to the total conviction
+            total_conviction = total_conviction.saturating_add(conviction);
+        }
+
+        // If there's no conviction, return the full amount
+        if total_conviction == 0 {
+            log::debug!("No conviction, returning full amount: {}", amount);
+            return amount;
+        }
+
+        // Convert convictions to a vector for the lion's share calculation
+        let convictions: Vec<u64> = hotkey_convictions.values().cloned().collect();
+
+        // Set the total subnet Conviction.
+        let largest_conviction = convictions.iter().max().cloned().unwrap_or(1);
+        SubnetLocked::<T>::insert( netuid, total_conviction ) ;
+        LargestLocked::<T>::insert( netuid, largest_conviction );
+
+        // Calculate shares using the lion's share distribution
+        let shares: Vec<I96F32> = Self::calculate_lions_share(convictions, 20);
+
+        // Initialize variable to track remaining amount to distribute
+        let mut remaining_amount = amount;
+
+        // Distribute the owner cut based on calculated shares
+        for ((hotkey, _conviction), share) in hotkey_convictions.iter().zip(shares.iter()) {
+            // Calculate the share for this hotkey
+            let share_amount = I96F32::from_num(amount)
+                .checked_mul(*share)
+                .unwrap_or(I96F32::from_num(0))
+                .to_num::<u64>();
+
+            // Get the coldkey associated with this hotkey
+            let owner_coldkey = Self::get_owning_coldkey_for_hotkey(hotkey);
+
+            // Emit the calculated share into the subnet for this hotkey
+            Self::emit_into_subnet(hotkey, &owner_coldkey, netuid, share_amount);
+            Self::increase_lock_by_amount(netuid, hotkey, &owner_coldkey, share_amount);
+
+            // Subtract the distributed share from the remaining amount
+            remaining_amount = remaining_amount.saturating_sub(share_amount);
+        }
+
+        // Return any undistributed amount
+        remaining_amount
+    }
+
+    /// Increases the lock amount for a given hotkey and coldkey in the specified subnet.
+    ///
+    /// # Arguments
+    /// * `netuid` - The network ID of the subnet.
+    /// * `hotkey` - The account ID of the hotkey.
+    /// * `coldkey` - The account ID of the coldkey.
+    /// * `amount` - The amount to increase the lock by.
+    ///
+    /// # Effects
+    /// - If a lock already exists for the hotkey and coldkey, it increases the lock amount.
+    /// - If no lock exists, it creates a new lock with the specified amount.
+    pub fn increase_lock_by_amount(
+        netuid: u16,
+        hotkey: &T::AccountId,
+        coldkey: &T::AccountId,
+        amount: u64,
+    ) {
+        // Check if the lock exists for the given hotkey and coldkey
+        let current_block = Self::get_current_block_as_u64();
+        if Locks::<T>::contains_key((netuid, hotkey.clone(), coldkey.clone())) {
+            // Retrieve the current lock details
+            let (current_lock, start_block, end_block) =
+                Locks::<T>::get((netuid, hotkey.clone(), coldkey.clone()));
+            // Calculate the new lock amount by adding the specified amount
+            let new_lock = current_lock.saturating_add(amount);
+            // Update the lock with the new amount
+            Locks::<T>::insert(
+                (netuid, hotkey.clone(), coldkey.clone()),
+                (new_lock, start_block, end_block),
+            );
+        } else {
+            // If the lock does not exist, create a new lock with the specified amount
+            Locks::<T>::insert(
+                (netuid, hotkey.clone(), coldkey.clone()),
+                (
+                    amount,
+                    current_block,
+                    current_block + Self::get_lock_interval_blocks(),
+                ),
+            );
+        }
+    }
+
+    /// Updates the owners of all subnets periodically.
+    ///
+    /// This function checks if it's time to update subnet owners based on the current block number
+    /// and a predefined update interval. If the condition is met, it iterates through all subnet
+    /// network IDs and calls the `update_subnet_owner` function for each subnet.
+    ///
+    /// # Details
+    /// - The update interval is set to 7200 * 15 blocks (approximately 15 days, assuming 7200 blocks per day).
+    /// - The update is triggered every two intervals (30 days) when the current block number is divisible by twice the update interval.
+    ///
+    /// # Effects
+    /// - When the update condition is met, it calls `update_subnet_owner` for each subnet,
+    ///   potentially changing the owner of each subnet based on conviction scores.
+    pub fn update_all_subnet_owners() {
+        let current_block = Self::get_current_block_as_u64();
+        let update_interval = 7200 * 15; // Approx 15 days.
+        if current_block % (update_interval * 2) == 0 {
+            for netuid in Self::get_all_subnet_netuids() {
+                Self::update_subnet_owner(netuid);
+            }
+        }
+    }
+
+    /// Determines the subnet owner based on the highest conviction score.
+    ///
+    /// This function calculates the conviction score for each hotkey in the subnet,
+    /// considering the lock amount and duration. The hotkey with the highest total
+    /// conviction score becomes the subnet owner.
+    ///
+    /// # Arguments
+    /// * `netuid` - The network ID of the subnet
+    ///
+    /// # Effects
+    /// * Updates the SubnetOwner storage item with the coldkey of the highest conviction hotkey
+    pub fn update_subnet_owner(netuid: u16) {
+        let mut max_total_conviction: I96F32 = I96F32::from_num(0.0);
+        let mut max_conviction_hotkey = None;
+        let mut hotkey_convictions = BTreeMap::new();
+        let mut total_conviction_across_all_hotkeys: I96F32 = I96F32::from_num(0.0);
+        let current_block = Self::get_current_block_as_u64();
+
+        // Iterate through all locks in the subnet
+        for ((iter_netuid, iter_hotkey, _), (lock_amount, _, end_block)) in Locks::<T>::iter() {
+            // Skip if the subnet does not match.
+            if iter_netuid != netuid {
+                continue;
+            }
+
+            // Calculate conviction score based on lock amount and duration
+            let conviction_score = I96F32::from_num(Self::calculate_conviction(
+                lock_amount,
+                end_block,
+                current_block,
+            ));
+
+            // Accumulate conviction scores for each hotkey
+            let total_conviction = hotkey_convictions
+                .entry(iter_hotkey.clone())
+                .or_insert(I96F32::from_num(0));
+            *total_conviction = total_conviction.saturating_add(conviction_score);
+
+            // Increment the total.
+            total_conviction_across_all_hotkeys = total_conviction_across_all_hotkeys.saturating_add(conviction_score);
+
+            // Update max conviction if current hotkey has higher total conviction
+            if *total_conviction > max_total_conviction {
+                max_total_conviction = *total_conviction;
+                max_conviction_hotkey = Some(iter_hotkey.clone());
+            }
+        }
+
+        // Handle the case where no locks exist for the subnet
+        if hotkey_convictions.is_empty() {
+            log::warn!("No locks found for subnet {}", netuid);
+            return;
+        }
+
+        // Implement a minimum conviction threshold for becoming a subnet owner
+        let min_conviction_threshold = I96F32::from_num(1000); // Example threshold, adjust as needed
+        if max_total_conviction < min_conviction_threshold {
+            return;
+        }
+
+        // Set the subnet owner to the coldkey of the hotkey with highest conviction
+        if let Some(hotkey) = max_conviction_hotkey {
+            let owning_coldkey = Self::get_owning_coldkey_for_hotkey(&hotkey);
+            SubnetOwner::<T>::insert(netuid, owning_coldkey.clone());
+        }
+
+        // Set the total subnet Conviction.
+        let largest_conviction: I96F32 = hotkey_convictions.values().cloned().max().unwrap_or(I96F32::from_num(1));
+        SubnetLocked::<T>::insert( netuid, total_conviction_across_all_hotkeys.to_num::<u64>() );
+        LargestLocked::<T>::insert( netuid, largest_conviction.to_num::<u64>() );
+
+        // Implement a tie-breaking mechanism for equal conviction scores
+        let tied_hotkeys: Vec<_> = hotkey_convictions
+            .iter()
+            .filter(|(_, &conviction)| conviction == max_total_conviction)
+            .collect();
+
+        if tied_hotkeys.len() > 1 {
+            // Use a deterministic method to break ties, e.g., lowest hotkey value
+            if let Some((winning_hotkey, _)) =
+                tied_hotkeys.iter().min_by_key(|(hotkey, _)| hotkey)
+            {
+                let owning_coldkey = Self::get_owning_coldkey_for_hotkey(winning_hotkey);
+                SubnetOwner::<T>::insert(netuid, owning_coldkey.clone());
+            }
+        }
+
+        // Log performance metrics for large subnets
+        if hotkey_convictions.len() > 1000 {
+            log::warn!(
+                "Large subnet {} processed with {} hotkeys",
+                netuid,
+                hotkey_convictions.len()
+            );
+        }
+    }
+
+    /// Calculates the conviction score for a locked stake.
+    ///
+    /// This function computes a conviction score based on the amount of locked stake and the
+    /// remaining lock duration. The score increases with both the lock amount and duration,
+    /// but with diminishing returns for longer lock periods.
+    ///
+    /// # Arguments
+    ///
+    /// * `lock_amount` - The amount of stake locked, as a u64.
+    /// * `end_block` - The block number when the lock expires, as a u64.
+    /// * `current_block` - The current block number, as a u64.
+    ///
+    /// # Returns
+    ///
+    /// * A u64 representing the calculated conviction score.
+    ///
+    /// # Formula
+    ///
+    /// The conviction score is calculated using the following formula:
+    /// score = lock_amount * (1 - e^(-lock_duration / (365 * 24 * 60 * 60)))
+    ///
+    /// Where:
+    /// - lock_duration is in blocks
+    /// - The denominator converts days to blocks (assuming 1 block per second)
+    /// - e is the mathematical constant (base of natural logarithm)
+    pub fn calculate_conviction(lock_amount: u64, end_block: u64, current_block: u64) -> u64 {
+        let lock_duration = end_block.saturating_sub(current_block);
+        let lock_interval_blocks = Self::get_lock_interval_blocks();
+        let time_factor =
+            -I96F32::from_num(lock_duration).saturating_div(I96F32::from_num(lock_interval_blocks));
+        let exp_term = I96F32::from_num(1) - exp_safe_f96(I96F32::from_num(time_factor));
+        let conviction_score = I96F32::from_num(lock_amount).saturating_mul(exp_term);
+        
+        conviction_score.to_num::<u64>()
+    }
+
+    /// Calculates the maximum amount of stake that can be unlocked for a given neuron.
+    ///
+    /// This function determines the maximum amount of stake that can be unlocked based on
+    /// the current lock status and conviction of the stake. If there's no lock, the entire
+    /// stake can be unlocked.
+    ///
+    /// # Arguments
+    ///
+    /// * `netuid` - The network UID.
+    /// * `hotkey` - The hotkey of the neuron.
+    /// * `coldkey` - The coldkey associated with the neuron.
+    ///
+    /// # Returns
+    ///
+    /// * `u64` - The maximum amount of stake that can be unlocked.
+    pub fn max_unlockable_stake(netuid: u16, hotkey: &T::AccountId, coldkey: &T::AccountId) -> u64 {
+        let current_block = Self::get_current_block_as_u64();
+        let total_stake: u64 =
+            Self::get_stake_for_hotkey_and_coldkey_on_subnet(hotkey, coldkey, netuid);
+
+        if Locks::<T>::contains_key((netuid, hotkey, coldkey)) {
+            let (alpha_locked, _, end_block) = Locks::<T>::get((netuid, hotkey, coldkey));
+            let conviction = Self::calculate_conviction(alpha_locked, end_block, current_block);
+            total_stake.saturating_sub(conviction)
+        } else {
+            total_stake
+        }
+    }
+}

--- a/pallets/subtensor/src/staking/lock.rs
+++ b/pallets/subtensor/src/staking/lock.rs
@@ -1,7 +1,17 @@
 use super::*;
 use crate::epoch::math::*;
-use alloc::collections::BTreeMap;
-use substrate_fixed::types::I96F32;
+use safe_math::*;
+use substrate_fixed::types::{I96F32, U64F64};
+use subtensor_runtime_common::NetUid;
+
+#[freeze_struct("79fc7facda47d89")]
+#[derive(
+    Clone, Copy, Decode, Default, Encode, Eq, MaxEncodedLen, PartialEq, RuntimeDebug, TypeInfo,
+)]
+pub struct StakeLock {
+    pub alpha_locked: u64,
+    pub end_block: u64,
+}
 
 impl<T: Config> Pallet<T> {
     /// Sets the lock interval in blocks.
@@ -20,7 +30,7 @@ impl<T: Config> Pallet<T> {
         LockIntervalBlocks::<T>::put(new_interval);
 
         // Emit an event for the new lock interval
-        Self::deposit_event(Event::LockIntervalSet(new_interval));
+        Self::deposit_event(Event::LockIntervalSet { new_interval });
     }
 
     /// Gets the current lock interval in blocks.
@@ -32,29 +42,6 @@ impl<T: Config> Pallet<T> {
     /// * `u64` - The current lock interval in blocks.
     pub fn get_lock_interval_blocks() -> u64 {
         LockIntervalBlocks::<T>::get()
-    }
-
-    /// Retrieves the amount of locked stake for a specific hotkey and coldkey pair on a given subnet.
-    ///
-    /// This function queries the `Locks` storage to get the locked stake amount for the specified
-    /// hotkey and coldkey combination on the given subnet.
-    ///
-    /// # Arguments
-    ///
-    /// * `hotkey` - The hotkey account ID.
-    /// * `coldkey` - The coldkey account ID.
-    /// * `netuid` - The subnet ID.
-    ///
-    /// # Returns
-    ///
-    /// * `u64` - The amount of locked stake. Returns the first element of the lock tuple,
-    ///           which represents the locked amount.
-    pub fn get_locked_for_hotkey_and_coldkey_on_subnet(
-        hotkey: &T::AccountId,
-        coldkey: &T::AccountId,
-        netuid: u16,
-    ) -> u64 {
-        Locks::<T>::get((netuid, hotkey.clone(), coldkey.clone())).0
     }
 
     /// Calculates the conviction score for a specific hotkey and coldkey pair on a given subnet.
@@ -74,11 +61,11 @@ impl<T: Config> Pallet<T> {
     pub fn get_conviction_for_hotkey_and_coldkey_on_subnet(
         hotkey: &T::AccountId,
         coldkey: &T::AccountId,
-        netuid: u16,
+        netuid: NetUid,
     ) -> u64 {
-        let (locked, _, end) = Locks::<T>::get((netuid, hotkey.clone(), coldkey.clone()));
-        
-        Self::calculate_conviction(locked, end, Self::get_current_block_as_u64())
+        let stake_lock = Locks::<T>::get((netuid, hotkey.clone(), coldkey.clone()));
+
+        Self::calculate_conviction(&stake_lock, Self::get_current_block_as_u64())
     }
 
     /// Locks a specified amount of stake for a given duration on a subnet.
@@ -118,7 +105,7 @@ impl<T: Config> Pallet<T> {
     pub fn do_lock(
         origin: T::RuntimeOrigin,
         hotkey: T::AccountId,
-        netuid: u16,
+        netuid: NetUid,
         duration: u64,
         alpha_locked: u64,
     ) -> dispatch::DispatchResult {
@@ -134,13 +121,6 @@ impl<T: Config> Pallet<T> {
             Self::hotkey_account_exists(&hotkey),
             Error::<T>::HotKeyAccountNotExists
         );
-
-        // Ensure the hotkey is registered on this subnet.
-        // DEPRECATED.
-        // ensure!(
-        //     Self::is_hotkey_registered_on_network(netuid, &hotkey),
-        //     Error::<T>::HotKeyNotRegisteredInSubNet
-        // );
 
         // Ensure the the lock is above zero.
         ensure!(alpha_locked > 0, Error::<T>::NotEnoughStakeToWithdraw);
@@ -163,16 +143,19 @@ impl<T: Config> Pallet<T> {
         // Check that we are not decreasing the current conviction.
         if Locks::<T>::contains_key((netuid, hotkey.clone(), coldkey.clone())) {
             // Get the current lock.
-            let (current_locked, _current_start, current_end) =
-                Locks::<T>::get((netuid, hotkey.clone(), coldkey.clone()));
+            let stake_lock = Locks::<T>::get((netuid, &hotkey, &coldkey));
 
             // Calculate the current conviction.
-            let current_conviction =
-                Self::calculate_conviction(current_locked, current_end, current_block);
+            let current_conviction = Self::calculate_conviction(&stake_lock, current_block);
 
             // Calculate the new conviction.
-            let new_conviction =
-                Self::calculate_conviction(alpha_locked, new_end_block, current_block);
+            let new_conviction = Self::calculate_conviction(
+                &StakeLock {
+                    alpha_locked,
+                    end_block: new_end_block,
+                },
+                current_block,
+            );
 
             // Ensure the new lock does not decrease the current conviction
             ensure!(
@@ -184,11 +167,10 @@ impl<T: Config> Pallet<T> {
         // Step 3: Set the new lock
         Locks::<T>::insert(
             (netuid, hotkey.clone(), coldkey.clone()),
-            (
+            StakeLock {
                 alpha_locked,
-                current_block,
-                current_block.saturating_add(duration),
-            ),
+                end_block: current_block.saturating_add(duration),
+            },
         );
 
         // Step 4: Emit event and return
@@ -200,200 +182,18 @@ impl<T: Config> Pallet<T> {
             netuid,
             alpha_locked
         );
-        Self::deposit_event(Event::LockIncreased(
-            coldkey.clone(),
-            hotkey.clone(),
+        Self::deposit_event(Event::LockIncreased {
+            coldkey: coldkey.clone(),
+            hotkey: hotkey.clone(),
             netuid,
             alpha_locked,
-        ));
+        });
 
         // Ok and return.
         Ok(())
     }
 
-    /// Calculates the "lion's share" distribution for a given set of convictions.
-    ///
-    /// This function applies an exponential function to create a sharp drop-off in the
-    /// distribution, favoring higher conviction scores more heavily.
-    ///
-    /// # Arguments
-    ///
-    /// * `convictions` - A vector of conviction scores.
-    /// * `sharpness` - The sharpness parameter for the exponential function (default: 20).
-    ///
-    /// # Returns
-    ///
-    /// * `Vec<I96F32>` - A vector of shares, represented as fixed-point numbers with 96 integer bits and 32 fractional bits.
-    pub fn calculate_lions_share(convictions: Vec<u64>, sharpness: u32) -> Vec<I96F32> {
-        // Handle empty convictions vector
-        if convictions.is_empty() {
-            return Vec::new();
-        }
-
-        // For a single conviction, return a vector with a single element of value 1
-        if convictions.len() == 1 {
-            return vec![I96F32::from_num(1)];
-        }
-
-        // Find the maximum conviction
-        let max_conviction = convictions.iter().max().cloned().unwrap_or(1);
-        // If the maximum conviction is zero, return a vector of zeros
-        if max_conviction == 0 {
-            return vec![I96F32::from_num(0); convictions.len()];
-        }
-
-        // Normalize convictions and apply exponential function
-        let mut powered_convictions: Vec<I96F32> = Vec::with_capacity(convictions.len());
-        for c in convictions.iter() {
-            let normalized = I96F32::from_num(*c) / I96F32::from_num(max_conviction);
-            // Use checked_mul to prevent overflow in exponentiation
-            let powered = exp_safe_f96(
-                I96F32::from_num(sharpness).saturating_mul(normalized - I96F32::from_num(1)),
-            );
-            powered_convictions.push(powered);
-        }
-
-        // Calculate total powered conviction
-        let total_powered: I96F32 = powered_convictions.iter().sum();
-
-        // Handle case where total_powered is zero to avoid division by zero
-        if total_powered == I96F32::from_num(0) {
-            return vec![I96F32::from_num(0); convictions.len()];
-        }
-
-        // Calculate shares
-        let shares: Vec<I96F32> = powered_convictions
-            .into_iter()
-            .map(|pc| pc / total_powered)
-            .collect();
-
-        shares
-    }
-
-    /// Distributes the owner payment among hotkeys based on their conviction scores.
-    ///
-    /// This function calculates the conviction scores for all locked hotkeys in a subnet,
-    /// and then distributes the payment proportionally based on these scores.
-    ///
-    /// # Arguments
-    ///
-    /// * `netuid` - The network ID of the subnet.
-    /// * `amount` - The total amount of payment to distribute.
-    ///
-    /// # Effects
-    ///
-    /// * Calculates conviction scores for all locked hotkeys in the subnet.
-    /// * Distributes the payment proportionally based on conviction scores.
-    /// * Adds the distributed share to each hotkey's balance.
-    /// * Emits an `OwnerPaymentDistributed` event for each distribution.
-    pub fn distribute_owner_cut(netuid: u16, amount: u64) -> u64 {
-        // Get the current block number
-        let current_block = Self::get_current_block_as_u64();
-
-        // Initialize variables to track total conviction and individual hotkey convictions
-        let mut total_conviction: u64 = 0;
-        let mut hotkey_convictions: BTreeMap<T::AccountId, u64> = BTreeMap::new();
-
-        // Calculate total conviction and individual hotkey convictions
-        for ((iter_netuid, hotkey, _), (lock_amount, _, end_block)) in Locks::<T>::iter() {
-            if iter_netuid != netuid {
-                continue;
-            }
-            // Calculate conviction for each lock
-            let conviction = Self::calculate_conviction(lock_amount, end_block, current_block);
-            // Add conviction to the hotkey's total
-            *hotkey_convictions.entry(hotkey.clone()).or_default() += conviction;
-            // Add to the total conviction
-            total_conviction = total_conviction.saturating_add(conviction);
-        }
-
-        // If there's no conviction, return the full amount
-        if total_conviction == 0 {
-            log::debug!("No conviction, returning full amount: {}", amount);
-            return amount;
-        }
-
-        // Convert convictions to a vector for the lion's share calculation
-        let convictions: Vec<u64> = hotkey_convictions.values().cloned().collect();
-
-        // Set the total subnet Conviction.
-        let largest_conviction = convictions.iter().max().cloned().unwrap_or(1);
-        SubnetLocked::<T>::insert( netuid, total_conviction ) ;
-        LargestLocked::<T>::insert( netuid, largest_conviction );
-
-        // Calculate shares using the lion's share distribution
-        let shares: Vec<I96F32> = Self::calculate_lions_share(convictions, 20);
-
-        // Initialize variable to track remaining amount to distribute
-        let mut remaining_amount = amount;
-
-        // Distribute the owner cut based on calculated shares
-        for ((hotkey, _conviction), share) in hotkey_convictions.iter().zip(shares.iter()) {
-            // Calculate the share for this hotkey
-            let share_amount = I96F32::from_num(amount)
-                .checked_mul(*share)
-                .unwrap_or(I96F32::from_num(0))
-                .to_num::<u64>();
-
-            // Get the coldkey associated with this hotkey
-            let owner_coldkey = Self::get_owning_coldkey_for_hotkey(hotkey);
-
-            // Emit the calculated share into the subnet for this hotkey
-            Self::emit_into_subnet(hotkey, &owner_coldkey, netuid, share_amount);
-            Self::increase_lock_by_amount(netuid, hotkey, &owner_coldkey, share_amount);
-
-            // Subtract the distributed share from the remaining amount
-            remaining_amount = remaining_amount.saturating_sub(share_amount);
-        }
-
-        // Return any undistributed amount
-        remaining_amount
-    }
-
-    /// Increases the lock amount for a given hotkey and coldkey in the specified subnet.
-    ///
-    /// # Arguments
-    /// * `netuid` - The network ID of the subnet.
-    /// * `hotkey` - The account ID of the hotkey.
-    /// * `coldkey` - The account ID of the coldkey.
-    /// * `amount` - The amount to increase the lock by.
-    ///
-    /// # Effects
-    /// - If a lock already exists for the hotkey and coldkey, it increases the lock amount.
-    /// - If no lock exists, it creates a new lock with the specified amount.
-    pub fn increase_lock_by_amount(
-        netuid: u16,
-        hotkey: &T::AccountId,
-        coldkey: &T::AccountId,
-        amount: u64,
-    ) {
-        // Check if the lock exists for the given hotkey and coldkey
-        let current_block = Self::get_current_block_as_u64();
-        if Locks::<T>::contains_key((netuid, hotkey.clone(), coldkey.clone())) {
-            // Retrieve the current lock details
-            let (current_lock, start_block, end_block) =
-                Locks::<T>::get((netuid, hotkey.clone(), coldkey.clone()));
-            // Calculate the new lock amount by adding the specified amount
-            let new_lock = current_lock.saturating_add(amount);
-            // Update the lock with the new amount
-            Locks::<T>::insert(
-                (netuid, hotkey.clone(), coldkey.clone()),
-                (new_lock, start_block, end_block),
-            );
-        } else {
-            // If the lock does not exist, create a new lock with the specified amount
-            Locks::<T>::insert(
-                (netuid, hotkey.clone(), coldkey.clone()),
-                (
-                    amount,
-                    current_block,
-                    current_block + Self::get_lock_interval_blocks(),
-                ),
-            );
-        }
-    }
-
-    /// Updates the owners of all subnets periodically.
+    /// Updates the stake lock EMAs and owners of all subnets periodically.
     ///
     /// This function checks if it's time to update subnet owners based on the current block number
     /// and a predefined update interval. If the condition is met, it iterates through all subnet
@@ -403,17 +203,45 @@ impl<T: Config> Pallet<T> {
     /// - The update interval is set to 7200 * 15 blocks (approximately 15 days, assuming 7200 blocks per day).
     /// - The update is triggered every two intervals (30 days) when the current block number is divisible by twice the update interval.
     ///
+    /// # Arguments
+    /// * `update_period` - How frequently this call is made (for EMA calculation)
+    ///
     /// # Effects
     /// - When the update condition is met, it calls `update_subnet_owner` for each subnet,
     ///   potentially changing the owner of each subnet based on conviction scores.
-    pub fn update_all_subnet_owners() {
+    pub fn update_stake_locks(update_period: u64) {
         let current_block = Self::get_current_block_as_u64();
         let update_interval = 7200 * 15; // Approx 15 days.
         if current_block % (update_interval * 2) == 0 {
             for netuid in Self::get_all_subnet_netuids() {
-                Self::update_subnet_owner(netuid);
+                Self::update_subnet_owner(netuid, update_period);
             }
         }
+    }
+
+    fn get_conviction_ema(
+        netuid: NetUid,
+        update_period: u64,
+        conviction: u64,
+        hotkey: &T::AccountId,
+        coldkey: &T::AccountId,
+    ) -> u64 {
+        let one = U64F64::saturating_from_num(1.0);
+        let mut smoothing_factor = U64F64::saturating_from_num(update_period)
+            .safe_div(U64F64::saturating_from_num(LockIntervalBlocks::<T>::get()));
+        if smoothing_factor > one {
+            smoothing_factor = one;
+        }
+
+        let old_ema =
+            U64F64::saturating_from_num(ConvictionEma::<T>::get((netuid, hotkey, coldkey)));
+
+        old_ema
+            .saturating_mul(one.saturating_sub(smoothing_factor))
+            .saturating_add(
+                smoothing_factor.saturating_mul(U64F64::saturating_from_num(conviction)),
+            )
+            .saturating_to_num::<u64>()
     }
 
     /// Determines the subnet owner based on the highest conviction score.
@@ -424,104 +252,71 @@ impl<T: Config> Pallet<T> {
     ///
     /// # Arguments
     /// * `netuid` - The network ID of the subnet
+    /// * `update_period` - How frequently this call is made (for EMA calculation)
     ///
     /// # Effects
     /// * Updates the SubnetOwner storage item with the coldkey of the highest conviction hotkey
-    pub fn update_subnet_owner(netuid: u16) {
-        let mut max_total_conviction: I96F32 = I96F32::from_num(0.0);
-        let mut max_conviction_hotkey = None;
-        let mut hotkey_convictions = BTreeMap::new();
-        let mut total_conviction_across_all_hotkeys: I96F32 = I96F32::from_num(0.0);
+    pub fn update_subnet_owner(netuid: NetUid, update_period: u64) {
         let current_block = Self::get_current_block_as_u64();
 
-        // Iterate through all locks in the subnet
-        for ((iter_netuid, iter_hotkey, _), (lock_amount, _, end_block)) in Locks::<T>::iter() {
-            // Skip if the subnet does not match.
-            if iter_netuid != netuid {
-                continue;
-            }
+        // Get the updated current owner's conviction first
+        let owner_coldkey = SubnetOwner::<T>::get(netuid);
+        let owner_hotkey = SubnetOwnerHotkey::<T>::get(netuid);
+        let owner_lock = Locks::<T>::get((netuid, owner_hotkey.clone(), owner_coldkey.clone()));
+        let updated_owner_conviction = Self::calculate_conviction(&owner_lock, current_block);
+        let updated_owner_conviction_ema = Self::get_conviction_ema(
+            netuid,
+            update_period,
+            updated_owner_conviction,
+            &owner_hotkey,
+            &owner_coldkey,
+        );
+        let mut new_owner_coldkey = owner_coldkey.clone();
+        let mut new_owner_hotkey = owner_hotkey.clone();
+        let mut owner_updated = false;
 
-            // Calculate conviction score based on lock amount and duration
-            let conviction_score = I96F32::from_num(Self::calculate_conviction(
-                lock_amount,
-                end_block,
-                current_block,
-            ));
+        for ((hotkey, coldkey), stake_lock) in Locks::<T>::iter_prefix((netuid,)) {
+            // Update EMAs. The update value depends on the update_period so that even if we change how
+            // frequently we update EMAs, the EMA curve doesn't change (except getting less or more
+            // accurate)
 
-            // Accumulate conviction scores for each hotkey
-            let total_conviction = hotkey_convictions
-                .entry(iter_hotkey.clone())
-                .or_insert(I96F32::from_num(0));
-            *total_conviction = total_conviction.saturating_add(conviction_score);
+            let new_conviction = Self::calculate_conviction(&stake_lock, current_block);
+            let new_ema =
+                Self::get_conviction_ema(netuid, update_period, new_conviction, &hotkey, &coldkey);
+            ConvictionEma::<T>::insert((netuid, hotkey.clone(), coldkey.clone()), new_ema);
 
-            // Increment the total.
-            total_conviction_across_all_hotkeys = total_conviction_across_all_hotkeys.saturating_add(conviction_score);
-
-            // Update max conviction if current hotkey has higher total conviction
-            if *total_conviction > max_total_conviction {
-                max_total_conviction = *total_conviction;
-                max_conviction_hotkey = Some(iter_hotkey.clone());
+            if new_ema > updated_owner_conviction_ema {
+                new_owner_coldkey = coldkey;
+                new_owner_hotkey = hotkey;
+                owner_updated = true;
             }
         }
 
-        // Handle the case where no locks exist for the subnet
-        if hotkey_convictions.is_empty() {
-            log::warn!("No locks found for subnet {}", netuid);
-            return;
-        }
-
+        // TODO: Is this needed?
         // Implement a minimum conviction threshold for becoming a subnet owner
-        let min_conviction_threshold = I96F32::from_num(1000); // Example threshold, adjust as needed
-        if max_total_conviction < min_conviction_threshold {
-            return;
-        }
+        // let min_conviction_threshold = I96F32::from_num(1000); // Example threshold, adjust as needed
+        // if max_total_conviction < min_conviction_threshold {
+        //     return;
+        // }
 
         // Set the subnet owner to the coldkey of the hotkey with highest conviction
-        if let Some(hotkey) = max_conviction_hotkey {
-            let owning_coldkey = Self::get_owning_coldkey_for_hotkey(&hotkey);
-            SubnetOwner::<T>::insert(netuid, owning_coldkey.clone());
-        }
-
-        // Set the total subnet Conviction.
-        let largest_conviction: I96F32 = hotkey_convictions.values().cloned().max().unwrap_or(I96F32::from_num(1));
-        SubnetLocked::<T>::insert( netuid, total_conviction_across_all_hotkeys.to_num::<u64>() );
-        LargestLocked::<T>::insert( netuid, largest_conviction.to_num::<u64>() );
-
-        // Implement a tie-breaking mechanism for equal conviction scores
-        let tied_hotkeys: Vec<_> = hotkey_convictions
-            .iter()
-            .filter(|(_, &conviction)| conviction == max_total_conviction)
-            .collect();
-
-        if tied_hotkeys.len() > 1 {
-            // Use a deterministic method to break ties, e.g., lowest hotkey value
-            if let Some((winning_hotkey, _)) =
-                tied_hotkeys.iter().min_by_key(|(hotkey, _)| hotkey)
-            {
-                let owning_coldkey = Self::get_owning_coldkey_for_hotkey(winning_hotkey);
-                SubnetOwner::<T>::insert(netuid, owning_coldkey.clone());
-            }
-        }
-
-        // Log performance metrics for large subnets
-        if hotkey_convictions.len() > 1000 {
-            log::warn!(
-                "Large subnet {} processed with {} hotkeys",
-                netuid,
-                hotkey_convictions.len()
-            );
+        if owner_updated {
+            SubnetOwner::<T>::insert(netuid, new_owner_coldkey.clone());
+            SubnetOwnerHotkey::<T>::insert(netuid, new_owner_hotkey.clone());
         }
     }
 
     /// Calculates the conviction score for a locked stake.
     ///
-    /// This function computes a conviction score based on the amount of locked stake and the
-    /// remaining lock duration. The score increases with both the lock amount and duration,
-    /// but with diminishing returns for longer lock periods.
+    /// This function computes a conviction score based on the amount of locked stake, the time
+    /// this lock existed (since start_block) and the remaining lock duration. The score increases
+    /// with both the lock amount and duration, but with diminishing returns for longer lock
+    /// periods.
     ///
     /// # Arguments
     ///
     /// * `lock_amount` - The amount of stake locked, as a u64.
+    /// * `start_block` - The block number when the lock was set, as a u64.
     /// * `end_block` - The block number when the lock expires, as a u64.
     /// * `current_block` - The current block number, as a u64.
     ///
@@ -532,49 +327,19 @@ impl<T: Config> Pallet<T> {
     /// # Formula
     ///
     /// The conviction score is calculated using the following formula:
-    /// score = lock_amount * (1 - e^(-lock_duration / (365 * 24 * 60 * 60)))
+    /// score = lock_amount * (1 - e^(-lock_duration / (lock_interval_blocks )))
     ///
     /// Where:
     /// - lock_duration is in blocks
-    /// - The denominator converts days to blocks (assuming 1 block per second)
-    /// - e is the mathematical constant (base of natural logarithm)
-    pub fn calculate_conviction(lock_amount: u64, end_block: u64, current_block: u64) -> u64 {
-        let lock_duration = end_block.saturating_sub(current_block);
+    ///
+    pub fn calculate_conviction(lock: &StakeLock, current_block: u64) -> u64 {
+        let lock_duration = lock.end_block.saturating_sub(current_block);
         let lock_interval_blocks = Self::get_lock_interval_blocks();
         let time_factor =
             -I96F32::from_num(lock_duration).saturating_div(I96F32::from_num(lock_interval_blocks));
         let exp_term = I96F32::from_num(1) - exp_safe_f96(I96F32::from_num(time_factor));
-        let conviction_score = I96F32::from_num(lock_amount).saturating_mul(exp_term);
-        
+        let conviction_score = I96F32::from_num(lock.alpha_locked).saturating_mul(exp_term);
+
         conviction_score.to_num::<u64>()
-    }
-
-    /// Calculates the maximum amount of stake that can be unlocked for a given neuron.
-    ///
-    /// This function determines the maximum amount of stake that can be unlocked based on
-    /// the current lock status and conviction of the stake. If there's no lock, the entire
-    /// stake can be unlocked.
-    ///
-    /// # Arguments
-    ///
-    /// * `netuid` - The network UID.
-    /// * `hotkey` - The hotkey of the neuron.
-    /// * `coldkey` - The coldkey associated with the neuron.
-    ///
-    /// # Returns
-    ///
-    /// * `u64` - The maximum amount of stake that can be unlocked.
-    pub fn max_unlockable_stake(netuid: u16, hotkey: &T::AccountId, coldkey: &T::AccountId) -> u64 {
-        let current_block = Self::get_current_block_as_u64();
-        let total_stake: u64 =
-            Self::get_stake_for_hotkey_and_coldkey_on_subnet(hotkey, coldkey, netuid);
-
-        if Locks::<T>::contains_key((netuid, hotkey, coldkey)) {
-            let (alpha_locked, _, end_block) = Locks::<T>::get((netuid, hotkey, coldkey));
-            let conviction = Self::calculate_conviction(alpha_locked, end_block, current_block);
-            total_stake.saturating_sub(conviction)
-        } else {
-            total_stake
-        }
     }
 }

--- a/pallets/subtensor/src/staking/lock.rs
+++ b/pallets/subtensor/src/staking/lock.rs
@@ -128,6 +128,12 @@ impl<T: Config> Pallet<T> {
             Error::<T>::NotEnoughStakeToWithdraw
         );
 
+        // Ensure the lock duration is at least the minimum
+        ensure!(
+            duration >= DefaultMinLockDuration::<T>::get(),
+            Error::<T>::DurationTooShort
+        );
+
         // Get the lockers current stake.
         let current_alpha_stake =
             Self::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);

--- a/pallets/subtensor/src/staking/mod.rs
+++ b/pallets/subtensor/src/staking/mod.rs
@@ -4,6 +4,7 @@ pub mod add_stake;
 pub mod decrease_take;
 pub mod helpers;
 pub mod increase_take;
+pub mod lock;
 pub mod move_stake;
 pub mod recycle_alpha;
 pub mod remove_stake;

--- a/pallets/subtensor/src/staking/move_stake.rs
+++ b/pallets/subtensor/src/staking/move_stake.rs
@@ -335,6 +335,14 @@ impl<T: Config> Pallet<T> {
             alpha_amount
         };
 
+        // Check stake locks
+        Self::check_locks_on_stake_reduction(
+            origin_hotkey,
+            origin_coldkey,
+            origin_netuid,
+            alpha_amount,
+        )?;
+
         // Validate user input
         Self::validate_stake_transition(
             origin_coldkey,

--- a/pallets/subtensor/src/staking/remove_stake.rs
+++ b/pallets/subtensor/src/staking/remove_stake.rs
@@ -54,6 +54,9 @@ impl<T: Config> Pallet<T> {
 
         Self::ensure_subtoken_enabled(netuid)?;
 
+        // Check stake locks
+        Self::check_locks_on_stake_reduction(&hotkey, &coldkey, netuid, alpha_unstaked)?;
+
         // 2. Validate the user input
         Self::validate_remove_stake(
             &coldkey,
@@ -351,6 +354,9 @@ impl<T: Config> Pallet<T> {
             possible_alpha = max_amount;
         }
 
+        // Check stake locks
+        Self::check_locks_on_stake_reduction(&hotkey, &coldkey, netuid, alpha_unstaked)?;
+
         // 3. Validate the user input
         Self::validate_remove_stake(
             &coldkey,
@@ -430,6 +436,9 @@ impl<T: Config> Pallet<T> {
 
         let alpha_unstaked =
             Self::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
+
+        // Check stake locks
+        Self::check_locks_on_stake_reduction(&hotkey, &coldkey, netuid, alpha_unstaked)?;
 
         if let Some(limit_price) = limit_price {
             Self::do_remove_stake_limit(origin, hotkey, netuid, alpha_unstaked, limit_price, false)

--- a/pallets/subtensor/src/tests/lock.rs
+++ b/pallets/subtensor/src/tests/lock.rs
@@ -12,17 +12,13 @@ use sp_core::U256;
 
 pub const UPDATE_INTERVAL: u64 = 7200 * 7;
 
-fn max_unlockable_stake(netuid: NetUid, hotkey: &U256, coldkey: &U256) -> u64 {
+fn max_unlockable_stake(netuid: NetUid, hotkey: &U256, coldkey: &U256) -> AlphaCurrency {
     let current_block = SubtensorModule::get_current_block_as_u64();
-    let total_stake: u64 =
+    let total_stake: AlphaCurrency =
         SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(hotkey, coldkey, netuid);
     if Locks::<Test>::contains_key((netuid, hotkey, coldkey)) {
         let stake_lock = Locks::<Test>::get((netuid, hotkey, coldkey));
         let conviction = SubtensorModule::calculate_conviction(&stake_lock, current_block);
-
-        println!("current_block = {:?}", current_block);
-        println!("stake_lock = {:?}", stake_lock);
-        println!("conviction = {:?}", conviction);
 
         total_stake.saturating_sub(conviction)
     } else {
@@ -38,7 +34,7 @@ fn test_do_lock_success() {
         let coldkey = U256::from(1);
         let hotkey = U256::from(2);
         let stake_amount = 500_000_000;
-        let lock_amount = 250_000_000;
+        let lock_amount = AlphaCurrency::from(250_000_000);
         let lock_duration = 7200 * 30; // 30 days
         let start_block = SubtensorModule::get_current_block_as_u64();
 
@@ -85,7 +81,7 @@ fn test_do_lock_subnet_does_not_exist() {
         let non_existent_netuid = NetUid::from(99);
         let coldkey = U256::from(1);
         let hotkey = U256::from(2);
-        let lock_amount = 250_000_000;
+        let lock_amount = AlphaCurrency::from(250_000_000);
         let lock_duration = 7200 * 30; // 30 days
 
         // Attempt to lock stake on a non-existent subnet
@@ -109,7 +105,7 @@ fn test_do_lock_hotkey_does_not_exist() {
         let netuid = NetUid::from(1);
         let coldkey = U256::from(1);
         let non_existent_hotkey = U256::from(99);
-        let lock_amount = 250_000_000;
+        let lock_amount = AlphaCurrency::from(250_000_000);
         let lock_duration = 7200 * 30; // 30 days
 
         // Set up network
@@ -138,7 +134,7 @@ fn test_do_lock_hotkey_not_registered() {
         let coldkey2 = U256::from(3);
         let hotkey = U256::from(2);
         let stake_amount = 500_000_000;
-        let lock_amount = 250_000_000;
+        let lock_amount = AlphaCurrency::from(250_000_000);
         let lock_duration = 7200 * 30; // 30 days
         let start_block = SubtensorModule::get_current_block_as_u64();
 
@@ -188,7 +184,7 @@ fn test_do_lock_zero_amount() {
         let netuid = NetUid::from(1);
         let coldkey = U256::from(1);
         let hotkey = U256::from(2);
-        let lock_amount = 0;
+        let lock_amount = AlphaCurrency::from(0);
         let lock_duration = 7200 * 30; // 30 days
 
         // Set up network and register neuron
@@ -220,7 +216,7 @@ fn test_do_lock_insufficient_stake() {
         let coldkey = U256::from(1);
         let hotkey = U256::from(2);
         let stake_amount = 500_000_000;
-        let lock_amount = 750_000_000; // More than available stake
+        let lock_amount = AlphaCurrency::from(750_000_000); // More than available stake
         let lock_duration = 7200 * 30; // 30 days
 
         // Set up network and register neuron
@@ -258,9 +254,9 @@ fn test_do_lock_increase_conviction() {
         let coldkey = U256::from(1);
         let hotkey = U256::from(2);
         let initial_stake = 1_000_000_000;
-        let initial_lock_amount = 500_000_000;
+        let initial_lock_amount = AlphaCurrency::from(500_000_000);
         let initial_lock_duration = 7200 * 30; // 30 days
-        let new_lock_amount = 750_000_000;
+        let new_lock_amount = AlphaCurrency::from(750_000_000);
         let new_lock_duration = 7200 * 60; // 60 days
 
         // Set up network and register neuron
@@ -323,9 +319,9 @@ fn test_do_lock_decrease_conviction() {
         let coldkey = U256::from(1);
         let hotkey = U256::from(2);
         let initial_stake = 1_000_000_000;
-        let initial_lock_amount = 500_000_000;
+        let initial_lock_amount = AlphaCurrency::from(500_000_000);
         let initial_lock_duration = 7200 * 30; // 30 days
-        let new_lock_amount = 400_000_000;
+        let new_lock_amount = AlphaCurrency::from(400_000_000);
         let new_lock_duration = 7200 * 20; // 20 days
 
         // Set up network and register neuron
@@ -380,7 +376,7 @@ fn test_do_lock_max_duration() {
         let coldkey = U256::from(1);
         let hotkey = U256::from(2);
         let initial_stake = 1_000_000_000;
-        let lock_amount = 500_000_000;
+        let lock_amount = AlphaCurrency::from(500_000_000);
         let max_lock_duration = 7200 * 365; // 1 year (assuming 7200 blocks per day)
 
         // Set up network and register neuron
@@ -434,8 +430,8 @@ fn test_do_lock_multiple_times() {
         let coldkey = U256::from(1);
         let hotkey = U256::from(2);
         let initial_stake = 1_000_000_000;
-        let lock_amount_1 = 300_000_000;
-        let lock_amount_2 = 500_000_000;
+        let lock_amount_1 = AlphaCurrency::from(300_000_000);
+        let lock_amount_2 = AlphaCurrency::from(500_000_000);
         let lock_duration_1 = 7200 * 30; // 30 days
         let lock_duration_2 = 7200 * 60; // 60 days
         let start_block = SubtensorModule::get_current_block_as_u64();
@@ -515,8 +511,8 @@ fn test_do_lock_different_subnets() {
         let coldkey = U256::from(1);
         let hotkey = U256::from(2);
         let initial_stake = 1_000_000_000;
-        let lock_amount_1 = 300_000_000;
-        let lock_amount_2 = 500_000_000;
+        let lock_amount_1 = AlphaCurrency::from(300_000_000);
+        let lock_amount_2 = AlphaCurrency::from(500_000_000);
         let lock_duration = 7200 * 30; // 30 days
         let start_block = SubtensorModule::get_current_block_as_u64();
 
@@ -602,7 +598,7 @@ fn test_remove_stake_fully_locked() {
         let coldkey = U256::from(1);
         let hotkey = U256::from(2);
         let initial_stake = 1_000_000_000;
-        let lock_amount = initial_stake - 1;
+        let lock_amount = AlphaCurrency::from(initial_stake - 1);
         let lock_duration = 7200 * 30; // 30 days
 
         // Set up network and register neuron
@@ -634,7 +630,7 @@ fn test_remove_stake_fully_locked() {
                 RuntimeOrigin::signed(coldkey),
                 hotkey,
                 netuid,
-                initial_stake
+                initial_stake.into()
             ),
             Error::<Test>::NotEnoughStakeToWithdraw
         );
@@ -653,7 +649,7 @@ fn test_remove_stake_partially_locked() {
         let coldkey = U256::from(1);
         let hotkey = U256::from(2);
         let initial_stake = 1_000_000_000;
-        let lock_amount = 600_000_000;
+        let lock_amount = AlphaCurrency::from(600_000_000);
         let lock_duration = 7200 * 30; // 30 days
 
         // Set up network and register neuron
@@ -691,7 +687,10 @@ fn test_remove_stake_partially_locked() {
         // Verify stake and lock after removal
         let stake_after_removal =
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
-        assert_eq!(stake_after_removal, initial_stake - unlocked_amount - 1);
+        assert_eq!(
+            stake_after_removal,
+            AlphaCurrency::from(initial_stake) - unlocked_amount - 1.into()
+        );
 
         let stake_lock = Locks::<Test>::get((netuid, hotkey, coldkey));
         assert_eq!(stake_lock.alpha_locked, lock_amount); // lock amount should not change
@@ -714,7 +713,7 @@ fn test_remove_stake_partially_locked() {
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
         assert_eq!(
             stake_after_failed_removal,
-            initial_stake - unlocked_amount - 1
+            AlphaCurrency::from(initial_stake) - unlocked_amount - 1.into()
         );
 
         let stake_lock_after = Locks::<Test>::get((netuid, hotkey, coldkey));
@@ -730,7 +729,7 @@ fn test_remove_stake_after_lock_expiry() {
         let coldkey = U256::from(1);
         let hotkey = U256::from(2);
         let initial_stake = 1_000_000_000;
-        let lock_amount = 600_000_000;
+        let lock_amount = AlphaCurrency::from(600_000_000);
         let lock_duration = 10; // 10 blocks
 
         // Set up network and register neuron
@@ -764,13 +763,13 @@ fn test_remove_stake_after_lock_expiry() {
             RuntimeOrigin::signed(coldkey),
             hotkey,
             netuid,
-            initial_stake - 1
+            (initial_stake - 1).into()
         ));
 
         // Verify stake and lock after removal
         let stake_after_removal =
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
-        assert_eq!(stake_after_removal, 0);
+        assert_eq!(stake_after_removal, 0.into());
 
         // Verify lock is removed
         assert!(!Locks::<Test>::contains_key((netuid, hotkey, coldkey)));
@@ -798,7 +797,11 @@ fn test_remove_stake_multiple_locks() {
         let netuid = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
         register_ok_neuron(netuid, hotkey, coldkey, 11);
 
-        mock::setup_reserves(netuid, initial_stake * 100, initial_stake * 100);
+        mock::setup_reserves(
+            netuid,
+            initial_stake * 100,
+            AlphaCurrency::from(initial_stake * 100),
+        );
 
         // Add balance to coldkey and stake
         SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
@@ -811,8 +814,8 @@ fn test_remove_stake_multiple_locks() {
         ));
         let alpha =
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
-        let lock_amount_1 = alpha * 3 / 10;
-        let lock_amount_2 = alpha * 4 / 10;
+        let lock_amount_1 = alpha * 3.into() / 10.into();
+        let lock_amount_2 = alpha * 4.into() / 10.into();
 
         // Also add more stake so that we don't get into low liquidity issues now
         assert_ok!(SubtensorModule::add_stake(
@@ -846,7 +849,7 @@ fn test_remove_stake_multiple_locks() {
                 RuntimeOrigin::signed(coldkey),
                 hotkey,
                 netuid,
-                max_removable + 1
+                max_removable + 1.into()
             ),
             Error::<Test>::NotEnoughStakeToWithdraw
         );
@@ -874,7 +877,7 @@ fn test_remove_stake_conviction_calculation() {
         let coldkey = U256::from(1);
         let hotkey = U256::from(2);
         let initial_stake = 1_000_000_000;
-        let lock_amount = 500_000_000;
+        let lock_amount = AlphaCurrency::from(500_000_000);
         let lock_duration = 10; // 10 blocks
 
         // Register and add stake
@@ -905,7 +908,7 @@ fn test_remove_stake_conviction_calculation() {
                 RuntimeOrigin::signed(coldkey),
                 hotkey,
                 netuid,
-                max_removable + 1
+                max_removable + 1.into()
             ),
             Error::<Test>::NotEnoughStakeToWithdraw
         );
@@ -916,13 +919,16 @@ fn test_remove_stake_conviction_calculation() {
             RuntimeOrigin::signed(coldkey),
             hotkey,
             netuid,
-            max_removable - 1
+            max_removable - 1.into()
         ));
 
         // Verify remaining stake
         let remaining_stake =
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
-        assert_eq!(remaining_stake, initial_stake - max_removable);
+        assert_eq!(
+            remaining_stake,
+            AlphaCurrency::from(initial_stake) - max_removable
+        );
 
         // Fast forward to just before lock expiry
         run_to_block(lock_duration - 1);
@@ -952,7 +958,7 @@ fn test_remove_stake_conviction_calculation() {
         // Verify no stake remains
         let final_stake =
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
-        assert_eq!(final_stake, 0);
+        assert_eq!(final_stake, 0.into());
 
         // Verify lock is removed
         assert!(!Locks::<Test>::contains_key((netuid, hotkey, coldkey)));
@@ -967,7 +973,7 @@ fn test_remove_stake_partial_lock_removal() {
         let coldkey = U256::from(1);
         let hotkey = U256::from(2);
         let initial_stake = 1_000_000_000;
-        let lock_amount = 500_000_000;
+        let lock_amount = AlphaCurrency::from(500_000_000);
         let lock_duration = 7200 * 30; // 30 days
 
         // Register and add stake
@@ -997,7 +1003,7 @@ fn test_remove_stake_partial_lock_removal() {
 
         // Calculate max removable stake
         let max_removable = max_unlockable_stake(netuid, &hotkey, &coldkey);
-        let partial_remove_amount = max_removable / 2;
+        let partial_remove_amount = max_removable / 2.into();
 
         // Remove part of the stake
         remove_stake_rate_limit_for_tests(&hotkey, &coldkey, netuid);
@@ -1011,7 +1017,10 @@ fn test_remove_stake_partial_lock_removal() {
         // Verify remaining stake and updated lock
         let remaining_stake =
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
-        assert_eq!(remaining_stake, initial_stake - partial_remove_amount - 1);
+        assert_eq!(
+            remaining_stake,
+            AlphaCurrency::from(initial_stake) - partial_remove_amount - 1.into()
+        );
 
         let stake_lock_after = Locks::<Test>::get((netuid, hotkey, coldkey));
         assert_eq!(stake_lock_after.alpha_locked, lock_amount); // lock never changes.
@@ -1029,7 +1038,7 @@ fn test_remove_stake_full_lock_removal() {
         let coldkey = U256::from(1);
         let hotkey = U256::from(2);
         let initial_stake = 1_000_000_000;
-        let lock_amount = 500_000_000;
+        let lock_amount = AlphaCurrency::from(500_000_000);
         let lock_duration = 10; // 10 blocks
 
         // Register and add stake
@@ -1065,13 +1074,13 @@ fn test_remove_stake_full_lock_removal() {
             RuntimeOrigin::signed(coldkey),
             hotkey,
             netuid,
-            initial_stake - 1
+            (initial_stake - 1).into()
         ));
 
         // Verify remaining stake
         let remaining_stake =
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
-        assert_eq!(remaining_stake, 0);
+        assert_eq!(remaining_stake, 0.into());
 
         // Verify lock is removed
         assert!(!Locks::<Test>::contains_key((netuid, hotkey, coldkey)));
@@ -1110,7 +1119,7 @@ fn test_remove_stake_across_subnets() {
         ));
         let initial_alpha_1 =
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid1);
-        let lock_amount_1 = initial_alpha_1 * 3 / 10;
+        let lock_amount_1 = initial_alpha_1 * 3.into() / 10.into();
         assert_ok!(SubtensorModule::add_stake(
             RuntimeOrigin::signed(coldkey),
             hotkey,
@@ -1119,7 +1128,7 @@ fn test_remove_stake_across_subnets() {
         ));
         let initial_alpha_2 =
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid2);
-        let lock_amount_2 = initial_alpha_2 * 4 / 10;
+        let lock_amount_2 = initial_alpha_2 * 4.into() / 10.into();
 
         // Create locks on both networks
         assert_ok!(SubtensorModule::lock_stake(
@@ -1146,7 +1155,7 @@ fn test_remove_stake_across_subnets() {
                 RuntimeOrigin::signed(coldkey),
                 hotkey,
                 netuid1,
-                max_removable_1 + 1
+                max_removable_1 + 1.into()
             ),
             Error::<Test>::NotEnoughStakeToWithdraw
         );
@@ -1178,7 +1187,7 @@ fn test_remove_stake_across_subnets() {
         // Verify no stake remains on netuid1
         let final_stake_1 =
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid1);
-        assert_eq!(final_stake_1, 0);
+        assert_eq!(final_stake_1, 0.into());
 
         // Attempt to remove stake from netuid2 (should still be partially locked)
         let max_removable_2 = max_unlockable_stake(netuid2, &hotkey, &coldkey);
@@ -1210,7 +1219,7 @@ fn test_remove_stake_across_subnets() {
         // Verify no stake remains on netuid2
         let final_stake_2 =
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid2);
-        assert_eq!(final_stake_2, 0);
+        assert_eq!(final_stake_2, 0.into());
 
         // Verify locks are removed from both networks
         assert!(!Locks::<Test>::contains_key((netuid1, hotkey, coldkey)));
@@ -1224,12 +1233,12 @@ fn test_calculate_conviction_zero_lock_amount() {
     new_test_ext(1).execute_with(|| {
         let current_block = 1000;
         let stake_lock = StakeLock {
-            alpha_locked: 0,
+            alpha_locked: 0.into(),
             start_block: 0,
             end_block: 2000,
         };
         let conviction = SubtensorModule::calculate_conviction(&stake_lock, current_block);
-        assert_eq!(conviction, 0);
+        assert_eq!(conviction, 0.into());
     });
 }
 
@@ -1239,12 +1248,12 @@ fn test_calculate_conviction_zero_duration() {
     new_test_ext(1).execute_with(|| {
         let current_block = 1000;
         let stake_lock = StakeLock {
-            alpha_locked: 1000000,
+            alpha_locked: 1000000.into(),
             start_block: 0,
             end_block: 1000,
         };
         let conviction = SubtensorModule::calculate_conviction(&stake_lock, current_block);
-        assert_eq!(conviction, 0);
+        assert_eq!(conviction, 0.into());
     });
 }
 
@@ -1254,13 +1263,13 @@ fn test_calculate_conviction_max_lock_amount() {
     new_test_ext(1).execute_with(|| {
         let current_block = 1000;
         let stake_lock = StakeLock {
-            alpha_locked: u64::MAX,
+            alpha_locked: u64::MAX.into(),
             start_block: 0,
             end_block: 2000,
         };
         let conviction = SubtensorModule::calculate_conviction(&stake_lock, current_block);
-        assert!(conviction > 0);
-        assert!(conviction < u64::MAX);
+        assert!(conviction > 0.into());
+        assert!(conviction < u64::MAX.into());
     });
 }
 
@@ -1270,12 +1279,12 @@ fn test_calculate_conviction_max_duration() {
     new_test_ext(1).execute_with(|| {
         let current_block = 0;
         let stake_lock = StakeLock {
-            alpha_locked: 1000000,
+            alpha_locked: 1000000.into(),
             start_block: 0,
             end_block: u64::MAX,
         };
         let conviction = SubtensorModule::calculate_conviction(&stake_lock, current_block);
-        assert!(conviction > 0);
+        assert!(conviction > 0.into());
         assert!(conviction <= stake_lock.alpha_locked);
     });
 }
@@ -1286,12 +1295,12 @@ fn test_calculate_conviction_overflow_check() {
     new_test_ext(1).execute_with(|| {
         let current_block = 0;
         let stake_lock = StakeLock {
-            alpha_locked: u64::MAX,
+            alpha_locked: u64::MAX.into(),
             start_block: 0,
             end_block: u64::MAX,
         };
         let conviction = SubtensorModule::calculate_conviction(&stake_lock, current_block);
-        assert_eq!(conviction, u64::MAX);
+        assert_eq!(conviction, u64::MAX.into());
     });
 }
 
@@ -1301,7 +1310,7 @@ fn test_calculate_conviction_precision_small_values() {
     new_test_ext(1).execute_with(|| {
         let current_block = 1000;
         let stake_lock = StakeLock {
-            alpha_locked: 1,
+            alpha_locked: 1.into(),
             start_block: 0,
             end_block: 1001,
         };
@@ -1316,7 +1325,7 @@ fn test_calculate_conviction_precision_large_values() {
     new_test_ext(1).execute_with(|| {
         let current_block = 0;
         let stake_lock = StakeLock {
-            alpha_locked: u64::MAX / 2,
+            alpha_locked: (u64::MAX / 2).into(),
             start_block: 0,
             end_block: u64::MAX / 2,
         };
@@ -1331,7 +1340,7 @@ fn test_calculate_conviction_rounding() {
     new_test_ext(1).execute_with(|| {
         let current_block = 1000;
         let end_block = 1100;
-        let lock_amount = 1000000;
+        let lock_amount = AlphaCurrency::from(1000000);
         let stake_lock1 = StakeLock {
             alpha_locked: lock_amount,
             start_block: 0,
@@ -1355,12 +1364,12 @@ fn test_calculate_conviction_lock_interval_boundary() {
         let current_block = 1000;
         let lock_interval = SubtensorModule::get_lock_interval_blocks();
         let stake_lock = StakeLock {
-            alpha_locked: 1000000,
+            alpha_locked: 1000000.into(),
             start_block: 0,
             end_block: current_block + lock_interval,
         };
         let conviction = SubtensorModule::calculate_conviction(&stake_lock, current_block);
-        assert!(conviction > 0);
+        assert!(conviction > 0.into());
         assert!(conviction < stake_lock.alpha_locked);
     });
 }
@@ -1371,7 +1380,7 @@ fn test_calculate_conviction_consistency() {
     new_test_ext(1).execute_with(|| {
         let current_block = 1000;
         let end_block = 2000;
-        let lock_amount = 1000000;
+        let lock_amount = AlphaCurrency::from(1000000);
 
         let stake_lock_base = StakeLock {
             alpha_locked: lock_amount,
@@ -1383,7 +1392,7 @@ fn test_calculate_conviction_consistency() {
 
         // Increasing lock amount
         let stake_lock_higher = StakeLock {
-            alpha_locked: lock_amount + 1000,
+            alpha_locked: lock_amount + 1000.into(),
             start_block: 0,
             end_block,
         };
@@ -1409,12 +1418,12 @@ fn test_calculate_conviction_expired_lock() {
     new_test_ext(1).execute_with(|| {
         let current_block = 21;
         let stake_lock = StakeLock {
-            alpha_locked: 394866833,
+            alpha_locked: 394866833.into(),
             start_block: 1,
             end_block: 21,
         };
         let conviction = SubtensorModule::calculate_conviction(&stake_lock, current_block);
-        assert_eq!(conviction, 0);
+        assert_eq!(conviction, 0.into());
     });
 }
 
@@ -1443,7 +1452,7 @@ fn test_update_subnet_owner_no_locks() {
         // Verify that the subnet locked amount is zero
         assert_eq!(
             SubnetLocked::<Test>::get(netuid),
-            0,
+            0.into(),
             "Subnet locked amount should be zero"
         );
 
@@ -1461,7 +1470,7 @@ fn test_update_subnet_owner_single_lock() {
         let netuid = NetUid::from(1);
         let hotkey = U256::from(1);
         let coldkey = U256::from(2);
-        let lock_amount = 1000000;
+        let lock_amount = AlphaCurrency::from(1000000);
         let current_block = 100;
         let lock_duration = 1000000;
 
@@ -1528,17 +1537,17 @@ fn test_update_subnet_owner_multiple_locks() {
 
         // Set up multiple locks with different amounts and durations
         let stake_lock_1 = StakeLock {
-            alpha_locked: 1000000,
+            alpha_locked: 1000000.into(),
             start_block: 0,
             end_block: current_block + 1000000,
         };
         let stake_lock_2 = StakeLock {
-            alpha_locked: 2000000,
+            alpha_locked: 2000000.into(),
             start_block: 0,
             end_block: current_block + 500000,
         };
         let stake_lock_3 = StakeLock {
-            alpha_locked: 1500000,
+            alpha_locked: 1500000.into(),
             start_block: 0,
             end_block: current_block + 2000000,
         };
@@ -1610,7 +1619,7 @@ fn test_update_subnet_owner_tie_breaking() {
 
         // Set up locks with equal convictions
         let stake_lock = StakeLock {
-            alpha_locked: 1000000,
+            alpha_locked: 1000000.into(),
             start_block: 0,
             end_block: current_block + 1000000,
         };
@@ -1643,7 +1652,7 @@ fn test_update_subnet_owner_tie_breaking() {
         let conviction1 = SubtensorModule::calculate_conviction(&stake_lock, current_block);
         assert_eq!(
             SubnetLocked::<Test>::get(netuid),
-            conviction1 * 3,
+            conviction1 * 3.into(),
             "Subnet locked amount should match the total calculated conviction"
         );
 
@@ -1669,12 +1678,12 @@ fn test_update_subnet_owner_below_threshold() {
 
         // Set up locks with low conviction scores
         let stake_lock_1 = StakeLock {
-            alpha_locked: 100,
+            alpha_locked: 100.into(),
             start_block: 0,
             end_block: current_block + 100,
         };
         let stake_lock_2 = StakeLock {
-            alpha_locked: 200,
+            alpha_locked: 200.into(),
             start_block: 0,
             end_block: current_block + 200,
         };
@@ -1730,12 +1739,12 @@ fn test_update_subnet_owner_conviction_calculation() {
 
         // Set up locks with different amounts and durations
         let stake_lock_1 = StakeLock {
-            alpha_locked: 1000000,
+            alpha_locked: 1000000.into(),
             start_block: 0,
             end_block: current_block + 1000000,
         };
         let stake_lock_2 = StakeLock {
-            alpha_locked: 2000000,
+            alpha_locked: 2000000.into(),
             start_block: 0,
             end_block: current_block + 500000,
         };
@@ -1795,12 +1804,12 @@ fn test_update_subnet_owner_different_subnets() {
 
         // Set up locks in different subnets
         let stake_lock_1 = StakeLock {
-            alpha_locked: 1000000,
+            alpha_locked: 1000000.into(),
             start_block: 0,
             end_block: current_block + 1000000,
         };
         let stake_lock_2 = StakeLock {
-            alpha_locked: 2000000,
+            alpha_locked: 2000000.into(),
             start_block: 0,
             end_block: current_block + 500000,
         };
@@ -1838,7 +1847,7 @@ fn test_update_subnet_owner_different_subnets() {
         );
         assert_eq!(
             SubnetLocked::<Test>::get(netuid2),
-            0,
+            0.into(),
             "Subnet locked amount for netuid2 should be zero"
         );
 
@@ -1884,7 +1893,7 @@ fn test_update_subnet_owner_large_subnet() {
         for i in 0..num_locks {
             let hotkey = U256::from(i);
             let coldkey = U256::from(i + num_locks);
-            let lock_amount = (i + 1) * 1000; // Varying lock amounts
+            let lock_amount = AlphaCurrency::from((i + 1) * 1000); // Varying lock amounts
             let lock_duration = (i % 10 + 1) * 100; // Varying lock durations
 
             let stake_lock = StakeLock {
@@ -1918,13 +1927,13 @@ fn test_update_subnet_owner_large_subnet() {
 
         // Verify that the subnet locked amount is non-zero
         assert!(
-            SubnetLocked::<Test>::get(netuid) > 0,
+            SubnetLocked::<Test>::get(netuid) > 0.into(),
             "Subnet locked amount should be non-zero"
         );
 
         // Verify that the subnet owner has the highest conviction
         let owner = SubnetOwner::<Test>::get(netuid);
-        let mut max_conviction_ema = 0;
+        let mut max_conviction_ema = AlphaCurrency::from(0);
         for ((iter_netuid, hotkey, coldkey), stake_lock) in Locks::<Test>::iter() {
             if iter_netuid == netuid {
                 let conviction = SubtensorModule::calculate_conviction(&stake_lock, current_block);
@@ -1956,7 +1965,7 @@ fn test_update_subnet_owner_large_subnet() {
         );
 
         // Subnet owner should have the highest conviction EMA
-        assert_abs_diff_eq!(owner_conviction_ema, max_conviction_ema, epsilon = 1,);
+        assert_abs_diff_eq!(owner_conviction_ema, max_conviction_ema, epsilon = 1.into());
     });
 }
 
@@ -1975,12 +1984,12 @@ fn test_update_subnet_owner_ownership_change() {
 
         // Set up initial locks
         let stake_lock_1 = StakeLock {
-            alpha_locked: 1000000,
+            alpha_locked: 1000000.into(),
             start_block: 0,
             end_block: current_block + lock_duration,
         };
         let stake_lock_2 = StakeLock {
-            alpha_locked: 500000,
+            alpha_locked: 500000.into(),
             start_block: 0,
             end_block: current_block + lock_duration,
         };
@@ -2011,7 +2020,7 @@ fn test_update_subnet_owner_ownership_change() {
 
         // Increase lock for hotkey2
         let stake_lock_2_increased = StakeLock {
-            alpha_locked: 2000000,
+            alpha_locked: 2000000.into(),
             start_block: new_block,
             end_block: current_block + lock_duration,
         };
@@ -2029,7 +2038,10 @@ fn test_update_subnet_owner_ownership_change() {
 
         // Verify subnet locked amount has increased
         let subnet_locked = SubnetLocked::<Test>::get(netuid);
-        assert!(subnet_locked > 0, "Subnet locked amount should be non-zero");
+        assert!(
+            subnet_locked > 0.into(),
+            "Subnet locked amount should be non-zero"
+        );
         assert!(
             subnet_locked > SubtensorModule::calculate_conviction(&stake_lock_1, new_block),
             "Subnet locked amount should increase"
@@ -2073,12 +2085,12 @@ fn test_update_subnet_owner_storage_updates() {
 
         // Set up initial locks
         let stake_lock_1 = StakeLock {
-            alpha_locked: 1000000,
+            alpha_locked: 1000000.into(),
             start_block: 0,
             end_block: current_block + lock_duration,
         };
         let stake_lock_2 = StakeLock {
-            alpha_locked: 500000,
+            alpha_locked: 500000.into(),
             start_block: 0,
             end_block: current_block + lock_duration,
         };
@@ -2104,7 +2116,7 @@ fn test_update_subnet_owner_storage_updates() {
         );
         let initial_locked = SubnetLocked::<Test>::get(netuid);
         assert!(
-            initial_locked > 0,
+            initial_locked > 0.into(),
             "Initial subnet locked amount should be non-zero"
         );
 
@@ -2114,7 +2126,7 @@ fn test_update_subnet_owner_storage_updates() {
 
         // Increase lock for hotkey2
         let stake_lock_3 = StakeLock {
-            alpha_locked: 2000000,
+            alpha_locked: 2000000.into(),
             start_block: 0,
             end_block: new_block + lock_duration,
         };
@@ -2170,9 +2182,9 @@ fn test_conviction_ema_basic() {
         let coldkey = U256::from(2);
         let update_period = 1_u64;
         let lock_interval = 2_u64;
-        let conviction_value = 1000_u64;
+        let conviction_value = AlphaCurrency::from(1000);
 
-        ConvictionEma::<Test>::insert((netuid, hotkey, coldkey), 0_u64);
+        ConvictionEma::<Test>::insert((netuid, hotkey, coldkey), AlphaCurrency::from(0));
         LockIntervalBlocks::<Test>::put(lock_interval);
 
         let ema = SubtensorModule::get_conviction_ema(
@@ -2182,7 +2194,7 @@ fn test_conviction_ema_basic() {
             &hotkey,
             &coldkey,
         );
-        assert!(ema > 0 && ema < conviction_value);
+        assert!(ema > 0.into() && ema < conviction_value);
     });
 }
 
@@ -2196,9 +2208,9 @@ fn test_conviction_ema_existing_ema() {
         let coldkey = U256::from(2);
         let update_period = 1;
         let lock_interval = 4;
-        let conviction_value = 800;
+        let conviction_value = AlphaCurrency::from(800);
 
-        ConvictionEma::<Test>::insert((netuid, hotkey, coldkey), 400_u64);
+        ConvictionEma::<Test>::insert((netuid, hotkey, coldkey), AlphaCurrency::from(400));
         LockIntervalBlocks::<Test>::put(lock_interval);
 
         let ema = SubtensorModule::get_conviction_ema(
@@ -2208,7 +2220,7 @@ fn test_conviction_ema_existing_ema() {
             &hotkey,
             &coldkey,
         );
-        assert!(ema > 400 && ema < conviction_value);
+        assert!(ema > 400.into() && ema < conviction_value);
     });
 }
 
@@ -2222,9 +2234,9 @@ fn test_conviction_ema_zero_update() {
         let coldkey = U256::from(4);
         let update_period = 0;
         let lock_interval = 10;
-        let conviction_value = 1000;
+        let conviction_value = AlphaCurrency::from(1000);
 
-        ConvictionEma::<Test>::insert((netuid, hotkey, coldkey), 500_u64);
+        ConvictionEma::<Test>::insert((netuid, hotkey, coldkey), AlphaCurrency::from(500));
         LockIntervalBlocks::<Test>::put(lock_interval);
 
         let ema = SubtensorModule::get_conviction_ema(
@@ -2234,7 +2246,7 @@ fn test_conviction_ema_zero_update() {
             &hotkey,
             &coldkey,
         );
-        assert_eq!(ema, 500);
+        assert_eq!(ema, 500.into());
     });
 }
 
@@ -2248,9 +2260,9 @@ fn test_conviction_ema_zero_lockint() {
         let coldkey = U256::from(6);
         let update_period = 1;
         let lock_interval = 0;
-        let conviction_value = 700;
+        let conviction_value = AlphaCurrency::from(700);
 
-        ConvictionEma::<Test>::insert((netuid, hotkey, coldkey), 300_u64);
+        ConvictionEma::<Test>::insert((netuid, hotkey, coldkey), AlphaCurrency::from(300));
         LockIntervalBlocks::<Test>::put(lock_interval);
 
         let ema = SubtensorModule::get_conviction_ema(
@@ -2274,9 +2286,9 @@ fn test_conviction_ema_large_update() {
         let coldkey = U256::from(8);
         let update_period = 100;
         let lock_interval = 10;
-        let conviction_value = 900;
+        let conviction_value = AlphaCurrency::from(900);
 
-        ConvictionEma::<Test>::insert((netuid, hotkey, coldkey), 200_u64);
+        ConvictionEma::<Test>::insert((netuid, hotkey, coldkey), AlphaCurrency::from(200));
         LockIntervalBlocks::<Test>::put(lock_interval);
 
         let ema = SubtensorModule::get_conviction_ema(
@@ -2300,9 +2312,9 @@ fn test_conviction_ema_conviction_0() {
         let coldkey = U256::from(10);
         let update_period = 2;
         let lock_interval = 4;
-        let conviction_value = 0;
+        let conviction_value = AlphaCurrency::from(0);
 
-        ConvictionEma::<Test>::insert((netuid, hotkey, coldkey), 1000_u64);
+        ConvictionEma::<Test>::insert((netuid, hotkey, coldkey), AlphaCurrency::from(1000));
         LockIntervalBlocks::<Test>::put(lock_interval);
 
         let ema = SubtensorModule::get_conviction_ema(
@@ -2312,7 +2324,7 @@ fn test_conviction_ema_conviction_0() {
             &hotkey,
             &coldkey,
         );
-        assert!(ema < 1000);
+        assert!(ema < 1000.into());
     });
 }
 
@@ -2326,9 +2338,9 @@ fn test_conviction_ema_conviction_max() {
         let coldkey = U256::from(12);
         let update_period = 2;
         let lock_interval = 4;
-        let conviction_value = u64::MAX;
+        let conviction_value = AlphaCurrency::from(u64::MAX);
 
-        ConvictionEma::<Test>::insert((netuid, hotkey, coldkey), 0_u64);
+        ConvictionEma::<Test>::insert((netuid, hotkey, coldkey), AlphaCurrency::from(0));
         LockIntervalBlocks::<Test>::put(lock_interval);
 
         let ema = SubtensorModule::get_conviction_ema(
@@ -2338,7 +2350,7 @@ fn test_conviction_ema_conviction_max() {
             &hotkey,
             &coldkey,
         );
-        assert!(ema > 0 && ema < conviction_value);
+        assert!(ema > 0.into() && ema < conviction_value);
     });
 }
 
@@ -2350,7 +2362,7 @@ fn test_locks_are_updated_in_block_step() {
         let hotkey = U256::from(1);
         let coldkey = U256::from(2);
         let coldkey2 = U256::from(3);
-        let lock_amount = 1000000;
+        let lock_amount = AlphaCurrency::from(1000000);
         let current_block = 216_000; // Triggers locks EMA and subnet owners update 
         let lock_duration = 1000000;
         add_network(netuid, 0, 0);

--- a/pallets/subtensor/src/tests/lock.rs
+++ b/pallets/subtensor/src/tests/lock.rs
@@ -1,0 +1,3387 @@
+use super::mock::*;
+use crate::*;
+
+use frame_support::{assert_noop, assert_ok};
+use sp_core::U256;
+use sp_runtime::DispatchError;
+use substrate_fixed::types::I96F32;
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_do_lock_success --exact --show-output
+#[test]
+fn test_do_lock_success() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let stake_amount = 500_000_000;
+        let lock_amount = 250_000_000;
+        let lock_duration = 7200 * 30; // 30 days
+        let start_block = SubtensorModule::get_current_block_as_u64();
+
+        // Set up initial balance and stake
+        add_network(netuid, 0, 0);
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey, 1_000_000_000);
+        register_ok_neuron(netuid, hotkey, coldkey, 11);
+        assert_ok!(SubtensorModule::add_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            stake_amount
+        ));
+        assert_ok!(SubtensorModule::lock_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            lock_duration,
+            lock_amount
+        ));
+
+        // Check that the lock was created correctly
+        let stake_lock = Locks::<Test>::get((netuid, hotkey, coldkey));
+        assert_eq!(stake_lock.alpha_locked, lock_amount);
+        assert_eq!(stake_lock.end_block, start_block + lock_duration);
+
+        // Verify the event was emitted
+        System::assert_last_event(
+            Event::LockIncreased{ coldkey, hotkey, netuid, alpha_locked: lock_amount }.into(),
+        );
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_do_lock_subnet_does_not_exist --exact --show-output
+#[test]
+fn test_do_lock_subnet_does_not_exist() {
+    new_test_ext(1).execute_with(|| {
+        let non_existent_netuid = NetUid::from(99);
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let lock_amount = 250_000_000;
+        let lock_duration = 7200 * 30; // 30 days
+
+        // Attempt to lock stake on a non-existent subnet
+        assert_noop!(
+            SubtensorModule::lock_stake(
+                RuntimeOrigin::signed(coldkey),
+                hotkey,
+                non_existent_netuid,
+                lock_duration,
+                lock_amount
+            ),
+            Error::<Test>::SubnetNotExists
+        );
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_do_lock_hotkey_does_not_exist --exact --show-output
+#[test]
+fn test_do_lock_hotkey_does_not_exist() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let coldkey = U256::from(1);
+        let non_existent_hotkey = U256::from(99);
+        let lock_amount = 250_000_000;
+        let lock_duration = 7200 * 30; // 30 days
+
+        // Set up network
+        add_network(netuid, 0, 0);
+
+        // Attempt to lock stake with a non-existent hotkey
+        assert_noop!(
+            SubtensorModule::lock_stake(
+                RuntimeOrigin::signed(coldkey),
+                non_existent_hotkey,
+                netuid,
+                lock_duration,
+                lock_amount
+            ),
+            Error::<Test>::HotKeyAccountNotExists
+        );
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_do_lock_hotkey_not_registered --exact --show-output
+#[test]
+fn test_do_lock_hotkey_not_registered() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let coldkey1 = U256::from(1);
+        let coldkey2 = U256::from(3);
+        let hotkey = U256::from(2);
+        let stake_amount = 500_000_000;
+        let lock_amount = 250_000_000;
+        let lock_duration = 7200 * 30; // 30 days
+        let start_block = SubtensorModule::get_current_block_as_u64();
+
+        // Set up network
+        add_network(netuid, 0, 0);
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey1, 1_000_000_000);
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey2, 1_000_000_000);
+        register_ok_neuron(netuid, hotkey, coldkey1, 11);
+
+        assert_ok!(SubtensorModule::add_stake(
+            RuntimeOrigin::signed(coldkey2),
+            hotkey,
+            netuid,
+            stake_amount
+        ));
+        
+        assert_ok!(SubtensorModule::lock_stake(
+            RuntimeOrigin::signed(coldkey2),
+            hotkey,
+            netuid,
+            lock_duration,
+            lock_amount
+        ));
+
+        // Check that the lock was created correctly
+        let stake_lock = Locks::<Test>::get((netuid, hotkey, coldkey2));
+        assert_eq!(stake_lock.alpha_locked, lock_amount);
+        assert_eq!(stake_lock.end_block, start_block + lock_duration);
+
+        // Verify the event was emitted
+        System::assert_last_event(
+            Event::LockIncreased{ coldkey: coldkey2, hotkey, netuid, alpha_locked: lock_amount }.into(),
+        );
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_do_lock_zero_amount --exact --show-output
+#[test]
+fn test_do_lock_zero_amount() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let lock_amount = 0;
+        let lock_duration = 7200 * 30; // 30 days
+
+        // Set up network and register neuron
+        add_network(netuid, 0, 0);
+        register_ok_neuron(netuid, hotkey, coldkey, 11);
+
+        // Add balance to coldkey
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey, 1_000_000_000);
+
+        // Attempt to lock zero stake
+        assert_noop!(
+            SubtensorModule::lock_stake(
+                RuntimeOrigin::signed(coldkey),
+                hotkey,
+                netuid,
+                lock_duration,
+                lock_amount
+            ),
+            Error::<Test>::NotEnoughStakeToWithdraw
+        );
+    });
+}
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_do_lock_insufficient_stake --exact --nocapture
+// #[test]
+// fn test_do_lock_insufficient_stake() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let coldkey = U256::from(1);
+//         let hotkey = U256::from(2);
+//         let stake_amount = 500_000_000;
+//         let lock_amount = 750_000_000; // More than available stake
+//         let lock_duration = 7200 * 30; // 30 days
+
+//         // Set up network and register neuron
+//         add_network(netuid, 0, 0);
+//         register_ok_neuron(netuid, hotkey, coldkey, 11);
+
+//         // Add balance to coldkey and stake
+//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, 1_000_000_000);
+//         assert_ok!(SubtensorModule::add_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             stake_amount
+//         ));
+
+//         // Attempt to lock more stake than available
+//         assert_noop!(
+//             SubtensorModule::lock_stake(
+//                 RuntimeOrigin::signed(coldkey),
+//                 hotkey,
+//                 netuid,
+//                 lock_duration,
+//                 lock_amount
+//             ),
+//             Error::<Test>::NotEnoughStakeToWithdraw
+//         );
+//     });
+// }
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_do_lock_increase_conviction --exact --nocapture
+// #[test]
+// fn test_do_lock_increase_conviction() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let coldkey = U256::from(1);
+//         let hotkey = U256::from(2);
+//         let initial_stake = 1_000_000_000;
+//         let initial_lock_amount = 500_000_000;
+//         let initial_lock_duration = 7200 * 30; // 30 days
+//         let new_lock_amount = 750_000_000;
+//         let new_lock_duration = 7200 * 60; // 60 days
+
+//         // Set up network and register neuron
+//         add_network(netuid, 0, 0);
+//         register_ok_neuron(netuid, hotkey, coldkey, 11);
+
+//         // Add balance to coldkey and stake
+//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
+//         assert_ok!(SubtensorModule::add_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             initial_stake
+//         ));
+
+//         // Initial lock
+//         assert_ok!(SubtensorModule::lock_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             initial_lock_duration,
+//             initial_lock_amount
+//         ));
+
+//         // Increase conviction with new lock
+//         assert_ok!(SubtensorModule::lock_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             new_lock_duration,
+//             new_lock_amount
+//         ));
+
+//         // Verify the new lock
+//         let (locked_amount, _start_block, end_block) =
+//             Locks::<Test>::get((netuid, hotkey, coldkey));
+//         assert_eq!(locked_amount, new_lock_amount);
+//         assert_eq!(
+//             end_block,
+//             SubtensorModule::get_current_block_as_u64() + new_lock_duration
+//         );
+
+//         // Verify event emission
+//         System::assert_last_event(
+//             Event::LockIncreased(coldkey, hotkey, netuid, new_lock_amount).into(),
+//         );
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_do_lock_decrease_conviction --exact --nocapture
+// #[test]
+// fn test_do_lock_decrease_conviction() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let coldkey = U256::from(1);
+//         let hotkey = U256::from(2);
+//         let initial_stake = 1_000_000_000;
+//         let initial_lock_amount = 500_000_000;
+//         let initial_lock_duration = 7200 * 30; // 30 days
+//         let new_lock_amount = 400_000_000;
+//         let new_lock_duration = 7200 * 20; // 20 days
+
+//         // Set up network and register neuron
+//         add_network(netuid, 0, 0);
+//         register_ok_neuron(netuid, hotkey, coldkey, 11);
+
+//         // Add balance to coldkey and stake
+//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
+//         assert_ok!(SubtensorModule::add_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             initial_stake
+//         ));
+
+//         // Initial lock
+//         assert_ok!(SubtensorModule::lock_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             initial_lock_duration,
+//             initial_lock_amount
+//         ));
+
+//         // Attempt to decrease conviction with new lock
+//         assert_noop!(
+//             SubtensorModule::lock_stake(
+//                 RuntimeOrigin::signed(coldkey),
+//                 hotkey,
+//                 netuid,
+//                 new_lock_duration,
+//                 new_lock_amount
+//             ),
+//             Error::<Test>::NotEnoughStakeToWithdraw
+//         );
+
+//         // Verify the lock remains unchanged
+//         let (locked_amount, _, end_block) = Locks::<Test>::get((netuid, hotkey, coldkey));
+//         assert_eq!(locked_amount, initial_lock_amount);
+//         assert_eq!(
+//             end_block,
+//             SubtensorModule::get_current_block_as_u64() + initial_lock_duration
+//         );
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_do_lock_max_duration --exact --nocapture
+// #[test]
+// fn test_do_lock_max_duration() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let coldkey = U256::from(1);
+//         let hotkey = U256::from(2);
+//         let initial_stake = 1_000_000_000;
+//         let lock_amount = 500_000_000;
+//         let max_lock_duration = 7200 * 365; // 1 year (assuming 7200 blocks per day)
+
+//         // Set up network and register neuron
+//         add_network(netuid, 0, 0);
+//         register_ok_neuron(netuid, hotkey, coldkey, 11);
+
+//         // Add balance to coldkey and stake
+//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
+//         assert_ok!(SubtensorModule::add_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             initial_stake
+//         ));
+
+//         // Lock stake for maximum duration
+//         assert_ok!(SubtensorModule::lock_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             max_lock_duration,
+//             lock_amount
+//         ));
+
+//         // Verify the lock
+//         let (locked_amount, _start_block, end_block) =
+//             Locks::<Test>::get((netuid, hotkey, coldkey));
+//         assert_eq!(locked_amount, lock_amount);
+//         assert_eq!(
+//             end_block,
+//             SubtensorModule::get_current_block_as_u64() + max_lock_duration
+//         );
+
+//         // Verify event emission
+//         System::assert_last_event(
+//             Event::LockIncreased(coldkey, hotkey, netuid, lock_amount).into(),
+//         );
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_do_lock_multiple_times --exact --nocapture
+// #[test]
+// fn test_do_lock_multiple_times() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let coldkey = U256::from(1);
+//         let hotkey = U256::from(2);
+//         let initial_stake = 1_000_000_000;
+//         let lock_amount_1 = 300_000_000;
+//         let lock_amount_2 = 500_000_000;
+//         let lock_duration_1 = 7200 * 30; // 30 days
+//         let lock_duration_2 = 7200 * 60; // 60 days
+
+//         // Set up network and register neuron
+//         add_network(netuid, 0, 0);
+//         register_ok_neuron(netuid, hotkey, coldkey, 11);
+
+//         // Add balance to coldkey and stake
+//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
+//         assert_ok!(SubtensorModule::add_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             initial_stake
+//         ));
+
+//         // First lock
+//         assert_ok!(SubtensorModule::lock_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             lock_duration_1,
+//             lock_amount_1
+//         ));
+
+//         // Verify the first lock
+//         let (locked_amount_1, start_block_1, end_block_1) =
+//             Locks::<Test>::get((netuid, hotkey, coldkey));
+//         assert_eq!(locked_amount_1, lock_amount_1);
+//         assert_eq!(end_block_1, start_block_1 + lock_duration_1);
+
+//         // Second lock
+//         assert_ok!(SubtensorModule::lock_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             lock_duration_2,
+//             lock_amount_2
+//         ));
+
+//         // Verify the second lock
+//         let (locked_amount_2, start_block_2, end_block_2) =
+//             Locks::<Test>::get((netuid, hotkey, coldkey));
+//         assert_eq!(locked_amount_2, lock_amount_2);
+//         assert_eq!(end_block_2, start_block_2 + lock_duration_2);
+
+//         // Ensure the locked amount increased
+//         assert!(locked_amount_2 > locked_amount_1);
+
+//         // Verify event emissions
+//         System::assert_has_event(
+//             Event::LockIncreased(coldkey, hotkey, netuid, lock_amount_1).into(),
+//         );
+//         System::assert_last_event(
+//             Event::LockIncreased(coldkey, hotkey, netuid, lock_amount_2).into(),
+//         );
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_do_lock_different_subnets --exact --nocapture
+// #[test]
+// fn test_do_lock_different_subnets() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid1 = 1;
+//         let netuid2 = 2;
+//         let coldkey = U256::from(1);
+//         let hotkey = U256::from(2);
+//         let initial_stake = 1_000_000_000;
+//         let lock_amount_1 = 300_000_000;
+//         let lock_amount_2 = 500_000_000;
+//         let lock_duration = 7200 * 30; // 30 days
+
+//         // Set up networks and register neuron
+//         add_network(netuid1, 0, 0);
+//         add_network(netuid2, 0, 0);
+//         register_ok_neuron(netuid1, hotkey, coldkey, 11);
+//         register_ok_neuron(netuid2, hotkey, coldkey, 12);
+
+//         // Add balance to coldkey and stake on both networks
+//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake * 2);
+//         assert_ok!(SubtensorModule::add_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid1,
+//             initial_stake
+//         ));
+//         assert_ok!(SubtensorModule::add_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid2,
+//             initial_stake
+//         ));
+
+//         // Lock stake on first subnet
+//         assert_ok!(SubtensorModule::lock_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid1,
+//             lock_duration,
+//             lock_amount_1
+//         ));
+
+//         // Verify the lock on first subnet
+//         let (locked_amount_1, start_block_1, end_block_1) =
+//             Locks::<Test>::get((netuid1, hotkey, coldkey));
+//         assert_eq!(locked_amount_1, lock_amount_1);
+//         assert_eq!(end_block_1, start_block_1 + lock_duration);
+
+//         // Lock stake on second subnet
+//         assert_ok!(SubtensorModule::lock_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid2,
+//             lock_duration,
+//             lock_amount_2
+//         ));
+
+//         // Verify the lock on second subnet
+//         let (locked_amount_2, start_block_2, end_block_2) =
+//             Locks::<Test>::get((netuid2, hotkey, coldkey));
+//         assert_eq!(locked_amount_2, lock_amount_2);
+//         assert_eq!(end_block_2, start_block_2 + lock_duration);
+
+//         // Ensure the locks are independent
+//         assert_ne!(locked_amount_1, locked_amount_2);
+
+//         // Verify event emissions
+//         System::assert_has_event(
+//             Event::LockIncreased(coldkey, hotkey, netuid1, lock_amount_1).into(),
+//         );
+//         System::assert_last_event(
+//             Event::LockIncreased(coldkey, hotkey, netuid2, lock_amount_2).into(),
+//         );
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_remove_stake_fully_locked --exact --nocapture
+// #[test]
+// fn test_remove_stake_fully_locked() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let coldkey = U256::from(1);
+//         let hotkey = U256::from(2);
+//         let initial_stake = 1_000_000_000;
+//         let lock_amount = initial_stake - 1;
+//         let lock_duration = 7200 * 30; // 30 days
+
+//         // Set up network and register neuron
+//         add_network(netuid, 0, 0);
+//         register_ok_neuron(netuid, hotkey, coldkey, 11);
+
+//         // Add balance to coldkey and stake
+//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
+//         assert_ok!(SubtensorModule::add_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             initial_stake
+//         ));
+
+//         // Lock all stake
+//         assert_ok!(SubtensorModule::lock_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             lock_duration,
+//             lock_amount
+//         ));
+
+//         // Attempt to remove stake
+//         assert_noop!(
+//             SubtensorModule::remove_stake(
+//                 RuntimeOrigin::signed(coldkey),
+//                 hotkey,
+//                 netuid,
+//                 initial_stake
+//             ),
+//             Error::<Test>::NotEnoughStakeToWithdraw
+//         );
+
+//         // Verify lock remains unchanged
+//         let (locked_amount, _, _) = Locks::<Test>::get((netuid, hotkey, coldkey));
+//         assert_eq!(locked_amount, lock_amount);
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_remove_stake_partially_locked --exact --nocapture
+// #[test]
+// fn test_remove_stake_partially_locked() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let coldkey = U256::from(1);
+//         let hotkey = U256::from(2);
+//         let initial_stake = 1_000_000_000;
+//         let lock_amount = 600_000_000;
+//         let lock_duration = 7200 * 30; // 30 days
+
+//         // Set up network and register neuron
+//         add_network(netuid, 0, 0);
+//         register_ok_neuron(netuid, hotkey, coldkey, 11);
+//         SubtensorModule::set_target_stakes_per_interval(10);
+
+//         // Add balance to coldkey and stake
+//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
+//         assert_ok!(SubtensorModule::add_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             initial_stake
+//         ));
+
+//         // Lock part of the stake
+//         assert_ok!(SubtensorModule::lock_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             lock_duration,
+//             lock_amount
+//         ));
+
+//         // Attempt to remove unlocked portion (should succeed)
+//         let unlocked_amount = SubtensorModule::max_unlockable_stake(netuid, &hotkey, &coldkey);
+//         assert_ok!(SubtensorModule::remove_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             unlocked_amount
+//         ));
+
+//         // Verify stake and lock after removal
+//         let stake_after_removal =
+//             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
+//         assert_eq!(stake_after_removal, initial_stake - unlocked_amount - 1);
+
+//         let (locked_amount, _, _) = Locks::<Test>::get((netuid, hotkey, coldkey));
+//         assert_eq!(locked_amount, lock_amount); // lock amount should not change
+
+//         // Attempt to remove more than unlocked portion (should fail)
+//         assert_noop!(
+//             SubtensorModule::remove_stake(RuntimeOrigin::signed(coldkey), hotkey, netuid, 1000), // Some random number
+//             Error::<Test>::NotEnoughStakeToWithdraw
+//         );
+
+//         // Verify stake and lock remain unchanged
+//         let stake_after_failed_removal =
+//             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
+//         assert_eq!(
+//             stake_after_failed_removal,
+//             initial_stake - unlocked_amount - 1
+//         );
+
+//         let (locked_amount_after_failed_removal, _, _) =
+//             Locks::<Test>::get((netuid, hotkey, coldkey));
+//         assert_eq!(locked_amount_after_failed_removal, lock_amount);
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_remove_stake_after_lock_expiry --exact --nocapture
+// #[test]
+// fn test_remove_stake_after_lock_expiry() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let coldkey = U256::from(1);
+//         let hotkey = U256::from(2);
+//         let initial_stake = 1_000_000_000;
+//         let lock_amount = 600_000_000;
+//         let lock_duration = 10; // 10 blocks
+
+//         // Set up network and register neuron
+//         add_network(netuid, 0, 0);
+//         register_ok_neuron(netuid, hotkey, coldkey, 11);
+//         SubtensorModule::set_target_stakes_per_interval(10);
+
+//         // Add balance to coldkey and stake
+//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
+//         assert_ok!(SubtensorModule::add_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             initial_stake
+//         ));
+
+//         // Lock part of the stake
+//         assert_ok!(SubtensorModule::lock_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             lock_duration,
+//             lock_amount
+//         ));
+
+//         // Fast forward to just after lock expiry
+//         run_to_block(lock_duration + 1);
+
+//         // Attempt to remove all stake (should succeed)
+//         assert_ok!(SubtensorModule::remove_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             initial_stake - 1
+//         ));
+
+//         // Verify stake and lock after removal
+//         let stake_after_removal =
+//             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
+//         assert_eq!(stake_after_removal, 0);
+
+//         // Verify lock is removed
+//         assert!(!Locks::<Test>::contains_key((netuid, hotkey, coldkey)));
+
+//         // Verify balance is returned to coldkey
+//         let coldkey_balance = SubtensorModule::get_coldkey_balance(&coldkey);
+//         assert_eq!(coldkey_balance, initial_stake);
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_remove_stake_multiple_locks --exact --nocapture
+// #[test]
+// fn test_remove_stake_multiple_locks() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let coldkey = U256::from(1);
+//         let hotkey = U256::from(2);
+//         let initial_stake = 1_000_000_000;
+//         let lock_amount_1 = 300_000_000;
+//         let lock_amount_2 = 400_000_000;
+//         let lock_duration_1 = 10; // 10 blocks
+//         let lock_duration_2 = 10; // 10 blocks
+
+//         // Set up network and register neuron
+//         add_network(netuid, 0, 0);
+//         register_ok_neuron(netuid, hotkey, coldkey, 11);
+//         SubtensorModule::set_target_stakes_per_interval(10);
+
+//         // Add balance to coldkey and stake
+//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
+//         assert_ok!(SubtensorModule::add_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             initial_stake
+//         ));
+
+//         // Create two locks
+//         assert_ok!(SubtensorModule::lock_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             lock_duration_1,
+//             lock_amount_1
+//         )); // first lock.
+//         assert_ok!(SubtensorModule::lock_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             lock_duration_2,
+//             lock_amount_2
+//         )); // second replaces first.
+
+//         // Attempt to remove more stake than unlocked (should fail)
+//         let max_removable = SubtensorModule::max_unlockable_stake(netuid, &hotkey, &coldkey);
+//         assert_noop!(
+//             SubtensorModule::remove_stake(
+//                 RuntimeOrigin::signed(coldkey),
+//                 hotkey,
+//                 netuid,
+//                 max_removable + 1
+//             ),
+//             Error::<Test>::NotEnoughStakeToWithdraw
+//         );
+
+//         // Remove unlocked stake (should succeed)
+//         assert_ok!(SubtensorModule::remove_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             max_removable
+//         ));
+
+//         // Verify remaining stake
+//         let remaining_stake =
+//             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
+//         assert_eq!(remaining_stake, initial_stake - max_removable - 1);
+
+//         // Fast forward to after first lock expiry
+//         run_to_block(lock_duration_2 + 1);
+
+//         // Attempt to remove more stake than available (should fail)
+//         assert_noop!(
+//             SubtensorModule::remove_stake(
+//                 RuntimeOrigin::signed(coldkey),
+//                 hotkey,
+//                 netuid,
+//                 initial_stake
+//             ),
+//             Error::<Test>::NotEnoughStakeToWithdraw
+//         );
+
+//         // Verify remaining stake
+//         let remaining_stake =
+//             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
+//         assert_eq!(remaining_stake, initial_stake - max_removable - 1);
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_remove_stake_conviction_calculation --exact --nocapture
+// #[test]
+// fn test_remove_stake_conviction_calculation() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let coldkey = U256::from(1);
+//         let hotkey = U256::from(2);
+//         let initial_stake = 1_000_000_000;
+//         let lock_amount = 500_000_000;
+//         let lock_duration = 10; // 10 blocks
+
+//         // Register and add stake
+//         add_network(netuid, 0, 0);
+//         register_ok_neuron(netuid, hotkey, coldkey, 11);
+//         SubtensorModule::set_lock_interval_blocks(lock_duration);
+//         SubtensorModule::set_target_stakes_per_interval(10);
+//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
+//         assert_ok!(SubtensorModule::add_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             initial_stake
+//         ));
+
+//         // Lock stake
+//         assert_ok!(SubtensorModule::do_lock(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             lock_duration,
+//             lock_amount
+//         ));
+
+//         // Try to remove more stake than allowed by conviction
+//         let max_removable = SubtensorModule::max_unlockable_stake(netuid, &hotkey, &coldkey);
+//         assert_noop!(
+//             SubtensorModule::remove_stake(
+//                 RuntimeOrigin::signed(coldkey),
+//                 hotkey,
+//                 netuid,
+//                 max_removable + 1
+//             ),
+//             Error::<Test>::NotEnoughStakeToWithdraw
+//         );
+
+//         // Remove allowed amount of stake
+//         assert_ok!(SubtensorModule::remove_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             max_removable - 1
+//         ));
+
+//         // Verify remaining stake
+//         let remaining_stake =
+//             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
+//         assert_eq!(remaining_stake, initial_stake - max_removable);
+
+//         // Fast forward to just before lock expiry
+//         run_to_block(lock_duration - 1);
+
+//         // Try to remove all remaining stake (should fail)
+//         assert_noop!(
+//             SubtensorModule::remove_stake(
+//                 RuntimeOrigin::signed(coldkey),
+//                 hotkey,
+//                 netuid,
+//                 remaining_stake
+//             ),
+//             Error::<Test>::NotEnoughStakeToWithdraw
+//         );
+
+//         // Fast forward to after lock expiry
+//         run_to_block(lock_duration + 1);
+
+//         // Now remove all remaining stake (should succeed)
+//         assert_ok!(SubtensorModule::remove_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             remaining_stake
+//         ));
+
+//         // Verify no stake remains
+//         let final_stake =
+//             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
+//         assert_eq!(final_stake, 0);
+
+//         // Verify lock is removed
+//         assert!(!Locks::<Test>::contains_key((netuid, hotkey, coldkey)));
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_remove_stake_partial_lock_removal --exact --nocapture
+// #[test]
+// fn test_remove_stake_partial_lock_removal() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let coldkey = U256::from(1);
+//         let hotkey = U256::from(2);
+//         let initial_stake = 1_000_000_000;
+//         let lock_amount = 500_000_000;
+//         let lock_duration = 7200 * 30; // 30 days
+
+//         // Register and add stake
+//         add_network(netuid, 0, 0);
+//         register_ok_neuron(netuid, hotkey, coldkey, 11);
+//         SubtensorModule::set_lock_interval_blocks(lock_duration);
+//         SubtensorModule::set_target_stakes_per_interval(10);
+//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
+//         assert_ok!(SubtensorModule::add_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             initial_stake
+//         ));
+
+//         // Lock stake
+//         assert_ok!(SubtensorModule::do_lock(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             lock_duration,
+//             lock_amount
+//         ));
+
+//         // Verify initial lock state
+//         let (initial_locked_amount, _, _) = Locks::<Test>::get((netuid, hotkey, coldkey));
+//         assert_eq!(initial_locked_amount, lock_amount);
+
+//         // Calculate max removable stake
+//         let max_removable = SubtensorModule::max_unlockable_stake(netuid, &hotkey, &coldkey);
+//         let partial_remove_amount = max_removable / 2;
+
+//         // Remove part of the stake
+//         assert_ok!(SubtensorModule::remove_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             partial_remove_amount
+//         ));
+
+//         // Verify remaining stake and updated lock
+//         let remaining_stake =
+//             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
+//         assert_eq!(remaining_stake, initial_stake - partial_remove_amount - 1);
+
+//         let (updated_locked_amount, _, _) = Locks::<Test>::get((netuid, hotkey, coldkey));
+//         assert_eq!(updated_locked_amount, lock_amount); // lock never changes.
+
+//         // Ensure lock still exists
+//         assert!(Locks::<Test>::contains_key((netuid, hotkey, coldkey)));
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_remove_stake_full_lock_removal --exact --nocapture
+// #[test]
+// fn test_remove_stake_full_lock_removal() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let coldkey = U256::from(1);
+//         let hotkey = U256::from(2);
+//         let initial_stake = 1_000_000_000;
+//         let lock_amount = 500_000_000;
+//         let lock_duration = 10; // 10 blocks
+
+//         // Register and add stake
+//         add_network(netuid, 0, 0);
+//         register_ok_neuron(netuid, hotkey, coldkey, 11);
+//         SubtensorModule::set_lock_interval_blocks(lock_duration);
+//         SubtensorModule::set_target_stakes_per_interval(10);
+//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
+//         assert_ok!(SubtensorModule::add_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             initial_stake
+//         ));
+
+//         // Lock stake
+//         assert_ok!(SubtensorModule::do_lock(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             lock_duration,
+//             lock_amount
+//         ));
+
+//         // Verify initial lock state
+//         let (initial_locked_amount, _, _) = Locks::<Test>::get((netuid, hotkey, coldkey));
+//         assert_eq!(initial_locked_amount, lock_amount);
+
+//         // Fast forward to just after lock expiry
+//         run_to_block(lock_duration + 1);
+
+//         // Remove all stake
+//         assert_ok!(SubtensorModule::remove_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             initial_stake - 1
+//         ));
+
+//         // Verify remaining stake
+//         let remaining_stake =
+//             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
+//         assert_eq!(remaining_stake, 0);
+
+//         // Verify lock is removed
+//         assert!(!Locks::<Test>::contains_key((netuid, hotkey, coldkey)));
+
+//         // Verify balance is returned to coldkey
+//         let coldkey_balance = SubtensorModule::get_coldkey_balance(&coldkey);
+//         assert_eq!(coldkey_balance, initial_stake);
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_remove_stake_across_subnets --exact --nocapture
+// #[test]
+// fn test_remove_stake_across_subnets() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid1 = 1;
+//         let netuid2 = 2;
+//         let coldkey = U256::from(1);
+//         let hotkey = U256::from(2);
+//         let initial_stake = 1_000_000_000;
+//         let lock_amount_1 = 300_000_000;
+//         let lock_amount_2 = 400_000_000;
+//         let lock_duration_1 = 10; // 10 blocks
+//         let lock_duration_2 = 20; // 20 blocks
+
+//         // Set up networks and register neuron
+//         add_network(netuid1, 0, 0);
+//         add_network(netuid2, 0, 0);
+//         register_ok_neuron(netuid1, hotkey, coldkey, 11);
+//         register_ok_neuron(netuid2, hotkey, coldkey, 11);
+//         SubtensorModule::set_target_stakes_per_interval(10);
+
+//         // Add balance to coldkey and stake on both networks
+//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake * 2);
+//         assert_ok!(SubtensorModule::add_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid1,
+//             initial_stake
+//         ));
+//         assert_ok!(SubtensorModule::add_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid2,
+//             initial_stake
+//         ));
+
+//         // Create locks on both networks
+//         assert_ok!(SubtensorModule::lock_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid1,
+//             lock_duration_1,
+//             lock_amount_1
+//         ));
+//         assert_ok!(SubtensorModule::lock_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid2,
+//             lock_duration_2,
+//             lock_amount_2
+//         ));
+
+//         // Attempt to remove more stake than unlocked from netuid1 (should fail)
+//         let max_removable_1 = SubtensorModule::max_unlockable_stake(netuid1, &hotkey, &coldkey);
+//         assert_noop!(
+//             SubtensorModule::remove_stake(
+//                 RuntimeOrigin::signed(coldkey),
+//                 hotkey,
+//                 netuid1,
+//                 max_removable_1 + 1
+//             ),
+//             Error::<Test>::NotEnoughStakeToWithdraw
+//         );
+
+//         // Remove unlocked stake from netuid1 (should succeed)
+//         assert_ok!(SubtensorModule::remove_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid1,
+//             max_removable_1
+//         ));
+
+//         // Verify remaining stake on netuid1
+//         let remaining_stake_1 =
+//             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid1);
+//         assert_eq!(remaining_stake_1, initial_stake - max_removable_1);
+
+//         // Fast forward to after first lock expiry
+//         run_to_block(lock_duration_1 + 1);
+
+//         // Remove all stake from netuid1 (should succeed now that lock has expired)
+//         assert_ok!(SubtensorModule::remove_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid1,
+//             remaining_stake_1
+//         ));
+
+//         // Verify no stake remains on netuid1
+//         let final_stake_1 =
+//             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid1);
+//         assert_eq!(final_stake_1, 0);
+
+//         // Attempt to remove stake from netuid2 (should still be partially locked)
+//         let max_removable_2 = SubtensorModule::max_unlockable_stake(netuid2, &hotkey, &coldkey);
+//         assert_ok!(SubtensorModule::remove_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid2,
+//             max_removable_2
+//         ));
+
+//         // Verify remaining stake on netuid2
+//         let remaining_stake_2 =
+//             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid2);
+//         assert_eq!(remaining_stake_2, initial_stake - max_removable_2 - 1);
+
+//         // Fast forward to after second lock expiry
+//         run_to_block(lock_duration_2 + 1);
+
+//         // Remove all remaining stake from netuid2
+//         assert_ok!(SubtensorModule::remove_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid2,
+//             remaining_stake_2
+//         ));
+
+//         // Verify no stake remains on netuid2
+//         let final_stake_2 =
+//             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid2);
+//         assert_eq!(final_stake_2, 0);
+
+//         // Verify locks are removed from both networks
+//         assert!(!Locks::<Test>::contains_key((netuid1, hotkey, coldkey)));
+//         assert!(!Locks::<Test>::contains_key((netuid2, hotkey, coldkey)));
+//     });
+// }
+
+// // Test names for calculate_lions_share function:
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_lions_share_empty_input --exact --nocapture
+// #[test]
+// fn test_calculate_lions_share_empty_input() {
+//     new_test_ext(1).execute_with(|| {
+//         let result = SubtensorModule::calculate_lions_share(vec![], 20);
+//         assert!(result.is_empty());
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_lions_share_single_conviction --exact --nocapture
+// #[test]
+// fn test_calculate_lions_share_single_conviction() {
+//     new_test_ext(1).execute_with(|| {
+//         let result = SubtensorModule::calculate_lions_share(vec![100], 20);
+//         assert_eq!(result.len(), 1);
+//         assert_eq!(result[0], I96F32::from_num(1));
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_lions_share_equal_convictions --exact --nocapture
+// #[test]
+// fn test_calculate_lions_share_equal_convictions() {
+//     new_test_ext(1).execute_with(|| {
+//         let result = SubtensorModule::calculate_lions_share(vec![100, 100, 100], 20);
+//         assert_eq!(result.len(), 3);
+//         for share in result {
+//             assert_eq!(share, I96F32::from_num(1) / I96F32::from_num(3));
+//         }
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_lions_share_varied_convictions --exact --nocapture
+// #[test]
+// fn test_calculate_lions_share_varied_convictions() {
+//     new_test_ext(1).execute_with(|| {
+//         let convictions = vec![100, 200, 300, 400];
+//         let result = SubtensorModule::calculate_lions_share(convictions, 20);
+//         assert_eq!(result.len(), 4);
+//         // Verify that shares are in ascending order and sum to approximately 1
+//         assert!(result[0] < result[1] && result[1] < result[2] && result[2] < result[3]);
+//         let sum: I96F32 = result.iter().sum();
+//         assert!((sum - I96F32::from_num(1)).abs() < I96F32::from_num(0.0001));
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_lions_share_zero_convictions --exact --nocapture
+// #[test]
+// fn test_calculate_lions_share_zero_convictions() {
+//     new_test_ext(1).execute_with(|| {
+//         let result = SubtensorModule::calculate_lions_share(vec![0, 0, 0], 20);
+//         assert_eq!(result.len(), 3);
+//         for share in result {
+//             assert_eq!(share, I96F32::from_num(0));
+//         }
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_lions_share_large_convictions --exact --nocapture
+// #[test]
+// fn test_calculate_lions_share_large_convictions() {
+//     new_test_ext(1).execute_with(|| {
+//         let convictions = vec![1_000_000, 2_000_000, 3_000_000];
+//         let result = SubtensorModule::calculate_lions_share(convictions, 20);
+//         assert_eq!(result.len(), 3);
+//         // Verify that shares are in ascending order and sum to approximately 1
+//         assert!(result[0] < result[1] && result[1] < result[2]);
+//         let sum: I96F32 = result.iter().sum();
+//         assert!((sum - I96F32::from_num(1)).abs() < I96F32::from_num(0.0001));
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_lions_share_different_sharpness --exact --nocapture
+// #[test]
+// fn test_calculate_lions_share_different_sharpness() {
+//     new_test_ext(1).execute_with(|| {
+//         let convictions = vec![100, 200, 300, 400];
+
+//         // Test with low sharpness
+//         let result_low = SubtensorModule::calculate_lions_share(convictions.clone(), 5);
+
+//         // Test with high sharpness
+//         let result_high = SubtensorModule::calculate_lions_share(convictions, 50);
+
+//         // Verify that higher sharpness leads to more extreme distribution
+//         assert!(result_high[3] > result_low[3]);
+//         assert!(result_high[0] < result_low[0]);
+
+//         // Verify sums are still approximately 1
+//         let sum_low: I96F32 = result_low.iter().sum();
+//         let sum_high: I96F32 = result_high.iter().sum();
+//         assert!((sum_low - I96F32::from_num(1)).abs() < I96F32::from_num(0.0001));
+//         assert!((sum_high - I96F32::from_num(1)).abs() < I96F32::from_num(0.0001));
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_lions_share_extreme_differences --exact --nocapture
+// #[test]
+// fn test_calculate_lions_share_extreme_differences() {
+//     new_test_ext(1).execute_with(|| {
+//         let convictions = vec![1, 1_000_000];
+//         let result = SubtensorModule::calculate_lions_share(convictions, 20);
+
+//         assert_eq!(result.len(), 2);
+
+//         // The share of the larger conviction should be very close to 1
+//         assert!(result[1] > I96F32::from_num(0.9999));
+
+//         // The share of the smaller conviction should be very close to 0
+//         assert!(result[0] < I96F32::from_num(0.0001));
+
+//         // Sum should still be approximately 1
+//         let sum: I96F32 = result.iter().sum();
+//         assert!((sum - I96F32::from_num(1)).abs() < I96F32::from_num(0.0001));
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_lions_share_overflow_handling --exact --nocapture
+// #[test]
+// fn test_calculate_lions_share_overflow_handling() {
+//     new_test_ext(1).execute_with(|| {
+//         // Use very large numbers to test overflow handling
+//         let convictions = vec![u64::MAX, u64::MAX - 1, u64::MAX - 2];
+//         let result = SubtensorModule::calculate_lions_share(convictions, 20);
+
+//         assert_eq!(result.len(), 3);
+
+//         // Verify that shares are still in descending order
+//         assert!(result[0] >= result[1] && result[1] >= result[2]);
+
+//         // Verify sum is still approximately 1
+//         let sum: I96F32 = result.iter().sum();
+//         assert!((sum - I96F32::from_num(1)).abs() < I96F32::from_num(0.0001));
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_lions_share_precision --exact --nocapture
+// #[test]
+// fn test_calculate_lions_share_precision() {
+//     new_test_ext(1).execute_with(|| {
+//         // Test with convictions that are close in value
+//         let convictions = vec![1_000_000, 1_000_001, 1_000_002];
+//         let result = SubtensorModule::calculate_lions_share(convictions, 20);
+
+//         // Verify that shares are in ascending order
+//         assert!(result[0] < result[1] && result[1] < result[2]);
+
+//         // Verify that the differences between shares are small but detectable
+//         assert!(result[1] - result[0] > I96F32::from_num(0.000001));
+//         assert!(result[2] - result[1] > I96F32::from_num(0.000001));
+
+//         // Verify sum is still approximately 1
+//         let sum: I96F32 = result.iter().sum();
+//         assert!((sum - I96F32::from_num(1)).abs() < I96F32::from_num(0.0001));
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_conviction_zero_lock_amount --exact --nocapture
+// #[test]
+// fn test_calculate_conviction_zero_lock_amount() {
+//     new_test_ext(1).execute_with(|| {
+//         let current_block = 1000;
+//         let end_block = 2000;
+//         let conviction = SubtensorModule::calculate_conviction(0, end_block, current_block);
+//         assert_eq!(conviction, 0);
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_conviction_zero_duration --exact --nocapture
+// #[test]
+// fn test_calculate_conviction_zero_duration() {
+//     new_test_ext(1).execute_with(|| {
+//         let current_block = 1000;
+//         let end_block = 1000;
+//         let lock_amount = 1000000;
+//         let conviction =
+//             SubtensorModule::calculate_conviction(lock_amount, end_block, current_block);
+//         assert_eq!(conviction, 0);
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_conviction_max_lock_amount --exact --nocapture
+// #[test]
+// fn test_calculate_conviction_max_lock_amount() {
+//     new_test_ext(1).execute_with(|| {
+//         let current_block = 1000;
+//         let end_block = 2000;
+//         let lock_amount = u64::MAX;
+//         let conviction =
+//             SubtensorModule::calculate_conviction(lock_amount, end_block, current_block);
+//         assert!(conviction > 0);
+//         assert!(conviction < u64::MAX);
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_conviction_max_duration --exact --nocapture
+// #[test]
+// fn test_calculate_conviction_max_duration() {
+//     new_test_ext(1).execute_with(|| {
+//         let current_block = 0;
+//         let end_block = u64::MAX;
+//         let lock_amount = 1000000;
+//         let conviction =
+//             SubtensorModule::calculate_conviction(lock_amount, end_block, current_block);
+//         assert!(conviction > 0);
+//         assert!(conviction <= lock_amount);
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_conviction_overflow_check --exact --nocapture
+// #[test]
+// fn test_calculate_conviction_overflow_check() {
+//     new_test_ext(1).execute_with(|| {
+//         let current_block = 0;
+//         let end_block = u64::MAX;
+//         let lock_amount = u64::MAX;
+//         let conviction =
+//             SubtensorModule::calculate_conviction(lock_amount, end_block, current_block);
+//         assert!(conviction > 0);
+//         assert!(conviction < u64::MAX);
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_conviction_precision_small_values --exact --nocapture
+// #[test]
+// fn test_calculate_conviction_precision_small_values() {
+//     new_test_ext(1).execute_with(|| {
+//         let current_block = 1000;
+//         let end_block = 1001;
+//         let lock_amount = 1;
+//         let conviction =
+//             SubtensorModule::calculate_conviction(lock_amount, end_block, current_block);
+//         assert!(conviction < lock_amount);
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_conviction_precision_large_values --exact --nocapture
+// #[test]
+// fn test_calculate_conviction_precision_large_values() {
+//     new_test_ext(1).execute_with(|| {
+//         let current_block = 0;
+//         let end_block = u64::MAX / 2;
+//         let lock_amount = u64::MAX / 2;
+//         let conviction =
+//             SubtensorModule::calculate_conviction(lock_amount, end_block, current_block);
+//         assert!(conviction > 0);
+//         assert!(conviction < lock_amount);
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_conviction_rounding --exact --nocapture
+// #[test]
+// fn test_calculate_conviction_rounding() {
+//     new_test_ext(1).execute_with(|| {
+//         let current_block = 1000;
+//         let end_block = 1100;
+//         let lock_amount = 1000000;
+//         let conviction1 =
+//             SubtensorModule::calculate_conviction(lock_amount, end_block, current_block);
+//         let conviction2 =
+//             SubtensorModule::calculate_conviction(lock_amount, end_block + 1, current_block);
+//         assert!(conviction2 >= conviction1);
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_conviction_lock_interval_boundary --exact --nocapture
+// #[test]
+// fn test_calculate_conviction_lock_interval_boundary() {
+//     new_test_ext(1).execute_with(|| {
+//         let current_block = 1000;
+//         let lock_interval = SubtensorModule::get_lock_interval_blocks();
+//         let end_block = current_block + lock_interval;
+//         let lock_amount = 1000000;
+//         let conviction =
+//             SubtensorModule::calculate_conviction(lock_amount, end_block, current_block);
+//         assert!(conviction > 0);
+//         assert!(conviction < lock_amount);
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_conviction_consistency --exact --nocapture
+// #[test]
+// fn test_calculate_conviction_consistency() {
+//     new_test_ext(1).execute_with(|| {
+//         let current_block = 1000;
+//         let end_block = 2000;
+//         let lock_amount = 1000000;
+//         let base_conviction =
+//             SubtensorModule::calculate_conviction(lock_amount, end_block, current_block);
+//         log::info!("Base conviction: {}", base_conviction);
+
+//         // Increasing lock amount
+//         let higher_amount_conviction =
+//             SubtensorModule::calculate_conviction(lock_amount + 1000, end_block, current_block);
+//         assert!(higher_amount_conviction > base_conviction);
+
+//         // Increasing duration
+//         let longer_duration_conviction =
+//             SubtensorModule::calculate_conviction(lock_amount, end_block + 1000, current_block);
+//         assert!(longer_duration_conviction > base_conviction);
+//     });
+// }
+
+// // pub fn calculate_lions_share(convictions: Vec<u64>, sharpness: u32) -> Vec<I96F32> {
+// //     // Handle empty convictions vector
+// //     if convictions.is_empty() {
+// //         return Vec::new();
+// //     }
+
+// //     // For a single conviction, return a vector with a single element of value 1
+// //     if convictions.len() == 1 {
+// //         return vec![I96F32::from_num(1)];
+// //     }
+
+// //     // Find the maximum conviction
+// //     let max_conviction = convictions.iter().max().cloned().unwrap_or(1);
+// //     // If the maximum conviction is zero, return a vector of zeros
+// //     if max_conviction == 0 {
+// //         return vec![I96F32::from_num(0); convictions.len()];
+// //     }
+
+// //     // Normalize convictions and apply exponential function
+// //     let mut powered_convictions: Vec<I96F32> = Vec::with_capacity(convictions.len());
+// //     for c in convictions.iter() {
+// //         let normalized = I96F32::from_num(*c) / I96F32::from_num(max_conviction);
+// //         // Use checked_mul to prevent overflow in exponentiation
+// //         let powered = exp_safe_f96(I96F32::from_num(sharpness).saturating_mul(normalized - I96F32::from_num(1)));
+// //         powered_convictions.push(powered);
+// //     }
+
+// //     // Calculate total powered conviction
+// //     let total_powered: I96F32 = powered_convictions.iter().sum();
+
+// //     // Handle case where total_powered is zero to avoid division by zero
+// //     if total_powered == I96F32::from_num(0) {
+// //         return vec![I96F32::from_num(0); convictions.len()];
+// //     }
+
+// //     // Calculate shares
+// //     let shares: Vec<I96F32> = powered_convictions.into_iter().map(|pc| {
+// //         pc / total_powered
+// //     }).collect();
+
+// //     shares
+// // }
+// // pub fn calculate_conviction(lock_amount: u64, end_block: u64, current_block: u64) -> u64 {
+// //     let lock_duration = end_block.saturating_sub(current_block);
+// //     let time_factor = -I96F32::from_num(lock_duration).saturating_div(I96F32::from_num(Self::get_lock_interval_blocks())); // Convert days to blocks
+// //     let exp_term = I96F32::from_num(1) - exp_safe_f96(I96F32::from_num(time_factor));
+// //     let conviction_score = I96F32::from_num(lock_amount).saturating_mul(exp_term);
+// //     let final_score = conviction_score.to_num::<u64>();
+// //     final_score
+// // }
+
+// // pub fn get_owning_coldkey_for_hotkey(hotkey: &T::AccountId) -> T::AccountId {
+// //     Owner::<T>::get(hotkey)
+// // }
+// // pub fn distribute_owner_cut(netuid: u16, amount: u64) -> u64 {
+// //     // Get the current block number
+// //     let current_block = Self::get_current_block_as_u64();
+
+// //     // Initialize variables to track total conviction and individual hotkey convictions
+// //     let mut total_conviction: u64 = 0;
+// //     let mut hotkey_convictions: BTreeMap<T::AccountId, u64> = BTreeMap::new();
+
+// //     // Calculate total conviction and individual hotkey convictions
+// //     for ((iter_netuid, hotkey, _), (lock_amount, _, end_block)) in Locks::<T>::iter() {
+// //         if iter_netuid != netuid { continue; }
+// //         // Calculate conviction for each lock
+// //         let conviction = Self::calculate_conviction(lock_amount, end_block, current_block);
+// //         // Add conviction to the hotkey's total
+// //         *hotkey_convictions.entry(hotkey).or_default() += conviction;
+// //         // Add to the total conviction
+// //         total_conviction = total_conviction.saturating_add(conviction);
+// //     }
+
+// //     // If there's no conviction, return the full amount
+// //     if total_conviction == 0 {
+// //         return amount;
+// //     }
+
+// //     // Convert convictions to a vector for the lion's share calculation
+// //     let convictions: Vec<u64> = hotkey_convictions.values().cloned().collect();
+
+// //     // Calculate shares using the lion's share distribution
+// //     let shares: Vec<I96F32> = Self::calculate_lions_share(convictions, 20);
+
+// //     // Initialize variable to track remaining amount to distribute
+// //     let mut remaining_amount = amount;
+
+// //     // Distribute the owner cut based on calculated shares
+// //     for ((hotkey, _), share) in hotkey_convictions.iter().zip(shares.iter()) {
+// //         // Calculate the share for this hotkey
+// //         let share_amount = I96F32::from_num(amount)
+// //             .checked_mul(*share)
+// //             .unwrap_or(I96F32::from_num(0))
+// //             .to_num::<u64>();
+
+// //         // Get the coldkey associated with this hotkey
+// //         let owner_coldkey = Self::get_owning_coldkey_for_hotkey(&hotkey);
+
+// //         // Emit the calculated share into the subnet for this hotkey
+// //         Self::emit_into_subnet(&hotkey, &owner_coldkey, netuid, share_amount);
+
+// //         // Add the share to the lock.
+// //         if Locks::<T>::contains_key((netuid, hotkey.clone(), owner_coldkey.clone())) {
+// //             let (current_lock, start_block, end_block) = Locks::<T>::get((netuid, hotkey.clone(), owner_coldkey.clone()));
+// //             let new_lock = current_lock.saturating_add(share_amount);
+// //             Locks::<T>::insert(
+// //             (netuid, hotkey.clone(), owner_coldkey.clone()),
+// //                 (new_lock, start_block, end_block)
+// //             );
+// //         }
+
+// //         // Subtract the distributed share from the remaining amount
+// //         remaining_amount = remaining_amount.saturating_sub(share_amount);
+// //     }
+
+// //     // Return any undistributed amount
+// //     remaining_amount
+// // }
+
+// // pub fn update_subnet_owner(netuid: u16) {
+// //     let mut max_total_conviction: I96F32 = I96F32::from_num(0.0);
+// //     let mut max_conviction_hotkey = None;
+// //     let mut hotkey_convictions = BTreeMap::new();
+// //     let current_block = Self::get_current_block_as_u64();
+
+// //     // Iterate through all locks in the subnet
+// //     for ((iter_netuid, iter_hotkey, _), (lock_amount, _, end_block)) in Locks::<T>::iter() {
+// //         // Skip if the subnet does not match.
+// //         if iter_netuid != netuid { continue; }
+
+// //         // Calculate conviction score based on lock amount and duration
+// //         let conviction_score = I96F32::from_num(Self::calculate_conviction(lock_amount, end_block, current_block));
+
+// //         // Accumulate conviction scores for each hotkey
+// //         let total_conviction = hotkey_convictions.entry(iter_hotkey.clone()).or_insert(I96F32::from_num(0));
+// //         *total_conviction = total_conviction.saturating_add(conviction_score);
+
+// //         // Update max conviction if current hotkey has higher total conviction
+// //         if *total_conviction > max_total_conviction {
+// //             max_total_conviction = *total_conviction;
+// //             max_conviction_hotkey = Some(iter_hotkey.clone());
+// //         }
+// //     }
+
+// //     // Set the total subnet Conviction.
+// //     SubnetLocked::<T>::insert(netuid, max_total_conviction.to_num::<u64>());
+
+// //     // Handle the case where no locks exist for the subnet
+// //     if hotkey_convictions.is_empty() {
+// //         log::warn!("No locks found for subnet {}", netuid);
+// //         return;
+// //     }
+
+// //     // Implement a minimum conviction threshold for becoming a subnet owner
+// //     let min_conviction_threshold = I96F32::from_num(1000); // Example threshold, adjust as needed
+// //     if max_total_conviction < min_conviction_threshold {
+// //         log::info!("No hotkey meets the minimum conviction threshold for subnet {}", netuid);
+// //         return;
+// //     }
+
+// //     // Set the subnet owner to the coldkey of the hotkey with highest conviction
+// //     if let Some(hotkey) = max_conviction_hotkey {
+// //         let owning_coldkey = Self::get_owning_coldkey_for_hotkey(&hotkey);
+// //         SubnetOwner::<T>::insert(netuid, owning_coldkey);
+// //     }
+
+// //     // Implement a tie-breaking mechanism for equal conviction scores
+// //     let tied_hotkeys: Vec<_> = hotkey_convictions
+// //         .iter()
+// //         .filter(|(_, &conviction)| conviction == max_total_conviction)
+// //         .collect();
+
+// //     if tied_hotkeys.len() > 1 {
+// //         // Use a deterministic method to break ties, e.g., lowest hotkey value
+// //         if let Some((winning_hotkey, _)) = tied_hotkeys.iter().min_by_key(|(&ref hotkey, _)| hotkey) {
+// //             let owning_coldkey = Self::get_owning_coldkey_for_hotkey(winning_hotkey);
+// //             SubnetOwner::<T>::insert(netuid, owning_coldkey);
+// //         }
+// //     }
+
+// //     // Log performance metrics for large subnets
+// //     if hotkey_convictions.len() > 1000 {
+// //         log::warn!("Large subnet {} processed with {} hotkeys", netuid, hotkey_convictions.len());
+// //     }
+// // }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_basic --exact --nocapture
+// #[test]
+// fn test_distribute_owner_cut_basic() {
+//     new_test_ext(1).execute_with(|| {
+//         // Setup
+//         let netuid = 1;
+//         let amount_to_distribute = 1000000;
+//         let current_block = 100;
+
+//         // Create multiple hotkeys with different lock amounts and end blocks
+//         let hotkey1 = AccountId::from([1u8; 32]);
+//         let hotkey2 = AccountId::from([2u8; 32]);
+//         let hotkey3 = AccountId::from([3u8; 32]);
+
+//         let coldkey1 = AccountId::from([4u8; 32]);
+//         let coldkey2 = AccountId::from([5u8; 32]);
+//         let coldkey3 = AccountId::from([6u8; 32]);
+//         SubtensorModule::set_lock_interval_blocks(10);
+
+//         // Set up locks
+//         Locks::<Test>::insert((netuid, hotkey1, coldkey1), (500, 0, 200));
+//         Locks::<Test>::insert((netuid, hotkey2, coldkey2), (300, 0, 150));
+//         Locks::<Test>::insert((netuid, hotkey3, coldkey3), (200, 0, 300));
+
+//         // Set up ownership
+//         Owner::<Test>::insert(hotkey1, coldkey1);
+//         Owner::<Test>::insert(hotkey2, coldkey2);
+//         Owner::<Test>::insert(hotkey3, coldkey3);
+
+//         // Mock the current block
+//         System::set_block_number(current_block);
+
+//         // Call the distribute_owner_cut function
+//         let remaining = SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
+
+//         // Verify distribution
+//         assert!(
+//             remaining < amount_to_distribute,
+//             "Some amount should be distributed"
+//         );
+
+//         // Check that locks have been updated
+//         let (new_lock1, _, _) = Locks::<Test>::get((netuid, hotkey1, coldkey1));
+//         let (new_lock2, _, _) = Locks::<Test>::get((netuid, hotkey2, coldkey2));
+//         let (new_lock3, _, _) = Locks::<Test>::get((netuid, hotkey3, coldkey3));
+
+//         assert!(new_lock1 > 500, "Hotkey1's lock should increase");
+//         assert!(new_lock2 > 300, "Hotkey2's lock should increase");
+//         assert!(new_lock3 > 200, "Hotkey3's lock should increase");
+
+//         // Verify that the total distributed amount matches the initial amount minus remaining
+//         let total_distributed = (new_lock1 - 500) + (new_lock2 - 300) + (new_lock3 - 200);
+//         assert_eq!(total_distributed, amount_to_distribute - remaining);
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_single_hotkey --exact --nocapture
+// #[test]
+// fn test_distribute_owner_cut_single_hotkey() {
+//     new_test_ext(1).execute_with(|| {
+//         // Setup
+//         let netuid = 1;
+//         let amount_to_distribute = 1000000;
+//         let current_block = 100;
+
+//         // Create a single hotkey with lock
+//         let hotkey = AccountId::from([1u8; 32]);
+//         let coldkey = AccountId::from([2u8; 32]);
+//         SubtensorModule::set_lock_interval_blocks(10);
+
+//         // Set up lock
+//         Locks::<Test>::insert((netuid, hotkey, coldkey), (500, 0, 200));
+
+//         // Set up ownership
+//         Owner::<Test>::insert(hotkey, coldkey);
+
+//         // Mock the current block
+//         System::set_block_number(current_block);
+
+//         // Call the distribute_owner_cut function
+//         let remaining = SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
+
+//         // Verify distribution
+//         assert_eq!(remaining, 0, "All amount should be distributed");
+
+//         // Check that lock has been updated
+//         let (new_lock, _, _) = Locks::<Test>::get((netuid, hotkey, coldkey));
+
+//         assert_eq!(
+//             new_lock,
+//             500 + amount_to_distribute,
+//             "Hotkey's lock should increase by the full amount"
+//         );
+
+//         // Verify that the total distributed amount matches the initial amount
+//         let total_distributed = new_lock - 500;
+//         assert_eq!(total_distributed, amount_to_distribute);
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_no_stake --exact --nocapture
+// #[test]
+// fn test_distribute_owner_cut_no_stake() {
+//     new_test_ext(1).execute_with(|| {
+//         // Setup
+//         let netuid = 1;
+//         let amount_to_distribute = 1000000;
+//         let current_block = 100;
+
+//         // No hotkeys or locks are set up
+
+//         // Mock the current block
+//         System::set_block_number(current_block);
+
+//         // Call the distribute_owner_cut function
+//         let remaining = SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
+
+//         // Verify that all amount is returned as remaining
+//         assert_eq!(
+//             remaining, amount_to_distribute,
+//             "All amount should be returned when no stake exists"
+//         );
+
+//         // Verify that no locks were created or modified
+//         assert_eq!(Locks::<Test>::iter().count(), 0, "No locks should exist");
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_zero_amount --exact --nocapture
+// #[test]
+// fn test_distribute_owner_cut_zero_amount() {
+//     new_test_ext(1).execute_with(|| {
+//         // Setup
+//         let netuid = 1;
+//         let amount_to_distribute = 0;
+//         let current_block = 100;
+//         let hotkey = U256::from(1);
+//         let coldkey = U256::from(2);
+//         let lock_amount = 500;
+//         let lock_duration = 1000;
+
+//         // Set up a lock
+//         Locks::<Test>::insert(
+//             (netuid, hotkey, coldkey),
+//             (lock_amount, current_block, current_block + lock_duration),
+//         );
+
+//         // Set up ownership
+//         Owner::<Test>::insert(hotkey, coldkey);
+
+//         // Mock the current block
+//         System::set_block_number(current_block);
+
+//         // Call the distribute_owner_cut function
+//         let remaining = SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
+
+//         // Verify that all amount is returned as remaining (which is 0 in this case)
+//         assert_eq!(
+//             remaining, 0,
+//             "Zero amount should be returned when distributing zero"
+//         );
+
+//         // Check that lock has not been updated
+//         let (new_lock, _, _) = Locks::<Test>::get((netuid, hotkey, coldkey));
+//         assert_eq!(
+//             new_lock, lock_amount,
+//             "Hotkey's lock should remain unchanged"
+//         );
+
+//         // Verify that no distribution occurred
+//         assert_eq!(new_lock, lock_amount, "Lock amount should remain the same");
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_large_amount --exact --nocapture
+// #[test]
+// fn test_distribute_owner_cut_large_amount() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let amount_to_distribute = u64::MAX;
+//         let current_block = 100;
+//         let hotkey1 = U256::from(1);
+//         let hotkey2 = U256::from(2);
+//         let coldkey = U256::from(3);
+//         let lock_amount = 1_000_000;
+//         let lock_duration = 1000;
+
+//         // Set up locks
+//         Locks::<Test>::insert(
+//             (netuid, hotkey1, coldkey),
+//             (lock_amount, current_block, current_block + lock_duration),
+//         );
+//         Locks::<Test>::insert(
+//             (netuid, hotkey2, coldkey),
+//             (lock_amount, current_block, current_block + lock_duration),
+//         );
+
+//         // Set up ownership
+//         Owner::<Test>::insert(hotkey1, coldkey);
+//         Owner::<Test>::insert(hotkey2, coldkey);
+
+//         System::set_block_number(current_block);
+
+//         let remaining = SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
+
+//         // Check that distribution occurred
+//         let (new_lock1, _, _) = Locks::<Test>::get((netuid, hotkey1, coldkey));
+//         let (new_lock2, _, _) = Locks::<Test>::get((netuid, hotkey2, coldkey));
+
+//         assert!(
+//             new_lock1 > lock_amount,
+//             "Hotkey1's lock should have increased"
+//         );
+//         assert!(
+//             new_lock2 > lock_amount,
+//             "Hotkey2's lock should have increased"
+//         );
+//         assert!(
+//             remaining < amount_to_distribute,
+//             "Some amount should have been distributed"
+//         );
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_uneven_stakes --exact --nocapture
+// #[test]
+// fn test_distribute_owner_cut_uneven_stakes() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let amount_to_distribute = 1_000_000;
+//         let current_block = 100;
+//         let hotkey1 = U256::from(1);
+//         let hotkey2 = U256::from(2);
+//         let coldkey = U256::from(3);
+//         let lock_amount1 = 1_000_000;
+//         let lock_amount2 = 100_000;
+//         let lock_duration = 1000;
+
+//         // Set up locks with uneven stakes
+//         Locks::<Test>::insert(
+//             (netuid, hotkey1, coldkey),
+//             (lock_amount1, current_block, current_block + lock_duration),
+//         );
+//         Locks::<Test>::insert(
+//             (netuid, hotkey2, coldkey),
+//             (lock_amount2, current_block, current_block + lock_duration),
+//         );
+
+//         // Set up ownership
+//         Owner::<Test>::insert(hotkey1, coldkey);
+//         Owner::<Test>::insert(hotkey2, coldkey);
+
+//         System::set_block_number(current_block);
+
+//         let remaining = SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
+
+//         // Check that distribution occurred proportionally
+//         let (new_lock1, _, _) = Locks::<Test>::get((netuid, hotkey1, coldkey));
+//         let (new_lock2, _, _) = Locks::<Test>::get((netuid, hotkey2, coldkey));
+
+//         assert!(
+//             new_lock1 - lock_amount1 > new_lock2 - lock_amount2,
+//             "Hotkey1 should receive a larger share"
+//         );
+//         assert!(
+//             remaining < amount_to_distribute,
+//             "Some amount should have been distributed"
+//         );
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_different_lock_durations --exact --nocapture
+// #[test]
+// fn test_distribute_owner_cut_different_lock_durations() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let amount_to_distribute = 1_000_000;
+//         let current_block = 100;
+//         let hotkey1 = U256::from(1);
+//         let hotkey2 = U256::from(2);
+//         let coldkey = U256::from(3);
+//         let lock_amount = 1_000_000;
+//         let lock_duration1 = 2000;
+//         let lock_duration2 = 1000;
+
+//         // Set up locks with different durations
+//         Locks::<Test>::insert(
+//             (netuid, hotkey1, coldkey),
+//             (lock_amount, current_block, current_block + lock_duration1),
+//         );
+//         Locks::<Test>::insert(
+//             (netuid, hotkey2, coldkey),
+//             (lock_amount, current_block, current_block + lock_duration2),
+//         );
+
+//         // Set up ownership
+//         Owner::<Test>::insert(hotkey1, coldkey);
+//         Owner::<Test>::insert(hotkey2, coldkey);
+
+//         System::set_block_number(current_block);
+
+//         let remaining = SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
+
+//         // Check that distribution occurred with preference to longer lock duration
+//         let (new_lock1, _, _) = Locks::<Test>::get((netuid, hotkey1, coldkey));
+//         let (new_lock2, _, _) = Locks::<Test>::get((netuid, hotkey2, coldkey));
+
+//         assert!(
+//             new_lock1 - lock_amount > new_lock2 - lock_amount,
+//             "Hotkey1 with longer lock duration should receive a larger share"
+//         );
+//         assert!(
+//             remaining < amount_to_distribute,
+//             "Some amount should have been distributed"
+//         );
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_expired_locks --exact --nocapture
+// #[test]
+// fn test_distribute_owner_cut_expired_locks() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let amount_to_distribute = 1_000_000;
+//         let current_block = 1000;
+//         let hotkey1 = U256::from(1);
+//         let hotkey2 = U256::from(2);
+//         let coldkey = U256::from(3);
+//         let lock_amount = 500_000;
+//         let active_lock_duration = 2000;
+//         let expired_lock_duration = 500;
+
+//         // Set up one active lock and one expired lock
+//         Locks::<Test>::insert(
+//             (netuid, hotkey1, coldkey),
+//             (
+//                 lock_amount,
+//                 current_block - 100,
+//                 current_block + active_lock_duration,
+//             ),
+//         );
+//         Locks::<Test>::insert(
+//             (netuid, hotkey2, coldkey),
+//             (
+//                 lock_amount,
+//                 current_block - expired_lock_duration,
+//                 current_block - 1,
+//             ),
+//         );
+
+//         // Set up ownership
+//         Owner::<Test>::insert(hotkey1, coldkey);
+//         Owner::<Test>::insert(hotkey2, coldkey);
+
+//         System::set_block_number(current_block);
+
+//         let remaining = SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
+
+//         // Check that distribution occurred only for the active lock
+//         let (new_lock1, _, _) = Locks::<Test>::get((netuid, hotkey1, coldkey));
+//         let (new_lock2, _, _) = Locks::<Test>::get((netuid, hotkey2, coldkey));
+
+//         assert!(
+//             new_lock1 > lock_amount,
+//             "Active lock should receive a share"
+//         );
+//         assert_eq!(
+//             new_lock2, lock_amount,
+//             "Expired lock should not receive a share"
+//         );
+//         assert!(
+//             remaining < amount_to_distribute,
+//             "Some amount should have been distributed"
+//         );
+//         assert_eq!(
+//             new_lock1 - lock_amount,
+//             amount_to_distribute - remaining,
+//             "All distributed amount should go to the active lock"
+//         );
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_multiple_subnets --exact --nocapture
+// #[test]
+// fn test_distribute_owner_cut_multiple_subnets() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid1 = 1;
+//         let netuid2 = 2;
+//         let amount_to_distribute = 1_000_000;
+//         let current_block = 100;
+//         let hotkey1 = U256::from(1);
+//         let hotkey2 = U256::from(2);
+//         let coldkey = U256::from(3);
+//         let lock_amount = 500_000;
+//         let lock_duration = 1000;
+
+//         // Set up locks in different subnets
+//         Locks::<Test>::insert(
+//             (netuid1, hotkey1, coldkey),
+//             (lock_amount, current_block, current_block + lock_duration),
+//         );
+//         Locks::<Test>::insert(
+//             (netuid2, hotkey2, coldkey),
+//             (lock_amount, current_block, current_block + lock_duration),
+//         );
+
+//         // Set up ownership
+//         Owner::<Test>::insert(hotkey1, coldkey);
+//         Owner::<Test>::insert(hotkey2, coldkey);
+
+//         System::set_block_number(current_block);
+
+//         // Distribute to netuid1
+//         SubtensorModule::set_lock_interval_blocks(10);
+//         let remaining1 = SubtensorModule::distribute_owner_cut(netuid1, amount_to_distribute);
+
+//         // Check distribution for netuid1
+//         let (new_lock1, _, _) = Locks::<Test>::get((netuid1, hotkey1, coldkey));
+//         let (lock2, _, _) = Locks::<Test>::get((netuid2, hotkey2, coldkey));
+
+//         assert!(
+//             new_lock1 > lock_amount,
+//             "Lock in netuid1 should receive a share"
+//         );
+//         assert_eq!(lock2, lock_amount, "Lock in netuid2 should not change");
+//         assert_eq!(remaining1, 0, "All amount should be distributed in netuid1");
+
+//         // Distribute to netuid2
+//         let remaining2 = SubtensorModule::distribute_owner_cut(netuid2, amount_to_distribute);
+
+//         // Check distribution for netuid2
+//         let (lock1, _, _) = Locks::<Test>::get((netuid1, hotkey1, coldkey));
+//         let (new_lock2, _, _) = Locks::<Test>::get((netuid2, hotkey2, coldkey));
+
+//         assert_eq!(lock1, new_lock1, "Lock in netuid1 should not change");
+//         assert!(
+//             new_lock2 > lock_amount,
+//             "Lock in netuid2 should receive a share"
+//         );
+//         assert_eq!(remaining2, 0, "All amount should be distributed in netuid2");
+
+//         // Verify total distribution
+//         assert_eq!(
+//             new_lock1 - lock_amount + new_lock2 - lock_amount,
+//             amount_to_distribute * 2,
+//             "Total distributed amount should match for both subnets"
+//         );
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_rounding --exact --nocapture
+// #[test]
+// fn test_distribute_owner_cut_rounding() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let amount_to_distribute = 1000; // Small amount to test rounding
+//         let current_block = 100;
+//         let hotkey1 = U256::from(1);
+//         let hotkey2 = U256::from(2);
+//         let coldkey = U256::from(3);
+//         let lock_amount1 = 500;
+//         let lock_amount2 = 501; // Slightly different to force rounding
+//         let lock_duration = 1000;
+
+//         // Set up locks
+//         add_network(netuid, 1, 1);
+//         SubtensorModule::set_lock_interval_blocks(10000);
+//         Locks::<Test>::insert(
+//             (netuid, hotkey1, coldkey),
+//             (lock_amount1, current_block, current_block + lock_duration),
+//         );
+//         Locks::<Test>::insert(
+//             (netuid, hotkey2, coldkey),
+//             (lock_amount2, current_block, current_block + lock_duration),
+//         );
+
+//         // Set up ownership
+//         Owner::<Test>::insert(hotkey1, coldkey);
+//         Owner::<Test>::insert(hotkey2, coldkey);
+
+//         System::set_block_number(current_block);
+
+//         let remaining = SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
+
+//         // Check that all funds were distributed despite potential rounding issues
+//         assert_eq!(remaining, 0, "All funds should be distributed");
+
+//         let (new_lock1, _, _) = Locks::<Test>::get((netuid, hotkey1, coldkey));
+//         let (new_lock2, _, _) = Locks::<Test>::get((netuid, hotkey2, coldkey));
+
+//         // Check that the sum of distributed amounts equals the original amount
+//         assert_eq!(
+//             (new_lock1 - lock_amount1) + (new_lock2 - lock_amount2),
+//             amount_to_distribute,
+//             "Sum of distributed amounts should equal the original amount"
+//         );
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_conviction_calculation --exact --nocapture
+// #[test]
+// fn test_distribute_owner_cut_conviction_calculation() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let amount_to_distribute = 1000000;
+//         let current_block = 100;
+//         let hotkey1 = U256::from(1);
+//         let hotkey2 = U256::from(2);
+//         let coldkey = U256::from(3);
+//         let lock_amount = 1000;
+//         let lock_duration1 = 2000;
+//         let lock_duration2 = 1000;
+
+//         // Set up locks with different durations
+//         Locks::<Test>::insert(
+//             (netuid, hotkey1, coldkey),
+//             (lock_amount, current_block, current_block + lock_duration1),
+//         );
+//         Locks::<Test>::insert(
+//             (netuid, hotkey2, coldkey),
+//             (lock_amount, current_block, current_block + lock_duration2),
+//         );
+
+//         // Set up ownership
+//         Owner::<Test>::insert(hotkey1, coldkey);
+//         Owner::<Test>::insert(hotkey2, coldkey);
+
+//         System::set_block_number(current_block);
+
+//         let _remaining = SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
+
+//         let (new_lock1, _, _) = Locks::<Test>::get((netuid, hotkey1, coldkey));
+//         let (new_lock2, _, _) = Locks::<Test>::get((netuid, hotkey2, coldkey));
+
+//         // Check that the hotkey with longer lock duration received more funds
+//         assert!(
+//             new_lock1 - lock_amount > new_lock2 - lock_amount,
+//             "Hotkey with longer lock duration should receive more funds"
+//         );
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_lions_share_distribution --exact --nocapture
+// #[test]
+// fn test_distribute_owner_cut_lions_share_distribution() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let amount_to_distribute = 1000000;
+//         let current_block = 100;
+//         let hotkey1 = U256::from(1);
+//         let hotkey2 = U256::from(2);
+//         let hotkey3 = U256::from(3);
+//         let coldkey = U256::from(4);
+//         let lock_amount1 = 1000;
+//         let lock_amount2 = 500;
+//         let lock_amount3 = 100;
+//         let lock_duration = 1000;
+
+//         // Set up locks with different amounts
+//         SubtensorModule::set_lock_interval_blocks(100);
+//         Locks::<Test>::insert(
+//             (netuid, hotkey1, coldkey),
+//             (lock_amount1, current_block, current_block + lock_duration),
+//         );
+//         Locks::<Test>::insert(
+//             (netuid, hotkey2, coldkey),
+//             (lock_amount2, current_block, current_block + lock_duration),
+//         );
+//         Locks::<Test>::insert(
+//             (netuid, hotkey3, coldkey),
+//             (lock_amount3, current_block, current_block + lock_duration),
+//         );
+
+//         // Set up ownership
+//         Owner::<Test>::insert(hotkey1, coldkey);
+//         Owner::<Test>::insert(hotkey2, coldkey);
+//         Owner::<Test>::insert(hotkey3, coldkey);
+
+//         System::set_block_number(current_block);
+
+//         let _remaining = SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
+
+//         let (new_lock1, _, _) = Locks::<Test>::get((netuid, hotkey1, coldkey));
+//         let (new_lock2, _, _) = Locks::<Test>::get((netuid, hotkey2, coldkey));
+//         let (new_lock3, _, _) = Locks::<Test>::get((netuid, hotkey3, coldkey));
+
+//         // Check that distribution follows the lion's share principle
+//         assert!(
+//             new_lock1 - lock_amount1 > new_lock2 - lock_amount2,
+//             "Hotkey with larger lock should receive a larger share"
+//         );
+//         assert!(
+//             new_lock2 - lock_amount2 > new_lock3 - lock_amount3,
+//             "Hotkey with larger lock should receive a larger share"
+//         );
+
+//         // Check that the total distributed amount matches the initial amount
+//         let total_distributed =
+//             (new_lock1 - lock_amount1) + (new_lock2 - lock_amount2) + (new_lock3 - lock_amount3);
+//         assert_eq!(
+//             total_distributed,
+//             amount_to_distribute - 1,
+//             "Total distributed amount should match initial amount"
+//         );
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_storage_updates --exact --nocapture
+// #[test]
+// fn test_distribute_owner_cut_storage_updates() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let amount_to_distribute = 1_000_000;
+//         let current_block = 100;
+//         let hotkey1 = U256::from(1);
+//         let hotkey2 = U256::from(2);
+//         let coldkey = U256::from(3);
+//         let lock_amount1 = 500_000;
+//         let lock_amount2 = 250_000;
+//         let lock_duration = 1000;
+
+//         // Set up initial locks
+//         Locks::<Test>::insert(
+//             (netuid, hotkey1, coldkey),
+//             (lock_amount1, current_block, current_block + lock_duration),
+//         );
+//         Locks::<Test>::insert(
+//             (netuid, hotkey2, coldkey),
+//             (lock_amount2, current_block, current_block + lock_duration),
+//         );
+
+//         // Set up ownership
+//         Owner::<Test>::insert(hotkey1, coldkey);
+//         Owner::<Test>::insert(hotkey2, coldkey);
+
+//         System::set_block_number(current_block);
+
+//         // Distribute owner cut
+//         SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
+
+//         // Check that locks have been updated
+//         let (new_lock1, _, _) = Locks::<Test>::get((netuid, hotkey1, coldkey));
+//         let (new_lock2, _, _) = Locks::<Test>::get((netuid, hotkey2, coldkey));
+
+//         assert!(
+//             new_lock1 > lock_amount1,
+//             "Lock for hotkey1 should have increased"
+//         );
+//         assert!(
+//             new_lock2 > lock_amount2,
+//             "Lock for hotkey2 should have increased"
+//         );
+
+//         // Verify that the total increase matches the distributed amount
+//         let total_increase = (new_lock1 - lock_amount1) + (new_lock2 - lock_amount2);
+//         assert_eq!(
+//             total_increase,
+//             amount_to_distribute - 1,
+//             "Total lock increase should match the distributed amount"
+//         );
+
+//         // Check that other storage items remain unchanged
+//         assert_eq!(
+//             Owner::<Test>::get(hotkey1),
+//             coldkey,
+//             "Owner mapping for hotkey1 should remain unchanged"
+//         );
+//         assert_eq!(
+//             Owner::<Test>::get(hotkey2),
+//             coldkey,
+//             "Owner mapping for hotkey2 should remain unchanged"
+//         );
+
+//         // Verify that no new locks were created
+//         assert_eq!(
+//             Locks::<Test>::iter().count(),
+//             2,
+//             "No new locks should have been created"
+//         );
+//     });
+// }
+
+// // Test cases for update_subnet_owner function:
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_update_subnet_owner_no_locks --exact --nocapture
+// #[test]
+// fn test_update_subnet_owner_no_locks() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+
+//         // Ensure there are no locks in the subnet
+//         assert_eq!(
+//             Locks::<Test>::iter().count(),
+//             0,
+//             "There should be no locks initially"
+//         );
+
+//         // Call the update_subnet_owner function
+//         SubtensorModule::update_subnet_owner(netuid);
+
+//         // Verify that no subnet owner was set
+//         assert!(
+//             !SubnetOwner::<Test>::contains_key(netuid),
+//             "No subnet owner should be set when there are no locks"
+//         );
+
+//         // Verify that the subnet locked amount is zero
+//         assert_eq!(
+//             SubnetLocked::<Test>::get(netuid),
+//             0,
+//             "Subnet locked amount should be zero"
+//         );
+
+//         // Check that a warning log was emitted
+//         // Note: In a real test environment, you would need a way to capture and assert on log output
+//         // For this example, we'll just comment on the expected behavior
+//         // assert_eq!(last_log_message(), "No locks found for subnet 1");
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_update_subnet_owner_single_lock --exact --nocapture
+// #[test]
+// fn test_update_subnet_owner_single_lock() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let hotkey = U256::from(1);
+//         let coldkey = U256::from(2);
+//         let lock_amount = 1000000;
+//         let current_block = 100;
+//         let lock_duration = 1000000;
+
+//         // Set up a single lock
+//         Locks::<Test>::insert(
+//             (netuid, hotkey, coldkey),
+//             (lock_amount, current_block, current_block + lock_duration),
+//         );
+
+//         // Set up ownership
+//         Owner::<Test>::insert(hotkey, coldkey);
+
+//         // Mock the current block
+//         System::set_block_number(current_block);
+
+//         // Call the update_subnet_owner function
+//         SubtensorModule::update_subnet_owner(netuid);
+
+//         // Verify that the subnet owner was set correctly
+//         assert_eq!(
+//             SubnetOwner::<Test>::get(netuid),
+//             coldkey.clone(),
+//             "Subnet owner should be set to the coldkey of the only lock"
+//         );
+
+//         // Verify that the subnet locked amount is correct
+//         let expected_conviction = SubtensorModule::calculate_conviction(
+//             lock_amount,
+//             current_block + lock_duration,
+//             current_block,
+//         );
+//         assert_eq!(
+//             SubnetLocked::<Test>::get(netuid),
+//             expected_conviction,
+//             "Subnet locked amount should match the calculated conviction"
+//         );
+
+//         // Verify that no new locks were created
+//         assert_eq!(
+//             Locks::<Test>::iter().count(),
+//             1,
+//             "There should still be only one lock"
+//         );
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_update_subnet_owner_multiple_locks --exact --nocapture
+// #[test]
+// fn test_update_subnet_owner_multiple_locks() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let hotkey1 = U256::from(1);
+//         let coldkey1 = U256::from(2);
+//         let hotkey2 = U256::from(3);
+//         let coldkey2 = U256::from(4);
+//         let hotkey3 = U256::from(5);
+//         let coldkey3 = U256::from(6);
+//         let current_block = 100;
+
+//         // Set up multiple locks with different amounts and durations
+//         Locks::<Test>::insert(
+//             (netuid, hotkey1, coldkey1),
+//             (1000000, current_block, current_block + 1000000),
+//         );
+//         Locks::<Test>::insert(
+//             (netuid, hotkey2, coldkey2),
+//             (2000000, current_block, current_block + 500000),
+//         );
+//         Locks::<Test>::insert(
+//             (netuid, hotkey3, coldkey3),
+//             (1500000, current_block, current_block + 2000000),
+//         );
+
+//         // Set up ownership
+//         Owner::<Test>::insert(hotkey1, coldkey1);
+//         Owner::<Test>::insert(hotkey2, coldkey2);
+//         Owner::<Test>::insert(hotkey3, coldkey3);
+
+//         // Mock the current block
+//         System::set_block_number(current_block);
+
+//         // Call the update_subnet_owner function
+//         SubtensorModule::update_subnet_owner(netuid);
+
+//         // Calculate expected convictions
+//         let conviction1 =
+//             SubtensorModule::calculate_conviction(1000000, current_block + 1000000, current_block);
+//         let conviction2 =
+//             SubtensorModule::calculate_conviction(2000000, current_block + 500000, current_block);
+//         let conviction3 =
+//             SubtensorModule::calculate_conviction(1500000, current_block + 2000000, current_block);
+
+//         // Determine the expected owner (hotkey with highest conviction)
+//         let expected_owner = if conviction1 > conviction2 && conviction1 > conviction3 {
+//             coldkey1
+//         } else if conviction2 > conviction1 && conviction2 > conviction3 {
+//             coldkey2
+//         } else {
+//             coldkey3
+//         };
+
+//         // Verify that the subnet owner was set correctly
+//         assert_eq!(
+//             SubnetOwner::<Test>::get(netuid),
+//             expected_owner,
+//             "Subnet owner should be set to the coldkey of the hotkey with highest conviction"
+//         );
+
+//         // Verify that the subnet locked amount is correct
+//         assert_eq!(
+//             SubnetLocked::<Test>::get(netuid),
+//             conviction1 + conviction2 + conviction3,
+//             "Subnet locked amount should match the total calculated conviction"
+//         );
+
+//         // Verify that no new locks were created
+//         assert_eq!(
+//             Locks::<Test>::iter().count(),
+//             3,
+//             "There should still be only three locks"
+//         );
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_update_subnet_owner_tie_breaking --exact --nocapture
+// #[test]
+// fn test_update_subnet_owner_tie_breaking() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let current_block = 100;
+//         let hotkey1 = U256::from(1);
+//         let hotkey2 = U256::from(2);
+//         let hotkey3 = U256::from(3);
+//         let coldkey1 = U256::from(4);
+//         let coldkey2 = U256::from(5);
+//         let coldkey3 = U256::from(6);
+
+//         // Set up locks with equal convictions
+//         Locks::<Test>::insert(
+//             (netuid, hotkey1, coldkey1),
+//             (1000000, current_block, current_block + 1000000),
+//         );
+//         Locks::<Test>::insert(
+//             (netuid, hotkey2, coldkey2),
+//             (1000000, current_block, current_block + 1000000),
+//         );
+//         Locks::<Test>::insert(
+//             (netuid, hotkey3, coldkey3),
+//             (1000000, current_block, current_block + 1000000),
+//         );
+
+//         // Set up ownership
+//         Owner::<Test>::insert(hotkey1, coldkey1);
+//         Owner::<Test>::insert(hotkey2, coldkey2);
+//         Owner::<Test>::insert(hotkey3, coldkey3);
+
+//         // Mock the current block
+//         System::set_block_number(current_block);
+
+//         // Call the update_subnet_owner function
+//         SubtensorModule::update_subnet_owner(netuid);
+
+//         // The expected owner should be the coldkey of the hotkey with the lowest value
+//         let expected_owner = coldkey1;
+
+//         // Verify that the subnet owner was set correctly
+//         assert_eq!(
+//             SubnetOwner::<Test>::get(netuid),
+//             expected_owner,
+//             "Subnet owner should be set to the coldkey of the hotkey with the lowest value"
+//         );
+
+//         // Verify that the subnet locked amount is correct
+//         let conviction1 = SubtensorModule::calculate_conviction(1000000, current_block + 1000000, current_block);
+//         assert_eq!(
+//             SubnetLocked::<Test>::get(netuid),
+//             conviction1 * 3,
+//             "Subnet locked amount should match the total calculated conviction"
+//         );
+
+//         // Verify that no new locks were created
+//         assert_eq!(
+//             Locks::<Test>::iter().count(),
+//             3,
+//             "There should still be only three locks"
+//         );
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_update_subnet_owner_below_threshold --exact --nocapture
+// #[test]
+// fn test_update_subnet_owner_below_threshold() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let current_block = 100;
+//         let hotkey1 = U256::from(1);
+//         let hotkey2 = U256::from(2);
+//         let coldkey1 = U256::from(3);
+//         let coldkey2 = U256::from(4);
+
+//         // Set up locks with low conviction scores
+//         Locks::<Test>::insert(
+//             (netuid, hotkey1, coldkey1),
+//             (100, current_block, current_block + 100),
+//         );
+//         Locks::<Test>::insert(
+//             (netuid, hotkey2, coldkey2),
+//             (200, current_block, current_block + 200),
+//         );
+
+//         // Set up ownership
+//         Owner::<Test>::insert(hotkey1, coldkey1);
+//         Owner::<Test>::insert(hotkey2, coldkey2);
+
+//         // Mock the current block
+//         System::set_block_number(current_block);
+
+//         // Call the update_subnet_owner function
+//         SubtensorModule::update_subnet_owner(netuid);
+
+//         // Verify that no subnet owner was set due to low conviction scores
+//         assert!(
+//             !SubnetOwner::<Test>::contains_key(netuid),
+//             "No subnet owner should be set when all convictions are below the threshold"
+//         );
+
+//         // Verify that the subnet locked amount is correct (should be the sum of all convictions)
+//         let expected_total_conviction =
+//             SubtensorModule::calculate_conviction(100, current_block + 100, current_block)
+//                 + SubtensorModule::calculate_conviction(200, current_block + 200, current_block);
+//         assert_eq!(
+//             SubnetLocked::<Test>::get(netuid),
+//             expected_total_conviction,
+//             "Subnet locked amount should match the total calculated conviction"
+//         );
+
+//         // Verify that no new locks were created
+//         assert_eq!(
+//             Locks::<Test>::iter().count(),
+//             2,
+//             "There should still be only two locks"
+//         );
+//     });
+// }
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_update_subnet_owner_conviction_calculation --exact --nocapture
+// #[test]
+// fn test_update_subnet_owner_conviction_calculation() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let current_block = 100;
+//         let hotkey1 = U256::from(1);
+//         let hotkey2 = U256::from(2);
+//         let coldkey1 = U256::from(3);
+//         let coldkey2 = U256::from(4);
+
+//         // Set up locks with different amounts and durations
+//         Locks::<Test>::insert(
+//             (netuid, hotkey1, coldkey1),
+//             (1000000, current_block, current_block + 1000000),
+//         );
+//         Locks::<Test>::insert(
+//             (netuid, hotkey2, coldkey2),
+//             (2000000, current_block, current_block + 500000),
+//         );
+
+//         // Set up ownership
+//         Owner::<Test>::insert(hotkey1, coldkey1);
+//         Owner::<Test>::insert(hotkey2, coldkey2);
+
+//         // Mock the current block
+//         System::set_block_number(current_block);
+
+//         // Call the update_subnet_owner function
+//         SubtensorModule::update_subnet_owner(netuid);
+
+//         // Calculate expected convictions
+//         let conviction1 =
+//             SubtensorModule::calculate_conviction(1000000, current_block + 1000000, current_block);
+//         let conviction2 =
+//             SubtensorModule::calculate_conviction(2000000, current_block + 500000, current_block);
+
+//         // Verify that the subnet owner is set to the hotkey with the highest conviction
+//         if conviction1 > conviction2 {
+//             assert_eq!(
+//                 SubnetOwner::<Test>::get(netuid),
+//                 coldkey1.clone(),
+//                 "Subnet owner should be set to coldkey1"
+//             );
+//         } else {
+//             assert_eq!(
+//                 SubnetOwner::<Test>::get(netuid),
+//                 coldkey2.clone(),
+//                 "Subnet owner should be set to coldkey2"
+//             );
+//         }
+
+//         // Verify that the subnet locked amount is correct
+//         assert_eq!(
+//             SubnetLocked::<Test>::get(netuid),
+//             conviction1 + conviction2,
+//             "Subnet locked amount should match the highest calculated conviction"
+//         );
+
+//         // Log the convictions for debugging
+//         println!("Conviction for hotkey1: {}", conviction1);
+//         println!("Conviction for hotkey2: {}", conviction2);
+//         println!("Total subnet locked: {}", SubnetLocked::<Test>::get(netuid));
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_update_subnet_owner_different_subnets --exact --nocapture
+// #[test]
+// fn test_update_subnet_owner_different_subnets() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid1 = 1;
+//         let netuid2 = 2;
+//         let current_block = 100;
+//         let hotkey1 = U256::from(1);
+//         let hotkey2 = U256::from(2);
+//         let coldkey1 = U256::from(3);
+//         let coldkey2 = U256::from(4);
+
+//         // Set up locks in different subnets
+//         Locks::<Test>::insert(
+//             (netuid1, hotkey1, coldkey1),
+//             (1000000, current_block, current_block + 1000000),
+//         );
+//         Locks::<Test>::insert(
+//             (netuid2, hotkey2, coldkey2),
+//             (2000000, current_block, current_block + 500000),
+//         );
+
+//         // Set up ownership
+//         Owner::<Test>::insert(hotkey1, coldkey1);
+//         Owner::<Test>::insert(hotkey2, coldkey2);
+
+//         // Mock the current block
+//         System::set_block_number(current_block);
+
+//         // Call the update_subnet_owner function for netuid1
+//         SubtensorModule::update_subnet_owner(netuid1);
+
+//         // Verify that only the lock from netuid1 is considered
+//         let conviction1 =
+//             SubtensorModule::calculate_conviction(1000000, current_block + 1000000, current_block);
+//         assert_eq!(
+//             SubnetOwner::<Test>::get(netuid1),
+//             coldkey1.clone(),
+//             "Subnet owner for netuid1 should be set to coldkey1"
+//         );
+//         assert_eq!(
+//             SubnetLocked::<Test>::get(netuid1),
+//             conviction1,
+//             "Subnet locked amount for netuid1 should match the conviction of its only lock"
+//         );
+
+//         // Verify that netuid2 is unaffected
+//         assert!(
+//             !SubnetOwner::<Test>::contains_key(netuid2),
+//             "Subnet owner for netuid2 should not be set"
+//         );
+//         assert_eq!(
+//             SubnetLocked::<Test>::get(netuid2),
+//             0,
+//             "Subnet locked amount for netuid2 should be zero"
+//         );
+
+//         // Call the update_subnet_owner function for netuid2
+//         SubtensorModule::update_subnet_owner(netuid2);
+
+//         // Verify that only the lock from netuid2 is now considered
+//         let conviction2 =
+//             SubtensorModule::calculate_conviction(2000000, current_block + 500000, current_block);
+//         assert_eq!(
+//             SubnetOwner::<Test>::get(netuid2),
+//             coldkey2.clone(),
+//             "Subnet owner for netuid2 should be set to coldkey2"
+//         );
+//         assert_eq!(
+//             SubnetLocked::<Test>::get(netuid2),
+//             conviction2,
+//             "Subnet locked amount for netuid2 should match the conviction of its only lock"
+//         );
+
+//         // Verify that netuid1 remains unchanged
+//         assert_eq!(
+//             SubnetOwner::<Test>::get(netuid1),
+//             coldkey1.clone(),
+//             "Subnet owner for netuid1 should still be set to coldkey1"
+//         );
+//         assert_eq!(
+//             SubnetLocked::<Test>::get(netuid1),
+//             conviction1,
+//             "Subnet locked amount for netuid1 should remain unchanged"
+//         );
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_update_subnet_owner_large_subnet --exact --nocapture
+// #[test]
+// fn test_update_subnet_owner_large_subnet() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let num_locks = 1500; // Large number of locks
+//         let current_block = 100;
+
+//         // Create a large number of locks
+//         for i in 0..num_locks {
+//             let hotkey = AccountId::from([i as u8; 32]);
+//             let coldkey = AccountId::from([(i + num_locks) as u8; 32]);
+//             let lock_amount = (i + 1) * 1000; // Varying lock amounts
+//             let lock_duration = (i % 10 + 1) * 100; // Varying lock durations
+
+//             Locks::<Test>::insert(
+//                 (netuid, hotkey, coldkey),
+//                 (lock_amount, current_block, current_block + lock_duration),
+//             );
+
+//             // Set up ownership
+//             Owner::<Test>::insert(hotkey, coldkey);
+//         }
+
+//         // Mock the current block
+//         System::set_block_number(current_block);
+
+//         // Measure the time taken to update subnet owner
+//         let start_time = std::time::Instant::now();
+//         SubtensorModule::update_subnet_owner(netuid);
+//         let duration = start_time.elapsed();
+
+//         // Log the time taken
+//         println!("Time taken to update subnet owner: {:?}", duration);
+
+//         // Verify that a subnet owner was set
+//         assert!(
+//             SubnetOwner::<Test>::contains_key(netuid),
+//             "A subnet owner should be set"
+//         );
+
+//         // Verify that the subnet locked amount is non-zero
+//         assert!(
+//             SubnetLocked::<Test>::get(netuid) > 0,
+//             "Subnet locked amount should be non-zero"
+//         );
+
+//         // Verify that the subnet owner has the highest conviction
+//         let owner = SubnetOwner::<Test>::get(netuid);
+//         let mut max_conviction = 0;
+//         for ((iter_netuid, _hotkey, _), (lock_amount, _, end_block)) in Locks::<Test>::iter() {
+//             if iter_netuid == netuid {
+//                 let conviction =
+//                     SubtensorModule::calculate_conviction(lock_amount, end_block, current_block);
+//                 if conviction > max_conviction {
+//                     max_conviction = conviction;
+//                 }
+//             }
+//         }
+//         let owner_hotkey = Locks::<Test>::iter()
+//             .find(|((_, _, coldkey), _)| *coldkey == owner)
+//             .map(|((_, hotkey, _), _)| hotkey)
+//             .unwrap();
+//         let (owner_lock_amount, _, owner_end_block) =
+//             Locks::<Test>::get((netuid, owner_hotkey, owner));
+//         let owner_conviction = SubtensorModule::calculate_conviction(
+//             owner_lock_amount,
+//             owner_end_block,
+//             current_block,
+//         );
+//         assert_eq!(
+//             owner_conviction, max_conviction,
+//             "Subnet owner should have the highest conviction"
+//         );
+
+//         // Check that a performance warning was logged
+//         // Note: In a real test environment, you would need a way to capture and assert on log output
+//         // For this example, we'll just comment on the expected behavior
+//         // assert!(log_contains("Large subnet 1 processed with 1500 hotkeys"));
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_update_subnet_owner_ownership_change --exact --nocapture
+// #[test]
+// fn test_update_subnet_owner_ownership_change() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let hotkey1 = U256::from(1);
+//         let coldkey1 = U256::from(2);
+//         let hotkey2 = U256::from(3);
+//         let coldkey2 = U256::from(4);
+//         let initial_block = 100000;
+//         let lock_duration = 1000000;
+
+//         // Set up initial locks
+//         Locks::<Test>::insert(
+//             (netuid, hotkey1, coldkey1),
+//             (1000000, initial_block, initial_block + lock_duration),
+//         );
+//         Locks::<Test>::insert(
+//             (netuid, hotkey2, coldkey2),
+//             (500000, initial_block, initial_block + lock_duration),
+//         );
+
+//         // Set up ownership
+//         Owner::<Test>::insert(hotkey1, coldkey1);
+//         Owner::<Test>::insert(hotkey2, coldkey2);
+
+//         // Set initial block
+//         System::set_block_number(initial_block);
+
+//         // Update subnet owner
+//         SubtensorModule::update_subnet_owner(netuid);
+
+//         // Check initial subnet owner
+//         assert_eq!(
+//             SubnetOwner::<Test>::get(netuid),
+//             coldkey1.clone(),
+//             "Initial subnet owner should be coldkey1"
+//         );
+
+//         // Simulate time passing and conviction changing
+//         let new_block = initial_block + 500000;
+//         System::set_block_number(new_block);
+
+//         // Increase lock for hotkey2
+//         Locks::<Test>::insert(
+//             (netuid, hotkey2, coldkey2),
+//             (2000000, new_block, new_block + lock_duration),
+//         );
+
+//         // Update subnet owner again
+//         SubtensorModule::update_subnet_owner(netuid);
+
+//         // Check if subnet owner has changed
+//         assert_eq!(
+//             SubnetOwner::<Test>::get(netuid),
+//             coldkey2.clone(),
+//             "Subnet owner should change to coldkey2"
+//         );
+
+//         // Verify subnet locked amount has increased
+//         let subnet_locked = SubnetLocked::<Test>::get(netuid);
+//         assert!(subnet_locked > 0, "Subnet locked amount should be non-zero");
+//         assert!(
+//             subnet_locked
+//                 > SubtensorModule::calculate_conviction(
+//                     1000000,
+//                     initial_block + lock_duration,
+//                     new_block
+//                 ),
+//             "Subnet locked amount should increase"
+//         );
+
+//         // Simulate more time passing
+//         let final_block = new_block + 600000;
+//         System::set_block_number(final_block);
+
+//         // Update subnet owner one last time
+//         SubtensorModule::update_subnet_owner(netuid);
+
+//         // Check if subnet owner remains the same
+//         assert_eq!(
+//             SubnetOwner::<Test>::get(netuid),
+//             coldkey2.clone(),
+//             "Subnet owner should still be coldkey2"
+//         );
+
+//         // Verify subnet locked amount has decreased due to time passing
+//         let final_subnet_locked = SubnetLocked::<Test>::get(netuid);
+//         assert!(
+//             final_subnet_locked < subnet_locked,
+//             "Subnet locked amount should decrease over time"
+//         );
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_update_subnet_owner_storage_updates --exact --nocapture
+// #[test]
+// fn test_update_subnet_owner_storage_updates() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let hotkey1 = U256::from(1);
+//         let coldkey1 = U256::from(2);
+//         let hotkey2 = U256::from(3);
+//         let coldkey2 = U256::from(4);
+//         let initial_block = 100000;
+//         let lock_duration = 1000000;
+
+//         // Set up initial locks
+//         Locks::<Test>::insert(
+//             (netuid, hotkey1, coldkey1),
+//             (1000000, initial_block, initial_block + lock_duration),
+//         );
+//         Locks::<Test>::insert(
+//             (netuid, hotkey2, coldkey2),
+//             (500000, initial_block, initial_block + lock_duration),
+//         );
+
+//         // Set up ownership
+//         Owner::<Test>::insert(hotkey1, coldkey1);
+//         Owner::<Test>::insert(hotkey2, coldkey2);
+
+//         // Set initial block
+//         System::set_block_number(initial_block);
+
+//         // Update subnet owner
+//         SubtensorModule::update_subnet_owner(netuid);
+
+//         // Check initial subnet owner and locked amount
+//         assert_eq!(
+//             SubnetOwner::<Test>::get(netuid),
+//             coldkey1.clone(),
+//             "Initial subnet owner should be coldkey1"
+//         );
+//         let initial_locked = SubnetLocked::<Test>::get(netuid);
+//         assert!(
+//             initial_locked > 0,
+//             "Initial subnet locked amount should be non-zero"
+//         );
+
+//         // Simulate time passing and conviction changing
+//         let new_block = initial_block + 500000;
+//         System::set_block_number(new_block);
+
+//         // Increase lock for hotkey2
+//         Locks::<Test>::insert(
+//             (netuid, hotkey2, coldkey2),
+//             (2000000, new_block, new_block + lock_duration),
+//         );
+
+//         // Update subnet owner again
+//         SubtensorModule::update_subnet_owner(netuid);
+
+//         // Check if subnet owner has changed
+//         assert_eq!(
+//             SubnetOwner::<Test>::get(netuid),
+//             coldkey2.clone(),
+//             "Subnet owner should change to coldkey2"
+//         );
+
+//         // Verify subnet locked amount has increased
+//         let new_locked = SubnetLocked::<Test>::get(netuid);
+//         assert!(
+//             new_locked > initial_locked,
+//             "Subnet locked amount should increase"
+//         );
+
+//         // Simulate more time passing
+//         let final_block = new_block + 600000;
+//         System::set_block_number(final_block);
+
+//         // Update subnet owner one last time
+//         SubtensorModule::update_subnet_owner(netuid);
+
+//         // Check if subnet owner remains the same
+//         assert_eq!(
+//             SubnetOwner::<Test>::get(netuid),
+//             coldkey2.clone(),
+//             "Subnet owner should still be coldkey2"
+//         );
+
+//         // Verify subnet locked amount has decreased due to time passing
+//         let final_locked = SubnetLocked::<Test>::get(netuid);
+//         assert!(
+//             final_locked < new_locked,
+//             "Subnet locked amount should decrease over time"
+//         );
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_sudo_set_lock_interval_blocks_success --exact --nocapture
+// #[test]
+// fn test_sudo_set_lock_interval_blocks_success() {
+//     new_test_ext(1).execute_with(|| {
+//         let new_interval = 1000;
+//         assert_ok!(SubtensorModule::sudo_set_lock_interval_blocks(
+//             RuntimeOrigin::root(),
+//             new_interval
+//         ));
+//         assert_eq!(SubtensorModule::get_lock_interval_blocks(), new_interval);
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_sudo_set_lock_interval_blocks_non_root_fails --exact --nocapture
+// #[test]
+// fn test_sudo_set_lock_interval_blocks_non_root_fails() {
+//     new_test_ext(1).execute_with(|| {
+//         let new_interval = 1000;
+//         let non_root = U256::from(1);
+//         assert_noop!(
+//             SubtensorModule::sudo_set_lock_interval_blocks(
+//                 RuntimeOrigin::signed(non_root),
+//                 new_interval
+//             ),
+//             DispatchError::BadOrigin
+//         );
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_sudo_set_lock_interval_blocks_zero --exact --nocapture
+// #[test]
+// fn test_sudo_set_lock_interval_blocks_zero() {
+//     new_test_ext(1).execute_with(|| {
+//         let new_interval = 0;
+//         assert_ok!(SubtensorModule::sudo_set_lock_interval_blocks(
+//             RuntimeOrigin::root(),
+//             new_interval
+//         ));
+//         assert_eq!(SubtensorModule::get_lock_interval_blocks(), new_interval);
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_sudo_set_lock_interval_blocks_max_value --exact --nocapture
+// #[test]
+// fn test_sudo_set_lock_interval_blocks_max_value() {
+//     new_test_ext(1).execute_with(|| {
+//         let new_interval = u64::MAX;
+//         assert_ok!(SubtensorModule::sudo_set_lock_interval_blocks(
+//             RuntimeOrigin::root(),
+//             new_interval
+//         ));
+//         assert_eq!(SubtensorModule::get_lock_interval_blocks(), new_interval);
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_sudo_set_lock_interval_blocks_multiple_calls --exact --nocapture
+// #[test]
+// fn test_sudo_set_lock_interval_blocks_multiple_calls() {
+//     new_test_ext(1).execute_with(|| {
+//         let intervals = [1000, 2000, 500, 10000];
+//         for interval in intervals.iter() {
+//             assert_ok!(SubtensorModule::sudo_set_lock_interval_blocks(
+//                 RuntimeOrigin::root(),
+//                 *interval
+//             ));
+//             assert_eq!(SubtensorModule::get_lock_interval_blocks(), *interval);
+//         }
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_sudo_set_lock_interval_blocks_effect_on_existing_locks --exact --nocapture
+// #[test]
+// fn test_sudo_set_lock_interval_blocks_effect_on_existing_locks() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let coldkey = U256::from(1);
+//         let hotkey = U256::from(2);
+//         let lock_amount = 1_000_000;
+//         let initial_lock_interval = 7200;
+//         let new_lock_interval = 14400;
+
+//         // Set up initial lock interval
+//         assert_ok!(SubtensorModule::sudo_set_lock_interval_blocks(
+//             RuntimeOrigin::root(),
+//             initial_lock_interval
+//         ));
+
+//         // Create a lock
+//         let current_block = SubtensorModule::get_current_block_as_u64();
+//         Locks::<Test>::insert(
+//             (netuid, hotkey, coldkey),
+//             (
+//                 lock_amount,
+//                 current_block,
+//                 current_block + initial_lock_interval,
+//             ),
+//         );
+
+//         // Change lock interval
+//         assert_ok!(SubtensorModule::sudo_set_lock_interval_blocks(
+//             RuntimeOrigin::root(),
+//             new_lock_interval
+//         ));
+
+//         // Verify that existing lock is not affected
+//         let (stored_amount, stored_start, stored_end) =
+//             Locks::<Test>::get((netuid, hotkey, coldkey));
+//         assert_eq!(stored_amount, lock_amount);
+//         assert_eq!(stored_start, current_block);
+//         assert_eq!(stored_end, current_block + initial_lock_interval);
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_sudo_set_lock_interval_blocks_effect_on_new_locks --exact --nocapture
+// #[test]
+// fn test_sudo_set_lock_interval_blocks_effect_on_new_locks() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let coldkey = U256::from(1);
+//         let hotkey = U256::from(2);
+//         let lock_amount = 1_000_000;
+//         let new_lock_interval = 14400;
+
+//         add_network(netuid, 0, 0);
+//         register_ok_neuron(netuid, hotkey, coldkey, 0);
+//         // Set new lock interval
+//         assert_ok!(SubtensorModule::sudo_set_lock_interval_blocks(
+//             RuntimeOrigin::root(),
+//             new_lock_interval
+//         ));
+
+//         // Add balance to coldkey account (more than needed to ensure sufficient funds)
+//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, lock_amount * 10);
+
+//         // Add stake to the hotkey (equal to lock_amount to ensure sufficient stake)
+//         assert_ok!(SubtensorModule::add_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             lock_amount
+//         ));
+//         // Create a new lock
+//         let current_block = SubtensorModule::get_current_block_as_u64();
+//         assert_ok!(SubtensorModule::lock_stake(
+//             RuntimeOrigin::signed(coldkey),
+//             hotkey,
+//             netuid,
+//             new_lock_interval,
+//             lock_amount
+//         ));
+
+//         // Verify that new lock uses the new interval
+//         let (stored_amount, stored_start, stored_end) =
+//             Locks::<Test>::get((netuid, hotkey, coldkey));
+//         assert_eq!(stored_amount, lock_amount);
+//         assert_eq!(stored_start, current_block);
+//         assert_eq!(stored_end, current_block + new_lock_interval);
+//     });
+// }
+
+
+
+
+////////////////////////
+
+
+
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut --exact --nocapture
+// #[test]
+// fn test_distribute_owner_cut() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let coldkey1 = U256::from(1);
+//         let hotkey1 = U256::from(2);
+//         let coldkey2 = U256::from(3);
+//         let hotkey2 = U256::from(4);
+
+//         // Set up initial balances and stakes
+//         SubtensorModule::add_balance_to_coldkey_account(&coldkey1, 1_000_000_000);
+//         SubtensorModule::add_balance_to_coldkey_account(&coldkey2, 1_000_000_000);
+
+//         // Register hotkeys
+//         assert_ok!(SubtensorModule::register(RuntimeOrigin::signed(coldkey1), netuid, hotkey1));
+//         assert_ok!(SubtensorModule::register(RuntimeOrigin::signed(coldkey2), netuid, hotkey2));
+
+//         // Lock stakes
+//         assert_ok!(SubtensorModule::increase_stake(RuntimeOrigin::signed(coldkey1), hotkey1, netuid, 500_000_000));
+//         assert_ok!(SubtensorModule::increase_stake(RuntimeOrigin::signed(coldkey2), hotkey2, netuid, 250_000_000));
+
+//         // Lock the stakes
+//         assert_ok!(SubtensorModule::lock_stake(RuntimeOrigin::signed(coldkey1), hotkey1, netuid, 500_000_000, 7200 * 30)); // 30 days
+//         assert_ok!(SubtensorModule::lock_stake(RuntimeOrigin::signed(coldkey2), hotkey2, netuid, 250_000_000, 7200 * 15)); // 15 days
+
+//         // Distribute owner cut
+//         let amount_to_distribute = 1_000_000;
+//         let remaining = SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
+
+//         // Check that all funds were distributed
+//         assert_eq!(remaining, 0);
+
+//         // Check that the locks were updated correctly
+//         let (lock1, _, _) = Locks::<Test>::get((netuid, hotkey1, coldkey1)).unwrap();
+//         let (lock2, _, _) = Locks::<Test>::get((netuid, hotkey2, coldkey2)).unwrap();
+
+//         // The exact distribution might vary, but hotkey1 should receive more than hotkey2
+//         assert!(lock1 > 500_000_000);
+//         assert!(lock2 > 250_000_000);
+//         assert!(lock1 - 500_000_000 > lock2 - 250_000_000);
+
+//         // Check that the total distributed amount matches the input amount
+//         assert_eq!(lock1 - 500_000_000 + lock2 - 250_000_000, amount_to_distribute);
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_no_conviction --exact --nocapture
+// #[test]
+// fn test_distribute_owner_cut_no_conviction() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let amount_to_distribute = 1_000_000;
+
+//         // Distribute owner cut when there are no stakes
+//         let remaining = SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
+
+//         // Check that all funds were returned as there were no stakes to distribute to
+//         assert_eq!(remaining, amount_to_distribute);
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_max_allowed_unstakable --exact --nocapture
+// #[test]
+// fn test_calculate_max_allowed_unstakable() {
+//     new_test_ext(1).execute_with(|| {
+//         let alpha_locked = 1_000_000;
+//         let start_block = 1000;
+//         let lock_interval_blocks = 7200 * 365; // One year in blocks
+
+//         // Test immediately after locking
+//         let current_block = start_block;
+//         let max_unstakable = SubtensorModule::calculate_max_allowed_unstakable(alpha_locked, start_block, current_block);
+//         assert_eq!(max_unstakable, 0, "Should not be able to unstake immediately after locking");
+
+//         // Test after 25% of the lock period
+//         let current_block = start_block + (lock_interval_blocks / 4);
+//         let max_unstakable = SubtensorModule::calculate_max_allowed_unstakable(alpha_locked, start_block, current_block);
+//         assert!(max_unstakable > 0 && max_unstakable < alpha_locked / 2, "Should be able to unstake some, but less than half after 25% of lock period");
+
+//         // Test after 50% of the lock period
+//         let current_block = start_block + (lock_interval_blocks / 2);
+//         let max_unstakable = SubtensorModule::calculate_max_allowed_unstakable(alpha_locked, start_block, current_block);
+//         assert!(max_unstakable > alpha_locked / 2 && max_unstakable < alpha_locked, "Should be able to unstake more than half, but not all after 50% of lock period");
+
+//         // Test after full lock period
+//         let current_block = start_block + lock_interval_blocks;
+//         let max_unstakable = SubtensorModule::calculate_max_allowed_unstakable(alpha_locked, start_block, current_block);
+//         assert_eq!(max_unstakable, alpha_locked, "Should be able to unstake all after full lock period");
+
+//         // Test long after lock period
+//         let current_block = start_block + (lock_interval_blocks * 2);
+//         let max_unstakable = SubtensorModule::calculate_max_allowed_unstakable(alpha_locked, start_block, current_block);
+//         assert_eq!(max_unstakable, alpha_locked, "Should still be able to unstake all long after lock period");
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_update_subnet_owner --exact --nocapture
+// #[test]
+// fn test_update_subnet_owner() {
+//     new_test_ext(1).execute_with(|| {
+//         let netuid = 1;
+//         let coldkey1 = U256::from(1);
+//         let hotkey1 = U256::from(2);
+//         let coldkey2 = U256::from(3);
+//         let hotkey2 = U256::from(4);
+
+//         // Add balance and register hotkeys
+//         SubtensorModule::add_balance_to_coldkey_account(&coldkey1, 1_000_000_000);
+//         SubtensorModule::add_balance_to_coldkey_account(&coldkey2, 1_000_000_000);
+//         assert_ok!(SubtensorModule::register(&hotkey1, &coldkey1, netuid));
+//         assert_ok!(SubtensorModule::register(&hotkey2, &coldkey2, netuid));
+
+//         // Create locks for both hotkeys
+//         let current_block = SubtensorModule::get_current_block_as_u64();
+//         let lock_amount1 = 500_000_000;
+//         let lock_amount2 = 750_000_000;
+//         let duration = 7200 * 365; // One year in blocks
+
+//         Locks::<Test>::insert(
+//             (netuid, hotkey1, coldkey1),
+//             (lock_amount1, current_block, current_block + duration)
+//         );
+//         Locks::<Test>::insert(
+//             (netuid, hotkey2, coldkey2),
+//             (lock_amount2, current_block, current_block + duration)
+//         );
+
+//         // Update subnet owner
+//         SubtensorModule::update_subnet_owner(netuid);
+
+//         // Check that the subnet owner is set to coldkey2 (which has a higher lock amount)
+//         assert_eq!(SubnetOwner::<Test>::get(netuid), Some(coldkey2));
+
+//         // Advance blocks and update locks to change conviction scores
+//         run_to_block(current_block + duration / 2);
+
+//         // Update lock for hotkey1 to have higher conviction
+//         Locks::<Test>::insert(
+//             (netuid, hotkey1, coldkey1),
+//             (lock_amount1 * 2, current_block, current_block + duration * 2)
+//         );
+
+//         // Update subnet owner again
+//         SubtensorModule::update_subnet_owner(netuid);
+
+//         // Check that the subnet owner is now set to coldkey1
+//         assert_eq!(SubnetOwner::<Test>::get(netuid), Some(coldkey1));
+//     });
+// }
+
+// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_conviction --exact --nocapture
+// #[test]
+// fn test_calculate_conviction() {
+//     new_test_ext(1).execute_with(|| {
+//         let lock_amount = 1_000_000;
+//         let current_block = 1000;
+//         let end_block = current_block + 7200 * 365; // One year from now
+
+//         // Test conviction at the start of the lock
+//         let conviction_start = SubtensorModule::calculate_conviction(lock_amount, end_block, current_block);
+//         assert!(conviction_start > 0, "Conviction should be positive at the start of the lock");
+//         assert!(conviction_start < lock_amount, "Conviction should be less than the lock amount");
+
+//         // Test conviction at the middle of the lock period
+//         let mid_block = current_block + (7200 * 365 / 2);
+//         let conviction_mid = SubtensorModule::calculate_conviction(lock_amount, end_block, mid_block);
+//         assert!(conviction_mid > conviction_start, "Conviction should increase over time");
+//         assert!(conviction_mid < lock_amount, "Conviction should still be less than the lock amount");
+
+//         // Test conviction near the end of the lock period
+//         let near_end_block = end_block - 1000;
+//         let conviction_near_end = SubtensorModule::calculate_conviction(lock_amount, end_block, near_end_block);
+//         assert!(conviction_near_end > conviction_mid, "Conviction should be higher near the end");
+//         assert!(conviction_near_end < lock_amount, "Conviction should still be less than the lock amount");
+
+//         // Test conviction with different lock amounts
+//         let larger_lock = lock_amount * 2;
+//         let conviction_larger = SubtensorModule::calculate_conviction(larger_lock, end_block, current_block);
+//         assert!(conviction_larger > conviction_start, "Larger lock should have higher conviction");
+
+//         // Test conviction with very short lock duration
+//         let short_end_block = current_block + 100;
+//         let conviction_short = SubtensorModule::calculate_conviction(lock_amount, short_end_block, current_block);
+//         assert!(conviction_short < conviction_start, "Short lock should have lower conviction");
+
+//         // Test conviction at the exact end of the lock
+//         let conviction_end = SubtensorModule::calculate_conviction(lock_amount, end_block, end_block);
+//         assert_eq!(conviction_end, lock_amount, "Conviction should equal lock amount at the end");
+//     });
+// }

--- a/pallets/subtensor/src/tests/lock.rs
+++ b/pallets/subtensor/src/tests/lock.rs
@@ -1,10 +1,34 @@
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::arithmetic_side_effects)]
+
 use super::mock::*;
+use crate::staking::lock::StakeLock;
+use crate::tests::mock;
 use crate::*;
 
+use approx::assert_abs_diff_eq;
 use frame_support::{assert_noop, assert_ok};
 use sp_core::U256;
-use sp_runtime::DispatchError;
-use substrate_fixed::types::I96F32;
+
+pub const UPDATE_INTERVAL: u64 = 7200 * 7;
+
+fn max_unlockable_stake(netuid: NetUid, hotkey: &U256, coldkey: &U256) -> u64 {
+    let current_block = SubtensorModule::get_current_block_as_u64();
+    let total_stake: u64 =
+        SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(hotkey, coldkey, netuid);
+    if Locks::<Test>::contains_key((netuid, hotkey, coldkey)) {
+        let stake_lock = Locks::<Test>::get((netuid, hotkey, coldkey));
+        let conviction = SubtensorModule::calculate_conviction(&stake_lock, current_block);
+
+        println!("current_block = {:?}", current_block);
+        println!("stake_lock = {:?}", stake_lock);
+        println!("conviction = {:?}", conviction);
+
+        total_stake.saturating_sub(conviction)
+    } else {
+        total_stake
+    }
+}
 
 // cargo test --package pallet-subtensor --lib -- tests::lock::test_do_lock_success --exact --show-output
 #[test]
@@ -43,7 +67,13 @@ fn test_do_lock_success() {
 
         // Verify the event was emitted
         System::assert_last_event(
-            Event::LockIncreased{ coldkey, hotkey, netuid, alpha_locked: lock_amount }.into(),
+            Event::LockIncreased {
+                coldkey,
+                hotkey,
+                netuid,
+                alpha_locked: lock_amount,
+            }
+            .into(),
         );
     });
 }
@@ -124,7 +154,7 @@ fn test_do_lock_hotkey_not_registered() {
             netuid,
             stake_amount
         ));
-        
+
         assert_ok!(SubtensorModule::lock_stake(
             RuntimeOrigin::signed(coldkey2),
             hotkey,
@@ -140,7 +170,13 @@ fn test_do_lock_hotkey_not_registered() {
 
         // Verify the event was emitted
         System::assert_last_event(
-            Event::LockIncreased{ coldkey: coldkey2, hotkey, netuid, alpha_locked: lock_amount }.into(),
+            Event::LockIncreased {
+                coldkey: coldkey2,
+                hotkey,
+                netuid,
+                alpha_locked: lock_amount,
+            }
+            .into(),
         );
     });
 }
@@ -176,3212 +212,2170 @@ fn test_do_lock_zero_amount() {
     });
 }
 
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_do_lock_insufficient_stake --exact --nocapture
-// #[test]
-// fn test_do_lock_insufficient_stake() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let coldkey = U256::from(1);
-//         let hotkey = U256::from(2);
-//         let stake_amount = 500_000_000;
-//         let lock_amount = 750_000_000; // More than available stake
-//         let lock_duration = 7200 * 30; // 30 days
-
-//         // Set up network and register neuron
-//         add_network(netuid, 0, 0);
-//         register_ok_neuron(netuid, hotkey, coldkey, 11);
-
-//         // Add balance to coldkey and stake
-//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, 1_000_000_000);
-//         assert_ok!(SubtensorModule::add_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             stake_amount
-//         ));
-
-//         // Attempt to lock more stake than available
-//         assert_noop!(
-//             SubtensorModule::lock_stake(
-//                 RuntimeOrigin::signed(coldkey),
-//                 hotkey,
-//                 netuid,
-//                 lock_duration,
-//                 lock_amount
-//             ),
-//             Error::<Test>::NotEnoughStakeToWithdraw
-//         );
-//     });
-// }
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_do_lock_increase_conviction --exact --nocapture
-// #[test]
-// fn test_do_lock_increase_conviction() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let coldkey = U256::from(1);
-//         let hotkey = U256::from(2);
-//         let initial_stake = 1_000_000_000;
-//         let initial_lock_amount = 500_000_000;
-//         let initial_lock_duration = 7200 * 30; // 30 days
-//         let new_lock_amount = 750_000_000;
-//         let new_lock_duration = 7200 * 60; // 60 days
-
-//         // Set up network and register neuron
-//         add_network(netuid, 0, 0);
-//         register_ok_neuron(netuid, hotkey, coldkey, 11);
-
-//         // Add balance to coldkey and stake
-//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
-//         assert_ok!(SubtensorModule::add_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             initial_stake
-//         ));
-
-//         // Initial lock
-//         assert_ok!(SubtensorModule::lock_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             initial_lock_duration,
-//             initial_lock_amount
-//         ));
-
-//         // Increase conviction with new lock
-//         assert_ok!(SubtensorModule::lock_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             new_lock_duration,
-//             new_lock_amount
-//         ));
-
-//         // Verify the new lock
-//         let (locked_amount, _start_block, end_block) =
-//             Locks::<Test>::get((netuid, hotkey, coldkey));
-//         assert_eq!(locked_amount, new_lock_amount);
-//         assert_eq!(
-//             end_block,
-//             SubtensorModule::get_current_block_as_u64() + new_lock_duration
-//         );
-
-//         // Verify event emission
-//         System::assert_last_event(
-//             Event::LockIncreased(coldkey, hotkey, netuid, new_lock_amount).into(),
-//         );
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_do_lock_decrease_conviction --exact --nocapture
-// #[test]
-// fn test_do_lock_decrease_conviction() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let coldkey = U256::from(1);
-//         let hotkey = U256::from(2);
-//         let initial_stake = 1_000_000_000;
-//         let initial_lock_amount = 500_000_000;
-//         let initial_lock_duration = 7200 * 30; // 30 days
-//         let new_lock_amount = 400_000_000;
-//         let new_lock_duration = 7200 * 20; // 20 days
-
-//         // Set up network and register neuron
-//         add_network(netuid, 0, 0);
-//         register_ok_neuron(netuid, hotkey, coldkey, 11);
-
-//         // Add balance to coldkey and stake
-//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
-//         assert_ok!(SubtensorModule::add_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             initial_stake
-//         ));
-
-//         // Initial lock
-//         assert_ok!(SubtensorModule::lock_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             initial_lock_duration,
-//             initial_lock_amount
-//         ));
-
-//         // Attempt to decrease conviction with new lock
-//         assert_noop!(
-//             SubtensorModule::lock_stake(
-//                 RuntimeOrigin::signed(coldkey),
-//                 hotkey,
-//                 netuid,
-//                 new_lock_duration,
-//                 new_lock_amount
-//             ),
-//             Error::<Test>::NotEnoughStakeToWithdraw
-//         );
-
-//         // Verify the lock remains unchanged
-//         let (locked_amount, _, end_block) = Locks::<Test>::get((netuid, hotkey, coldkey));
-//         assert_eq!(locked_amount, initial_lock_amount);
-//         assert_eq!(
-//             end_block,
-//             SubtensorModule::get_current_block_as_u64() + initial_lock_duration
-//         );
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_do_lock_max_duration --exact --nocapture
-// #[test]
-// fn test_do_lock_max_duration() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let coldkey = U256::from(1);
-//         let hotkey = U256::from(2);
-//         let initial_stake = 1_000_000_000;
-//         let lock_amount = 500_000_000;
-//         let max_lock_duration = 7200 * 365; // 1 year (assuming 7200 blocks per day)
-
-//         // Set up network and register neuron
-//         add_network(netuid, 0, 0);
-//         register_ok_neuron(netuid, hotkey, coldkey, 11);
-
-//         // Add balance to coldkey and stake
-//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
-//         assert_ok!(SubtensorModule::add_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             initial_stake
-//         ));
-
-//         // Lock stake for maximum duration
-//         assert_ok!(SubtensorModule::lock_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             max_lock_duration,
-//             lock_amount
-//         ));
-
-//         // Verify the lock
-//         let (locked_amount, _start_block, end_block) =
-//             Locks::<Test>::get((netuid, hotkey, coldkey));
-//         assert_eq!(locked_amount, lock_amount);
-//         assert_eq!(
-//             end_block,
-//             SubtensorModule::get_current_block_as_u64() + max_lock_duration
-//         );
-
-//         // Verify event emission
-//         System::assert_last_event(
-//             Event::LockIncreased(coldkey, hotkey, netuid, lock_amount).into(),
-//         );
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_do_lock_multiple_times --exact --nocapture
-// #[test]
-// fn test_do_lock_multiple_times() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let coldkey = U256::from(1);
-//         let hotkey = U256::from(2);
-//         let initial_stake = 1_000_000_000;
-//         let lock_amount_1 = 300_000_000;
-//         let lock_amount_2 = 500_000_000;
-//         let lock_duration_1 = 7200 * 30; // 30 days
-//         let lock_duration_2 = 7200 * 60; // 60 days
-
-//         // Set up network and register neuron
-//         add_network(netuid, 0, 0);
-//         register_ok_neuron(netuid, hotkey, coldkey, 11);
-
-//         // Add balance to coldkey and stake
-//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
-//         assert_ok!(SubtensorModule::add_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             initial_stake
-//         ));
-
-//         // First lock
-//         assert_ok!(SubtensorModule::lock_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             lock_duration_1,
-//             lock_amount_1
-//         ));
-
-//         // Verify the first lock
-//         let (locked_amount_1, start_block_1, end_block_1) =
-//             Locks::<Test>::get((netuid, hotkey, coldkey));
-//         assert_eq!(locked_amount_1, lock_amount_1);
-//         assert_eq!(end_block_1, start_block_1 + lock_duration_1);
-
-//         // Second lock
-//         assert_ok!(SubtensorModule::lock_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             lock_duration_2,
-//             lock_amount_2
-//         ));
-
-//         // Verify the second lock
-//         let (locked_amount_2, start_block_2, end_block_2) =
-//             Locks::<Test>::get((netuid, hotkey, coldkey));
-//         assert_eq!(locked_amount_2, lock_amount_2);
-//         assert_eq!(end_block_2, start_block_2 + lock_duration_2);
-
-//         // Ensure the locked amount increased
-//         assert!(locked_amount_2 > locked_amount_1);
-
-//         // Verify event emissions
-//         System::assert_has_event(
-//             Event::LockIncreased(coldkey, hotkey, netuid, lock_amount_1).into(),
-//         );
-//         System::assert_last_event(
-//             Event::LockIncreased(coldkey, hotkey, netuid, lock_amount_2).into(),
-//         );
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_do_lock_different_subnets --exact --nocapture
-// #[test]
-// fn test_do_lock_different_subnets() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid1 = 1;
-//         let netuid2 = 2;
-//         let coldkey = U256::from(1);
-//         let hotkey = U256::from(2);
-//         let initial_stake = 1_000_000_000;
-//         let lock_amount_1 = 300_000_000;
-//         let lock_amount_2 = 500_000_000;
-//         let lock_duration = 7200 * 30; // 30 days
-
-//         // Set up networks and register neuron
-//         add_network(netuid1, 0, 0);
-//         add_network(netuid2, 0, 0);
-//         register_ok_neuron(netuid1, hotkey, coldkey, 11);
-//         register_ok_neuron(netuid2, hotkey, coldkey, 12);
-
-//         // Add balance to coldkey and stake on both networks
-//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake * 2);
-//         assert_ok!(SubtensorModule::add_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid1,
-//             initial_stake
-//         ));
-//         assert_ok!(SubtensorModule::add_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid2,
-//             initial_stake
-//         ));
-
-//         // Lock stake on first subnet
-//         assert_ok!(SubtensorModule::lock_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid1,
-//             lock_duration,
-//             lock_amount_1
-//         ));
-
-//         // Verify the lock on first subnet
-//         let (locked_amount_1, start_block_1, end_block_1) =
-//             Locks::<Test>::get((netuid1, hotkey, coldkey));
-//         assert_eq!(locked_amount_1, lock_amount_1);
-//         assert_eq!(end_block_1, start_block_1 + lock_duration);
-
-//         // Lock stake on second subnet
-//         assert_ok!(SubtensorModule::lock_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid2,
-//             lock_duration,
-//             lock_amount_2
-//         ));
-
-//         // Verify the lock on second subnet
-//         let (locked_amount_2, start_block_2, end_block_2) =
-//             Locks::<Test>::get((netuid2, hotkey, coldkey));
-//         assert_eq!(locked_amount_2, lock_amount_2);
-//         assert_eq!(end_block_2, start_block_2 + lock_duration);
-
-//         // Ensure the locks are independent
-//         assert_ne!(locked_amount_1, locked_amount_2);
-
-//         // Verify event emissions
-//         System::assert_has_event(
-//             Event::LockIncreased(coldkey, hotkey, netuid1, lock_amount_1).into(),
-//         );
-//         System::assert_last_event(
-//             Event::LockIncreased(coldkey, hotkey, netuid2, lock_amount_2).into(),
-//         );
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_remove_stake_fully_locked --exact --nocapture
-// #[test]
-// fn test_remove_stake_fully_locked() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let coldkey = U256::from(1);
-//         let hotkey = U256::from(2);
-//         let initial_stake = 1_000_000_000;
-//         let lock_amount = initial_stake - 1;
-//         let lock_duration = 7200 * 30; // 30 days
-
-//         // Set up network and register neuron
-//         add_network(netuid, 0, 0);
-//         register_ok_neuron(netuid, hotkey, coldkey, 11);
-
-//         // Add balance to coldkey and stake
-//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
-//         assert_ok!(SubtensorModule::add_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             initial_stake
-//         ));
-
-//         // Lock all stake
-//         assert_ok!(SubtensorModule::lock_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             lock_duration,
-//             lock_amount
-//         ));
-
-//         // Attempt to remove stake
-//         assert_noop!(
-//             SubtensorModule::remove_stake(
-//                 RuntimeOrigin::signed(coldkey),
-//                 hotkey,
-//                 netuid,
-//                 initial_stake
-//             ),
-//             Error::<Test>::NotEnoughStakeToWithdraw
-//         );
-
-//         // Verify lock remains unchanged
-//         let (locked_amount, _, _) = Locks::<Test>::get((netuid, hotkey, coldkey));
-//         assert_eq!(locked_amount, lock_amount);
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_remove_stake_partially_locked --exact --nocapture
-// #[test]
-// fn test_remove_stake_partially_locked() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let coldkey = U256::from(1);
-//         let hotkey = U256::from(2);
-//         let initial_stake = 1_000_000_000;
-//         let lock_amount = 600_000_000;
-//         let lock_duration = 7200 * 30; // 30 days
-
-//         // Set up network and register neuron
-//         add_network(netuid, 0, 0);
-//         register_ok_neuron(netuid, hotkey, coldkey, 11);
-//         SubtensorModule::set_target_stakes_per_interval(10);
-
-//         // Add balance to coldkey and stake
-//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
-//         assert_ok!(SubtensorModule::add_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             initial_stake
-//         ));
-
-//         // Lock part of the stake
-//         assert_ok!(SubtensorModule::lock_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             lock_duration,
-//             lock_amount
-//         ));
-
-//         // Attempt to remove unlocked portion (should succeed)
-//         let unlocked_amount = SubtensorModule::max_unlockable_stake(netuid, &hotkey, &coldkey);
-//         assert_ok!(SubtensorModule::remove_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             unlocked_amount
-//         ));
-
-//         // Verify stake and lock after removal
-//         let stake_after_removal =
-//             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
-//         assert_eq!(stake_after_removal, initial_stake - unlocked_amount - 1);
-
-//         let (locked_amount, _, _) = Locks::<Test>::get((netuid, hotkey, coldkey));
-//         assert_eq!(locked_amount, lock_amount); // lock amount should not change
-
-//         // Attempt to remove more than unlocked portion (should fail)
-//         assert_noop!(
-//             SubtensorModule::remove_stake(RuntimeOrigin::signed(coldkey), hotkey, netuid, 1000), // Some random number
-//             Error::<Test>::NotEnoughStakeToWithdraw
-//         );
-
-//         // Verify stake and lock remain unchanged
-//         let stake_after_failed_removal =
-//             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
-//         assert_eq!(
-//             stake_after_failed_removal,
-//             initial_stake - unlocked_amount - 1
-//         );
-
-//         let (locked_amount_after_failed_removal, _, _) =
-//             Locks::<Test>::get((netuid, hotkey, coldkey));
-//         assert_eq!(locked_amount_after_failed_removal, lock_amount);
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_remove_stake_after_lock_expiry --exact --nocapture
-// #[test]
-// fn test_remove_stake_after_lock_expiry() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let coldkey = U256::from(1);
-//         let hotkey = U256::from(2);
-//         let initial_stake = 1_000_000_000;
-//         let lock_amount = 600_000_000;
-//         let lock_duration = 10; // 10 blocks
-
-//         // Set up network and register neuron
-//         add_network(netuid, 0, 0);
-//         register_ok_neuron(netuid, hotkey, coldkey, 11);
-//         SubtensorModule::set_target_stakes_per_interval(10);
-
-//         // Add balance to coldkey and stake
-//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
-//         assert_ok!(SubtensorModule::add_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             initial_stake
-//         ));
-
-//         // Lock part of the stake
-//         assert_ok!(SubtensorModule::lock_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             lock_duration,
-//             lock_amount
-//         ));
-
-//         // Fast forward to just after lock expiry
-//         run_to_block(lock_duration + 1);
-
-//         // Attempt to remove all stake (should succeed)
-//         assert_ok!(SubtensorModule::remove_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             initial_stake - 1
-//         ));
-
-//         // Verify stake and lock after removal
-//         let stake_after_removal =
-//             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
-//         assert_eq!(stake_after_removal, 0);
-
-//         // Verify lock is removed
-//         assert!(!Locks::<Test>::contains_key((netuid, hotkey, coldkey)));
-
-//         // Verify balance is returned to coldkey
-//         let coldkey_balance = SubtensorModule::get_coldkey_balance(&coldkey);
-//         assert_eq!(coldkey_balance, initial_stake);
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_remove_stake_multiple_locks --exact --nocapture
-// #[test]
-// fn test_remove_stake_multiple_locks() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let coldkey = U256::from(1);
-//         let hotkey = U256::from(2);
-//         let initial_stake = 1_000_000_000;
-//         let lock_amount_1 = 300_000_000;
-//         let lock_amount_2 = 400_000_000;
-//         let lock_duration_1 = 10; // 10 blocks
-//         let lock_duration_2 = 10; // 10 blocks
-
-//         // Set up network and register neuron
-//         add_network(netuid, 0, 0);
-//         register_ok_neuron(netuid, hotkey, coldkey, 11);
-//         SubtensorModule::set_target_stakes_per_interval(10);
-
-//         // Add balance to coldkey and stake
-//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
-//         assert_ok!(SubtensorModule::add_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             initial_stake
-//         ));
-
-//         // Create two locks
-//         assert_ok!(SubtensorModule::lock_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             lock_duration_1,
-//             lock_amount_1
-//         )); // first lock.
-//         assert_ok!(SubtensorModule::lock_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             lock_duration_2,
-//             lock_amount_2
-//         )); // second replaces first.
-
-//         // Attempt to remove more stake than unlocked (should fail)
-//         let max_removable = SubtensorModule::max_unlockable_stake(netuid, &hotkey, &coldkey);
-//         assert_noop!(
-//             SubtensorModule::remove_stake(
-//                 RuntimeOrigin::signed(coldkey),
-//                 hotkey,
-//                 netuid,
-//                 max_removable + 1
-//             ),
-//             Error::<Test>::NotEnoughStakeToWithdraw
-//         );
-
-//         // Remove unlocked stake (should succeed)
-//         assert_ok!(SubtensorModule::remove_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             max_removable
-//         ));
-
-//         // Verify remaining stake
-//         let remaining_stake =
-//             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
-//         assert_eq!(remaining_stake, initial_stake - max_removable - 1);
-
-//         // Fast forward to after first lock expiry
-//         run_to_block(lock_duration_2 + 1);
-
-//         // Attempt to remove more stake than available (should fail)
-//         assert_noop!(
-//             SubtensorModule::remove_stake(
-//                 RuntimeOrigin::signed(coldkey),
-//                 hotkey,
-//                 netuid,
-//                 initial_stake
-//             ),
-//             Error::<Test>::NotEnoughStakeToWithdraw
-//         );
-
-//         // Verify remaining stake
-//         let remaining_stake =
-//             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
-//         assert_eq!(remaining_stake, initial_stake - max_removable - 1);
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_remove_stake_conviction_calculation --exact --nocapture
-// #[test]
-// fn test_remove_stake_conviction_calculation() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let coldkey = U256::from(1);
-//         let hotkey = U256::from(2);
-//         let initial_stake = 1_000_000_000;
-//         let lock_amount = 500_000_000;
-//         let lock_duration = 10; // 10 blocks
-
-//         // Register and add stake
-//         add_network(netuid, 0, 0);
-//         register_ok_neuron(netuid, hotkey, coldkey, 11);
-//         SubtensorModule::set_lock_interval_blocks(lock_duration);
-//         SubtensorModule::set_target_stakes_per_interval(10);
-//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
-//         assert_ok!(SubtensorModule::add_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             initial_stake
-//         ));
-
-//         // Lock stake
-//         assert_ok!(SubtensorModule::do_lock(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             lock_duration,
-//             lock_amount
-//         ));
-
-//         // Try to remove more stake than allowed by conviction
-//         let max_removable = SubtensorModule::max_unlockable_stake(netuid, &hotkey, &coldkey);
-//         assert_noop!(
-//             SubtensorModule::remove_stake(
-//                 RuntimeOrigin::signed(coldkey),
-//                 hotkey,
-//                 netuid,
-//                 max_removable + 1
-//             ),
-//             Error::<Test>::NotEnoughStakeToWithdraw
-//         );
-
-//         // Remove allowed amount of stake
-//         assert_ok!(SubtensorModule::remove_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             max_removable - 1
-//         ));
-
-//         // Verify remaining stake
-//         let remaining_stake =
-//             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
-//         assert_eq!(remaining_stake, initial_stake - max_removable);
-
-//         // Fast forward to just before lock expiry
-//         run_to_block(lock_duration - 1);
-
-//         // Try to remove all remaining stake (should fail)
-//         assert_noop!(
-//             SubtensorModule::remove_stake(
-//                 RuntimeOrigin::signed(coldkey),
-//                 hotkey,
-//                 netuid,
-//                 remaining_stake
-//             ),
-//             Error::<Test>::NotEnoughStakeToWithdraw
-//         );
-
-//         // Fast forward to after lock expiry
-//         run_to_block(lock_duration + 1);
-
-//         // Now remove all remaining stake (should succeed)
-//         assert_ok!(SubtensorModule::remove_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             remaining_stake
-//         ));
-
-//         // Verify no stake remains
-//         let final_stake =
-//             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
-//         assert_eq!(final_stake, 0);
-
-//         // Verify lock is removed
-//         assert!(!Locks::<Test>::contains_key((netuid, hotkey, coldkey)));
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_remove_stake_partial_lock_removal --exact --nocapture
-// #[test]
-// fn test_remove_stake_partial_lock_removal() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let coldkey = U256::from(1);
-//         let hotkey = U256::from(2);
-//         let initial_stake = 1_000_000_000;
-//         let lock_amount = 500_000_000;
-//         let lock_duration = 7200 * 30; // 30 days
-
-//         // Register and add stake
-//         add_network(netuid, 0, 0);
-//         register_ok_neuron(netuid, hotkey, coldkey, 11);
-//         SubtensorModule::set_lock_interval_blocks(lock_duration);
-//         SubtensorModule::set_target_stakes_per_interval(10);
-//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
-//         assert_ok!(SubtensorModule::add_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             initial_stake
-//         ));
-
-//         // Lock stake
-//         assert_ok!(SubtensorModule::do_lock(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             lock_duration,
-//             lock_amount
-//         ));
-
-//         // Verify initial lock state
-//         let (initial_locked_amount, _, _) = Locks::<Test>::get((netuid, hotkey, coldkey));
-//         assert_eq!(initial_locked_amount, lock_amount);
-
-//         // Calculate max removable stake
-//         let max_removable = SubtensorModule::max_unlockable_stake(netuid, &hotkey, &coldkey);
-//         let partial_remove_amount = max_removable / 2;
-
-//         // Remove part of the stake
-//         assert_ok!(SubtensorModule::remove_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             partial_remove_amount
-//         ));
-
-//         // Verify remaining stake and updated lock
-//         let remaining_stake =
-//             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
-//         assert_eq!(remaining_stake, initial_stake - partial_remove_amount - 1);
-
-//         let (updated_locked_amount, _, _) = Locks::<Test>::get((netuid, hotkey, coldkey));
-//         assert_eq!(updated_locked_amount, lock_amount); // lock never changes.
-
-//         // Ensure lock still exists
-//         assert!(Locks::<Test>::contains_key((netuid, hotkey, coldkey)));
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_remove_stake_full_lock_removal --exact --nocapture
-// #[test]
-// fn test_remove_stake_full_lock_removal() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let coldkey = U256::from(1);
-//         let hotkey = U256::from(2);
-//         let initial_stake = 1_000_000_000;
-//         let lock_amount = 500_000_000;
-//         let lock_duration = 10; // 10 blocks
-
-//         // Register and add stake
-//         add_network(netuid, 0, 0);
-//         register_ok_neuron(netuid, hotkey, coldkey, 11);
-//         SubtensorModule::set_lock_interval_blocks(lock_duration);
-//         SubtensorModule::set_target_stakes_per_interval(10);
-//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
-//         assert_ok!(SubtensorModule::add_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             initial_stake
-//         ));
-
-//         // Lock stake
-//         assert_ok!(SubtensorModule::do_lock(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             lock_duration,
-//             lock_amount
-//         ));
-
-//         // Verify initial lock state
-//         let (initial_locked_amount, _, _) = Locks::<Test>::get((netuid, hotkey, coldkey));
-//         assert_eq!(initial_locked_amount, lock_amount);
-
-//         // Fast forward to just after lock expiry
-//         run_to_block(lock_duration + 1);
-
-//         // Remove all stake
-//         assert_ok!(SubtensorModule::remove_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             initial_stake - 1
-//         ));
-
-//         // Verify remaining stake
-//         let remaining_stake =
-//             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
-//         assert_eq!(remaining_stake, 0);
-
-//         // Verify lock is removed
-//         assert!(!Locks::<Test>::contains_key((netuid, hotkey, coldkey)));
-
-//         // Verify balance is returned to coldkey
-//         let coldkey_balance = SubtensorModule::get_coldkey_balance(&coldkey);
-//         assert_eq!(coldkey_balance, initial_stake);
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_remove_stake_across_subnets --exact --nocapture
-// #[test]
-// fn test_remove_stake_across_subnets() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid1 = 1;
-//         let netuid2 = 2;
-//         let coldkey = U256::from(1);
-//         let hotkey = U256::from(2);
-//         let initial_stake = 1_000_000_000;
-//         let lock_amount_1 = 300_000_000;
-//         let lock_amount_2 = 400_000_000;
-//         let lock_duration_1 = 10; // 10 blocks
-//         let lock_duration_2 = 20; // 20 blocks
-
-//         // Set up networks and register neuron
-//         add_network(netuid1, 0, 0);
-//         add_network(netuid2, 0, 0);
-//         register_ok_neuron(netuid1, hotkey, coldkey, 11);
-//         register_ok_neuron(netuid2, hotkey, coldkey, 11);
-//         SubtensorModule::set_target_stakes_per_interval(10);
-
-//         // Add balance to coldkey and stake on both networks
-//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake * 2);
-//         assert_ok!(SubtensorModule::add_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid1,
-//             initial_stake
-//         ));
-//         assert_ok!(SubtensorModule::add_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid2,
-//             initial_stake
-//         ));
-
-//         // Create locks on both networks
-//         assert_ok!(SubtensorModule::lock_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid1,
-//             lock_duration_1,
-//             lock_amount_1
-//         ));
-//         assert_ok!(SubtensorModule::lock_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid2,
-//             lock_duration_2,
-//             lock_amount_2
-//         ));
-
-//         // Attempt to remove more stake than unlocked from netuid1 (should fail)
-//         let max_removable_1 = SubtensorModule::max_unlockable_stake(netuid1, &hotkey, &coldkey);
-//         assert_noop!(
-//             SubtensorModule::remove_stake(
-//                 RuntimeOrigin::signed(coldkey),
-//                 hotkey,
-//                 netuid1,
-//                 max_removable_1 + 1
-//             ),
-//             Error::<Test>::NotEnoughStakeToWithdraw
-//         );
-
-//         // Remove unlocked stake from netuid1 (should succeed)
-//         assert_ok!(SubtensorModule::remove_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid1,
-//             max_removable_1
-//         ));
-
-//         // Verify remaining stake on netuid1
-//         let remaining_stake_1 =
-//             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid1);
-//         assert_eq!(remaining_stake_1, initial_stake - max_removable_1);
-
-//         // Fast forward to after first lock expiry
-//         run_to_block(lock_duration_1 + 1);
-
-//         // Remove all stake from netuid1 (should succeed now that lock has expired)
-//         assert_ok!(SubtensorModule::remove_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid1,
-//             remaining_stake_1
-//         ));
-
-//         // Verify no stake remains on netuid1
-//         let final_stake_1 =
-//             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid1);
-//         assert_eq!(final_stake_1, 0);
-
-//         // Attempt to remove stake from netuid2 (should still be partially locked)
-//         let max_removable_2 = SubtensorModule::max_unlockable_stake(netuid2, &hotkey, &coldkey);
-//         assert_ok!(SubtensorModule::remove_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid2,
-//             max_removable_2
-//         ));
-
-//         // Verify remaining stake on netuid2
-//         let remaining_stake_2 =
-//             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid2);
-//         assert_eq!(remaining_stake_2, initial_stake - max_removable_2 - 1);
-
-//         // Fast forward to after second lock expiry
-//         run_to_block(lock_duration_2 + 1);
-
-//         // Remove all remaining stake from netuid2
-//         assert_ok!(SubtensorModule::remove_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid2,
-//             remaining_stake_2
-//         ));
-
-//         // Verify no stake remains on netuid2
-//         let final_stake_2 =
-//             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid2);
-//         assert_eq!(final_stake_2, 0);
-
-//         // Verify locks are removed from both networks
-//         assert!(!Locks::<Test>::contains_key((netuid1, hotkey, coldkey)));
-//         assert!(!Locks::<Test>::contains_key((netuid2, hotkey, coldkey)));
-//     });
-// }
-
-// // Test names for calculate_lions_share function:
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_lions_share_empty_input --exact --nocapture
-// #[test]
-// fn test_calculate_lions_share_empty_input() {
-//     new_test_ext(1).execute_with(|| {
-//         let result = SubtensorModule::calculate_lions_share(vec![], 20);
-//         assert!(result.is_empty());
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_lions_share_single_conviction --exact --nocapture
-// #[test]
-// fn test_calculate_lions_share_single_conviction() {
-//     new_test_ext(1).execute_with(|| {
-//         let result = SubtensorModule::calculate_lions_share(vec![100], 20);
-//         assert_eq!(result.len(), 1);
-//         assert_eq!(result[0], I96F32::from_num(1));
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_lions_share_equal_convictions --exact --nocapture
-// #[test]
-// fn test_calculate_lions_share_equal_convictions() {
-//     new_test_ext(1).execute_with(|| {
-//         let result = SubtensorModule::calculate_lions_share(vec![100, 100, 100], 20);
-//         assert_eq!(result.len(), 3);
-//         for share in result {
-//             assert_eq!(share, I96F32::from_num(1) / I96F32::from_num(3));
-//         }
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_lions_share_varied_convictions --exact --nocapture
-// #[test]
-// fn test_calculate_lions_share_varied_convictions() {
-//     new_test_ext(1).execute_with(|| {
-//         let convictions = vec![100, 200, 300, 400];
-//         let result = SubtensorModule::calculate_lions_share(convictions, 20);
-//         assert_eq!(result.len(), 4);
-//         // Verify that shares are in ascending order and sum to approximately 1
-//         assert!(result[0] < result[1] && result[1] < result[2] && result[2] < result[3]);
-//         let sum: I96F32 = result.iter().sum();
-//         assert!((sum - I96F32::from_num(1)).abs() < I96F32::from_num(0.0001));
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_lions_share_zero_convictions --exact --nocapture
-// #[test]
-// fn test_calculate_lions_share_zero_convictions() {
-//     new_test_ext(1).execute_with(|| {
-//         let result = SubtensorModule::calculate_lions_share(vec![0, 0, 0], 20);
-//         assert_eq!(result.len(), 3);
-//         for share in result {
-//             assert_eq!(share, I96F32::from_num(0));
-//         }
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_lions_share_large_convictions --exact --nocapture
-// #[test]
-// fn test_calculate_lions_share_large_convictions() {
-//     new_test_ext(1).execute_with(|| {
-//         let convictions = vec![1_000_000, 2_000_000, 3_000_000];
-//         let result = SubtensorModule::calculate_lions_share(convictions, 20);
-//         assert_eq!(result.len(), 3);
-//         // Verify that shares are in ascending order and sum to approximately 1
-//         assert!(result[0] < result[1] && result[1] < result[2]);
-//         let sum: I96F32 = result.iter().sum();
-//         assert!((sum - I96F32::from_num(1)).abs() < I96F32::from_num(0.0001));
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_lions_share_different_sharpness --exact --nocapture
-// #[test]
-// fn test_calculate_lions_share_different_sharpness() {
-//     new_test_ext(1).execute_with(|| {
-//         let convictions = vec![100, 200, 300, 400];
-
-//         // Test with low sharpness
-//         let result_low = SubtensorModule::calculate_lions_share(convictions.clone(), 5);
-
-//         // Test with high sharpness
-//         let result_high = SubtensorModule::calculate_lions_share(convictions, 50);
-
-//         // Verify that higher sharpness leads to more extreme distribution
-//         assert!(result_high[3] > result_low[3]);
-//         assert!(result_high[0] < result_low[0]);
-
-//         // Verify sums are still approximately 1
-//         let sum_low: I96F32 = result_low.iter().sum();
-//         let sum_high: I96F32 = result_high.iter().sum();
-//         assert!((sum_low - I96F32::from_num(1)).abs() < I96F32::from_num(0.0001));
-//         assert!((sum_high - I96F32::from_num(1)).abs() < I96F32::from_num(0.0001));
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_lions_share_extreme_differences --exact --nocapture
-// #[test]
-// fn test_calculate_lions_share_extreme_differences() {
-//     new_test_ext(1).execute_with(|| {
-//         let convictions = vec![1, 1_000_000];
-//         let result = SubtensorModule::calculate_lions_share(convictions, 20);
-
-//         assert_eq!(result.len(), 2);
-
-//         // The share of the larger conviction should be very close to 1
-//         assert!(result[1] > I96F32::from_num(0.9999));
-
-//         // The share of the smaller conviction should be very close to 0
-//         assert!(result[0] < I96F32::from_num(0.0001));
-
-//         // Sum should still be approximately 1
-//         let sum: I96F32 = result.iter().sum();
-//         assert!((sum - I96F32::from_num(1)).abs() < I96F32::from_num(0.0001));
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_lions_share_overflow_handling --exact --nocapture
-// #[test]
-// fn test_calculate_lions_share_overflow_handling() {
-//     new_test_ext(1).execute_with(|| {
-//         // Use very large numbers to test overflow handling
-//         let convictions = vec![u64::MAX, u64::MAX - 1, u64::MAX - 2];
-//         let result = SubtensorModule::calculate_lions_share(convictions, 20);
-
-//         assert_eq!(result.len(), 3);
-
-//         // Verify that shares are still in descending order
-//         assert!(result[0] >= result[1] && result[1] >= result[2]);
-
-//         // Verify sum is still approximately 1
-//         let sum: I96F32 = result.iter().sum();
-//         assert!((sum - I96F32::from_num(1)).abs() < I96F32::from_num(0.0001));
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_lions_share_precision --exact --nocapture
-// #[test]
-// fn test_calculate_lions_share_precision() {
-//     new_test_ext(1).execute_with(|| {
-//         // Test with convictions that are close in value
-//         let convictions = vec![1_000_000, 1_000_001, 1_000_002];
-//         let result = SubtensorModule::calculate_lions_share(convictions, 20);
-
-//         // Verify that shares are in ascending order
-//         assert!(result[0] < result[1] && result[1] < result[2]);
-
-//         // Verify that the differences between shares are small but detectable
-//         assert!(result[1] - result[0] > I96F32::from_num(0.000001));
-//         assert!(result[2] - result[1] > I96F32::from_num(0.000001));
-
-//         // Verify sum is still approximately 1
-//         let sum: I96F32 = result.iter().sum();
-//         assert!((sum - I96F32::from_num(1)).abs() < I96F32::from_num(0.0001));
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_conviction_zero_lock_amount --exact --nocapture
-// #[test]
-// fn test_calculate_conviction_zero_lock_amount() {
-//     new_test_ext(1).execute_with(|| {
-//         let current_block = 1000;
-//         let end_block = 2000;
-//         let conviction = SubtensorModule::calculate_conviction(0, end_block, current_block);
-//         assert_eq!(conviction, 0);
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_conviction_zero_duration --exact --nocapture
-// #[test]
-// fn test_calculate_conviction_zero_duration() {
-//     new_test_ext(1).execute_with(|| {
-//         let current_block = 1000;
-//         let end_block = 1000;
-//         let lock_amount = 1000000;
-//         let conviction =
-//             SubtensorModule::calculate_conviction(lock_amount, end_block, current_block);
-//         assert_eq!(conviction, 0);
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_conviction_max_lock_amount --exact --nocapture
-// #[test]
-// fn test_calculate_conviction_max_lock_amount() {
-//     new_test_ext(1).execute_with(|| {
-//         let current_block = 1000;
-//         let end_block = 2000;
-//         let lock_amount = u64::MAX;
-//         let conviction =
-//             SubtensorModule::calculate_conviction(lock_amount, end_block, current_block);
-//         assert!(conviction > 0);
-//         assert!(conviction < u64::MAX);
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_conviction_max_duration --exact --nocapture
-// #[test]
-// fn test_calculate_conviction_max_duration() {
-//     new_test_ext(1).execute_with(|| {
-//         let current_block = 0;
-//         let end_block = u64::MAX;
-//         let lock_amount = 1000000;
-//         let conviction =
-//             SubtensorModule::calculate_conviction(lock_amount, end_block, current_block);
-//         assert!(conviction > 0);
-//         assert!(conviction <= lock_amount);
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_conviction_overflow_check --exact --nocapture
-// #[test]
-// fn test_calculate_conviction_overflow_check() {
-//     new_test_ext(1).execute_with(|| {
-//         let current_block = 0;
-//         let end_block = u64::MAX;
-//         let lock_amount = u64::MAX;
-//         let conviction =
-//             SubtensorModule::calculate_conviction(lock_amount, end_block, current_block);
-//         assert!(conviction > 0);
-//         assert!(conviction < u64::MAX);
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_conviction_precision_small_values --exact --nocapture
-// #[test]
-// fn test_calculate_conviction_precision_small_values() {
-//     new_test_ext(1).execute_with(|| {
-//         let current_block = 1000;
-//         let end_block = 1001;
-//         let lock_amount = 1;
-//         let conviction =
-//             SubtensorModule::calculate_conviction(lock_amount, end_block, current_block);
-//         assert!(conviction < lock_amount);
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_conviction_precision_large_values --exact --nocapture
-// #[test]
-// fn test_calculate_conviction_precision_large_values() {
-//     new_test_ext(1).execute_with(|| {
-//         let current_block = 0;
-//         let end_block = u64::MAX / 2;
-//         let lock_amount = u64::MAX / 2;
-//         let conviction =
-//             SubtensorModule::calculate_conviction(lock_amount, end_block, current_block);
-//         assert!(conviction > 0);
-//         assert!(conviction < lock_amount);
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_conviction_rounding --exact --nocapture
-// #[test]
-// fn test_calculate_conviction_rounding() {
-//     new_test_ext(1).execute_with(|| {
-//         let current_block = 1000;
-//         let end_block = 1100;
-//         let lock_amount = 1000000;
-//         let conviction1 =
-//             SubtensorModule::calculate_conviction(lock_amount, end_block, current_block);
-//         let conviction2 =
-//             SubtensorModule::calculate_conviction(lock_amount, end_block + 1, current_block);
-//         assert!(conviction2 >= conviction1);
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_conviction_lock_interval_boundary --exact --nocapture
-// #[test]
-// fn test_calculate_conviction_lock_interval_boundary() {
-//     new_test_ext(1).execute_with(|| {
-//         let current_block = 1000;
-//         let lock_interval = SubtensorModule::get_lock_interval_blocks();
-//         let end_block = current_block + lock_interval;
-//         let lock_amount = 1000000;
-//         let conviction =
-//             SubtensorModule::calculate_conviction(lock_amount, end_block, current_block);
-//         assert!(conviction > 0);
-//         assert!(conviction < lock_amount);
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_conviction_consistency --exact --nocapture
-// #[test]
-// fn test_calculate_conviction_consistency() {
-//     new_test_ext(1).execute_with(|| {
-//         let current_block = 1000;
-//         let end_block = 2000;
-//         let lock_amount = 1000000;
-//         let base_conviction =
-//             SubtensorModule::calculate_conviction(lock_amount, end_block, current_block);
-//         log::info!("Base conviction: {}", base_conviction);
-
-//         // Increasing lock amount
-//         let higher_amount_conviction =
-//             SubtensorModule::calculate_conviction(lock_amount + 1000, end_block, current_block);
-//         assert!(higher_amount_conviction > base_conviction);
-
-//         // Increasing duration
-//         let longer_duration_conviction =
-//             SubtensorModule::calculate_conviction(lock_amount, end_block + 1000, current_block);
-//         assert!(longer_duration_conviction > base_conviction);
-//     });
-// }
-
-// // pub fn calculate_lions_share(convictions: Vec<u64>, sharpness: u32) -> Vec<I96F32> {
-// //     // Handle empty convictions vector
-// //     if convictions.is_empty() {
-// //         return Vec::new();
-// //     }
-
-// //     // For a single conviction, return a vector with a single element of value 1
-// //     if convictions.len() == 1 {
-// //         return vec![I96F32::from_num(1)];
-// //     }
-
-// //     // Find the maximum conviction
-// //     let max_conviction = convictions.iter().max().cloned().unwrap_or(1);
-// //     // If the maximum conviction is zero, return a vector of zeros
-// //     if max_conviction == 0 {
-// //         return vec![I96F32::from_num(0); convictions.len()];
-// //     }
-
-// //     // Normalize convictions and apply exponential function
-// //     let mut powered_convictions: Vec<I96F32> = Vec::with_capacity(convictions.len());
-// //     for c in convictions.iter() {
-// //         let normalized = I96F32::from_num(*c) / I96F32::from_num(max_conviction);
-// //         // Use checked_mul to prevent overflow in exponentiation
-// //         let powered = exp_safe_f96(I96F32::from_num(sharpness).saturating_mul(normalized - I96F32::from_num(1)));
-// //         powered_convictions.push(powered);
-// //     }
-
-// //     // Calculate total powered conviction
-// //     let total_powered: I96F32 = powered_convictions.iter().sum();
-
-// //     // Handle case where total_powered is zero to avoid division by zero
-// //     if total_powered == I96F32::from_num(0) {
-// //         return vec![I96F32::from_num(0); convictions.len()];
-// //     }
-
-// //     // Calculate shares
-// //     let shares: Vec<I96F32> = powered_convictions.into_iter().map(|pc| {
-// //         pc / total_powered
-// //     }).collect();
-
-// //     shares
-// // }
-// // pub fn calculate_conviction(lock_amount: u64, end_block: u64, current_block: u64) -> u64 {
-// //     let lock_duration = end_block.saturating_sub(current_block);
-// //     let time_factor = -I96F32::from_num(lock_duration).saturating_div(I96F32::from_num(Self::get_lock_interval_blocks())); // Convert days to blocks
-// //     let exp_term = I96F32::from_num(1) - exp_safe_f96(I96F32::from_num(time_factor));
-// //     let conviction_score = I96F32::from_num(lock_amount).saturating_mul(exp_term);
-// //     let final_score = conviction_score.to_num::<u64>();
-// //     final_score
-// // }
-
-// // pub fn get_owning_coldkey_for_hotkey(hotkey: &T::AccountId) -> T::AccountId {
-// //     Owner::<T>::get(hotkey)
-// // }
-// // pub fn distribute_owner_cut(netuid: u16, amount: u64) -> u64 {
-// //     // Get the current block number
-// //     let current_block = Self::get_current_block_as_u64();
-
-// //     // Initialize variables to track total conviction and individual hotkey convictions
-// //     let mut total_conviction: u64 = 0;
-// //     let mut hotkey_convictions: BTreeMap<T::AccountId, u64> = BTreeMap::new();
-
-// //     // Calculate total conviction and individual hotkey convictions
-// //     for ((iter_netuid, hotkey, _), (lock_amount, _, end_block)) in Locks::<T>::iter() {
-// //         if iter_netuid != netuid { continue; }
-// //         // Calculate conviction for each lock
-// //         let conviction = Self::calculate_conviction(lock_amount, end_block, current_block);
-// //         // Add conviction to the hotkey's total
-// //         *hotkey_convictions.entry(hotkey).or_default() += conviction;
-// //         // Add to the total conviction
-// //         total_conviction = total_conviction.saturating_add(conviction);
-// //     }
-
-// //     // If there's no conviction, return the full amount
-// //     if total_conviction == 0 {
-// //         return amount;
-// //     }
-
-// //     // Convert convictions to a vector for the lion's share calculation
-// //     let convictions: Vec<u64> = hotkey_convictions.values().cloned().collect();
-
-// //     // Calculate shares using the lion's share distribution
-// //     let shares: Vec<I96F32> = Self::calculate_lions_share(convictions, 20);
-
-// //     // Initialize variable to track remaining amount to distribute
-// //     let mut remaining_amount = amount;
-
-// //     // Distribute the owner cut based on calculated shares
-// //     for ((hotkey, _), share) in hotkey_convictions.iter().zip(shares.iter()) {
-// //         // Calculate the share for this hotkey
-// //         let share_amount = I96F32::from_num(amount)
-// //             .checked_mul(*share)
-// //             .unwrap_or(I96F32::from_num(0))
-// //             .to_num::<u64>();
-
-// //         // Get the coldkey associated with this hotkey
-// //         let owner_coldkey = Self::get_owning_coldkey_for_hotkey(&hotkey);
-
-// //         // Emit the calculated share into the subnet for this hotkey
-// //         Self::emit_into_subnet(&hotkey, &owner_coldkey, netuid, share_amount);
-
-// //         // Add the share to the lock.
-// //         if Locks::<T>::contains_key((netuid, hotkey.clone(), owner_coldkey.clone())) {
-// //             let (current_lock, start_block, end_block) = Locks::<T>::get((netuid, hotkey.clone(), owner_coldkey.clone()));
-// //             let new_lock = current_lock.saturating_add(share_amount);
-// //             Locks::<T>::insert(
-// //             (netuid, hotkey.clone(), owner_coldkey.clone()),
-// //                 (new_lock, start_block, end_block)
-// //             );
-// //         }
-
-// //         // Subtract the distributed share from the remaining amount
-// //         remaining_amount = remaining_amount.saturating_sub(share_amount);
-// //     }
-
-// //     // Return any undistributed amount
-// //     remaining_amount
-// // }
-
-// // pub fn update_subnet_owner(netuid: u16) {
-// //     let mut max_total_conviction: I96F32 = I96F32::from_num(0.0);
-// //     let mut max_conviction_hotkey = None;
-// //     let mut hotkey_convictions = BTreeMap::new();
-// //     let current_block = Self::get_current_block_as_u64();
-
-// //     // Iterate through all locks in the subnet
-// //     for ((iter_netuid, iter_hotkey, _), (lock_amount, _, end_block)) in Locks::<T>::iter() {
-// //         // Skip if the subnet does not match.
-// //         if iter_netuid != netuid { continue; }
-
-// //         // Calculate conviction score based on lock amount and duration
-// //         let conviction_score = I96F32::from_num(Self::calculate_conviction(lock_amount, end_block, current_block));
-
-// //         // Accumulate conviction scores for each hotkey
-// //         let total_conviction = hotkey_convictions.entry(iter_hotkey.clone()).or_insert(I96F32::from_num(0));
-// //         *total_conviction = total_conviction.saturating_add(conviction_score);
-
-// //         // Update max conviction if current hotkey has higher total conviction
-// //         if *total_conviction > max_total_conviction {
-// //             max_total_conviction = *total_conviction;
-// //             max_conviction_hotkey = Some(iter_hotkey.clone());
-// //         }
-// //     }
-
-// //     // Set the total subnet Conviction.
-// //     SubnetLocked::<T>::insert(netuid, max_total_conviction.to_num::<u64>());
-
-// //     // Handle the case where no locks exist for the subnet
-// //     if hotkey_convictions.is_empty() {
-// //         log::warn!("No locks found for subnet {}", netuid);
-// //         return;
-// //     }
-
-// //     // Implement a minimum conviction threshold for becoming a subnet owner
-// //     let min_conviction_threshold = I96F32::from_num(1000); // Example threshold, adjust as needed
-// //     if max_total_conviction < min_conviction_threshold {
-// //         log::info!("No hotkey meets the minimum conviction threshold for subnet {}", netuid);
-// //         return;
-// //     }
-
-// //     // Set the subnet owner to the coldkey of the hotkey with highest conviction
-// //     if let Some(hotkey) = max_conviction_hotkey {
-// //         let owning_coldkey = Self::get_owning_coldkey_for_hotkey(&hotkey);
-// //         SubnetOwner::<T>::insert(netuid, owning_coldkey);
-// //     }
-
-// //     // Implement a tie-breaking mechanism for equal conviction scores
-// //     let tied_hotkeys: Vec<_> = hotkey_convictions
-// //         .iter()
-// //         .filter(|(_, &conviction)| conviction == max_total_conviction)
-// //         .collect();
-
-// //     if tied_hotkeys.len() > 1 {
-// //         // Use a deterministic method to break ties, e.g., lowest hotkey value
-// //         if let Some((winning_hotkey, _)) = tied_hotkeys.iter().min_by_key(|(&ref hotkey, _)| hotkey) {
-// //             let owning_coldkey = Self::get_owning_coldkey_for_hotkey(winning_hotkey);
-// //             SubnetOwner::<T>::insert(netuid, owning_coldkey);
-// //         }
-// //     }
-
-// //     // Log performance metrics for large subnets
-// //     if hotkey_convictions.len() > 1000 {
-// //         log::warn!("Large subnet {} processed with {} hotkeys", netuid, hotkey_convictions.len());
-// //     }
-// // }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_basic --exact --nocapture
-// #[test]
-// fn test_distribute_owner_cut_basic() {
-//     new_test_ext(1).execute_with(|| {
-//         // Setup
-//         let netuid = 1;
-//         let amount_to_distribute = 1000000;
-//         let current_block = 100;
-
-//         // Create multiple hotkeys with different lock amounts and end blocks
-//         let hotkey1 = AccountId::from([1u8; 32]);
-//         let hotkey2 = AccountId::from([2u8; 32]);
-//         let hotkey3 = AccountId::from([3u8; 32]);
-
-//         let coldkey1 = AccountId::from([4u8; 32]);
-//         let coldkey2 = AccountId::from([5u8; 32]);
-//         let coldkey3 = AccountId::from([6u8; 32]);
-//         SubtensorModule::set_lock_interval_blocks(10);
-
-//         // Set up locks
-//         Locks::<Test>::insert((netuid, hotkey1, coldkey1), (500, 0, 200));
-//         Locks::<Test>::insert((netuid, hotkey2, coldkey2), (300, 0, 150));
-//         Locks::<Test>::insert((netuid, hotkey3, coldkey3), (200, 0, 300));
-
-//         // Set up ownership
-//         Owner::<Test>::insert(hotkey1, coldkey1);
-//         Owner::<Test>::insert(hotkey2, coldkey2);
-//         Owner::<Test>::insert(hotkey3, coldkey3);
-
-//         // Mock the current block
-//         System::set_block_number(current_block);
-
-//         // Call the distribute_owner_cut function
-//         let remaining = SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
-
-//         // Verify distribution
-//         assert!(
-//             remaining < amount_to_distribute,
-//             "Some amount should be distributed"
-//         );
-
-//         // Check that locks have been updated
-//         let (new_lock1, _, _) = Locks::<Test>::get((netuid, hotkey1, coldkey1));
-//         let (new_lock2, _, _) = Locks::<Test>::get((netuid, hotkey2, coldkey2));
-//         let (new_lock3, _, _) = Locks::<Test>::get((netuid, hotkey3, coldkey3));
-
-//         assert!(new_lock1 > 500, "Hotkey1's lock should increase");
-//         assert!(new_lock2 > 300, "Hotkey2's lock should increase");
-//         assert!(new_lock3 > 200, "Hotkey3's lock should increase");
-
-//         // Verify that the total distributed amount matches the initial amount minus remaining
-//         let total_distributed = (new_lock1 - 500) + (new_lock2 - 300) + (new_lock3 - 200);
-//         assert_eq!(total_distributed, amount_to_distribute - remaining);
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_single_hotkey --exact --nocapture
-// #[test]
-// fn test_distribute_owner_cut_single_hotkey() {
-//     new_test_ext(1).execute_with(|| {
-//         // Setup
-//         let netuid = 1;
-//         let amount_to_distribute = 1000000;
-//         let current_block = 100;
-
-//         // Create a single hotkey with lock
-//         let hotkey = AccountId::from([1u8; 32]);
-//         let coldkey = AccountId::from([2u8; 32]);
-//         SubtensorModule::set_lock_interval_blocks(10);
-
-//         // Set up lock
-//         Locks::<Test>::insert((netuid, hotkey, coldkey), (500, 0, 200));
-
-//         // Set up ownership
-//         Owner::<Test>::insert(hotkey, coldkey);
-
-//         // Mock the current block
-//         System::set_block_number(current_block);
-
-//         // Call the distribute_owner_cut function
-//         let remaining = SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
-
-//         // Verify distribution
-//         assert_eq!(remaining, 0, "All amount should be distributed");
-
-//         // Check that lock has been updated
-//         let (new_lock, _, _) = Locks::<Test>::get((netuid, hotkey, coldkey));
-
-//         assert_eq!(
-//             new_lock,
-//             500 + amount_to_distribute,
-//             "Hotkey's lock should increase by the full amount"
-//         );
-
-//         // Verify that the total distributed amount matches the initial amount
-//         let total_distributed = new_lock - 500;
-//         assert_eq!(total_distributed, amount_to_distribute);
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_no_stake --exact --nocapture
-// #[test]
-// fn test_distribute_owner_cut_no_stake() {
-//     new_test_ext(1).execute_with(|| {
-//         // Setup
-//         let netuid = 1;
-//         let amount_to_distribute = 1000000;
-//         let current_block = 100;
-
-//         // No hotkeys or locks are set up
-
-//         // Mock the current block
-//         System::set_block_number(current_block);
-
-//         // Call the distribute_owner_cut function
-//         let remaining = SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
-
-//         // Verify that all amount is returned as remaining
-//         assert_eq!(
-//             remaining, amount_to_distribute,
-//             "All amount should be returned when no stake exists"
-//         );
-
-//         // Verify that no locks were created or modified
-//         assert_eq!(Locks::<Test>::iter().count(), 0, "No locks should exist");
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_zero_amount --exact --nocapture
-// #[test]
-// fn test_distribute_owner_cut_zero_amount() {
-//     new_test_ext(1).execute_with(|| {
-//         // Setup
-//         let netuid = 1;
-//         let amount_to_distribute = 0;
-//         let current_block = 100;
-//         let hotkey = U256::from(1);
-//         let coldkey = U256::from(2);
-//         let lock_amount = 500;
-//         let lock_duration = 1000;
-
-//         // Set up a lock
-//         Locks::<Test>::insert(
-//             (netuid, hotkey, coldkey),
-//             (lock_amount, current_block, current_block + lock_duration),
-//         );
-
-//         // Set up ownership
-//         Owner::<Test>::insert(hotkey, coldkey);
-
-//         // Mock the current block
-//         System::set_block_number(current_block);
-
-//         // Call the distribute_owner_cut function
-//         let remaining = SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
-
-//         // Verify that all amount is returned as remaining (which is 0 in this case)
-//         assert_eq!(
-//             remaining, 0,
-//             "Zero amount should be returned when distributing zero"
-//         );
-
-//         // Check that lock has not been updated
-//         let (new_lock, _, _) = Locks::<Test>::get((netuid, hotkey, coldkey));
-//         assert_eq!(
-//             new_lock, lock_amount,
-//             "Hotkey's lock should remain unchanged"
-//         );
-
-//         // Verify that no distribution occurred
-//         assert_eq!(new_lock, lock_amount, "Lock amount should remain the same");
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_large_amount --exact --nocapture
-// #[test]
-// fn test_distribute_owner_cut_large_amount() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let amount_to_distribute = u64::MAX;
-//         let current_block = 100;
-//         let hotkey1 = U256::from(1);
-//         let hotkey2 = U256::from(2);
-//         let coldkey = U256::from(3);
-//         let lock_amount = 1_000_000;
-//         let lock_duration = 1000;
-
-//         // Set up locks
-//         Locks::<Test>::insert(
-//             (netuid, hotkey1, coldkey),
-//             (lock_amount, current_block, current_block + lock_duration),
-//         );
-//         Locks::<Test>::insert(
-//             (netuid, hotkey2, coldkey),
-//             (lock_amount, current_block, current_block + lock_duration),
-//         );
-
-//         // Set up ownership
-//         Owner::<Test>::insert(hotkey1, coldkey);
-//         Owner::<Test>::insert(hotkey2, coldkey);
-
-//         System::set_block_number(current_block);
-
-//         let remaining = SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
-
-//         // Check that distribution occurred
-//         let (new_lock1, _, _) = Locks::<Test>::get((netuid, hotkey1, coldkey));
-//         let (new_lock2, _, _) = Locks::<Test>::get((netuid, hotkey2, coldkey));
-
-//         assert!(
-//             new_lock1 > lock_amount,
-//             "Hotkey1's lock should have increased"
-//         );
-//         assert!(
-//             new_lock2 > lock_amount,
-//             "Hotkey2's lock should have increased"
-//         );
-//         assert!(
-//             remaining < amount_to_distribute,
-//             "Some amount should have been distributed"
-//         );
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_uneven_stakes --exact --nocapture
-// #[test]
-// fn test_distribute_owner_cut_uneven_stakes() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let amount_to_distribute = 1_000_000;
-//         let current_block = 100;
-//         let hotkey1 = U256::from(1);
-//         let hotkey2 = U256::from(2);
-//         let coldkey = U256::from(3);
-//         let lock_amount1 = 1_000_000;
-//         let lock_amount2 = 100_000;
-//         let lock_duration = 1000;
-
-//         // Set up locks with uneven stakes
-//         Locks::<Test>::insert(
-//             (netuid, hotkey1, coldkey),
-//             (lock_amount1, current_block, current_block + lock_duration),
-//         );
-//         Locks::<Test>::insert(
-//             (netuid, hotkey2, coldkey),
-//             (lock_amount2, current_block, current_block + lock_duration),
-//         );
-
-//         // Set up ownership
-//         Owner::<Test>::insert(hotkey1, coldkey);
-//         Owner::<Test>::insert(hotkey2, coldkey);
-
-//         System::set_block_number(current_block);
-
-//         let remaining = SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
-
-//         // Check that distribution occurred proportionally
-//         let (new_lock1, _, _) = Locks::<Test>::get((netuid, hotkey1, coldkey));
-//         let (new_lock2, _, _) = Locks::<Test>::get((netuid, hotkey2, coldkey));
-
-//         assert!(
-//             new_lock1 - lock_amount1 > new_lock2 - lock_amount2,
-//             "Hotkey1 should receive a larger share"
-//         );
-//         assert!(
-//             remaining < amount_to_distribute,
-//             "Some amount should have been distributed"
-//         );
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_different_lock_durations --exact --nocapture
-// #[test]
-// fn test_distribute_owner_cut_different_lock_durations() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let amount_to_distribute = 1_000_000;
-//         let current_block = 100;
-//         let hotkey1 = U256::from(1);
-//         let hotkey2 = U256::from(2);
-//         let coldkey = U256::from(3);
-//         let lock_amount = 1_000_000;
-//         let lock_duration1 = 2000;
-//         let lock_duration2 = 1000;
-
-//         // Set up locks with different durations
-//         Locks::<Test>::insert(
-//             (netuid, hotkey1, coldkey),
-//             (lock_amount, current_block, current_block + lock_duration1),
-//         );
-//         Locks::<Test>::insert(
-//             (netuid, hotkey2, coldkey),
-//             (lock_amount, current_block, current_block + lock_duration2),
-//         );
-
-//         // Set up ownership
-//         Owner::<Test>::insert(hotkey1, coldkey);
-//         Owner::<Test>::insert(hotkey2, coldkey);
-
-//         System::set_block_number(current_block);
-
-//         let remaining = SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
-
-//         // Check that distribution occurred with preference to longer lock duration
-//         let (new_lock1, _, _) = Locks::<Test>::get((netuid, hotkey1, coldkey));
-//         let (new_lock2, _, _) = Locks::<Test>::get((netuid, hotkey2, coldkey));
-
-//         assert!(
-//             new_lock1 - lock_amount > new_lock2 - lock_amount,
-//             "Hotkey1 with longer lock duration should receive a larger share"
-//         );
-//         assert!(
-//             remaining < amount_to_distribute,
-//             "Some amount should have been distributed"
-//         );
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_expired_locks --exact --nocapture
-// #[test]
-// fn test_distribute_owner_cut_expired_locks() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let amount_to_distribute = 1_000_000;
-//         let current_block = 1000;
-//         let hotkey1 = U256::from(1);
-//         let hotkey2 = U256::from(2);
-//         let coldkey = U256::from(3);
-//         let lock_amount = 500_000;
-//         let active_lock_duration = 2000;
-//         let expired_lock_duration = 500;
-
-//         // Set up one active lock and one expired lock
-//         Locks::<Test>::insert(
-//             (netuid, hotkey1, coldkey),
-//             (
-//                 lock_amount,
-//                 current_block - 100,
-//                 current_block + active_lock_duration,
-//             ),
-//         );
-//         Locks::<Test>::insert(
-//             (netuid, hotkey2, coldkey),
-//             (
-//                 lock_amount,
-//                 current_block - expired_lock_duration,
-//                 current_block - 1,
-//             ),
-//         );
-
-//         // Set up ownership
-//         Owner::<Test>::insert(hotkey1, coldkey);
-//         Owner::<Test>::insert(hotkey2, coldkey);
-
-//         System::set_block_number(current_block);
-
-//         let remaining = SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
-
-//         // Check that distribution occurred only for the active lock
-//         let (new_lock1, _, _) = Locks::<Test>::get((netuid, hotkey1, coldkey));
-//         let (new_lock2, _, _) = Locks::<Test>::get((netuid, hotkey2, coldkey));
-
-//         assert!(
-//             new_lock1 > lock_amount,
-//             "Active lock should receive a share"
-//         );
-//         assert_eq!(
-//             new_lock2, lock_amount,
-//             "Expired lock should not receive a share"
-//         );
-//         assert!(
-//             remaining < amount_to_distribute,
-//             "Some amount should have been distributed"
-//         );
-//         assert_eq!(
-//             new_lock1 - lock_amount,
-//             amount_to_distribute - remaining,
-//             "All distributed amount should go to the active lock"
-//         );
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_multiple_subnets --exact --nocapture
-// #[test]
-// fn test_distribute_owner_cut_multiple_subnets() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid1 = 1;
-//         let netuid2 = 2;
-//         let amount_to_distribute = 1_000_000;
-//         let current_block = 100;
-//         let hotkey1 = U256::from(1);
-//         let hotkey2 = U256::from(2);
-//         let coldkey = U256::from(3);
-//         let lock_amount = 500_000;
-//         let lock_duration = 1000;
-
-//         // Set up locks in different subnets
-//         Locks::<Test>::insert(
-//             (netuid1, hotkey1, coldkey),
-//             (lock_amount, current_block, current_block + lock_duration),
-//         );
-//         Locks::<Test>::insert(
-//             (netuid2, hotkey2, coldkey),
-//             (lock_amount, current_block, current_block + lock_duration),
-//         );
-
-//         // Set up ownership
-//         Owner::<Test>::insert(hotkey1, coldkey);
-//         Owner::<Test>::insert(hotkey2, coldkey);
-
-//         System::set_block_number(current_block);
-
-//         // Distribute to netuid1
-//         SubtensorModule::set_lock_interval_blocks(10);
-//         let remaining1 = SubtensorModule::distribute_owner_cut(netuid1, amount_to_distribute);
-
-//         // Check distribution for netuid1
-//         let (new_lock1, _, _) = Locks::<Test>::get((netuid1, hotkey1, coldkey));
-//         let (lock2, _, _) = Locks::<Test>::get((netuid2, hotkey2, coldkey));
-
-//         assert!(
-//             new_lock1 > lock_amount,
-//             "Lock in netuid1 should receive a share"
-//         );
-//         assert_eq!(lock2, lock_amount, "Lock in netuid2 should not change");
-//         assert_eq!(remaining1, 0, "All amount should be distributed in netuid1");
-
-//         // Distribute to netuid2
-//         let remaining2 = SubtensorModule::distribute_owner_cut(netuid2, amount_to_distribute);
-
-//         // Check distribution for netuid2
-//         let (lock1, _, _) = Locks::<Test>::get((netuid1, hotkey1, coldkey));
-//         let (new_lock2, _, _) = Locks::<Test>::get((netuid2, hotkey2, coldkey));
-
-//         assert_eq!(lock1, new_lock1, "Lock in netuid1 should not change");
-//         assert!(
-//             new_lock2 > lock_amount,
-//             "Lock in netuid2 should receive a share"
-//         );
-//         assert_eq!(remaining2, 0, "All amount should be distributed in netuid2");
-
-//         // Verify total distribution
-//         assert_eq!(
-//             new_lock1 - lock_amount + new_lock2 - lock_amount,
-//             amount_to_distribute * 2,
-//             "Total distributed amount should match for both subnets"
-//         );
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_rounding --exact --nocapture
-// #[test]
-// fn test_distribute_owner_cut_rounding() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let amount_to_distribute = 1000; // Small amount to test rounding
-//         let current_block = 100;
-//         let hotkey1 = U256::from(1);
-//         let hotkey2 = U256::from(2);
-//         let coldkey = U256::from(3);
-//         let lock_amount1 = 500;
-//         let lock_amount2 = 501; // Slightly different to force rounding
-//         let lock_duration = 1000;
-
-//         // Set up locks
-//         add_network(netuid, 1, 1);
-//         SubtensorModule::set_lock_interval_blocks(10000);
-//         Locks::<Test>::insert(
-//             (netuid, hotkey1, coldkey),
-//             (lock_amount1, current_block, current_block + lock_duration),
-//         );
-//         Locks::<Test>::insert(
-//             (netuid, hotkey2, coldkey),
-//             (lock_amount2, current_block, current_block + lock_duration),
-//         );
-
-//         // Set up ownership
-//         Owner::<Test>::insert(hotkey1, coldkey);
-//         Owner::<Test>::insert(hotkey2, coldkey);
-
-//         System::set_block_number(current_block);
-
-//         let remaining = SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
-
-//         // Check that all funds were distributed despite potential rounding issues
-//         assert_eq!(remaining, 0, "All funds should be distributed");
-
-//         let (new_lock1, _, _) = Locks::<Test>::get((netuid, hotkey1, coldkey));
-//         let (new_lock2, _, _) = Locks::<Test>::get((netuid, hotkey2, coldkey));
-
-//         // Check that the sum of distributed amounts equals the original amount
-//         assert_eq!(
-//             (new_lock1 - lock_amount1) + (new_lock2 - lock_amount2),
-//             amount_to_distribute,
-//             "Sum of distributed amounts should equal the original amount"
-//         );
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_conviction_calculation --exact --nocapture
-// #[test]
-// fn test_distribute_owner_cut_conviction_calculation() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let amount_to_distribute = 1000000;
-//         let current_block = 100;
-//         let hotkey1 = U256::from(1);
-//         let hotkey2 = U256::from(2);
-//         let coldkey = U256::from(3);
-//         let lock_amount = 1000;
-//         let lock_duration1 = 2000;
-//         let lock_duration2 = 1000;
-
-//         // Set up locks with different durations
-//         Locks::<Test>::insert(
-//             (netuid, hotkey1, coldkey),
-//             (lock_amount, current_block, current_block + lock_duration1),
-//         );
-//         Locks::<Test>::insert(
-//             (netuid, hotkey2, coldkey),
-//             (lock_amount, current_block, current_block + lock_duration2),
-//         );
-
-//         // Set up ownership
-//         Owner::<Test>::insert(hotkey1, coldkey);
-//         Owner::<Test>::insert(hotkey2, coldkey);
-
-//         System::set_block_number(current_block);
-
-//         let _remaining = SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
-
-//         let (new_lock1, _, _) = Locks::<Test>::get((netuid, hotkey1, coldkey));
-//         let (new_lock2, _, _) = Locks::<Test>::get((netuid, hotkey2, coldkey));
-
-//         // Check that the hotkey with longer lock duration received more funds
-//         assert!(
-//             new_lock1 - lock_amount > new_lock2 - lock_amount,
-//             "Hotkey with longer lock duration should receive more funds"
-//         );
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_lions_share_distribution --exact --nocapture
-// #[test]
-// fn test_distribute_owner_cut_lions_share_distribution() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let amount_to_distribute = 1000000;
-//         let current_block = 100;
-//         let hotkey1 = U256::from(1);
-//         let hotkey2 = U256::from(2);
-//         let hotkey3 = U256::from(3);
-//         let coldkey = U256::from(4);
-//         let lock_amount1 = 1000;
-//         let lock_amount2 = 500;
-//         let lock_amount3 = 100;
-//         let lock_duration = 1000;
-
-//         // Set up locks with different amounts
-//         SubtensorModule::set_lock_interval_blocks(100);
-//         Locks::<Test>::insert(
-//             (netuid, hotkey1, coldkey),
-//             (lock_amount1, current_block, current_block + lock_duration),
-//         );
-//         Locks::<Test>::insert(
-//             (netuid, hotkey2, coldkey),
-//             (lock_amount2, current_block, current_block + lock_duration),
-//         );
-//         Locks::<Test>::insert(
-//             (netuid, hotkey3, coldkey),
-//             (lock_amount3, current_block, current_block + lock_duration),
-//         );
-
-//         // Set up ownership
-//         Owner::<Test>::insert(hotkey1, coldkey);
-//         Owner::<Test>::insert(hotkey2, coldkey);
-//         Owner::<Test>::insert(hotkey3, coldkey);
-
-//         System::set_block_number(current_block);
-
-//         let _remaining = SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
-
-//         let (new_lock1, _, _) = Locks::<Test>::get((netuid, hotkey1, coldkey));
-//         let (new_lock2, _, _) = Locks::<Test>::get((netuid, hotkey2, coldkey));
-//         let (new_lock3, _, _) = Locks::<Test>::get((netuid, hotkey3, coldkey));
-
-//         // Check that distribution follows the lion's share principle
-//         assert!(
-//             new_lock1 - lock_amount1 > new_lock2 - lock_amount2,
-//             "Hotkey with larger lock should receive a larger share"
-//         );
-//         assert!(
-//             new_lock2 - lock_amount2 > new_lock3 - lock_amount3,
-//             "Hotkey with larger lock should receive a larger share"
-//         );
-
-//         // Check that the total distributed amount matches the initial amount
-//         let total_distributed =
-//             (new_lock1 - lock_amount1) + (new_lock2 - lock_amount2) + (new_lock3 - lock_amount3);
-//         assert_eq!(
-//             total_distributed,
-//             amount_to_distribute - 1,
-//             "Total distributed amount should match initial amount"
-//         );
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_storage_updates --exact --nocapture
-// #[test]
-// fn test_distribute_owner_cut_storage_updates() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let amount_to_distribute = 1_000_000;
-//         let current_block = 100;
-//         let hotkey1 = U256::from(1);
-//         let hotkey2 = U256::from(2);
-//         let coldkey = U256::from(3);
-//         let lock_amount1 = 500_000;
-//         let lock_amount2 = 250_000;
-//         let lock_duration = 1000;
-
-//         // Set up initial locks
-//         Locks::<Test>::insert(
-//             (netuid, hotkey1, coldkey),
-//             (lock_amount1, current_block, current_block + lock_duration),
-//         );
-//         Locks::<Test>::insert(
-//             (netuid, hotkey2, coldkey),
-//             (lock_amount2, current_block, current_block + lock_duration),
-//         );
-
-//         // Set up ownership
-//         Owner::<Test>::insert(hotkey1, coldkey);
-//         Owner::<Test>::insert(hotkey2, coldkey);
-
-//         System::set_block_number(current_block);
-
-//         // Distribute owner cut
-//         SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
-
-//         // Check that locks have been updated
-//         let (new_lock1, _, _) = Locks::<Test>::get((netuid, hotkey1, coldkey));
-//         let (new_lock2, _, _) = Locks::<Test>::get((netuid, hotkey2, coldkey));
-
-//         assert!(
-//             new_lock1 > lock_amount1,
-//             "Lock for hotkey1 should have increased"
-//         );
-//         assert!(
-//             new_lock2 > lock_amount2,
-//             "Lock for hotkey2 should have increased"
-//         );
-
-//         // Verify that the total increase matches the distributed amount
-//         let total_increase = (new_lock1 - lock_amount1) + (new_lock2 - lock_amount2);
-//         assert_eq!(
-//             total_increase,
-//             amount_to_distribute - 1,
-//             "Total lock increase should match the distributed amount"
-//         );
-
-//         // Check that other storage items remain unchanged
-//         assert_eq!(
-//             Owner::<Test>::get(hotkey1),
-//             coldkey,
-//             "Owner mapping for hotkey1 should remain unchanged"
-//         );
-//         assert_eq!(
-//             Owner::<Test>::get(hotkey2),
-//             coldkey,
-//             "Owner mapping for hotkey2 should remain unchanged"
-//         );
-
-//         // Verify that no new locks were created
-//         assert_eq!(
-//             Locks::<Test>::iter().count(),
-//             2,
-//             "No new locks should have been created"
-//         );
-//     });
-// }
-
-// // Test cases for update_subnet_owner function:
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_update_subnet_owner_no_locks --exact --nocapture
-// #[test]
-// fn test_update_subnet_owner_no_locks() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-
-//         // Ensure there are no locks in the subnet
-//         assert_eq!(
-//             Locks::<Test>::iter().count(),
-//             0,
-//             "There should be no locks initially"
-//         );
-
-//         // Call the update_subnet_owner function
-//         SubtensorModule::update_subnet_owner(netuid);
-
-//         // Verify that no subnet owner was set
-//         assert!(
-//             !SubnetOwner::<Test>::contains_key(netuid),
-//             "No subnet owner should be set when there are no locks"
-//         );
-
-//         // Verify that the subnet locked amount is zero
-//         assert_eq!(
-//             SubnetLocked::<Test>::get(netuid),
-//             0,
-//             "Subnet locked amount should be zero"
-//         );
-
-//         // Check that a warning log was emitted
-//         // Note: In a real test environment, you would need a way to capture and assert on log output
-//         // For this example, we'll just comment on the expected behavior
-//         // assert_eq!(last_log_message(), "No locks found for subnet 1");
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_update_subnet_owner_single_lock --exact --nocapture
-// #[test]
-// fn test_update_subnet_owner_single_lock() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let hotkey = U256::from(1);
-//         let coldkey = U256::from(2);
-//         let lock_amount = 1000000;
-//         let current_block = 100;
-//         let lock_duration = 1000000;
-
-//         // Set up a single lock
-//         Locks::<Test>::insert(
-//             (netuid, hotkey, coldkey),
-//             (lock_amount, current_block, current_block + lock_duration),
-//         );
-
-//         // Set up ownership
-//         Owner::<Test>::insert(hotkey, coldkey);
-
-//         // Mock the current block
-//         System::set_block_number(current_block);
-
-//         // Call the update_subnet_owner function
-//         SubtensorModule::update_subnet_owner(netuid);
-
-//         // Verify that the subnet owner was set correctly
-//         assert_eq!(
-//             SubnetOwner::<Test>::get(netuid),
-//             coldkey.clone(),
-//             "Subnet owner should be set to the coldkey of the only lock"
-//         );
-
-//         // Verify that the subnet locked amount is correct
-//         let expected_conviction = SubtensorModule::calculate_conviction(
-//             lock_amount,
-//             current_block + lock_duration,
-//             current_block,
-//         );
-//         assert_eq!(
-//             SubnetLocked::<Test>::get(netuid),
-//             expected_conviction,
-//             "Subnet locked amount should match the calculated conviction"
-//         );
-
-//         // Verify that no new locks were created
-//         assert_eq!(
-//             Locks::<Test>::iter().count(),
-//             1,
-//             "There should still be only one lock"
-//         );
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_update_subnet_owner_multiple_locks --exact --nocapture
-// #[test]
-// fn test_update_subnet_owner_multiple_locks() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let hotkey1 = U256::from(1);
-//         let coldkey1 = U256::from(2);
-//         let hotkey2 = U256::from(3);
-//         let coldkey2 = U256::from(4);
-//         let hotkey3 = U256::from(5);
-//         let coldkey3 = U256::from(6);
-//         let current_block = 100;
-
-//         // Set up multiple locks with different amounts and durations
-//         Locks::<Test>::insert(
-//             (netuid, hotkey1, coldkey1),
-//             (1000000, current_block, current_block + 1000000),
-//         );
-//         Locks::<Test>::insert(
-//             (netuid, hotkey2, coldkey2),
-//             (2000000, current_block, current_block + 500000),
-//         );
-//         Locks::<Test>::insert(
-//             (netuid, hotkey3, coldkey3),
-//             (1500000, current_block, current_block + 2000000),
-//         );
-
-//         // Set up ownership
-//         Owner::<Test>::insert(hotkey1, coldkey1);
-//         Owner::<Test>::insert(hotkey2, coldkey2);
-//         Owner::<Test>::insert(hotkey3, coldkey3);
-
-//         // Mock the current block
-//         System::set_block_number(current_block);
-
-//         // Call the update_subnet_owner function
-//         SubtensorModule::update_subnet_owner(netuid);
-
-//         // Calculate expected convictions
-//         let conviction1 =
-//             SubtensorModule::calculate_conviction(1000000, current_block + 1000000, current_block);
-//         let conviction2 =
-//             SubtensorModule::calculate_conviction(2000000, current_block + 500000, current_block);
-//         let conviction3 =
-//             SubtensorModule::calculate_conviction(1500000, current_block + 2000000, current_block);
-
-//         // Determine the expected owner (hotkey with highest conviction)
-//         let expected_owner = if conviction1 > conviction2 && conviction1 > conviction3 {
-//             coldkey1
-//         } else if conviction2 > conviction1 && conviction2 > conviction3 {
-//             coldkey2
-//         } else {
-//             coldkey3
-//         };
-
-//         // Verify that the subnet owner was set correctly
-//         assert_eq!(
-//             SubnetOwner::<Test>::get(netuid),
-//             expected_owner,
-//             "Subnet owner should be set to the coldkey of the hotkey with highest conviction"
-//         );
-
-//         // Verify that the subnet locked amount is correct
-//         assert_eq!(
-//             SubnetLocked::<Test>::get(netuid),
-//             conviction1 + conviction2 + conviction3,
-//             "Subnet locked amount should match the total calculated conviction"
-//         );
-
-//         // Verify that no new locks were created
-//         assert_eq!(
-//             Locks::<Test>::iter().count(),
-//             3,
-//             "There should still be only three locks"
-//         );
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_update_subnet_owner_tie_breaking --exact --nocapture
-// #[test]
-// fn test_update_subnet_owner_tie_breaking() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let current_block = 100;
-//         let hotkey1 = U256::from(1);
-//         let hotkey2 = U256::from(2);
-//         let hotkey3 = U256::from(3);
-//         let coldkey1 = U256::from(4);
-//         let coldkey2 = U256::from(5);
-//         let coldkey3 = U256::from(6);
-
-//         // Set up locks with equal convictions
-//         Locks::<Test>::insert(
-//             (netuid, hotkey1, coldkey1),
-//             (1000000, current_block, current_block + 1000000),
-//         );
-//         Locks::<Test>::insert(
-//             (netuid, hotkey2, coldkey2),
-//             (1000000, current_block, current_block + 1000000),
-//         );
-//         Locks::<Test>::insert(
-//             (netuid, hotkey3, coldkey3),
-//             (1000000, current_block, current_block + 1000000),
-//         );
-
-//         // Set up ownership
-//         Owner::<Test>::insert(hotkey1, coldkey1);
-//         Owner::<Test>::insert(hotkey2, coldkey2);
-//         Owner::<Test>::insert(hotkey3, coldkey3);
-
-//         // Mock the current block
-//         System::set_block_number(current_block);
-
-//         // Call the update_subnet_owner function
-//         SubtensorModule::update_subnet_owner(netuid);
-
-//         // The expected owner should be the coldkey of the hotkey with the lowest value
-//         let expected_owner = coldkey1;
-
-//         // Verify that the subnet owner was set correctly
-//         assert_eq!(
-//             SubnetOwner::<Test>::get(netuid),
-//             expected_owner,
-//             "Subnet owner should be set to the coldkey of the hotkey with the lowest value"
-//         );
-
-//         // Verify that the subnet locked amount is correct
-//         let conviction1 = SubtensorModule::calculate_conviction(1000000, current_block + 1000000, current_block);
-//         assert_eq!(
-//             SubnetLocked::<Test>::get(netuid),
-//             conviction1 * 3,
-//             "Subnet locked amount should match the total calculated conviction"
-//         );
-
-//         // Verify that no new locks were created
-//         assert_eq!(
-//             Locks::<Test>::iter().count(),
-//             3,
-//             "There should still be only three locks"
-//         );
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_update_subnet_owner_below_threshold --exact --nocapture
-// #[test]
-// fn test_update_subnet_owner_below_threshold() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let current_block = 100;
-//         let hotkey1 = U256::from(1);
-//         let hotkey2 = U256::from(2);
-//         let coldkey1 = U256::from(3);
-//         let coldkey2 = U256::from(4);
-
-//         // Set up locks with low conviction scores
-//         Locks::<Test>::insert(
-//             (netuid, hotkey1, coldkey1),
-//             (100, current_block, current_block + 100),
-//         );
-//         Locks::<Test>::insert(
-//             (netuid, hotkey2, coldkey2),
-//             (200, current_block, current_block + 200),
-//         );
-
-//         // Set up ownership
-//         Owner::<Test>::insert(hotkey1, coldkey1);
-//         Owner::<Test>::insert(hotkey2, coldkey2);
-
-//         // Mock the current block
-//         System::set_block_number(current_block);
-
-//         // Call the update_subnet_owner function
-//         SubtensorModule::update_subnet_owner(netuid);
-
-//         // Verify that no subnet owner was set due to low conviction scores
-//         assert!(
-//             !SubnetOwner::<Test>::contains_key(netuid),
-//             "No subnet owner should be set when all convictions are below the threshold"
-//         );
-
-//         // Verify that the subnet locked amount is correct (should be the sum of all convictions)
-//         let expected_total_conviction =
-//             SubtensorModule::calculate_conviction(100, current_block + 100, current_block)
-//                 + SubtensorModule::calculate_conviction(200, current_block + 200, current_block);
-//         assert_eq!(
-//             SubnetLocked::<Test>::get(netuid),
-//             expected_total_conviction,
-//             "Subnet locked amount should match the total calculated conviction"
-//         );
-
-//         // Verify that no new locks were created
-//         assert_eq!(
-//             Locks::<Test>::iter().count(),
-//             2,
-//             "There should still be only two locks"
-//         );
-//     });
-// }
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_update_subnet_owner_conviction_calculation --exact --nocapture
-// #[test]
-// fn test_update_subnet_owner_conviction_calculation() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let current_block = 100;
-//         let hotkey1 = U256::from(1);
-//         let hotkey2 = U256::from(2);
-//         let coldkey1 = U256::from(3);
-//         let coldkey2 = U256::from(4);
-
-//         // Set up locks with different amounts and durations
-//         Locks::<Test>::insert(
-//             (netuid, hotkey1, coldkey1),
-//             (1000000, current_block, current_block + 1000000),
-//         );
-//         Locks::<Test>::insert(
-//             (netuid, hotkey2, coldkey2),
-//             (2000000, current_block, current_block + 500000),
-//         );
-
-//         // Set up ownership
-//         Owner::<Test>::insert(hotkey1, coldkey1);
-//         Owner::<Test>::insert(hotkey2, coldkey2);
-
-//         // Mock the current block
-//         System::set_block_number(current_block);
-
-//         // Call the update_subnet_owner function
-//         SubtensorModule::update_subnet_owner(netuid);
-
-//         // Calculate expected convictions
-//         let conviction1 =
-//             SubtensorModule::calculate_conviction(1000000, current_block + 1000000, current_block);
-//         let conviction2 =
-//             SubtensorModule::calculate_conviction(2000000, current_block + 500000, current_block);
-
-//         // Verify that the subnet owner is set to the hotkey with the highest conviction
-//         if conviction1 > conviction2 {
-//             assert_eq!(
-//                 SubnetOwner::<Test>::get(netuid),
-//                 coldkey1.clone(),
-//                 "Subnet owner should be set to coldkey1"
-//             );
-//         } else {
-//             assert_eq!(
-//                 SubnetOwner::<Test>::get(netuid),
-//                 coldkey2.clone(),
-//                 "Subnet owner should be set to coldkey2"
-//             );
-//         }
-
-//         // Verify that the subnet locked amount is correct
-//         assert_eq!(
-//             SubnetLocked::<Test>::get(netuid),
-//             conviction1 + conviction2,
-//             "Subnet locked amount should match the highest calculated conviction"
-//         );
-
-//         // Log the convictions for debugging
-//         println!("Conviction for hotkey1: {}", conviction1);
-//         println!("Conviction for hotkey2: {}", conviction2);
-//         println!("Total subnet locked: {}", SubnetLocked::<Test>::get(netuid));
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_update_subnet_owner_different_subnets --exact --nocapture
-// #[test]
-// fn test_update_subnet_owner_different_subnets() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid1 = 1;
-//         let netuid2 = 2;
-//         let current_block = 100;
-//         let hotkey1 = U256::from(1);
-//         let hotkey2 = U256::from(2);
-//         let coldkey1 = U256::from(3);
-//         let coldkey2 = U256::from(4);
-
-//         // Set up locks in different subnets
-//         Locks::<Test>::insert(
-//             (netuid1, hotkey1, coldkey1),
-//             (1000000, current_block, current_block + 1000000),
-//         );
-//         Locks::<Test>::insert(
-//             (netuid2, hotkey2, coldkey2),
-//             (2000000, current_block, current_block + 500000),
-//         );
-
-//         // Set up ownership
-//         Owner::<Test>::insert(hotkey1, coldkey1);
-//         Owner::<Test>::insert(hotkey2, coldkey2);
-
-//         // Mock the current block
-//         System::set_block_number(current_block);
-
-//         // Call the update_subnet_owner function for netuid1
-//         SubtensorModule::update_subnet_owner(netuid1);
-
-//         // Verify that only the lock from netuid1 is considered
-//         let conviction1 =
-//             SubtensorModule::calculate_conviction(1000000, current_block + 1000000, current_block);
-//         assert_eq!(
-//             SubnetOwner::<Test>::get(netuid1),
-//             coldkey1.clone(),
-//             "Subnet owner for netuid1 should be set to coldkey1"
-//         );
-//         assert_eq!(
-//             SubnetLocked::<Test>::get(netuid1),
-//             conviction1,
-//             "Subnet locked amount for netuid1 should match the conviction of its only lock"
-//         );
-
-//         // Verify that netuid2 is unaffected
-//         assert!(
-//             !SubnetOwner::<Test>::contains_key(netuid2),
-//             "Subnet owner for netuid2 should not be set"
-//         );
-//         assert_eq!(
-//             SubnetLocked::<Test>::get(netuid2),
-//             0,
-//             "Subnet locked amount for netuid2 should be zero"
-//         );
-
-//         // Call the update_subnet_owner function for netuid2
-//         SubtensorModule::update_subnet_owner(netuid2);
-
-//         // Verify that only the lock from netuid2 is now considered
-//         let conviction2 =
-//             SubtensorModule::calculate_conviction(2000000, current_block + 500000, current_block);
-//         assert_eq!(
-//             SubnetOwner::<Test>::get(netuid2),
-//             coldkey2.clone(),
-//             "Subnet owner for netuid2 should be set to coldkey2"
-//         );
-//         assert_eq!(
-//             SubnetLocked::<Test>::get(netuid2),
-//             conviction2,
-//             "Subnet locked amount for netuid2 should match the conviction of its only lock"
-//         );
-
-//         // Verify that netuid1 remains unchanged
-//         assert_eq!(
-//             SubnetOwner::<Test>::get(netuid1),
-//             coldkey1.clone(),
-//             "Subnet owner for netuid1 should still be set to coldkey1"
-//         );
-//         assert_eq!(
-//             SubnetLocked::<Test>::get(netuid1),
-//             conviction1,
-//             "Subnet locked amount for netuid1 should remain unchanged"
-//         );
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_update_subnet_owner_large_subnet --exact --nocapture
-// #[test]
-// fn test_update_subnet_owner_large_subnet() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let num_locks = 1500; // Large number of locks
-//         let current_block = 100;
-
-//         // Create a large number of locks
-//         for i in 0..num_locks {
-//             let hotkey = AccountId::from([i as u8; 32]);
-//             let coldkey = AccountId::from([(i + num_locks) as u8; 32]);
-//             let lock_amount = (i + 1) * 1000; // Varying lock amounts
-//             let lock_duration = (i % 10 + 1) * 100; // Varying lock durations
-
-//             Locks::<Test>::insert(
-//                 (netuid, hotkey, coldkey),
-//                 (lock_amount, current_block, current_block + lock_duration),
-//             );
-
-//             // Set up ownership
-//             Owner::<Test>::insert(hotkey, coldkey);
-//         }
-
-//         // Mock the current block
-//         System::set_block_number(current_block);
-
-//         // Measure the time taken to update subnet owner
-//         let start_time = std::time::Instant::now();
-//         SubtensorModule::update_subnet_owner(netuid);
-//         let duration = start_time.elapsed();
-
-//         // Log the time taken
-//         println!("Time taken to update subnet owner: {:?}", duration);
-
-//         // Verify that a subnet owner was set
-//         assert!(
-//             SubnetOwner::<Test>::contains_key(netuid),
-//             "A subnet owner should be set"
-//         );
-
-//         // Verify that the subnet locked amount is non-zero
-//         assert!(
-//             SubnetLocked::<Test>::get(netuid) > 0,
-//             "Subnet locked amount should be non-zero"
-//         );
-
-//         // Verify that the subnet owner has the highest conviction
-//         let owner = SubnetOwner::<Test>::get(netuid);
-//         let mut max_conviction = 0;
-//         for ((iter_netuid, _hotkey, _), (lock_amount, _, end_block)) in Locks::<Test>::iter() {
-//             if iter_netuid == netuid {
-//                 let conviction =
-//                     SubtensorModule::calculate_conviction(lock_amount, end_block, current_block);
-//                 if conviction > max_conviction {
-//                     max_conviction = conviction;
-//                 }
-//             }
-//         }
-//         let owner_hotkey = Locks::<Test>::iter()
-//             .find(|((_, _, coldkey), _)| *coldkey == owner)
-//             .map(|((_, hotkey, _), _)| hotkey)
-//             .unwrap();
-//         let (owner_lock_amount, _, owner_end_block) =
-//             Locks::<Test>::get((netuid, owner_hotkey, owner));
-//         let owner_conviction = SubtensorModule::calculate_conviction(
-//             owner_lock_amount,
-//             owner_end_block,
-//             current_block,
-//         );
-//         assert_eq!(
-//             owner_conviction, max_conviction,
-//             "Subnet owner should have the highest conviction"
-//         );
-
-//         // Check that a performance warning was logged
-//         // Note: In a real test environment, you would need a way to capture and assert on log output
-//         // For this example, we'll just comment on the expected behavior
-//         // assert!(log_contains("Large subnet 1 processed with 1500 hotkeys"));
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_update_subnet_owner_ownership_change --exact --nocapture
-// #[test]
-// fn test_update_subnet_owner_ownership_change() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let hotkey1 = U256::from(1);
-//         let coldkey1 = U256::from(2);
-//         let hotkey2 = U256::from(3);
-//         let coldkey2 = U256::from(4);
-//         let initial_block = 100000;
-//         let lock_duration = 1000000;
-
-//         // Set up initial locks
-//         Locks::<Test>::insert(
-//             (netuid, hotkey1, coldkey1),
-//             (1000000, initial_block, initial_block + lock_duration),
-//         );
-//         Locks::<Test>::insert(
-//             (netuid, hotkey2, coldkey2),
-//             (500000, initial_block, initial_block + lock_duration),
-//         );
-
-//         // Set up ownership
-//         Owner::<Test>::insert(hotkey1, coldkey1);
-//         Owner::<Test>::insert(hotkey2, coldkey2);
-
-//         // Set initial block
-//         System::set_block_number(initial_block);
-
-//         // Update subnet owner
-//         SubtensorModule::update_subnet_owner(netuid);
-
-//         // Check initial subnet owner
-//         assert_eq!(
-//             SubnetOwner::<Test>::get(netuid),
-//             coldkey1.clone(),
-//             "Initial subnet owner should be coldkey1"
-//         );
-
-//         // Simulate time passing and conviction changing
-//         let new_block = initial_block + 500000;
-//         System::set_block_number(new_block);
-
-//         // Increase lock for hotkey2
-//         Locks::<Test>::insert(
-//             (netuid, hotkey2, coldkey2),
-//             (2000000, new_block, new_block + lock_duration),
-//         );
-
-//         // Update subnet owner again
-//         SubtensorModule::update_subnet_owner(netuid);
-
-//         // Check if subnet owner has changed
-//         assert_eq!(
-//             SubnetOwner::<Test>::get(netuid),
-//             coldkey2.clone(),
-//             "Subnet owner should change to coldkey2"
-//         );
-
-//         // Verify subnet locked amount has increased
-//         let subnet_locked = SubnetLocked::<Test>::get(netuid);
-//         assert!(subnet_locked > 0, "Subnet locked amount should be non-zero");
-//         assert!(
-//             subnet_locked
-//                 > SubtensorModule::calculate_conviction(
-//                     1000000,
-//                     initial_block + lock_duration,
-//                     new_block
-//                 ),
-//             "Subnet locked amount should increase"
-//         );
-
-//         // Simulate more time passing
-//         let final_block = new_block + 600000;
-//         System::set_block_number(final_block);
-
-//         // Update subnet owner one last time
-//         SubtensorModule::update_subnet_owner(netuid);
-
-//         // Check if subnet owner remains the same
-//         assert_eq!(
-//             SubnetOwner::<Test>::get(netuid),
-//             coldkey2.clone(),
-//             "Subnet owner should still be coldkey2"
-//         );
-
-//         // Verify subnet locked amount has decreased due to time passing
-//         let final_subnet_locked = SubnetLocked::<Test>::get(netuid);
-//         assert!(
-//             final_subnet_locked < subnet_locked,
-//             "Subnet locked amount should decrease over time"
-//         );
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_update_subnet_owner_storage_updates --exact --nocapture
-// #[test]
-// fn test_update_subnet_owner_storage_updates() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let hotkey1 = U256::from(1);
-//         let coldkey1 = U256::from(2);
-//         let hotkey2 = U256::from(3);
-//         let coldkey2 = U256::from(4);
-//         let initial_block = 100000;
-//         let lock_duration = 1000000;
-
-//         // Set up initial locks
-//         Locks::<Test>::insert(
-//             (netuid, hotkey1, coldkey1),
-//             (1000000, initial_block, initial_block + lock_duration),
-//         );
-//         Locks::<Test>::insert(
-//             (netuid, hotkey2, coldkey2),
-//             (500000, initial_block, initial_block + lock_duration),
-//         );
-
-//         // Set up ownership
-//         Owner::<Test>::insert(hotkey1, coldkey1);
-//         Owner::<Test>::insert(hotkey2, coldkey2);
-
-//         // Set initial block
-//         System::set_block_number(initial_block);
-
-//         // Update subnet owner
-//         SubtensorModule::update_subnet_owner(netuid);
-
-//         // Check initial subnet owner and locked amount
-//         assert_eq!(
-//             SubnetOwner::<Test>::get(netuid),
-//             coldkey1.clone(),
-//             "Initial subnet owner should be coldkey1"
-//         );
-//         let initial_locked = SubnetLocked::<Test>::get(netuid);
-//         assert!(
-//             initial_locked > 0,
-//             "Initial subnet locked amount should be non-zero"
-//         );
-
-//         // Simulate time passing and conviction changing
-//         let new_block = initial_block + 500000;
-//         System::set_block_number(new_block);
-
-//         // Increase lock for hotkey2
-//         Locks::<Test>::insert(
-//             (netuid, hotkey2, coldkey2),
-//             (2000000, new_block, new_block + lock_duration),
-//         );
-
-//         // Update subnet owner again
-//         SubtensorModule::update_subnet_owner(netuid);
-
-//         // Check if subnet owner has changed
-//         assert_eq!(
-//             SubnetOwner::<Test>::get(netuid),
-//             coldkey2.clone(),
-//             "Subnet owner should change to coldkey2"
-//         );
-
-//         // Verify subnet locked amount has increased
-//         let new_locked = SubnetLocked::<Test>::get(netuid);
-//         assert!(
-//             new_locked > initial_locked,
-//             "Subnet locked amount should increase"
-//         );
-
-//         // Simulate more time passing
-//         let final_block = new_block + 600000;
-//         System::set_block_number(final_block);
-
-//         // Update subnet owner one last time
-//         SubtensorModule::update_subnet_owner(netuid);
-
-//         // Check if subnet owner remains the same
-//         assert_eq!(
-//             SubnetOwner::<Test>::get(netuid),
-//             coldkey2.clone(),
-//             "Subnet owner should still be coldkey2"
-//         );
-
-//         // Verify subnet locked amount has decreased due to time passing
-//         let final_locked = SubnetLocked::<Test>::get(netuid);
-//         assert!(
-//             final_locked < new_locked,
-//             "Subnet locked amount should decrease over time"
-//         );
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_sudo_set_lock_interval_blocks_success --exact --nocapture
-// #[test]
-// fn test_sudo_set_lock_interval_blocks_success() {
-//     new_test_ext(1).execute_with(|| {
-//         let new_interval = 1000;
-//         assert_ok!(SubtensorModule::sudo_set_lock_interval_blocks(
-//             RuntimeOrigin::root(),
-//             new_interval
-//         ));
-//         assert_eq!(SubtensorModule::get_lock_interval_blocks(), new_interval);
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_sudo_set_lock_interval_blocks_non_root_fails --exact --nocapture
-// #[test]
-// fn test_sudo_set_lock_interval_blocks_non_root_fails() {
-//     new_test_ext(1).execute_with(|| {
-//         let new_interval = 1000;
-//         let non_root = U256::from(1);
-//         assert_noop!(
-//             SubtensorModule::sudo_set_lock_interval_blocks(
-//                 RuntimeOrigin::signed(non_root),
-//                 new_interval
-//             ),
-//             DispatchError::BadOrigin
-//         );
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_sudo_set_lock_interval_blocks_zero --exact --nocapture
-// #[test]
-// fn test_sudo_set_lock_interval_blocks_zero() {
-//     new_test_ext(1).execute_with(|| {
-//         let new_interval = 0;
-//         assert_ok!(SubtensorModule::sudo_set_lock_interval_blocks(
-//             RuntimeOrigin::root(),
-//             new_interval
-//         ));
-//         assert_eq!(SubtensorModule::get_lock_interval_blocks(), new_interval);
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_sudo_set_lock_interval_blocks_max_value --exact --nocapture
-// #[test]
-// fn test_sudo_set_lock_interval_blocks_max_value() {
-//     new_test_ext(1).execute_with(|| {
-//         let new_interval = u64::MAX;
-//         assert_ok!(SubtensorModule::sudo_set_lock_interval_blocks(
-//             RuntimeOrigin::root(),
-//             new_interval
-//         ));
-//         assert_eq!(SubtensorModule::get_lock_interval_blocks(), new_interval);
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_sudo_set_lock_interval_blocks_multiple_calls --exact --nocapture
-// #[test]
-// fn test_sudo_set_lock_interval_blocks_multiple_calls() {
-//     new_test_ext(1).execute_with(|| {
-//         let intervals = [1000, 2000, 500, 10000];
-//         for interval in intervals.iter() {
-//             assert_ok!(SubtensorModule::sudo_set_lock_interval_blocks(
-//                 RuntimeOrigin::root(),
-//                 *interval
-//             ));
-//             assert_eq!(SubtensorModule::get_lock_interval_blocks(), *interval);
-//         }
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_sudo_set_lock_interval_blocks_effect_on_existing_locks --exact --nocapture
-// #[test]
-// fn test_sudo_set_lock_interval_blocks_effect_on_existing_locks() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let coldkey = U256::from(1);
-//         let hotkey = U256::from(2);
-//         let lock_amount = 1_000_000;
-//         let initial_lock_interval = 7200;
-//         let new_lock_interval = 14400;
-
-//         // Set up initial lock interval
-//         assert_ok!(SubtensorModule::sudo_set_lock_interval_blocks(
-//             RuntimeOrigin::root(),
-//             initial_lock_interval
-//         ));
-
-//         // Create a lock
-//         let current_block = SubtensorModule::get_current_block_as_u64();
-//         Locks::<Test>::insert(
-//             (netuid, hotkey, coldkey),
-//             (
-//                 lock_amount,
-//                 current_block,
-//                 current_block + initial_lock_interval,
-//             ),
-//         );
-
-//         // Change lock interval
-//         assert_ok!(SubtensorModule::sudo_set_lock_interval_blocks(
-//             RuntimeOrigin::root(),
-//             new_lock_interval
-//         ));
-
-//         // Verify that existing lock is not affected
-//         let (stored_amount, stored_start, stored_end) =
-//             Locks::<Test>::get((netuid, hotkey, coldkey));
-//         assert_eq!(stored_amount, lock_amount);
-//         assert_eq!(stored_start, current_block);
-//         assert_eq!(stored_end, current_block + initial_lock_interval);
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_sudo_set_lock_interval_blocks_effect_on_new_locks --exact --nocapture
-// #[test]
-// fn test_sudo_set_lock_interval_blocks_effect_on_new_locks() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let coldkey = U256::from(1);
-//         let hotkey = U256::from(2);
-//         let lock_amount = 1_000_000;
-//         let new_lock_interval = 14400;
-
-//         add_network(netuid, 0, 0);
-//         register_ok_neuron(netuid, hotkey, coldkey, 0);
-//         // Set new lock interval
-//         assert_ok!(SubtensorModule::sudo_set_lock_interval_blocks(
-//             RuntimeOrigin::root(),
-//             new_lock_interval
-//         ));
-
-//         // Add balance to coldkey account (more than needed to ensure sufficient funds)
-//         SubtensorModule::add_balance_to_coldkey_account(&coldkey, lock_amount * 10);
-
-//         // Add stake to the hotkey (equal to lock_amount to ensure sufficient stake)
-//         assert_ok!(SubtensorModule::add_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             lock_amount
-//         ));
-//         // Create a new lock
-//         let current_block = SubtensorModule::get_current_block_as_u64();
-//         assert_ok!(SubtensorModule::lock_stake(
-//             RuntimeOrigin::signed(coldkey),
-//             hotkey,
-//             netuid,
-//             new_lock_interval,
-//             lock_amount
-//         ));
-
-//         // Verify that new lock uses the new interval
-//         let (stored_amount, stored_start, stored_end) =
-//             Locks::<Test>::get((netuid, hotkey, coldkey));
-//         assert_eq!(stored_amount, lock_amount);
-//         assert_eq!(stored_start, current_block);
-//         assert_eq!(stored_end, current_block + new_lock_interval);
-//     });
-// }
-
-
-
-
-////////////////////////
-
-
-
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut --exact --nocapture
-// #[test]
-// fn test_distribute_owner_cut() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let coldkey1 = U256::from(1);
-//         let hotkey1 = U256::from(2);
-//         let coldkey2 = U256::from(3);
-//         let hotkey2 = U256::from(4);
-
-//         // Set up initial balances and stakes
-//         SubtensorModule::add_balance_to_coldkey_account(&coldkey1, 1_000_000_000);
-//         SubtensorModule::add_balance_to_coldkey_account(&coldkey2, 1_000_000_000);
-
-//         // Register hotkeys
-//         assert_ok!(SubtensorModule::register(RuntimeOrigin::signed(coldkey1), netuid, hotkey1));
-//         assert_ok!(SubtensorModule::register(RuntimeOrigin::signed(coldkey2), netuid, hotkey2));
-
-//         // Lock stakes
-//         assert_ok!(SubtensorModule::increase_stake(RuntimeOrigin::signed(coldkey1), hotkey1, netuid, 500_000_000));
-//         assert_ok!(SubtensorModule::increase_stake(RuntimeOrigin::signed(coldkey2), hotkey2, netuid, 250_000_000));
-
-//         // Lock the stakes
-//         assert_ok!(SubtensorModule::lock_stake(RuntimeOrigin::signed(coldkey1), hotkey1, netuid, 500_000_000, 7200 * 30)); // 30 days
-//         assert_ok!(SubtensorModule::lock_stake(RuntimeOrigin::signed(coldkey2), hotkey2, netuid, 250_000_000, 7200 * 15)); // 15 days
-
-//         // Distribute owner cut
-//         let amount_to_distribute = 1_000_000;
-//         let remaining = SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
-
-//         // Check that all funds were distributed
-//         assert_eq!(remaining, 0);
-
-//         // Check that the locks were updated correctly
-//         let (lock1, _, _) = Locks::<Test>::get((netuid, hotkey1, coldkey1)).unwrap();
-//         let (lock2, _, _) = Locks::<Test>::get((netuid, hotkey2, coldkey2)).unwrap();
-
-//         // The exact distribution might vary, but hotkey1 should receive more than hotkey2
-//         assert!(lock1 > 500_000_000);
-//         assert!(lock2 > 250_000_000);
-//         assert!(lock1 - 500_000_000 > lock2 - 250_000_000);
-
-//         // Check that the total distributed amount matches the input amount
-//         assert_eq!(lock1 - 500_000_000 + lock2 - 250_000_000, amount_to_distribute);
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_distribute_owner_cut_no_conviction --exact --nocapture
-// #[test]
-// fn test_distribute_owner_cut_no_conviction() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let amount_to_distribute = 1_000_000;
-
-//         // Distribute owner cut when there are no stakes
-//         let remaining = SubtensorModule::distribute_owner_cut(netuid, amount_to_distribute);
-
-//         // Check that all funds were returned as there were no stakes to distribute to
-//         assert_eq!(remaining, amount_to_distribute);
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_max_allowed_unstakable --exact --nocapture
-// #[test]
-// fn test_calculate_max_allowed_unstakable() {
-//     new_test_ext(1).execute_with(|| {
-//         let alpha_locked = 1_000_000;
-//         let start_block = 1000;
-//         let lock_interval_blocks = 7200 * 365; // One year in blocks
-
-//         // Test immediately after locking
-//         let current_block = start_block;
-//         let max_unstakable = SubtensorModule::calculate_max_allowed_unstakable(alpha_locked, start_block, current_block);
-//         assert_eq!(max_unstakable, 0, "Should not be able to unstake immediately after locking");
-
-//         // Test after 25% of the lock period
-//         let current_block = start_block + (lock_interval_blocks / 4);
-//         let max_unstakable = SubtensorModule::calculate_max_allowed_unstakable(alpha_locked, start_block, current_block);
-//         assert!(max_unstakable > 0 && max_unstakable < alpha_locked / 2, "Should be able to unstake some, but less than half after 25% of lock period");
-
-//         // Test after 50% of the lock period
-//         let current_block = start_block + (lock_interval_blocks / 2);
-//         let max_unstakable = SubtensorModule::calculate_max_allowed_unstakable(alpha_locked, start_block, current_block);
-//         assert!(max_unstakable > alpha_locked / 2 && max_unstakable < alpha_locked, "Should be able to unstake more than half, but not all after 50% of lock period");
-
-//         // Test after full lock period
-//         let current_block = start_block + lock_interval_blocks;
-//         let max_unstakable = SubtensorModule::calculate_max_allowed_unstakable(alpha_locked, start_block, current_block);
-//         assert_eq!(max_unstakable, alpha_locked, "Should be able to unstake all after full lock period");
-
-//         // Test long after lock period
-//         let current_block = start_block + (lock_interval_blocks * 2);
-//         let max_unstakable = SubtensorModule::calculate_max_allowed_unstakable(alpha_locked, start_block, current_block);
-//         assert_eq!(max_unstakable, alpha_locked, "Should still be able to unstake all long after lock period");
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_update_subnet_owner --exact --nocapture
-// #[test]
-// fn test_update_subnet_owner() {
-//     new_test_ext(1).execute_with(|| {
-//         let netuid = 1;
-//         let coldkey1 = U256::from(1);
-//         let hotkey1 = U256::from(2);
-//         let coldkey2 = U256::from(3);
-//         let hotkey2 = U256::from(4);
-
-//         // Add balance and register hotkeys
-//         SubtensorModule::add_balance_to_coldkey_account(&coldkey1, 1_000_000_000);
-//         SubtensorModule::add_balance_to_coldkey_account(&coldkey2, 1_000_000_000);
-//         assert_ok!(SubtensorModule::register(&hotkey1, &coldkey1, netuid));
-//         assert_ok!(SubtensorModule::register(&hotkey2, &coldkey2, netuid));
-
-//         // Create locks for both hotkeys
-//         let current_block = SubtensorModule::get_current_block_as_u64();
-//         let lock_amount1 = 500_000_000;
-//         let lock_amount2 = 750_000_000;
-//         let duration = 7200 * 365; // One year in blocks
-
-//         Locks::<Test>::insert(
-//             (netuid, hotkey1, coldkey1),
-//             (lock_amount1, current_block, current_block + duration)
-//         );
-//         Locks::<Test>::insert(
-//             (netuid, hotkey2, coldkey2),
-//             (lock_amount2, current_block, current_block + duration)
-//         );
-
-//         // Update subnet owner
-//         SubtensorModule::update_subnet_owner(netuid);
-
-//         // Check that the subnet owner is set to coldkey2 (which has a higher lock amount)
-//         assert_eq!(SubnetOwner::<Test>::get(netuid), Some(coldkey2));
-
-//         // Advance blocks and update locks to change conviction scores
-//         run_to_block(current_block + duration / 2);
-
-//         // Update lock for hotkey1 to have higher conviction
-//         Locks::<Test>::insert(
-//             (netuid, hotkey1, coldkey1),
-//             (lock_amount1 * 2, current_block, current_block + duration * 2)
-//         );
-
-//         // Update subnet owner again
-//         SubtensorModule::update_subnet_owner(netuid);
-
-//         // Check that the subnet owner is now set to coldkey1
-//         assert_eq!(SubnetOwner::<Test>::get(netuid), Some(coldkey1));
-//     });
-// }
-
-// // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --test lock -- test_calculate_conviction --exact --nocapture
-// #[test]
-// fn test_calculate_conviction() {
-//     new_test_ext(1).execute_with(|| {
-//         let lock_amount = 1_000_000;
-//         let current_block = 1000;
-//         let end_block = current_block + 7200 * 365; // One year from now
-
-//         // Test conviction at the start of the lock
-//         let conviction_start = SubtensorModule::calculate_conviction(lock_amount, end_block, current_block);
-//         assert!(conviction_start > 0, "Conviction should be positive at the start of the lock");
-//         assert!(conviction_start < lock_amount, "Conviction should be less than the lock amount");
-
-//         // Test conviction at the middle of the lock period
-//         let mid_block = current_block + (7200 * 365 / 2);
-//         let conviction_mid = SubtensorModule::calculate_conviction(lock_amount, end_block, mid_block);
-//         assert!(conviction_mid > conviction_start, "Conviction should increase over time");
-//         assert!(conviction_mid < lock_amount, "Conviction should still be less than the lock amount");
-
-//         // Test conviction near the end of the lock period
-//         let near_end_block = end_block - 1000;
-//         let conviction_near_end = SubtensorModule::calculate_conviction(lock_amount, end_block, near_end_block);
-//         assert!(conviction_near_end > conviction_mid, "Conviction should be higher near the end");
-//         assert!(conviction_near_end < lock_amount, "Conviction should still be less than the lock amount");
-
-//         // Test conviction with different lock amounts
-//         let larger_lock = lock_amount * 2;
-//         let conviction_larger = SubtensorModule::calculate_conviction(larger_lock, end_block, current_block);
-//         assert!(conviction_larger > conviction_start, "Larger lock should have higher conviction");
-
-//         // Test conviction with very short lock duration
-//         let short_end_block = current_block + 100;
-//         let conviction_short = SubtensorModule::calculate_conviction(lock_amount, short_end_block, current_block);
-//         assert!(conviction_short < conviction_start, "Short lock should have lower conviction");
-
-//         // Test conviction at the exact end of the lock
-//         let conviction_end = SubtensorModule::calculate_conviction(lock_amount, end_block, end_block);
-//         assert_eq!(conviction_end, lock_amount, "Conviction should equal lock amount at the end");
-//     });
-// }
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_do_lock_insufficient_stake --exact --show-output
+#[test]
+fn test_do_lock_insufficient_stake() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let stake_amount = 500_000_000;
+        let lock_amount = 750_000_000; // More than available stake
+        let lock_duration = 7200 * 30; // 30 days
+
+        // Set up network and register neuron
+        add_network(netuid, 0, 0);
+        register_ok_neuron(netuid, hotkey, coldkey, 11);
+
+        // Add balance to coldkey and stake
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey, 1_000_000_000);
+        assert_ok!(SubtensorModule::add_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            stake_amount
+        ));
+
+        // Attempt to lock more stake than available
+        assert_noop!(
+            SubtensorModule::lock_stake(
+                RuntimeOrigin::signed(coldkey),
+                hotkey,
+                netuid,
+                lock_duration,
+                lock_amount
+            ),
+            Error::<Test>::NotEnoughStakeToWithdraw
+        );
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_do_lock_increase_conviction --exact --show-output
+#[test]
+fn test_do_lock_increase_conviction() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let initial_stake = 1_000_000_000;
+        let initial_lock_amount = 500_000_000;
+        let initial_lock_duration = 7200 * 30; // 30 days
+        let new_lock_amount = 750_000_000;
+        let new_lock_duration = 7200 * 60; // 60 days
+
+        // Set up network and register neuron
+        add_network(netuid, 0, 0);
+        register_ok_neuron(netuid, hotkey, coldkey, 11);
+
+        // Add balance to coldkey and stake
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
+        assert_ok!(SubtensorModule::add_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            initial_stake
+        ));
+
+        // Initial lock
+        assert_ok!(SubtensorModule::lock_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            initial_lock_duration,
+            initial_lock_amount
+        ));
+
+        // Increase conviction with new lock
+        assert_ok!(SubtensorModule::lock_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            new_lock_duration,
+            new_lock_amount
+        ));
+
+        // Verify the new lock
+        let stake_lock = Locks::<Test>::get((netuid, hotkey, coldkey));
+        assert_eq!(stake_lock.alpha_locked, new_lock_amount);
+        assert_eq!(
+            stake_lock.end_block,
+            SubtensorModule::get_current_block_as_u64() + new_lock_duration
+        );
+
+        // Verify event emission
+        System::assert_last_event(
+            Event::LockIncreased {
+                coldkey,
+                hotkey,
+                netuid,
+                alpha_locked: new_lock_amount,
+            }
+            .into(),
+        );
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_do_lock_decrease_conviction --exact --show-output
+#[test]
+fn test_do_lock_decrease_conviction() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let initial_stake = 1_000_000_000;
+        let initial_lock_amount = 500_000_000;
+        let initial_lock_duration = 7200 * 30; // 30 days
+        let new_lock_amount = 400_000_000;
+        let new_lock_duration = 7200 * 20; // 20 days
+
+        // Set up network and register neuron
+        add_network(netuid, 0, 0);
+        register_ok_neuron(netuid, hotkey, coldkey, 11);
+
+        // Add balance to coldkey and stake
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
+        assert_ok!(SubtensorModule::add_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            initial_stake
+        ));
+
+        // Initial lock
+        assert_ok!(SubtensorModule::lock_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            initial_lock_duration,
+            initial_lock_amount
+        ));
+
+        // Attempt to decrease conviction with new lock
+        assert_noop!(
+            SubtensorModule::lock_stake(
+                RuntimeOrigin::signed(coldkey),
+                hotkey,
+                netuid,
+                new_lock_duration,
+                new_lock_amount
+            ),
+            Error::<Test>::NotEnoughStakeToWithdraw
+        );
+
+        // Verify the lock remains unchanged
+        let stake_lock = Locks::<Test>::get((netuid, hotkey, coldkey));
+        assert_eq!(stake_lock.alpha_locked, initial_lock_amount);
+        assert_eq!(
+            stake_lock.end_block,
+            SubtensorModule::get_current_block_as_u64() + initial_lock_duration
+        );
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_do_lock_max_duration --exact --show-output
+#[test]
+fn test_do_lock_max_duration() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let initial_stake = 1_000_000_000;
+        let lock_amount = 500_000_000;
+        let max_lock_duration = 7200 * 365; // 1 year (assuming 7200 blocks per day)
+
+        // Set up network and register neuron
+        add_network(netuid, 0, 0);
+        register_ok_neuron(netuid, hotkey, coldkey, 11);
+
+        // Add balance to coldkey and stake
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
+        assert_ok!(SubtensorModule::add_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            initial_stake
+        ));
+
+        // Lock stake for maximum duration
+        assert_ok!(SubtensorModule::lock_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            max_lock_duration,
+            lock_amount
+        ));
+
+        // Verify the lock
+        let stake_lock = Locks::<Test>::get((netuid, hotkey, coldkey));
+        assert_eq!(stake_lock.alpha_locked, lock_amount);
+        assert_eq!(
+            stake_lock.end_block,
+            SubtensorModule::get_current_block_as_u64() + max_lock_duration
+        );
+
+        // Verify event emission
+        System::assert_last_event(
+            Event::LockIncreased {
+                coldkey,
+                hotkey,
+                netuid,
+                alpha_locked: lock_amount,
+            }
+            .into(),
+        );
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_do_lock_multiple_times --exact --show-output
+#[test]
+fn test_do_lock_multiple_times() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let initial_stake = 1_000_000_000;
+        let lock_amount_1 = 300_000_000;
+        let lock_amount_2 = 500_000_000;
+        let lock_duration_1 = 7200 * 30; // 30 days
+        let lock_duration_2 = 7200 * 60; // 60 days
+        let start_block = SubtensorModule::get_current_block_as_u64();
+
+        // Set up network and register neuron
+        add_network(netuid, 0, 0);
+        register_ok_neuron(netuid, hotkey, coldkey, 11);
+
+        // Add balance to coldkey and stake
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
+        assert_ok!(SubtensorModule::add_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            initial_stake
+        ));
+
+        // First lock
+        assert_ok!(SubtensorModule::lock_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            lock_duration_1,
+            lock_amount_1
+        ));
+
+        // Verify the first lock
+        let stake_lock_1 = Locks::<Test>::get((netuid, hotkey, coldkey));
+        assert_eq!(stake_lock_1.alpha_locked, lock_amount_1);
+        assert_eq!(stake_lock_1.end_block, start_block + lock_duration_1);
+
+        // Second lock
+        assert_ok!(SubtensorModule::lock_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            lock_duration_2,
+            lock_amount_2
+        ));
+
+        // Verify the second lock
+        let stake_lock_2 = Locks::<Test>::get((netuid, hotkey, coldkey));
+        assert_eq!(stake_lock_2.alpha_locked, lock_amount_2);
+        assert_eq!(stake_lock_2.end_block, start_block + lock_duration_2);
+
+        // Ensure the locked amount increased
+        assert!(stake_lock_2.alpha_locked > stake_lock_1.alpha_locked);
+
+        // Verify event emissions
+        System::assert_has_event(
+            Event::LockIncreased {
+                coldkey,
+                hotkey,
+                netuid,
+                alpha_locked: lock_amount_1,
+            }
+            .into(),
+        );
+        System::assert_last_event(
+            Event::LockIncreased {
+                coldkey,
+                hotkey,
+                netuid,
+                alpha_locked: lock_amount_2,
+            }
+            .into(),
+        );
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_do_lock_different_subnets --exact --show-output
+#[test]
+fn test_do_lock_different_subnets() {
+    new_test_ext(1).execute_with(|| {
+        let netuid1 = NetUid::from(1);
+        let netuid2 = NetUid::from(2);
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let initial_stake = 1_000_000_000;
+        let lock_amount_1 = 300_000_000;
+        let lock_amount_2 = 500_000_000;
+        let lock_duration = 7200 * 30; // 30 days
+        let start_block = SubtensorModule::get_current_block_as_u64();
+
+        // Set up networks and register neuron
+        add_network(netuid1, 0, 0);
+        add_network(netuid2, 0, 0);
+        register_ok_neuron(netuid1, hotkey, coldkey, 11);
+        register_ok_neuron(netuid2, hotkey, coldkey, 12);
+
+        // Add balance to coldkey and stake on both networks
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake * 2);
+        assert_ok!(SubtensorModule::add_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid1,
+            initial_stake
+        ));
+        assert_ok!(SubtensorModule::add_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid2,
+            initial_stake
+        ));
+
+        // Lock stake on first subnet
+        assert_ok!(SubtensorModule::lock_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid1,
+            lock_duration,
+            lock_amount_1
+        ));
+
+        // Verify the lock on first subnet
+        let stake_lock_1 = Locks::<Test>::get((netuid1, hotkey, coldkey));
+        assert_eq!(stake_lock_1.alpha_locked, lock_amount_1);
+        assert_eq!(stake_lock_1.end_block, start_block + lock_duration);
+
+        // Lock stake on second subnet
+        assert_ok!(SubtensorModule::lock_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid2,
+            lock_duration,
+            lock_amount_2
+        ));
+
+        // Verify the lock on second subnet
+        let stake_lock_2 = Locks::<Test>::get((netuid2, hotkey, coldkey));
+        assert_eq!(stake_lock_2.alpha_locked, lock_amount_2);
+        assert_eq!(stake_lock_2.end_block, start_block + lock_duration);
+
+        // Ensure the locks are independent
+        assert_ne!(stake_lock_1.alpha_locked, stake_lock_2.alpha_locked);
+
+        // Verify event emissions
+        System::assert_has_event(
+            Event::LockIncreased {
+                coldkey,
+                hotkey,
+                netuid: netuid1,
+                alpha_locked: lock_amount_1,
+            }
+            .into(),
+        );
+        System::assert_last_event(
+            Event::LockIncreased {
+                coldkey,
+                hotkey,
+                netuid: netuid2,
+                alpha_locked: lock_amount_2,
+            }
+            .into(),
+        );
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_remove_stake_fully_locked --exact --show-output
+#[test]
+fn test_remove_stake_fully_locked() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let initial_stake = 1_000_000_000;
+        let lock_amount = initial_stake - 1;
+        let lock_duration = 7200 * 30; // 30 days
+
+        // Set up network and register neuron
+        add_network(netuid, 0, 0);
+        register_ok_neuron(netuid, hotkey, coldkey, 11);
+
+        // Add balance to coldkey and stake
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
+        assert_ok!(SubtensorModule::add_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            initial_stake
+        ));
+
+        // Lock all stake
+        assert_ok!(SubtensorModule::lock_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            lock_duration,
+            lock_amount
+        ));
+
+        // Attempt to remove stake
+        remove_stake_rate_limit_for_tests(&hotkey, &coldkey, netuid);
+        assert_noop!(
+            SubtensorModule::remove_stake(
+                RuntimeOrigin::signed(coldkey),
+                hotkey,
+                netuid,
+                initial_stake
+            ),
+            Error::<Test>::NotEnoughStakeToWithdraw
+        );
+
+        // Verify lock remains unchanged
+        let stake_lock = Locks::<Test>::get((netuid, hotkey, coldkey));
+        assert_eq!(stake_lock.alpha_locked, lock_amount);
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_remove_stake_partially_locked --exact --show-output
+#[test]
+fn test_remove_stake_partially_locked() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let initial_stake = 1_000_000_000;
+        let lock_amount = 600_000_000;
+        let lock_duration = 7200 * 30; // 30 days
+
+        // Set up network and register neuron
+        add_network(netuid, 0, 0);
+        register_ok_neuron(netuid, hotkey, coldkey, 11);
+
+        // Add balance to coldkey and stake
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
+        assert_ok!(SubtensorModule::add_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            initial_stake
+        ));
+
+        // Lock part of the stake
+        assert_ok!(SubtensorModule::lock_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            lock_duration,
+            lock_amount
+        ));
+
+        // Attempt to remove unlocked portion (should succeed)
+        let unlocked_amount = max_unlockable_stake(netuid, &hotkey, &coldkey);
+        remove_stake_rate_limit_for_tests(&hotkey, &coldkey, netuid);
+        assert_ok!(SubtensorModule::remove_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            unlocked_amount
+        ));
+
+        // Verify stake and lock after removal
+        let stake_after_removal =
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
+        assert_eq!(stake_after_removal, initial_stake - unlocked_amount - 1);
+
+        let stake_lock = Locks::<Test>::get((netuid, hotkey, coldkey));
+        assert_eq!(stake_lock.alpha_locked, lock_amount); // lock amount should not change
+
+        // Attempt to remove more than unlocked portion (should fail)
+        let stake_to_remove_2 =
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
+        assert_noop!(
+            SubtensorModule::remove_stake(
+                RuntimeOrigin::signed(coldkey),
+                hotkey,
+                netuid,
+                stake_to_remove_2
+            ),
+            Error::<Test>::NotEnoughStakeToWithdraw
+        );
+
+        // Verify stake and lock remain unchanged
+        let stake_after_failed_removal =
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
+        assert_eq!(
+            stake_after_failed_removal,
+            initial_stake - unlocked_amount - 1
+        );
+
+        let stake_lock_after = Locks::<Test>::get((netuid, hotkey, coldkey));
+        assert_eq!(stake_lock_after.alpha_locked, lock_amount);
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_remove_stake_after_lock_expiry --exact --show-output
+#[test]
+fn test_remove_stake_after_lock_expiry() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let initial_stake = 1_000_000_000;
+        let lock_amount = 600_000_000;
+        let lock_duration = 10; // 10 blocks
+
+        // Set up network and register neuron
+        add_network(netuid, 0, 0);
+        register_ok_neuron(netuid, hotkey, coldkey, 11);
+
+        // Add balance to coldkey and stake
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
+        assert_ok!(SubtensorModule::add_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            initial_stake
+        ));
+
+        // Lock part of the stake
+        assert_ok!(SubtensorModule::lock_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            lock_duration,
+            lock_amount
+        ));
+
+        // Fast forward to just after lock expiry
+        run_to_block(lock_duration + 1);
+
+        // Attempt to remove all stake (should succeed)
+        remove_stake_rate_limit_for_tests(&hotkey, &coldkey, netuid);
+        assert_ok!(SubtensorModule::remove_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            initial_stake - 1
+        ));
+
+        // Verify stake and lock after removal
+        let stake_after_removal =
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
+        assert_eq!(stake_after_removal, 0);
+
+        // Verify lock is removed
+        assert!(!Locks::<Test>::contains_key((netuid, hotkey, coldkey)));
+
+        // Verify balance is returned to coldkey
+        let coldkey_balance = SubtensorModule::get_coldkey_balance(&coldkey);
+        assert_eq!(coldkey_balance, initial_stake);
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_remove_stake_multiple_locks --exact --show-output
+#[test]
+fn test_remove_stake_multiple_locks() {
+    new_test_ext(1).execute_with(|| {
+        let subnet_owner_coldkey = U256::from(1001);
+        let subnet_owner_hotkey = U256::from(1002);
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let coldkey2 = U256::from(3); // To keep additional stake
+        let initial_stake = 1_000_000_000;
+        let lock_duration_1 = 10; // 10 blocks
+        let lock_duration_2 = 10; // 10 blocks
+
+        // Set up network and register neuron
+        let netuid = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
+        register_ok_neuron(netuid, hotkey, coldkey, 11);
+
+        mock::setup_reserves(netuid, initial_stake * 100, initial_stake * 100);
+
+        // Add balance to coldkey and stake
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey2, initial_stake);
+        assert_ok!(SubtensorModule::add_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            initial_stake
+        ));
+        let alpha =
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
+        let lock_amount_1 = alpha * 3 / 10;
+        let lock_amount_2 = alpha * 4 / 10;
+
+        // Also add more stake so that we don't get into low liquidity issues now
+        assert_ok!(SubtensorModule::add_stake(
+            RuntimeOrigin::signed(coldkey2),
+            hotkey,
+            netuid,
+            initial_stake
+        ));
+
+        // Create two locks
+        assert_ok!(SubtensorModule::lock_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            lock_duration_1,
+            lock_amount_1
+        )); // first lock.
+        assert_ok!(SubtensorModule::lock_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            lock_duration_2,
+            lock_amount_2
+        )); // second replaces first.
+
+        // Attempt to remove more stake than unlocked (should fail)
+        let max_removable = max_unlockable_stake(netuid, &hotkey, &coldkey);
+        remove_stake_rate_limit_for_tests(&hotkey, &coldkey, netuid);
+        assert_noop!(
+            SubtensorModule::remove_stake(
+                RuntimeOrigin::signed(coldkey),
+                hotkey,
+                netuid,
+                max_removable + 1
+            ),
+            Error::<Test>::NotEnoughStakeToWithdraw
+        );
+
+        // Remove unlocked stake (should succeed)
+        assert_ok!(SubtensorModule::remove_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            max_removable
+        ));
+
+        // Verify remaining stake
+        let remaining_stake =
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
+        assert_eq!(remaining_stake, alpha - max_removable);
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_remove_stake_conviction_calculation --exact --show-output
+#[test]
+fn test_remove_stake_conviction_calculation() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let initial_stake = 1_000_000_000;
+        let lock_amount = 500_000_000;
+        let lock_duration = 10; // 10 blocks
+
+        // Register and add stake
+        add_network(netuid, 0, 0);
+        register_ok_neuron(netuid, hotkey, coldkey, 11);
+        SubtensorModule::set_lock_interval_blocks(lock_duration);
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
+        assert_ok!(SubtensorModule::add_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            initial_stake
+        ));
+
+        // Lock stake
+        assert_ok!(SubtensorModule::do_lock(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            lock_duration,
+            lock_amount
+        ));
+
+        // Try to remove more stake than allowed by conviction
+        let max_removable = max_unlockable_stake(netuid, &hotkey, &coldkey);
+        assert_noop!(
+            SubtensorModule::remove_stake(
+                RuntimeOrigin::signed(coldkey),
+                hotkey,
+                netuid,
+                max_removable + 1
+            ),
+            Error::<Test>::NotEnoughStakeToWithdraw
+        );
+
+        // Remove allowed amount of stake
+        remove_stake_rate_limit_for_tests(&hotkey, &coldkey, netuid);
+        assert_ok!(SubtensorModule::remove_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            max_removable - 1
+        ));
+
+        // Verify remaining stake
+        let remaining_stake =
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
+        assert_eq!(remaining_stake, initial_stake - max_removable);
+
+        // Fast forward to just before lock expiry
+        run_to_block(lock_duration - 1);
+
+        // Try to remove all remaining stake (should fail)
+        assert_noop!(
+            SubtensorModule::remove_stake(
+                RuntimeOrigin::signed(coldkey),
+                hotkey,
+                netuid,
+                remaining_stake
+            ),
+            Error::<Test>::NotEnoughStakeToWithdraw
+        );
+
+        // Fast forward to after lock expiry
+        run_to_block(lock_duration + 1);
+
+        // Now remove all remaining stake (should succeed)
+        assert_ok!(SubtensorModule::remove_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            remaining_stake
+        ));
+
+        // Verify no stake remains
+        let final_stake =
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
+        assert_eq!(final_stake, 0);
+
+        // Verify lock is removed
+        assert!(!Locks::<Test>::contains_key((netuid, hotkey, coldkey)));
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_remove_stake_partial_lock_removal --exact --show-output
+#[test]
+fn test_remove_stake_partial_lock_removal() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let initial_stake = 1_000_000_000;
+        let lock_amount = 500_000_000;
+        let lock_duration = 7200 * 30; // 30 days
+
+        // Register and add stake
+        add_network(netuid, 0, 0);
+        register_ok_neuron(netuid, hotkey, coldkey, 11);
+        SubtensorModule::set_lock_interval_blocks(lock_duration);
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
+        assert_ok!(SubtensorModule::add_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            initial_stake
+        ));
+
+        // Lock stake
+        assert_ok!(SubtensorModule::do_lock(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            lock_duration,
+            lock_amount
+        ));
+
+        // Verify initial lock state
+        let stake_lock_before = Locks::<Test>::get((netuid, hotkey, coldkey));
+        assert_eq!(stake_lock_before.alpha_locked, lock_amount);
+
+        // Calculate max removable stake
+        let max_removable = max_unlockable_stake(netuid, &hotkey, &coldkey);
+        let partial_remove_amount = max_removable / 2;
+
+        // Remove part of the stake
+        remove_stake_rate_limit_for_tests(&hotkey, &coldkey, netuid);
+        assert_ok!(SubtensorModule::remove_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            partial_remove_amount
+        ));
+
+        // Verify remaining stake and updated lock
+        let remaining_stake =
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
+        assert_eq!(remaining_stake, initial_stake - partial_remove_amount - 1);
+
+        let stake_lock_after = Locks::<Test>::get((netuid, hotkey, coldkey));
+        assert_eq!(stake_lock_after.alpha_locked, lock_amount); // lock never changes.
+
+        // Ensure lock still exists
+        assert!(Locks::<Test>::contains_key((netuid, hotkey, coldkey)));
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_remove_stake_partial_lock_removal --exact --show-output
+#[test]
+fn test_remove_stake_full_lock_removal() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let initial_stake = 1_000_000_000;
+        let lock_amount = 500_000_000;
+        let lock_duration = 10; // 10 blocks
+
+        // Register and add stake
+        add_network(netuid, 0, 0);
+        register_ok_neuron(netuid, hotkey, coldkey, 11);
+        SubtensorModule::set_lock_interval_blocks(lock_duration);
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake);
+        assert_ok!(SubtensorModule::add_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            initial_stake
+        ));
+
+        // Lock stake
+        assert_ok!(SubtensorModule::do_lock(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            lock_duration,
+            lock_amount
+        ));
+
+        // Verify initial lock state
+        let stake_lock = Locks::<Test>::get((netuid, hotkey, coldkey));
+        assert_eq!(stake_lock.alpha_locked, lock_amount);
+
+        // Fast forward to just after lock expiry
+        run_to_block(lock_duration + 1);
+
+        // Remove all stake
+        assert_ok!(SubtensorModule::remove_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            initial_stake - 1
+        ));
+
+        // Verify remaining stake
+        let remaining_stake =
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
+        assert_eq!(remaining_stake, 0);
+
+        // Verify lock is removed
+        assert!(!Locks::<Test>::contains_key((netuid, hotkey, coldkey)));
+
+        // Verify balance is returned to coldkey
+        let coldkey_balance = SubtensorModule::get_coldkey_balance(&coldkey);
+        assert_eq!(coldkey_balance, initial_stake);
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_remove_stake_across_subnets --exact --show-output
+#[test]
+fn test_remove_stake_across_subnets() {
+    new_test_ext(1).execute_with(|| {
+        let subnet_owner_coldkey = U256::from(1001);
+        let subnet_owner_hotkey = U256::from(1002);
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let initial_stake = 1_000_000_000;
+        let lock_duration_1 = 10; // 10 blocks
+        let lock_duration_2 = 20; // 20 blocks
+
+        // Set up networks and register neuron
+        let netuid1 = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
+        let netuid2 = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
+        register_ok_neuron(netuid1, hotkey, coldkey, 11);
+        register_ok_neuron(netuid2, hotkey, coldkey, 11);
+
+        // Add balance to coldkey and stake on both networks
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey, initial_stake * 2);
+        assert_ok!(SubtensorModule::add_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid1,
+            initial_stake
+        ));
+        let initial_alpha_1 =
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid1);
+        let lock_amount_1 = initial_alpha_1 * 3 / 10;
+        assert_ok!(SubtensorModule::add_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid2,
+            initial_stake
+        ));
+        let initial_alpha_2 =
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid2);
+        let lock_amount_2 = initial_alpha_2 * 4 / 10;
+
+        // Create locks on both networks
+        assert_ok!(SubtensorModule::lock_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid1,
+            lock_duration_1,
+            lock_amount_1
+        ));
+        assert_ok!(SubtensorModule::lock_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid2,
+            lock_duration_2,
+            lock_amount_2
+        ));
+
+        // Attempt to remove more stake than unlocked from netuid1 (should fail)
+        let max_removable_1 = max_unlockable_stake(netuid1, &hotkey, &coldkey);
+        remove_stake_rate_limit_for_tests(&hotkey, &coldkey, netuid1);
+        remove_stake_rate_limit_for_tests(&hotkey, &coldkey, netuid2);
+        assert_noop!(
+            SubtensorModule::remove_stake(
+                RuntimeOrigin::signed(coldkey),
+                hotkey,
+                netuid1,
+                max_removable_1 + 1
+            ),
+            Error::<Test>::NotEnoughStakeToWithdraw
+        );
+
+        // Remove unlocked stake from netuid1 (should succeed)
+        assert_ok!(SubtensorModule::remove_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid1,
+            max_removable_1
+        ));
+
+        // Verify remaining stake on netuid1
+        let remaining_stake_1 =
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid1);
+        assert_eq!(remaining_stake_1, initial_alpha_1 - max_removable_1);
+
+        // Fast forward to after first lock expiry
+        run_to_block(lock_duration_1 + 1);
+
+        // Remove all stake from netuid1 (should succeed now that lock has expired)
+        assert_ok!(SubtensorModule::remove_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid1,
+            remaining_stake_1
+        ));
+
+        // Verify no stake remains on netuid1
+        let final_stake_1 =
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid1);
+        assert_eq!(final_stake_1, 0);
+
+        // Attempt to remove stake from netuid2 (should still be partially locked)
+        let max_removable_2 = max_unlockable_stake(netuid2, &hotkey, &coldkey);
+        assert_ok!(SubtensorModule::remove_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid2,
+            max_removable_2
+        ));
+
+        // Verify remaining stake on netuid2
+        let remaining_stake_2 =
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid2);
+        assert_eq!(remaining_stake_2, initial_alpha_2 - max_removable_2);
+
+        // Fast forward to after second lock expiry
+        run_to_block(lock_duration_2 + 1);
+
+        println!("======================");
+
+        // Remove all remaining stake from netuid2
+        assert_ok!(SubtensorModule::remove_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid2,
+            remaining_stake_2
+        ));
+
+        // Verify no stake remains on netuid2
+        let final_stake_2 =
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid2);
+        assert_eq!(final_stake_2, 0);
+
+        // Verify locks are removed from both networks
+        assert!(!Locks::<Test>::contains_key((netuid1, hotkey, coldkey)));
+        assert!(!Locks::<Test>::contains_key((netuid2, hotkey, coldkey)));
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_calculate_conviction_zero_lock_amount --exact --show-output
+#[test]
+fn test_calculate_conviction_zero_lock_amount() {
+    new_test_ext(1).execute_with(|| {
+        let current_block = 1000;
+        let stake_lock = StakeLock {
+            alpha_locked: 0,
+            start_block: 0,
+            end_block: 2000,
+        };
+        let conviction = SubtensorModule::calculate_conviction(&stake_lock, current_block);
+        assert_eq!(conviction, 0);
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_calculate_conviction_zero_duration --exact --show-output
+#[test]
+fn test_calculate_conviction_zero_duration() {
+    new_test_ext(1).execute_with(|| {
+        let current_block = 1000;
+        let stake_lock = StakeLock {
+            alpha_locked: 1000000,
+            start_block: 0,
+            end_block: 1000,
+        };
+        let conviction = SubtensorModule::calculate_conviction(&stake_lock, current_block);
+        assert_eq!(conviction, 0);
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_calculate_conviction_max_lock_amount --exact --show-output
+#[test]
+fn test_calculate_conviction_max_lock_amount() {
+    new_test_ext(1).execute_with(|| {
+        let current_block = 1000;
+        let stake_lock = StakeLock {
+            alpha_locked: u64::MAX,
+            start_block: 0,
+            end_block: 2000,
+        };
+        let conviction = SubtensorModule::calculate_conviction(&stake_lock, current_block);
+        assert!(conviction > 0);
+        assert!(conviction < u64::MAX);
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_calculate_conviction_max_duration --exact --show-output
+#[test]
+fn test_calculate_conviction_max_duration() {
+    new_test_ext(1).execute_with(|| {
+        let current_block = 0;
+        let stake_lock = StakeLock {
+            alpha_locked: 1000000,
+            start_block: 0,
+            end_block: u64::MAX,
+        };
+        let conviction = SubtensorModule::calculate_conviction(&stake_lock, current_block);
+        assert!(conviction > 0);
+        assert!(conviction <= stake_lock.alpha_locked);
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_calculate_conviction_overflow_check --exact --show-output
+#[test]
+fn test_calculate_conviction_overflow_check() {
+    new_test_ext(1).execute_with(|| {
+        let current_block = 0;
+        let stake_lock = StakeLock {
+            alpha_locked: u64::MAX,
+            start_block: 0,
+            end_block: u64::MAX,
+        };
+        let conviction = SubtensorModule::calculate_conviction(&stake_lock, current_block);
+        assert_eq!(conviction, u64::MAX);
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_calculate_conviction_precision_small_values --exact --show-output
+#[test]
+fn test_calculate_conviction_precision_small_values() {
+    new_test_ext(1).execute_with(|| {
+        let current_block = 1000;
+        let stake_lock = StakeLock {
+            alpha_locked: 1,
+            start_block: 0,
+            end_block: 1001,
+        };
+        let conviction = SubtensorModule::calculate_conviction(&stake_lock, current_block);
+        assert!(conviction < stake_lock.alpha_locked);
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_calculate_conviction_precision_large_values --exact --show-output
+#[test]
+fn test_calculate_conviction_precision_large_values() {
+    new_test_ext(1).execute_with(|| {
+        let current_block = 0;
+        let stake_lock = StakeLock {
+            alpha_locked: u64::MAX / 2,
+            start_block: 0,
+            end_block: u64::MAX / 2,
+        };
+        let conviction = SubtensorModule::calculate_conviction(&stake_lock, current_block);
+        assert!(conviction == stake_lock.alpha_locked);
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_calculate_conviction_rounding --exact --show-output
+#[test]
+fn test_calculate_conviction_rounding() {
+    new_test_ext(1).execute_with(|| {
+        let current_block = 1000;
+        let end_block = 1100;
+        let lock_amount = 1000000;
+        let stake_lock1 = StakeLock {
+            alpha_locked: lock_amount,
+            start_block: 0,
+            end_block,
+        };
+        let conviction1 = SubtensorModule::calculate_conviction(&stake_lock1, current_block);
+        let stake_lock2 = StakeLock {
+            alpha_locked: lock_amount,
+            start_block: 0,
+            end_block: end_block + 1,
+        };
+        let conviction2 = SubtensorModule::calculate_conviction(&stake_lock2, current_block);
+        assert!(conviction2 >= conviction1);
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_calculate_conviction_lock_interval_boundary --exact --show-output
+#[test]
+fn test_calculate_conviction_lock_interval_boundary() {
+    new_test_ext(1).execute_with(|| {
+        let current_block = 1000;
+        let lock_interval = SubtensorModule::get_lock_interval_blocks();
+        let stake_lock = StakeLock {
+            alpha_locked: 1000000,
+            start_block: 0,
+            end_block: current_block + lock_interval,
+        };
+        let conviction = SubtensorModule::calculate_conviction(&stake_lock, current_block);
+        assert!(conviction > 0);
+        assert!(conviction < stake_lock.alpha_locked);
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_calculate_conviction_consistency --exact --show-output
+#[test]
+fn test_calculate_conviction_consistency() {
+    new_test_ext(1).execute_with(|| {
+        let current_block = 1000;
+        let end_block = 2000;
+        let lock_amount = 1000000;
+
+        let stake_lock_base = StakeLock {
+            alpha_locked: lock_amount,
+            start_block: 0,
+            end_block,
+        };
+        let base_conviction =
+            SubtensorModule::calculate_conviction(&stake_lock_base, current_block);
+
+        // Increasing lock amount
+        let stake_lock_higher = StakeLock {
+            alpha_locked: lock_amount + 1000,
+            start_block: 0,
+            end_block,
+        };
+        let higher_amount_conviction =
+            SubtensorModule::calculate_conviction(&stake_lock_higher, current_block);
+        assert!(higher_amount_conviction > base_conviction);
+
+        // Increasing duration
+        let stake_lock_longer = StakeLock {
+            alpha_locked: lock_amount,
+            start_block: 0,
+            end_block: end_block + 1000,
+        };
+        let longer_duration_conviction =
+            SubtensorModule::calculate_conviction(&stake_lock_longer, current_block);
+        assert!(longer_duration_conviction > base_conviction);
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_calculate_conviction_expired_lock --exact --show-output
+#[test]
+fn test_calculate_conviction_expired_lock() {
+    new_test_ext(1).execute_with(|| {
+        let current_block = 21;
+        let stake_lock = StakeLock {
+            alpha_locked: 394866833,
+            start_block: 1,
+            end_block: 21,
+        };
+        let conviction = SubtensorModule::calculate_conviction(&stake_lock, current_block);
+        assert_eq!(conviction, 0);
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_update_subnet_owner_no_locks --exact --show-output
+#[test]
+fn test_update_subnet_owner_no_locks() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+
+        // Ensure there are no locks in the subnet
+        assert_eq!(
+            Locks::<Test>::iter().count(),
+            0,
+            "There should be no locks initially"
+        );
+
+        // Call the update_subnet_owner function
+        SubtensorModule::update_subnet_owner(netuid, UPDATE_INTERVAL);
+
+        // Verify that no subnet owner was set
+        assert!(
+            !SubnetOwner::<Test>::contains_key(netuid),
+            "No subnet owner should be set when there are no locks"
+        );
+
+        // Verify that the subnet locked amount is zero
+        assert_eq!(
+            SubnetLocked::<Test>::get(netuid),
+            0,
+            "Subnet locked amount should be zero"
+        );
+
+        // Check that a warning log was emitted
+        // Note: In a real test environment, you would need a way to capture and assert on log output
+        // For this example, we'll just comment on the expected behavior
+        // assert_eq!(last_log_message(), "No locks found for subnet 1");
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_update_subnet_owner_single_lock --exact --show-output
+#[test]
+fn test_update_subnet_owner_single_lock() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let hotkey = U256::from(1);
+        let coldkey = U256::from(2);
+        let lock_amount = 1000000;
+        let current_block = 100;
+        let lock_duration = 1000000;
+
+        // Set up a single lock
+        let stake_lock = StakeLock {
+            alpha_locked: lock_amount,
+            start_block: 0,
+            end_block: current_block + lock_duration,
+        };
+        Locks::<Test>::insert((netuid, hotkey, coldkey), stake_lock);
+
+        // Set up ownership
+        Owner::<Test>::insert(hotkey, coldkey);
+
+        // Mock the current block
+        System::set_block_number(current_block);
+
+        // Call the update_subnet_owner function
+        SubtensorModule::update_subnet_owner(netuid, UPDATE_INTERVAL);
+
+        // Verify that the subnet owner was set correctly
+        assert_eq!(
+            SubnetOwner::<Test>::get(netuid),
+            coldkey.clone(),
+            "Subnet owner should be set to the coldkey of the only lock"
+        );
+
+        // Verify that the subnet locked amount is correct
+        let expected_conviction = SubtensorModule::calculate_conviction(
+            &StakeLock {
+                alpha_locked: lock_amount,
+                start_block: 0,
+                end_block: current_block + lock_duration,
+            },
+            current_block,
+        );
+        assert_eq!(
+            SubnetLocked::<Test>::get(netuid),
+            expected_conviction,
+            "Subnet locked amount should match the calculated conviction"
+        );
+
+        // Verify that no new locks were created
+        assert_eq!(
+            Locks::<Test>::iter().count(),
+            1,
+            "There should still be only one lock"
+        );
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_update_subnet_owner_multiple_locks --exact --show-output
+#[test]
+fn test_update_subnet_owner_multiple_locks() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let hotkey1 = U256::from(1);
+        let coldkey1 = U256::from(2);
+        let hotkey2 = U256::from(3);
+        let coldkey2 = U256::from(4);
+        let hotkey3 = U256::from(5);
+        let coldkey3 = U256::from(6);
+        let current_block = 100;
+
+        // Set up multiple locks with different amounts and durations
+        let stake_lock_1 = StakeLock {
+            alpha_locked: 1000000,
+            start_block: 0,
+            end_block: current_block + 1000000,
+        };
+        let stake_lock_2 = StakeLock {
+            alpha_locked: 2000000,
+            start_block: 0,
+            end_block: current_block + 500000,
+        };
+        let stake_lock_3 = StakeLock {
+            alpha_locked: 1500000,
+            start_block: 0,
+            end_block: current_block + 2000000,
+        };
+
+        Locks::<Test>::insert((netuid, hotkey1, coldkey1), stake_lock_1);
+        Locks::<Test>::insert((netuid, hotkey2, coldkey2), stake_lock_2);
+        Locks::<Test>::insert((netuid, hotkey3, coldkey3), stake_lock_3);
+
+        // Set up ownership
+        Owner::<Test>::insert(hotkey1, coldkey1);
+        Owner::<Test>::insert(hotkey2, coldkey2);
+        Owner::<Test>::insert(hotkey3, coldkey3);
+
+        // Mock the current block
+        System::set_block_number(current_block);
+
+        // Call the update_subnet_owner function
+        SubtensorModule::update_subnet_owner(netuid, UPDATE_INTERVAL);
+
+        // Calculate expected convictions
+        let conviction1 = SubtensorModule::calculate_conviction(&stake_lock_1, current_block);
+        let conviction2 = SubtensorModule::calculate_conviction(&stake_lock_2, current_block);
+        let conviction3 = SubtensorModule::calculate_conviction(&stake_lock_3, current_block);
+
+        // Determine the expected owner (hotkey with highest conviction)
+        let expected_owner = if conviction1 > conviction2 && conviction1 > conviction3 {
+            coldkey1
+        } else if conviction2 > conviction1 && conviction2 > conviction3 {
+            coldkey2
+        } else {
+            coldkey3
+        };
+
+        // Verify that the subnet owner was set correctly
+        assert_eq!(
+            SubnetOwner::<Test>::get(netuid),
+            expected_owner,
+            "Subnet owner should be set to the coldkey of the hotkey with highest conviction"
+        );
+
+        // Verify that the subnet locked amount is correct
+        assert_eq!(
+            SubnetLocked::<Test>::get(netuid),
+            conviction1 + conviction2 + conviction3,
+            "Subnet locked amount should match the total calculated conviction"
+        );
+
+        // Verify that no new locks were created
+        assert_eq!(
+            Locks::<Test>::iter().count(),
+            3,
+            "There should still be only three locks"
+        );
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_update_subnet_owner_tie_breaking --exact --show-output
+#[test]
+fn test_update_subnet_owner_tie_breaking() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let current_block = 100;
+        let hotkey1 = U256::from(1);
+        let hotkey2 = U256::from(2);
+        let hotkey3 = U256::from(3);
+        let coldkey1 = U256::from(4);
+        let coldkey2 = U256::from(5);
+        let coldkey3 = U256::from(6);
+
+        // Set up locks with equal convictions
+        let stake_lock = StakeLock {
+            alpha_locked: 1000000,
+            start_block: 0,
+            end_block: current_block + 1000000,
+        };
+        Locks::<Test>::insert((netuid, hotkey1, coldkey1), stake_lock);
+        Locks::<Test>::insert((netuid, hotkey2, coldkey2), stake_lock);
+        Locks::<Test>::insert((netuid, hotkey3, coldkey3), stake_lock);
+
+        // Set up ownership
+        Owner::<Test>::insert(hotkey1, coldkey1);
+        Owner::<Test>::insert(hotkey2, coldkey2);
+        Owner::<Test>::insert(hotkey3, coldkey3);
+
+        // Mock the current block
+        System::set_block_number(current_block);
+
+        // Call the update_subnet_owner function
+        SubtensorModule::update_subnet_owner(netuid, UPDATE_INTERVAL);
+
+        // The expected owner should be the coldkey of the hotkey with the lowest value
+        let expected_owner = coldkey1;
+
+        // Verify that the subnet owner was set correctly
+        assert_eq!(
+            SubnetOwner::<Test>::get(netuid),
+            expected_owner,
+            "Subnet owner should be set to the coldkey of the hotkey with the lowest value"
+        );
+
+        // Verify that the subnet locked amount is correct
+        let conviction1 = SubtensorModule::calculate_conviction(&stake_lock, current_block);
+        assert_eq!(
+            SubnetLocked::<Test>::get(netuid),
+            conviction1 * 3,
+            "Subnet locked amount should match the total calculated conviction"
+        );
+
+        // Verify that no new locks were created
+        assert_eq!(
+            Locks::<Test>::iter().count(),
+            3,
+            "There should still be only three locks"
+        );
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_update_subnet_owner_below_threshold --exact --show-output
+#[test]
+fn test_update_subnet_owner_below_threshold() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let current_block = 100;
+        let hotkey1 = U256::from(1);
+        let hotkey2 = U256::from(2);
+        let coldkey1 = U256::from(3);
+        let coldkey2 = U256::from(4);
+
+        // Set up locks with low conviction scores
+        let stake_lock_1 = StakeLock {
+            alpha_locked: 100,
+            start_block: 0,
+            end_block: current_block + 100,
+        };
+        let stake_lock_2 = StakeLock {
+            alpha_locked: 200,
+            start_block: 0,
+            end_block: current_block + 200,
+        };
+
+        Locks::<Test>::insert((netuid, hotkey1, coldkey1), stake_lock_1);
+        Locks::<Test>::insert((netuid, hotkey2, coldkey2), stake_lock_2);
+
+        // Set up ownership
+        Owner::<Test>::insert(hotkey1, coldkey1);
+        Owner::<Test>::insert(hotkey2, coldkey2);
+
+        // Mock the current block
+        System::set_block_number(current_block);
+
+        // Call the update_subnet_owner function
+        SubtensorModule::update_subnet_owner(netuid, UPDATE_INTERVAL);
+
+        // Verify that no subnet owner was set due to low conviction scores
+        assert!(
+            !SubnetOwner::<Test>::contains_key(netuid),
+            "No subnet owner should be set when all convictions are below the threshold"
+        );
+
+        // Verify that the subnet locked amount is correct (should be the sum of all convictions)
+        let expected_total_conviction =
+            SubtensorModule::calculate_conviction(&stake_lock_1, current_block)
+                + SubtensorModule::calculate_conviction(&stake_lock_2, current_block);
+        assert_eq!(
+            SubnetLocked::<Test>::get(netuid),
+            expected_total_conviction,
+            "Subnet locked amount should match the total calculated conviction"
+        );
+
+        // Verify that no new locks were created
+        assert_eq!(
+            Locks::<Test>::iter().count(),
+            2,
+            "There should still be only two locks"
+        );
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_update_subnet_owner_conviction_calculation --exact --show-output
+#[test]
+fn test_update_subnet_owner_conviction_calculation() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let current_block = 100;
+        let hotkey1 = U256::from(1);
+        let hotkey2 = U256::from(2);
+        let coldkey1 = U256::from(3);
+        let coldkey2 = U256::from(4);
+
+        // Set up locks with different amounts and durations
+        let stake_lock_1 = StakeLock {
+            alpha_locked: 1000000,
+            start_block: 0,
+            end_block: current_block + 1000000,
+        };
+        let stake_lock_2 = StakeLock {
+            alpha_locked: 2000000,
+            start_block: 0,
+            end_block: current_block + 500000,
+        };
+
+        Locks::<Test>::insert((netuid, hotkey1, coldkey1), stake_lock_1);
+        Locks::<Test>::insert((netuid, hotkey2, coldkey2), stake_lock_2);
+
+        // Set up ownership
+        Owner::<Test>::insert(hotkey1, coldkey1);
+        Owner::<Test>::insert(hotkey2, coldkey2);
+
+        // Mock the current block
+        System::set_block_number(current_block);
+
+        // Call the update_subnet_owner function
+        SubtensorModule::update_subnet_owner(netuid, UPDATE_INTERVAL);
+
+        // Calculate expected convictions
+        let conviction1 = SubtensorModule::calculate_conviction(&stake_lock_1, current_block);
+        let conviction2 = SubtensorModule::calculate_conviction(&stake_lock_2, current_block);
+
+        // Verify that the subnet owner is set to the hotkey with the highest conviction
+        if conviction1 > conviction2 {
+            assert_eq!(
+                SubnetOwner::<Test>::get(netuid),
+                coldkey1.clone(),
+                "Subnet owner should be set to coldkey1"
+            );
+        } else {
+            assert_eq!(
+                SubnetOwner::<Test>::get(netuid),
+                coldkey2.clone(),
+                "Subnet owner should be set to coldkey2"
+            );
+        }
+
+        // Verify that the subnet locked amount is correct
+        assert_eq!(
+            SubnetLocked::<Test>::get(netuid),
+            conviction1 + conviction2,
+            "Subnet locked amount should match the highest calculated conviction"
+        );
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_update_subnet_owner_different_subnets --exact --show-output
+#[test]
+fn test_update_subnet_owner_different_subnets() {
+    new_test_ext(1).execute_with(|| {
+        let netuid1 = NetUid::from(1);
+        let netuid2 = NetUid::from(2);
+        let current_block = 100;
+        let hotkey1 = U256::from(1);
+        let hotkey2 = U256::from(2);
+        let coldkey1 = U256::from(3);
+        let coldkey2 = U256::from(4);
+
+        // Set up locks in different subnets
+        let stake_lock_1 = StakeLock {
+            alpha_locked: 1000000,
+            start_block: 0,
+            end_block: current_block + 1000000,
+        };
+        let stake_lock_2 = StakeLock {
+            alpha_locked: 2000000,
+            start_block: 0,
+            end_block: current_block + 500000,
+        };
+
+        Locks::<Test>::insert((netuid1, hotkey1, coldkey1), stake_lock_1);
+        Locks::<Test>::insert((netuid2, hotkey2, coldkey2), stake_lock_2);
+
+        // Set up ownership
+        Owner::<Test>::insert(hotkey1, coldkey1);
+        Owner::<Test>::insert(hotkey2, coldkey2);
+
+        // Mock the current block
+        System::set_block_number(current_block);
+
+        // Call the update_subnet_owner function for netuid1
+        SubtensorModule::update_subnet_owner(netuid1, UPDATE_INTERVAL);
+
+        // Verify that only the lock from netuid1 is considered
+        let conviction1 = SubtensorModule::calculate_conviction(&stake_lock_1, current_block);
+        assert_eq!(
+            SubnetOwner::<Test>::get(netuid1),
+            coldkey1.clone(),
+            "Subnet owner for netuid1 should be set to coldkey1"
+        );
+        assert_eq!(
+            SubnetLocked::<Test>::get(netuid1),
+            conviction1,
+            "Subnet locked amount for netuid1 should match the conviction of its only lock"
+        );
+
+        // Verify that netuid2 is unaffected
+        assert!(
+            !SubnetOwner::<Test>::contains_key(netuid2),
+            "Subnet owner for netuid2 should not be set"
+        );
+        assert_eq!(
+            SubnetLocked::<Test>::get(netuid2),
+            0,
+            "Subnet locked amount for netuid2 should be zero"
+        );
+
+        // Call the update_subnet_owner function for netuid2
+        SubtensorModule::update_subnet_owner(netuid2, UPDATE_INTERVAL);
+
+        // Verify that only the lock from netuid2 is now considered
+        let conviction2 = SubtensorModule::calculate_conviction(&stake_lock_2, current_block);
+        assert_eq!(
+            SubnetOwner::<Test>::get(netuid2),
+            coldkey2.clone(),
+            "Subnet owner for netuid2 should be set to coldkey2"
+        );
+        assert_eq!(
+            SubnetLocked::<Test>::get(netuid2),
+            conviction2,
+            "Subnet locked amount for netuid2 should match the conviction of its only lock"
+        );
+
+        // Verify that netuid1 remains unchanged
+        assert_eq!(
+            SubnetOwner::<Test>::get(netuid1),
+            coldkey1.clone(),
+            "Subnet owner for netuid1 should still be set to coldkey1"
+        );
+        assert_eq!(
+            SubnetLocked::<Test>::get(netuid1),
+            conviction1,
+            "Subnet locked amount for netuid1 should remain unchanged"
+        );
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_update_subnet_owner_large_subnet --exact --show-output
+#[test]
+fn test_update_subnet_owner_large_subnet() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let num_locks = 1500; // Large number of locks
+        let current_block = 100;
+
+        // Create a large number of locks
+        for i in 0..num_locks {
+            let hotkey = U256::from(i);
+            let coldkey = U256::from(i + num_locks);
+            let lock_amount = (i + 1) * 1000; // Varying lock amounts
+            let lock_duration = (i % 10 + 1) * 100; // Varying lock durations
+
+            let stake_lock = StakeLock {
+                alpha_locked: lock_amount,
+                start_block: 0,
+                end_block: current_block + lock_duration,
+            };
+
+            Locks::<Test>::insert((netuid, hotkey, coldkey), stake_lock);
+
+            // Set up ownership
+            Owner::<Test>::insert(hotkey, coldkey);
+        }
+
+        // Mock the current block
+        System::set_block_number(current_block);
+
+        // Measure the time taken to update subnet owner
+        let start_time = std::time::Instant::now();
+        SubtensorModule::update_subnet_owner(netuid, UPDATE_INTERVAL);
+        let duration = start_time.elapsed();
+
+        // Log the time taken
+        println!("Time taken to update subnet owner: {:?}", duration);
+
+        // Verify that a subnet owner was set
+        assert!(
+            SubnetOwner::<Test>::contains_key(netuid),
+            "A subnet owner should be set"
+        );
+
+        // Verify that the subnet locked amount is non-zero
+        assert!(
+            SubnetLocked::<Test>::get(netuid) > 0,
+            "Subnet locked amount should be non-zero"
+        );
+
+        // Verify that the subnet owner has the highest conviction
+        let owner = SubnetOwner::<Test>::get(netuid);
+        let mut max_conviction_ema = 0;
+        for ((iter_netuid, hotkey, coldkey), stake_lock) in Locks::<Test>::iter() {
+            if iter_netuid == netuid {
+                let conviction = SubtensorModule::calculate_conviction(&stake_lock, current_block);
+                let conviction_ema = SubtensorModule::get_conviction_ema(
+                    netuid,
+                    UPDATE_INTERVAL,
+                    conviction,
+                    &hotkey,
+                    &coldkey,
+                );
+
+                if conviction_ema > max_conviction_ema {
+                    max_conviction_ema = conviction_ema;
+                }
+            }
+        }
+        let owner_hotkey = Locks::<Test>::iter()
+            .find(|((_, _, coldkey), _)| *coldkey == owner)
+            .map(|((_, hotkey, _), _)| hotkey)
+            .unwrap();
+        let stake_lock = Locks::<Test>::get((netuid, owner_hotkey, owner));
+        let owner_conviction = SubtensorModule::calculate_conviction(&stake_lock, current_block);
+        let owner_conviction_ema = SubtensorModule::get_conviction_ema(
+            netuid,
+            UPDATE_INTERVAL,
+            owner_conviction,
+            &owner_hotkey,
+            &owner,
+        );
+
+        // Subnet owner should have the highest conviction EMA
+        assert_abs_diff_eq!(owner_conviction_ema, max_conviction_ema, epsilon = 1,);
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_update_subnet_owner_ownership_change --exact --show-output
+#[test]
+fn test_update_subnet_owner_ownership_change() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let hotkey1 = U256::from(1);
+        let coldkey1 = U256::from(2);
+        let hotkey2 = U256::from(3);
+        let coldkey2 = U256::from(4);
+        let initial_block = 100000;
+        let lock_duration = 1000000;
+        let current_block = SubtensorModule::get_current_block_as_u64();
+
+        // Set up initial locks
+        let stake_lock_1 = StakeLock {
+            alpha_locked: 1000000,
+            start_block: 0,
+            end_block: current_block + lock_duration,
+        };
+        let stake_lock_2 = StakeLock {
+            alpha_locked: 500000,
+            start_block: 0,
+            end_block: current_block + lock_duration,
+        };
+
+        Locks::<Test>::insert((netuid, hotkey1, coldkey1), stake_lock_1);
+        Locks::<Test>::insert((netuid, hotkey2, coldkey2), stake_lock_2);
+
+        // Set up ownership
+        Owner::<Test>::insert(hotkey1, coldkey1);
+        Owner::<Test>::insert(hotkey2, coldkey2);
+
+        // Set initial block
+        System::set_block_number(initial_block);
+
+        // Update subnet owner
+        SubtensorModule::update_subnet_owner(netuid, UPDATE_INTERVAL);
+
+        // Check initial subnet owner
+        assert_eq!(
+            SubnetOwner::<Test>::get(netuid),
+            coldkey1.clone(),
+            "Initial subnet owner should be coldkey1"
+        );
+
+        // Simulate time passing and conviction changing
+        let new_block = initial_block + 500000;
+        System::set_block_number(new_block);
+
+        // Increase lock for hotkey2
+        let stake_lock_2_increased = StakeLock {
+            alpha_locked: 2000000,
+            start_block: new_block,
+            end_block: current_block + lock_duration,
+        };
+        Locks::<Test>::insert((netuid, hotkey2, coldkey2), stake_lock_2_increased);
+
+        // Update subnet owner again
+        SubtensorModule::update_subnet_owner(netuid, UPDATE_INTERVAL);
+
+        // Check if subnet owner has changed
+        assert_eq!(
+            SubnetOwner::<Test>::get(netuid),
+            coldkey2.clone(),
+            "Subnet owner should change to coldkey2"
+        );
+
+        // Verify subnet locked amount has increased
+        let subnet_locked = SubnetLocked::<Test>::get(netuid);
+        assert!(subnet_locked > 0, "Subnet locked amount should be non-zero");
+        assert!(
+            subnet_locked > SubtensorModule::calculate_conviction(&stake_lock_1, new_block),
+            "Subnet locked amount should increase"
+        );
+
+        // Simulate more time passing
+        let final_block = new_block + 600000;
+        System::set_block_number(final_block);
+
+        // Update subnet owner one last time
+        SubtensorModule::update_subnet_owner(netuid, UPDATE_INTERVAL);
+
+        // Check if subnet owner remains the same
+        assert_eq!(
+            SubnetOwner::<Test>::get(netuid),
+            coldkey2.clone(),
+            "Subnet owner should still be coldkey2"
+        );
+
+        // Verify subnet locked amount has decreased due to time passing
+        let final_subnet_locked = SubnetLocked::<Test>::get(netuid);
+        assert!(
+            final_subnet_locked < subnet_locked,
+            "Subnet locked amount should decrease over time"
+        );
+    });
+}
+
+// cargo test --package pallet-subtensor --lib -- tests::lock::test_update_subnet_owner_storage_updates --exact --show-output
+#[test]
+fn test_update_subnet_owner_storage_updates() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let hotkey1 = U256::from(1);
+        let coldkey1 = U256::from(2);
+        let hotkey2 = U256::from(3);
+        let coldkey2 = U256::from(4);
+        let initial_block = 100000;
+        let lock_duration = 1000000;
+        let current_block = SubtensorModule::get_current_block_as_u64();
+
+        // Set up initial locks
+        let stake_lock_1 = StakeLock {
+            alpha_locked: 1000000,
+            start_block: 0,
+            end_block: current_block + lock_duration,
+        };
+        let stake_lock_2 = StakeLock {
+            alpha_locked: 500000,
+            start_block: 0,
+            end_block: current_block + lock_duration,
+        };
+
+        Locks::<Test>::insert((netuid, hotkey1, coldkey1), stake_lock_1);
+        Locks::<Test>::insert((netuid, hotkey2, coldkey2), stake_lock_2);
+
+        // Set up ownership
+        Owner::<Test>::insert(hotkey1, coldkey1);
+        Owner::<Test>::insert(hotkey2, coldkey2);
+
+        // Set initial block
+        System::set_block_number(initial_block);
+
+        // Update subnet owner
+        SubtensorModule::update_subnet_owner(netuid, UPDATE_INTERVAL);
+
+        // Check initial subnet owner and locked amount
+        assert_eq!(
+            SubnetOwner::<Test>::get(netuid),
+            coldkey1.clone(),
+            "Initial subnet owner should be coldkey1"
+        );
+        let initial_locked = SubnetLocked::<Test>::get(netuid);
+        assert!(
+            initial_locked > 0,
+            "Initial subnet locked amount should be non-zero"
+        );
+
+        // Simulate time passing and conviction changing
+        let new_block = initial_block + 500000;
+        System::set_block_number(new_block);
+
+        // Increase lock for hotkey2
+        let stake_lock_3 = StakeLock {
+            alpha_locked: 2000000,
+            start_block: 0,
+            end_block: new_block + lock_duration,
+        };
+        Locks::<Test>::insert((netuid, hotkey2, coldkey2), stake_lock_3);
+
+        // Update subnet owner again
+        SubtensorModule::update_subnet_owner(netuid, UPDATE_INTERVAL);
+
+        // Check if subnet owner has changed
+        assert_eq!(
+            SubnetOwner::<Test>::get(netuid),
+            coldkey2.clone(),
+            "Subnet owner should change to coldkey2"
+        );
+
+        // Verify subnet locked amount has increased
+        let new_locked = SubnetLocked::<Test>::get(netuid);
+        assert!(
+            new_locked > initial_locked,
+            "Subnet locked amount should increase"
+        );
+
+        // Simulate more time passing
+        let final_block = new_block + 600000;
+        System::set_block_number(final_block);
+
+        // Update subnet owner one last time
+        SubtensorModule::update_subnet_owner(netuid, UPDATE_INTERVAL);
+
+        // Check if subnet owner remains the same
+        assert_eq!(
+            SubnetOwner::<Test>::get(netuid),
+            coldkey2.clone(),
+            "Subnet owner should still be coldkey2"
+        );
+
+        // Verify subnet locked amount has decreased due to time passing
+        let final_locked = SubnetLocked::<Test>::get(netuid);
+        assert!(
+            final_locked < new_locked,
+            "Subnet locked amount should decrease over time"
+        );
+    });
+}
+
+/// Basic test, EMA starts from zero
+/// cargo test --package pallet-subtensor --lib -- tests::lock::test_conviction_ema_basic --exact --show-output
+#[test]
+fn test_conviction_ema_basic() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let hotkey = U256::from(1);
+        let coldkey = U256::from(2);
+        let update_period = 1_u64;
+        let lock_interval = 2_u64;
+        let conviction_value = 1000_u64;
+
+        ConvictionEma::<Test>::insert((netuid, hotkey, coldkey), 0_u64);
+        LockIntervalBlocks::<Test>::put(lock_interval);
+
+        let ema = SubtensorModule::get_conviction_ema(
+            netuid,
+            update_period,
+            conviction_value,
+            &hotkey,
+            &coldkey,
+        );
+        assert!(ema > 0 && ema < conviction_value);
+    });
+}
+
+/// Non-zero existing EMA
+/// cargo test --package pallet-subtensor --lib -- tests::lock::test_conviction_ema_existing_ema --exact --show-output
+#[test]
+fn test_conviction_ema_existing_ema() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let hotkey = U256::from(1);
+        let coldkey = U256::from(2);
+        let update_period = 1;
+        let lock_interval = 4;
+        let conviction_value = 800;
+
+        ConvictionEma::<Test>::insert((netuid, hotkey, coldkey), 400_u64);
+        LockIntervalBlocks::<Test>::put(lock_interval);
+
+        let ema = SubtensorModule::get_conviction_ema(
+            netuid,
+            update_period,
+            conviction_value,
+            &hotkey,
+            &coldkey,
+        );
+        assert!(ema > 400 && ema < conviction_value);
+    });
+}
+
+/// Update period is zero (no update to EMA)
+/// cargo test --package pallet-subtensor --lib -- tests::lock::test_conviction_ema_zero_update --exact --show-output
+#[test]
+fn test_conviction_ema_zero_update() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let hotkey = U256::from(3);
+        let coldkey = U256::from(4);
+        let update_period = 0;
+        let lock_interval = 10;
+        let conviction_value = 1000;
+
+        ConvictionEma::<Test>::insert((netuid, hotkey, coldkey), 500_u64);
+        LockIntervalBlocks::<Test>::put(lock_interval);
+
+        let ema = SubtensorModule::get_conviction_ema(
+            netuid,
+            update_period,
+            conviction_value,
+            &hotkey,
+            &coldkey,
+        );
+        assert_eq!(ema, 500);
+    });
+}
+
+/// Lock interval is zero (should fallback to zero via safe_div_or)
+/// cargo test --package pallet-subtensor --lib -- tests::lock::test_conviction_ema_zero_lockint --exact --show-output
+#[test]
+fn test_conviction_ema_zero_lockint() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let hotkey = U256::from(5);
+        let coldkey = U256::from(6);
+        let update_period = 1;
+        let lock_interval = 0;
+        let conviction_value = 700;
+
+        ConvictionEma::<Test>::insert((netuid, hotkey, coldkey), 300_u64);
+        LockIntervalBlocks::<Test>::put(lock_interval);
+
+        let ema = SubtensorModule::get_conviction_ema(
+            netuid,
+            update_period,
+            conviction_value,
+            &hotkey,
+            &coldkey,
+        );
+        assert_eq!(ema, conviction_value);
+    });
+}
+
+/// Smoothing factor would be >1, but must be capped at 1.0
+/// cargo test --package pallet-subtensor --lib -- tests::lock::test_conviction_ema_large_update --exact --show-output
+#[test]
+fn test_conviction_ema_large_update() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let hotkey = U256::from(7);
+        let coldkey = U256::from(8);
+        let update_period = 100;
+        let lock_interval = 10;
+        let conviction_value = 900;
+
+        ConvictionEma::<Test>::insert((netuid, hotkey, coldkey), 200_u64);
+        LockIntervalBlocks::<Test>::put(lock_interval);
+
+        let ema = SubtensorModule::get_conviction_ema(
+            netuid,
+            update_period,
+            conviction_value,
+            &hotkey,
+            &coldkey,
+        );
+        assert_eq!(ema, conviction_value);
+    });
+}
+
+/// Conviction is 0 (EMA should decay)
+/// cargo test --package pallet-subtensor --lib -- tests::lock::test_conviction_ema_conviction_0 --exact --show-output
+#[test]
+fn test_conviction_ema_conviction_0() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let hotkey = U256::from(9);
+        let coldkey = U256::from(10);
+        let update_period = 2;
+        let lock_interval = 4;
+        let conviction_value = 0;
+
+        ConvictionEma::<Test>::insert((netuid, hotkey, coldkey), 1000_u64);
+        LockIntervalBlocks::<Test>::put(lock_interval);
+
+        let ema = SubtensorModule::get_conviction_ema(
+            netuid,
+            update_period,
+            conviction_value,
+            &hotkey,
+            &coldkey,
+        );
+        assert!(ema < 1000);
+    });
+}
+
+/// Conviction is max (EMA rises toward it)
+/// cargo test --package pallet-subtensor --lib -- tests::lock::test_conviction_ema_conviction_max --exact --show-output
+#[test]
+fn test_conviction_ema_conviction_max() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let hotkey = U256::from(11);
+        let coldkey = U256::from(12);
+        let update_period = 2;
+        let lock_interval = 4;
+        let conviction_value = u64::MAX;
+
+        ConvictionEma::<Test>::insert((netuid, hotkey, coldkey), 0_u64);
+        LockIntervalBlocks::<Test>::put(lock_interval);
+
+        let ema = SubtensorModule::get_conviction_ema(
+            netuid,
+            update_period,
+            conviction_value,
+            &hotkey,
+            &coldkey,
+        );
+        assert!(ema > 0 && ema < conviction_value);
+    });
+}
+
+/// cargo test --package pallet-subtensor --lib -- tests::lock::test_locks_are_updated_in_block_step --exact --show-output
+#[test]
+fn test_locks_are_updated_in_block_step() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let hotkey = U256::from(1);
+        let coldkey = U256::from(2);
+        let coldkey2 = U256::from(3);
+        let lock_amount = 1000000;
+        let current_block = 216_000; // Triggers locks EMA and subnet owners update 
+        let lock_duration = 1000000;
+        add_network(netuid, 0, 0);
+
+        // Set up a single lock for coldkey2
+        let stake_lock = StakeLock {
+            alpha_locked: lock_amount,
+            start_block: 0,
+            end_block: current_block + lock_duration,
+        };
+        Locks::<Test>::insert((netuid, hotkey, coldkey2), stake_lock);
+
+        // Set up ownership
+        Owner::<Test>::insert(hotkey, coldkey);
+        SubnetOwner::<Test>::set(netuid, coldkey);
+
+        // Cause block step to execute on the update block
+        System::set_block_number(current_block);
+        let _ = SubtensorModule::block_step();
+
+        // Verify that the subnet owner was changed correctly
+        assert_eq!(
+            SubnetOwner::<Test>::get(netuid),
+            coldkey2.clone(),
+            "Subnet owner should be set to the coldkey of the only lock"
+        );
+    });
+}

--- a/pallets/subtensor/src/tests/mod.rs
+++ b/pallets/subtensor/src/tests/mod.rs
@@ -8,6 +8,7 @@ mod emission;
 mod epoch;
 mod evm;
 mod leasing;
+mod lock;
 mod math;
 mod migration;
 mod mock;

--- a/pallets/subtensor/src/tests/serving.rs
+++ b/pallets/subtensor/src/tests/serving.rs
@@ -55,7 +55,7 @@ fn test_serving_subscribe_ok_dispatch_info_ok() {
         assert_eq!(
             call.get_dispatch_info(),
             DispatchInfo {
-                call_weight: frame_support::weights::Weight::from_parts(235_670_000, 0),
+                call_weight: frame_support::weights::Weight::from_parts(249_840_000, 0),
                 extension_weight: frame_support::weights::Weight::zero(),
                 class: DispatchClass::Normal,
                 pays_fee: Pays::No

--- a/pallets/subtensor/src/utils/misc.rs
+++ b/pallets/subtensor/src/utils/misc.rs
@@ -277,18 +277,18 @@ impl<T: Config> Pallet<T> {
         TotalIssuance::<T>::put(TotalIssuance::<T>::get().saturating_add(amount));
     }
 
-    pub fn set_subnet_locked_balance(netuid: NetUid, amount: u64) {
+    pub fn set_subnet_locked_balance(netuid: NetUid, amount: AlphaCurrency) {
         SubnetLocked::<T>::insert(netuid, amount);
     }
-    pub fn get_subnet_locked_balance(netuid: NetUid) -> u64 {
+    pub fn get_subnet_locked_balance(netuid: NetUid) -> AlphaCurrency {
         SubnetLocked::<T>::get(netuid)
     }
-    pub fn get_total_subnet_locked() -> u64 {
+    pub fn get_total_subnet_locked() -> AlphaCurrency {
         let mut total_subnet_locked: u64 = 0;
         for (_, locked) in SubnetLocked::<T>::iter() {
-            total_subnet_locked.saturating_accrue(locked);
+            total_subnet_locked.saturating_accrue(u64::from(locked));
         }
-        total_subnet_locked
+        total_subnet_locked.into()
     }
 
     // ========================

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -218,7 +218,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 294,
+    spec_version: 295,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description

Change subnet owner based on subnet stake lock. Locks are linear with 100% being locked at the start block and 0% on the end block. Any staker can lock their stake. Approximately once per month (7200 * 30 blocks) the lock EMAs are recalculated and, if stake lock EMA is the highest for some account, it becomes the owner of the subnet.

If stake is locked, then only unlocked portion of it can be unstaked at a given block.

In order to prevent subnet sniping, the lock EMA is applied, which gives subnet owner enough warning to act.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
