### PR TITLE
Fix/uniswapv3 lp injection

### DIFF
--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -55,9 +55,6 @@ impl<T: Config> Pallet<T> {
         let mut alpha_out: BTreeMap<NetUid, U96F32> = BTreeMap::new();
         // Only calculate for subnets that we are emitting to.
         for netuid_i in subnets_to_emit_to.iter() {
-            // Get subnet price.
-            let price_i = T::SwapInterface::current_alpha_price((*netuid_i).into());
-            log::debug!("price_i: {:?}", price_i);
             // Get subnet TAO.
             let moving_price_i: U96F32 = Self::get_moving_alpha_price(*netuid_i);
             log::debug!("moving_price_i: {:?}", moving_price_i);
@@ -74,10 +71,8 @@ impl<T: Config> Pallet<T> {
             );
             log::debug!("alpha_emission_i: {:?}", alpha_emission_i);
             // Get initial alpha_in
-            let alpha_in_i: U96F32 = tao_in_i
-                .checked_div(price_i)
-                .unwrap_or(alpha_emission_i)
-                .min(alpha_emission_i);
+            let alpha_in_i: U96F32 =
+                T::SwapInterface::calculate_injected_alpha(NetUid::from(*netuid_i), tao_in_i);
             log::debug!("alpha_in_i: {:?}", alpha_in_i);
             // Get alpha_out.
             let alpha_out_i = alpha_emission_i;

--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -72,7 +72,8 @@ impl<T: Config> Pallet<T> {
             log::debug!("alpha_emission_i: {:?}", alpha_emission_i);
             // Get initial alpha_in
             let alpha_in_i: U96F32 =
-                T::SwapInterface::calculate_injected_alpha(NetUid::from(*netuid_i), tao_in_i);
+                T::SwapInterface::calculate_injected_alpha(NetUid::from(*netuid_i), tao_in_i)
+                    .min(alpha_emission_i);
             log::debug!("alpha_in_i: {:?}", alpha_in_i);
             // Get alpha_out.
             let alpha_out_i = alpha_emission_i;

--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -71,9 +71,14 @@ impl<T: Config> Pallet<T> {
             );
             log::debug!("alpha_emission_i: {:?}", alpha_emission_i);
             // Get initial alpha_in
-            let alpha_in_i: U96F32 =
-                T::SwapInterface::calculate_injected_alpha(NetUid::from(*netuid_i), tao_in_i)
-                    .min(alpha_emission_i);
+            let alpha_per_tao =
+                T::SwapInterface::get_current_alpha_per_tao(NetUid::from(*netuid_i));
+            let alpha_in_i: U96F32 = if alpha_per_tao.saturating_mul(tao_in_i) > alpha_emission_i {
+                tao_in_i = alpha_emission_i.safe_div(alpha_per_tao);
+                alpha_emission_i
+            } else {
+                alpha_per_tao.saturating_mul(tao_in_i)
+            };
             log::debug!("alpha_in_i: {:?}", alpha_in_i);
             // Get alpha_out.
             let alpha_out_i = alpha_emission_i;

--- a/pallets/swap-interface/src/lib.rs
+++ b/pallets/swap-interface/src/lib.rs
@@ -30,6 +30,7 @@ pub trait SwapHandler<AccountId> {
     fn min_price() -> u64;
     fn adjust_protocol_liquidity(netuid: NetUid, tao_delta: u64, alpha_delta: u64);
     fn is_user_liquidity_enabled(netuid: NetUid) -> bool;
+    fn calculate_injected_alpha(netuid: NetUid, tao: U96F32) -> U96F32;
 }
 
 #[derive(Debug, PartialEq)]

--- a/pallets/swap-interface/src/lib.rs
+++ b/pallets/swap-interface/src/lib.rs
@@ -30,7 +30,7 @@ pub trait SwapHandler<AccountId> {
     fn min_price() -> u64;
     fn adjust_protocol_liquidity(netuid: NetUid, tao_delta: u64, alpha_delta: AlphaCurrency);
     fn is_user_liquidity_enabled(netuid: NetUid) -> bool;
-    fn calculate_injected_alpha(netuid: NetUid, tao: U96F32) -> U96F32;
+    fn get_current_alpha_per_tao(netuid: NetUid) -> U96F32;
 }
 
 #[derive(Debug, PartialEq)]

--- a/pallets/swap/src/pallet/impls.rs
+++ b/pallets/swap/src/pallet/impls.rs
@@ -1277,18 +1277,17 @@ impl<T: Config> SwapHandler<T::AccountId> for Pallet<T> {
         EnabledUserLiquidity::<T>::get(netuid)
     }
 
-    fn calculate_injected_alpha(netuid: NetUid, tao: U96F32) -> U96F32 {
-        let tao_fixed = SqrtPrice::saturating_from_num(tao);
+    fn get_current_alpha_per_tao(netuid: NetUid) -> U96F32 {
         let one = SqrtPrice::saturating_from_num(1);
         let sqrt_price_current = Self::current_price_sqrt(netuid.into());
         let sqrt_price_min = TickIndex::min_sqrt_price();
         let sqrt_price_max = TickIndex::max_sqrt_price();
-        let liquidity = tao_fixed.safe_div(sqrt_price_current.saturating_sub(sqrt_price_min));
-        liquidity
-            .saturating_mul(
-                one.safe_div(sqrt_price_current)
-                    .saturating_sub(one.safe_div(sqrt_price_max)),
-            )
+        let price_diff = sqrt_price_current.saturating_sub(sqrt_price_min);
+        let inv_price_diff = one
+            .safe_div(sqrt_price_current)
+            .saturating_sub(one.safe_div(sqrt_price_max));
+        price_diff
+            .saturating_mul(inv_price_diff)
             .saturating_to_num::<U96F32>()
     }
 }

--- a/pallets/swap/src/pallet/impls.rs
+++ b/pallets/swap/src/pallet/impls.rs
@@ -1271,6 +1271,21 @@ impl<T: Config> SwapHandler<T::AccountId> for Pallet<T> {
     fn is_user_liquidity_enabled(netuid: NetUid) -> bool {
         EnabledUserLiquidity::<T>::get(netuid)
     }
+
+    fn calculate_injected_alpha(netuid: NetUid, tao: U96F32) -> U96F32 {
+        let tao_fixed = SqrtPrice::saturating_from_num(tao);
+        let one = SqrtPrice::saturating_from_num(1);
+        let sqrt_price_current = Self::current_price_sqrt(netuid.into());
+        let sqrt_price_min = TickIndex::min_sqrt_price();
+        let sqrt_price_max = TickIndex::max_sqrt_price();
+        let liquidity = tao_fixed.safe_div(sqrt_price_current.saturating_sub(sqrt_price_min));
+        liquidity
+            .saturating_mul(
+                one.safe_div(sqrt_price_current)
+                    .saturating_sub(one.safe_div(sqrt_price_max)),
+            )
+            .saturating_to_num::<U96F32>()
+    }
 }
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
## Description

The proportion that was used previously for calculating how much alpha we need to inject to keep the alpha price does not work for uniswap v3. This is the fix.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
