### PR TITLE
Block-Based Commit-Reveal Weight Masking for Deregistered UIDs

### DIFF
--- a/pallets/subtensor/src/coinbase/reveal_commits.rs
+++ b/pallets/subtensor/src/coinbase/reveal_commits.rs
@@ -34,9 +34,9 @@ impl<T: Config> Pallet<T> {
             cur_epoch.saturating_sub(Self::get_reveal_period(netuid).saturating_sub(1));
 
         // Clean expired commits
-        for (epoch, _) in CRV3WeightCommits::<T>::iter_prefix(netuid) {
+        for (epoch, _) in CRV3WeightCommitsV2::<T>::iter_prefix(netuid) {
             if epoch < reveal_epoch {
-                CRV3WeightCommits::<T>::remove(netuid, epoch);
+                CRV3WeightCommitsV2::<T>::remove(netuid, epoch);
             }
         }
 
@@ -46,7 +46,7 @@ impl<T: Config> Pallet<T> {
             return Ok(());
         }
 
-        let mut entries = CRV3WeightCommits::<T>::take(netuid, reveal_epoch);
+        let mut entries = CRV3WeightCommitsV2::<T>::take(netuid, reveal_epoch);
 
         // Keep popping item off the end of the queue until we sucessfully reveal a commit.
         while let Some((who, _commit_block, serialized_compresssed_commit, round_number)) =

--- a/pallets/subtensor/src/coinbase/reveal_commits.rs
+++ b/pallets/subtensor/src/coinbase/reveal_commits.rs
@@ -49,7 +49,9 @@ impl<T: Config> Pallet<T> {
         let mut entries = CRV3WeightCommits::<T>::take(netuid, reveal_epoch);
 
         // Keep popping item off the end of the queue until we sucessfully reveal a commit.
-        while let Some((who, serialized_compresssed_commit, round_number)) = entries.pop_front() {
+        while let Some((who, _commit_block, serialized_compresssed_commit, round_number)) =
+            entries.pop_front()
+        {
             let reader = &mut &serialized_compresssed_commit[..];
             let commit = match TLECiphertext::<TinyBLS381>::deserialize_compressed(reader) {
                 Ok(c) => c,

--- a/pallets/subtensor/src/epoch/run_epoch.rs
+++ b/pallets/subtensor/src/epoch/run_epoch.rs
@@ -601,7 +601,7 @@ impl<T: Config> Pallet<T> {
             }
 
             // ---------- v3 ------------------------------------------------------
-            for (_epoch, q) in CRV3WeightCommits::<T>::iter_prefix(netuid) {
+            for (_epoch, q) in CRV3WeightCommitsV2::<T>::iter_prefix(netuid) {
                 for (who, cb, ..) in q.iter() {
                     if !Self::is_commit_expired(netuid, *cb) {
                         if let Some(i) = uid_of(who) {

--- a/pallets/subtensor/src/epoch/run_epoch.rs
+++ b/pallets/subtensor/src/epoch/run_epoch.rs
@@ -578,28 +578,49 @@ impl<T: Config> Pallet<T> {
         log::trace!("Weights (permit+diag+outdate): {:?}", &weights);
 
         if Self::get_commit_reveal_weights_enabled(netuid) {
-            // Precompute safe blocks for all UIDs
-            let safe_blocks: Vec<u64> = block_at_registration
-                .iter()
-                .map(|reg_block| {
-                    let reg_epoch = Self::get_epoch_index(netuid, *reg_block);
-                    let safe_epoch =
-                        reg_epoch.saturating_add(Self::get_reveal_period(netuid).saturating_mul(2));
+            let mut commit_blocks: Vec<u64> = vec![u64::MAX; n as usize]; // MAX ⇒ “no active commit”
 
-                    Self::get_first_block_of_epoch(netuid, safe_epoch)
-                })
-                .collect();
+            // helper: hotkey → uid
+            let uid_of = |acct: &T::AccountId| -> Option<usize> {
+                hotkeys
+                    .iter()
+                    .find(|(_, a)| a == acct)
+                    .map(|(uid, _)| *uid as usize)
+            };
 
-            // Mask out weights to recently registered UIDs
+            // ---------- v2 ------------------------------------------------------
+            for (who, q) in WeightCommits::<T>::iter_prefix(netuid) {
+                for (_, cb, _, _) in q.iter() {
+                    if !Self::is_commit_expired(netuid, *cb) {
+                        if let Some(i) = uid_of(&who) {
+                            commit_blocks[i] = commit_blocks[i].min(*cb);
+                        }
+                        break; // earliest active found
+                    }
+                }
+            }
+
+            // ---------- v3 ------------------------------------------------------
+            for (_epoch, q) in CRV3WeightCommits::<T>::iter_prefix(netuid) {
+                for (who, cb, ..) in q.iter() {
+                    if !Self::is_commit_expired(netuid, *cb) {
+                        if let Some(i) = uid_of(who) {
+                            commit_blocks[i] = commit_blocks[i].min(*cb);
+                        }
+                    }
+                }
+            }
+
             weights = vec_mask_sparse_matrix(
                 &weights,
-                &last_update,
-                &safe_blocks,
-                &|updated, safe_block| updated < safe_block,
+                &commit_blocks,
+                &block_at_registration,
+                &|cb, reg| cb < reg,
             );
 
             log::trace!(
-                "Masking weights to miners inside reveal window (recent registrations masked)"
+                "Commit-reveal column mask applied ({} masked rows)",
+                commit_blocks.iter().filter(|&&cb| cb != u64::MAX).count()
             );
         }
 

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1642,15 +1642,17 @@ pub mod pallet {
         OptionQuery,
     >;
     #[pallet::storage]
-    /// --- MAP (netuid, commit_epoch) --> VecDeque<(who, serialized_compressed_commit, reveal_round)> | Stores a queue of v3 commits for an account on a given netuid.
+    /// MAP (netuid, commit_epoch) -> VecDeque<(who, commit_block, serialized_compressed_commit, reveal_round)>
+    /// Stores a queue of v3 commits for an account on a given netuid.
     pub type CRV3WeightCommits<T: Config> = StorageDoubleMap<
         _,
         Twox64Concat,
         NetUid,
         Twox64Concat,
-        u64,
+        u64, // epoch key
         VecDeque<(
             T::AccountId,
+            u64, // commit_block
             BoundedVec<u8, ConstU32<MAX_CRV3_COMMIT_SIZE_BYTES>>,
             RoundNumber,
         )>,

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1647,7 +1647,7 @@ pub mod pallet {
     >;
     #[pallet::storage]
     /// MAP (netuid, epoch) → VecDeque<(who, ciphertext, reveal_round)>
-    /// DEPRICATED for CRV3WeightCommitsV2
+    /// DEPRECATED for CRV3WeightCommitsV2
     pub type CRV3WeightCommits<T: Config> = StorageDoubleMap<
         _,
         Twox64Concat,

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1643,7 +1643,7 @@ pub mod pallet {
     >;
     #[pallet::storage]
     /// MAP (netuid, epoch) → VecDeque<(who, ciphertext, reveal_round)>
-    /// Stores a queue of v3 commits for an account on a given netuid.
+    /// DEPRICATED for CRV3WeightCommitsV2
     pub type CRV3WeightCommits<T: Config> = StorageDoubleMap<
         _,
         Twox64Concat,

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1642,9 +1642,25 @@ pub mod pallet {
         OptionQuery,
     >;
     #[pallet::storage]
-    /// MAP (netuid, commit_epoch) -> VecDeque<(who, commit_block, serialized_compressed_commit, reveal_round)>
+    /// MAP (netuid, epoch) → VecDeque<(who, ciphertext, reveal_round)>
     /// Stores a queue of v3 commits for an account on a given netuid.
     pub type CRV3WeightCommits<T: Config> = StorageDoubleMap<
+        _,
+        Twox64Concat,
+        NetUid,
+        Twox64Concat,
+        u64, // epoch key
+        VecDeque<(
+            T::AccountId,
+            BoundedVec<u8, ConstU32<MAX_CRV3_COMMIT_SIZE_BYTES>>,
+            RoundNumber,
+        )>,
+        ValueQuery,
+    >;
+    #[pallet::storage]
+    /// MAP (netuid, epoch) → VecDeque<(who, commit_block, ciphertext, reveal_round)>
+    /// Stores a queue of v3 commits for an account on a given netuid.
+    pub type CRV3WeightCommitsV2<T: Config> = StorageDoubleMap<
         _,
         Twox64Concat,
         NetUid,

--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -127,7 +127,9 @@ mod hooks {
                 // Migrate Subnet Identities to V3
                 .saturating_add(migrations::migrate_subnet_identities_to_v3::migrate_subnet_identities_to_v3::<T>())
                 // Migrate subnet symbols to fix the shift after subnet 81
-                .saturating_add(migrations::migrate_subnet_symbols::migrate_subnet_symbols::<T>());
+                .saturating_add(migrations::migrate_subnet_symbols::migrate_subnet_symbols::<T>())
+                // Migrate CRV3 add commit_block
+                .saturating_add(migrations::migrate_crv3_commits_add_block::migrate_crv3_commits_add_block::<T>());
             weight
         }
 

--- a/pallets/subtensor/src/migrations/migrate_crv3_commits_add_block.rs
+++ b/pallets/subtensor/src/migrations/migrate_crv3_commits_add_block.rs
@@ -1,0 +1,68 @@
+use super::*;
+use frame_support::{storage_alias, traits::Get, weights::Weight};
+use log;
+use pallet_drand::types::RoundNumber;
+use scale_info::prelude::string::String;
+use sp_core::ConstU32;
+use sp_runtime::BoundedVec;
+use sp_std::collections::vec_deque::VecDeque;
+
+/// ---------- OLD layout (3-tuple, no commit_block) --------------------
+#[storage_alias]
+pub type OldCRV3WeightCommits<T: Config> = StorageDoubleMap<
+    Pallet<T>,
+    Twox64Concat,
+    NetUid,
+    Twox64Concat,
+    u64,
+    VecDeque<(
+        <T as frame_system::Config>::AccountId,
+        BoundedVec<u8, ConstU32<MAX_CRV3_COMMIT_SIZE_BYTES>>,
+        RoundNumber,
+    )>,
+    ValueQuery,
+>;
+
+/// --------------- Migration ------------------------------------------
+/// Upgrades every entry to the new 4-tuple layout by inserting
+/// `commit_block = first_block_of_epoch(netuid, epoch)`.
+pub fn migrate_crv3_commits_add_block<T: Config>() -> Weight {
+    let mig_name: Vec<u8> = b"crv3_commits_add_block_v1".to_vec();
+    let mut total_weight = T::DbWeight::get().reads(1);
+
+    // run once
+    if HasMigrationRun::<T>::get(&mig_name) {
+        log::info!(
+            "Migration '{}' already executed - skipping",
+            String::from_utf8_lossy(&mig_name)
+        );
+        return total_weight;
+    }
+    log::info!("Running migration '{}'", String::from_utf8_lossy(&mig_name));
+
+    // iterate over *all* (netuid, epoch, queue) triples
+    for (netuid, epoch, old_q) in OldCRV3WeightCommits::<T>::drain() {
+        total_weight = total_weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
+
+        let commit_block = Pallet::<T>::get_first_block_of_epoch(netuid, epoch);
+
+        // convert VecDeque<(who,cipher,rnd)> → VecDeque<(who,cb,cipher,rnd)>
+        let new_q: VecDeque<_> = old_q
+            .into_iter()
+            .map(|(who, cipher, rnd)| (who, commit_block, cipher, rnd))
+            .collect();
+
+        // write back under *new* storage definition
+        CRV3WeightCommits::<T>::insert(netuid, epoch, new_q);
+    }
+
+    // mark as done
+    HasMigrationRun::<T>::insert(&mig_name, true);
+    total_weight = total_weight.saturating_add(T::DbWeight::get().writes(1));
+
+    log::info!(
+        "Migration '{}' completed",
+        String::from_utf8_lossy(&mig_name)
+    );
+    total_weight
+}

--- a/pallets/subtensor/src/migrations/mod.rs
+++ b/pallets/subtensor/src/migrations/mod.rs
@@ -8,6 +8,7 @@ pub mod migrate_chain_identity;
 pub mod migrate_coldkey_swap_scheduled;
 pub mod migrate_commit_reveal_v2;
 pub mod migrate_create_root_network;
+pub mod migrate_crv3_commits_add_block;
 pub mod migrate_delete_subnet_21;
 pub mod migrate_delete_subnet_3;
 pub mod migrate_fix_is_network_member;

--- a/pallets/subtensor/src/subnets/weights.rs
+++ b/pallets/subtensor/src/subnets/weights.rs
@@ -274,7 +274,7 @@ impl<T: Config> Pallet<T> {
 
             let unrevealed_commits_for_who = commits
                 .iter()
-                .filter(|(account, _, _)| account == &who)
+                .filter(|(account, _, _, _)| account == &who)
                 .count();
             ensure!(
                 unrevealed_commits_for_who < 10,
@@ -284,7 +284,7 @@ impl<T: Config> Pallet<T> {
             // 7. Append the new commit with calculated reveal blocks.
             // Hash the commit before it is moved, for the event
             let commit_hash = BlakeTwo256::hash(&commit);
-            commits.push_back((who.clone(), commit, reveal_round));
+            commits.push_back((who.clone(), cur_block, commit, reveal_round));
 
             // 8. Emit the WeightsCommitted event
             Self::deposit_event(Event::CRV3WeightsCommitted(

--- a/pallets/subtensor/src/subnets/weights.rs
+++ b/pallets/subtensor/src/subnets/weights.rs
@@ -269,7 +269,7 @@ impl<T: Config> Pallet<T> {
             false => Self::get_epoch_index(netuid, cur_block),
         };
 
-        CRV3WeightCommits::<T>::try_mutate(netuid, cur_epoch, |commits| -> DispatchResult {
+        CRV3WeightCommitsV2::<T>::try_mutate(netuid, cur_epoch, |commits| -> DispatchResult {
             // 6. Verify that the number of unrevealed commits is within the allowed limit.
 
             let unrevealed_commits_for_who = commits

--- a/pallets/subtensor/src/tests/epoch.rs
+++ b/pallets/subtensor/src/tests/epoch.rs
@@ -3541,241 +3541,6 @@ fn test_liquid_alpha_equal_values_against_itself() {
 }
 
 #[test]
-fn test_epoch_masks_first_tempo() {
-    new_test_ext(1).execute_with(|| {
-        let netuid = NetUid::from(4);
-        let tempo: u16 = 50;
-        add_network(netuid, tempo, 0);
-        SubtensorModule::set_reveal_period(netuid, 1);
-        SubtensorModule::set_commit_reveal_weights_enabled(netuid, true);
-
-        /* uid‑0 (old) */
-        let (hot0, cold0) = (U256::from(2), U256::from(22));
-        register_ok_neuron(netuid, hot0, cold0, 0);
-        SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
-            &hot0, &cold0, netuid, 1_000,
-        );
-        run_to_block(tempo as u64 + 1);
-
-        /* uid‑1 (brand new) */
-        let (hot1, cold1) = (U256::from(3), U256::from(23));
-        register_ok_neuron(netuid, hot1, cold1, 0);
-        SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
-            &hot1, &cold1, netuid, 1_000,
-        );
-
-        // WAIT one block so out‑dated rule will _not_ wipe the cell
-        run_to_block(System::block_number() + 1);
-
-        /* uid‑0 votes for uid‑1 */
-        SubtensorModule::set_commit_reveal_weights_enabled(netuid, false);
-        SubtensorModule::set_weights_set_rate_limit(netuid, 0);
-        assert_ok!(SubtensorModule::set_weights(
-            RuntimeOrigin::signed(hot0),
-            netuid,
-            vec![1],
-            vec![u16::MAX],
-            0
-        ));
-        SubtensorModule::set_commit_reveal_weights_enabled(netuid, true);
-
-        /* epoch inside first tempo: uid‑1 must get ZERO reward */
-        SubtensorModule::epoch(netuid, 1_000);
-        assert_eq!(SubtensorModule::get_rank_for_uid(netuid, 1), 0);
-        assert_eq!(SubtensorModule::get_incentive_for_uid(netuid, 1), 0);
-    });
-}
-
-#[test]
-fn test_epoch_masks_full_reveal_window() {
-    new_test_ext(1).execute_with(|| {
-        let netuid = NetUid::from(20);
-        let tempo: u16 = 10;
-        let reveal_period: u16 = 3;
-
-        add_network(netuid, tempo, 0);
-        SubtensorModule::set_reveal_period(netuid, reveal_period as u64);
-        SubtensorModule::set_commit_reveal_weights_enabled(netuid, true);
-
-        let (hot0, cold0) = (U256::from(400), U256::from(440));
-        let (hot1, cold1) = (U256::from(401), U256::from(441));
-        register_ok_neuron(netuid, hot0, cold0, 0);
-        SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
-            &hot0, &cold0, netuid, 1_000,
-        );
-        SubtensorModule::set_validator_permit_for_uid(netuid, 0, true);
-        run_to_block(tempo as u64 + 1);
-
-        register_ok_neuron(netuid, hot1, cold1, 0);
-        SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
-            &hot1, &cold1, netuid, 1_000,
-        );
-        SubtensorModule::set_validator_permit_for_uid(netuid, 1, true);
-        SubtensorModule::set_max_allowed_validators(netuid, 2);
-
-        /* +1 block so out‑dated rule doesn’t trigger */
-        run_to_block(System::block_number() + 1);
-
-        SubtensorModule::set_commit_reveal_weights_enabled(netuid, false);
-        SubtensorModule::set_weights_set_rate_limit(netuid, 0);
-        assert_ok!(SubtensorModule::set_weights(
-            RuntimeOrigin::signed(hot0),
-            netuid,
-            vec![1],
-            vec![u16::MAX],
-            0
-        ));
-        SubtensorModule::set_commit_reveal_weights_enabled(netuid, true);
-
-        /* inside the 2×reveal window uid‑1 must have rank 0 */
-        for _ in 0..(reveal_period * 2) {
-            SubtensorModule::epoch(netuid, 1);
-            assert_eq!(Rank::<Test>::get(netuid)[1], 0);
-            run_to_block(System::block_number() + tempo as u64 + 1);
-        }
-
-        /* boundary + sender refresh ⇒ mask lifts */
-        run_to_block(System::block_number() + tempo as u64 + 1);
-        SubtensorModule::set_commit_reveal_weights_enabled(netuid, false);
-        assert_ok!(SubtensorModule::set_weights(
-            RuntimeOrigin::signed(hot0),
-            netuid,
-            vec![1],
-            vec![u16::MAX],
-            0
-        ));
-        SubtensorModule::set_commit_reveal_weights_enabled(netuid, true);
-
-        SubtensorModule::epoch(netuid, 1);
-        assert!(Rank::<Test>::get(netuid)[1] > 0);
-    });
-}
-
-#[test]
-fn test_epoch_mask_boundary() {
-    new_test_ext(1).execute_with(|| {
-        let netuid = NetUid::from(22);
-        let tempo: u16 = 4;
-        let reveal: u16 = 2;
-
-        add_network(netuid, tempo, 0);
-        SubtensorModule::set_reveal_period(netuid, reveal as u64);
-        SubtensorModule::set_commit_reveal_weights_enabled(netuid, true);
-
-        let (hot0, cold0) = (U256::from(600), U256::from(650));
-        let (hot1, cold1) = (U256::from(601), U256::from(651));
-        register_ok_neuron(netuid, hot0, cold0, 0);
-        SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
-            &hot0, &cold0, netuid, 1_000,
-        );
-        SubtensorModule::set_validator_permit_for_uid(netuid, 0, true);
-        run_to_block(tempo as u64 + 1);
-
-        register_ok_neuron(netuid, hot1, cold1, 0);
-        SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
-            &hot1, &cold1, netuid, 1_000,
-        );
-        SubtensorModule::set_validator_permit_for_uid(netuid, 1, true);
-        SubtensorModule::set_max_allowed_validators(netuid, 2);
-
-        run_to_block(System::block_number() + 1); // avoid out‑dated
-
-        SubtensorModule::set_commit_reveal_weights_enabled(netuid, false);
-        SubtensorModule::set_weights_set_rate_limit(netuid, 0);
-        assert_ok!(SubtensorModule::set_weights(
-            RuntimeOrigin::signed(hot0),
-            netuid,
-            vec![1],
-            vec![u16::MAX],
-            0
-        ));
-        SubtensorModule::set_commit_reveal_weights_enabled(netuid, true);
-
-        /* epoch 0 – masked */
-        SubtensorModule::epoch(netuid, 1);
-        assert_eq!(Rank::<Test>::get(netuid)[1], 0);
-
-        /* advance beyond window */
-        for _ in 0..(reveal * 2 + 1) {
-            run_to_block(System::block_number() + tempo as u64 + 1);
-        }
-
-        /* sender refreshes weights */
-        SubtensorModule::set_commit_reveal_weights_enabled(netuid, false);
-        assert_ok!(SubtensorModule::set_weights(
-            RuntimeOrigin::signed(hot0),
-            netuid,
-            vec![1],
-            vec![u16::MAX],
-            0
-        ));
-        SubtensorModule::set_commit_reveal_weights_enabled(netuid, true);
-
-        SubtensorModule::epoch(netuid, 1);
-        assert!(Rank::<Test>::get(netuid)[1] > 0);
-    });
-}
-
-#[test]
-fn test_epoch_masking_resumes_after_feature_toggle() {
-    new_test_ext(1).execute_with(|| {
-        let netuid = NetUid::from(33);
-        let tempo: u16 = 8;
-        let reveal: u16 = 2;
-
-        add_network(netuid, tempo, 0);
-        SubtensorModule::set_reveal_period(netuid, reveal as u64);
-        SubtensorModule::set_commit_reveal_weights_enabled(netuid, false);
-
-        let (hot0, cold0) = (U256::from(1200), U256::from(1250));
-        register_ok_neuron(netuid, hot0, cold0, 0);
-        SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
-            &hot0, &cold0, netuid, 1_000,
-        );
-        SubtensorModule::set_validator_permit_for_uid(netuid, 0, true);
-
-        SubtensorModule::set_weights_set_rate_limit(netuid, 0);
-        assert_ok!(SubtensorModule::set_weights(
-            RuntimeOrigin::signed(hot0),
-            netuid,
-            vec![0],
-            vec![u16::MAX],
-            0
-        ));
-        run_to_block(System::block_number() + tempo as u64 + 1);
-
-        /* turn CR back on */
-        SubtensorModule::set_commit_reveal_weights_enabled(netuid, true);
-
-        /* new UID‑1 */
-        let (hot1, cold1) = (U256::from(1201), U256::from(1251));
-        register_ok_neuron(netuid, hot1, cold1, 0);
-        SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
-            &hot1, &cold1, netuid, 1_000,
-        );
-
-        run_to_block(System::block_number() + 1); // avoid out‑dated
-
-        SubtensorModule::set_commit_reveal_weights_enabled(netuid, false);
-        assert_ok!(SubtensorModule::set_weights(
-            RuntimeOrigin::signed(hot0),
-            netuid,
-            vec![1],
-            vec![u16::MAX],
-            0
-        ));
-        SubtensorModule::set_commit_reveal_weights_enabled(netuid, true);
-
-        /* uid‑1 must stay masked for two epochs */
-        for _ in 0..reveal {
-            SubtensorModule::epoch(netuid, 1);
-            assert_eq!(SubtensorModule::get_rank_for_uid(netuid, 1), 0);
-            run_to_block(System::block_number() + tempo as u64 + 1);
-        }
-    });
-}
-
-#[test]
 fn test_epoch_masks_incoming_to_sniped_uid_prevents_inheritance() {
     new_test_ext(1).execute_with(|| {
         let netuid = NetUid::from(40);
@@ -3788,7 +3553,7 @@ fn test_epoch_masks_incoming_to_sniped_uid_prevents_inheritance() {
         SubtensorModule::set_max_allowed_uids(netuid, 3);
         SubtensorModule::set_target_registrations_per_interval(netuid, u16::MAX);
 
-        /* validator uid‑0 */
+        /* Validator uid‑0 */
         let (val_hot, val_cold) = (U256::from(100), U256::from(200));
         register_ok_neuron(netuid, val_hot, val_cold, 0);
         SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
@@ -3796,7 +3561,7 @@ fn test_epoch_masks_incoming_to_sniped_uid_prevents_inheritance() {
         );
         SubtensorModule::set_validator_permit_for_uid(netuid, 0, true);
 
-        /* old miner uid‑1 */
+        /* Miner uid‑1 (to be sniped later) */
         let (old_hot, old_cold) = (U256::from(101), U256::from(201));
         register_ok_neuron(netuid, old_hot, old_cold, 0);
         SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
@@ -3813,6 +3578,10 @@ fn test_epoch_masks_incoming_to_sniped_uid_prevents_inheritance() {
 
         run_to_block(tempo as u64 * 2 + 1);
 
+        /* commit, then move one block ahead so reg_block > commit_block */
+        commit_dummy(val_hot, netuid);
+        run_to_block(System::block_number() + 1);
+
         /* validator weights uid‑1 */
         SubtensorModule::set_commit_reveal_weights_enabled(netuid, false);
         SubtensorModule::set_weights_set_rate_limit(netuid, 0);
@@ -3826,18 +3595,15 @@ fn test_epoch_masks_incoming_to_sniped_uid_prevents_inheritance() {
         SubtensorModule::set_commit_reveal_weights_enabled(netuid, true);
         SubtensorModule::epoch(netuid, 1_000);
 
-        /* snipe uid‑1 */
+        /* register new miner (snipes) */
         let (new_hot, new_cold) = (U256::from(103), U256::from(203));
         register_ok_neuron(netuid, new_hot, new_cold, 0);
         SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
             &new_hot, &new_cold, netuid, 10_000,
         );
-        assert_eq!(
-            SubtensorModule::get_uid_for_net_and_hotkey(netuid, &new_hot).unwrap(),
-            1
-        );
+        let new_uid = SubtensorModule::get_uid_for_net_and_hotkey(netuid, &new_hot)
+            .expect("new miner gets UID");
 
-        /* +1 block so out‑dated rule can’t help */
         run_to_block(System::block_number() + 1);
 
         /* validator refreshes vote (still inside window) */
@@ -3845,16 +3611,15 @@ fn test_epoch_masks_incoming_to_sniped_uid_prevents_inheritance() {
         assert_ok!(SubtensorModule::set_weights(
             RuntimeOrigin::signed(val_hot),
             netuid,
-            vec![0, 1],
+            vec![0, new_uid],
             vec![u16::MAX / 2, u16::MAX / 2],
             0
         ));
         SubtensorModule::set_commit_reveal_weights_enabled(netuid, true);
 
-        /* epoch inside window – new uid‑1 must NOT inherit */
         SubtensorModule::epoch(netuid, 1_000);
-        assert_eq!(SubtensorModule::get_rank_for_uid(netuid, 1), 0);
-        assert_eq!(SubtensorModule::get_incentive_for_uid(netuid, 1), 0);
+        assert_eq!(SubtensorModule::get_rank_for_uid(netuid, new_uid), 0);
+        assert_eq!(SubtensorModule::get_incentive_for_uid(netuid, new_uid), 0);
     });
 }
 
@@ -3863,7 +3628,6 @@ fn test_epoch_no_mask_when_commit_reveal_disabled() {
     new_test_ext(1).execute_with(|| {
         let netuid = NetUid::from(32);
         let tempo: u16 = 5;
-
         add_network(netuid, tempo, 0);
         SubtensorModule::set_commit_reveal_weights_enabled(netuid, false);
 
@@ -3891,8 +3655,10 @@ fn test_epoch_no_mask_when_commit_reveal_disabled() {
 
         for _ in 0..3 {
             SubtensorModule::epoch(netuid, 1);
-            let row = SubtensorModule::get_weights_sparse(netuid)[0].clone();
-            assert!(!row.is_empty(), "no mask when CR disabled");
+            assert!(
+                !SubtensorModule::get_weights_sparse(netuid)[0].is_empty(),
+                "row visible when CR disabled"
+            );
             run_to_block(System::block_number() + tempo as u64 + 1);
         }
     });
@@ -3901,16 +3667,16 @@ fn test_epoch_no_mask_when_commit_reveal_disabled() {
 #[test]
 fn test_epoch_does_not_mask_outside_window_but_masks_inside() {
     new_test_ext(1).execute_with(|| {
-        /* network parameters ------------------------------------------------ */
         let netuid = NetUid::from(50);
-        let tempo: u16 = 8; // epoch length
-        let reveal_period: u16 = 2; // mask lasts 2·reveal = 4 epochs
+        let tempo: u16 = 8;
+        let reveal: u16 = 2;
+
         add_network(netuid, tempo, 0);
-        SubtensorModule::set_reveal_period(netuid, reveal_period as u64);
+        SubtensorModule::set_reveal_period(netuid, reveal as u64);
         SubtensorModule::set_commit_reveal_weights_enabled(netuid, true);
         SubtensorModule::set_target_registrations_per_interval(netuid, u16::MAX);
 
-        /* UID‑0 – validator, registered at genesis -------------------------- */
+        /* validator uid‑0 */
         let (v_hot, v_cold) = (U256::from(2000), U256::from(2100));
         register_ok_neuron(netuid, v_hot, v_cold, 0);
         SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
@@ -3919,70 +3685,71 @@ fn test_epoch_does_not_mask_outside_window_but_masks_inside() {
         SubtensorModule::set_validator_permit_for_uid(netuid, 0, true);
         SubtensorModule::set_max_allowed_validators(netuid, 1);
 
-        /* advance one tempo so validator is “old” */
         run_to_block(tempo as u64 + 1);
 
-        /* UID‑1 – old miner: will be OUTSIDE mask window -------------------- */
+        /* first commit */
+        commit_dummy(v_hot, netuid);
+
+        /* UID‑1 — outside window */
         let (old_hot, old_cold) = (U256::from(2001), U256::from(2101));
         register_ok_neuron(netuid, old_hot, old_cold, 0);
         SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
             &old_hot, &old_cold, netuid, 1_000,
         );
 
-        /* advance (2·reveal + 1) epochs so UID‑1 exits the window */
-        for _ in 0..(reveal_period * 2 + 1) {
+        /* let first commit expire for UID‑1 */
+        for _ in 0..(reveal + 1) {
             run_to_block(System::block_number() + tempo as u64 + 1);
         }
 
-        /* UID‑2 – mid miner: still INSIDE window at the tested epoch -------- */
+        /* second commit — will mask UID‑2 & UID‑3 */
+        commit_dummy(v_hot, netuid);
+
+        /* ensure commit_block < reg_block for the new registrations */
+        run_to_block(System::block_number() + 1);
+
+        /* UID‑2, UID‑3 — inside window */
         let (mid_hot, mid_cold) = (U256::from(2002), U256::from(2102));
         register_ok_neuron(netuid, mid_hot, mid_cold, 0);
         SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
             &mid_hot, &mid_cold, netuid, 1_000,
         );
 
-        /* UID‑3 – brand‑new miner: also INSIDE window ----------------------- */
         let (new_hot, new_cold) = (U256::from(2003), U256::from(2103));
         register_ok_neuron(netuid, new_hot, new_cold, 0);
         SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
             &new_hot, &new_cold, netuid, 1_000,
         );
 
-        /* +1 block so the “out‑dated” rule cannot zero any cell on its own */
-        run_to_block(System::block_number() + 1);
+        run_to_block(System::block_number() + 1); // avoid out‑dated
 
-        /* Validator 0 votes equally for all three miners -------------------- */
-        SubtensorModule::set_commit_reveal_weights_enabled(netuid, false); // bypass CR
+        /* vote */
+        SubtensorModule::set_commit_reveal_weights_enabled(netuid, false);
         SubtensorModule::set_weights_set_rate_limit(netuid, 0);
         assert_ok!(SubtensorModule::set_weights(
             RuntimeOrigin::signed(v_hot),
             netuid,
-            vec![1, 2, 3], // target UIDs
+            vec![1, 2, 3],
             vec![u16::MAX / 3, u16::MAX / 3, u16::MAX / 3],
             0
         ));
         SubtensorModule::set_commit_reveal_weights_enabled(netuid, true);
 
-        /* run the tested epoch --------------------------------------------- */
         SubtensorModule::epoch(netuid, 1_000);
 
-        /* ASSERTIONS -------------------------------------------------------- */
-        // UID‑1 (old miner) should be **unmasked**
         assert!(
             SubtensorModule::get_rank_for_uid(netuid, 1) > 0,
-            "UID-1 registered long ago: must NOT be masked"
+            "UID-1 (old) unmasked"
         );
-
-        // UID‑2 and UID‑3 should remain **masked**
         assert_eq!(
             SubtensorModule::get_rank_for_uid(netuid, 2),
             0,
-            "UID-2 is still inside 2xreveal window: must be masked"
+            "UID-2 (inside window) masked"
         );
         assert_eq!(
             SubtensorModule::get_rank_for_uid(netuid, 3),
             0,
-            "UID-3 is brand-new: must be masked"
+            "UID-3 (inside window) masked"
         );
     });
 }

--- a/pallets/subtensor/src/tests/epoch.rs
+++ b/pallets/subtensor/src/tests/epoch.rs
@@ -3590,7 +3590,10 @@ fn test_epoch_masks_incoming_to_sniped_uid_prevents_inheritance() {
         let (val_hot, val_cold) = (U256::from(100), U256::from(200));
         register_ok_neuron(netuid, val_hot, val_cold, 0);
         SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
-            &val_hot, &val_cold, netuid, 10_000,
+            &val_hot,
+            &val_cold,
+            netuid,
+            10_000.into(),
         );
         SubtensorModule::set_validator_permit_for_uid(netuid, 0, true);
 
@@ -3598,14 +3601,20 @@ fn test_epoch_masks_incoming_to_sniped_uid_prevents_inheritance() {
         let (old_hot, old_cold) = (U256::from(101), U256::from(201));
         register_ok_neuron(netuid, old_hot, old_cold, 0);
         SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
-            &old_hot, &old_cold, netuid, 100,
+            &old_hot,
+            &old_cold,
+            netuid,
+            100.into(),
         );
 
         /* filler uid‑2 */
         let (fill_hot, fill_cold) = (U256::from(102), U256::from(202));
         register_ok_neuron(netuid, fill_hot, fill_cold, 0);
         SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
-            &fill_hot, &fill_cold, netuid, 5_000,
+            &fill_hot,
+            &fill_cold,
+            netuid,
+            5_000.into(),
         );
         SubtensorModule::set_max_allowed_validators(netuid, 3);
 
@@ -3626,13 +3635,16 @@ fn test_epoch_masks_incoming_to_sniped_uid_prevents_inheritance() {
             0
         ));
         SubtensorModule::set_commit_reveal_weights_enabled(netuid, true);
-        SubtensorModule::epoch(netuid, 1_000);
+        SubtensorModule::epoch(netuid, 1_000.into());
 
         /* register new miner (snipes) */
         let (new_hot, new_cold) = (U256::from(103), U256::from(203));
         register_ok_neuron(netuid, new_hot, new_cold, 0);
         SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
-            &new_hot, &new_cold, netuid, 10_000,
+            &new_hot,
+            &new_cold,
+            netuid,
+            10_000.into(),
         );
         let new_uid = SubtensorModule::get_uid_for_net_and_hotkey(netuid, &new_hot)
             .expect("new miner gets UID");
@@ -3650,7 +3662,7 @@ fn test_epoch_masks_incoming_to_sniped_uid_prevents_inheritance() {
         ));
         SubtensorModule::set_commit_reveal_weights_enabled(netuid, true);
 
-        SubtensorModule::epoch(netuid, 1_000);
+        SubtensorModule::epoch(netuid, 1_000.into());
         assert_eq!(SubtensorModule::get_rank_for_uid(netuid, new_uid), 0);
         assert_eq!(SubtensorModule::get_incentive_for_uid(netuid, new_uid), 0);
     });
@@ -3667,7 +3679,10 @@ fn test_epoch_no_mask_when_commit_reveal_disabled() {
         let (hot, cold) = (U256::from(1000), U256::from(1100));
         register_ok_neuron(netuid, hot, cold, 0);
         SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
-            &hot, &cold, netuid, 1_000,
+            &hot,
+            &cold,
+            netuid,
+            1_000.into(),
         );
         SubtensorModule::set_validator_permit_for_uid(netuid, 0, true);
 
@@ -3690,7 +3705,7 @@ fn test_epoch_no_mask_when_commit_reveal_disabled() {
         ));
 
         for _ in 0..3 {
-            SubtensorModule::epoch(netuid, 1);
+            SubtensorModule::epoch(netuid, 1.into());
             assert!(
                 !SubtensorModule::get_weights_sparse(netuid)[0].is_empty(),
                 "row visible when CR disabled"
@@ -3716,7 +3731,10 @@ fn test_epoch_does_not_mask_outside_window_but_masks_inside() {
         let (v_hot, v_cold) = (U256::from(2000), U256::from(2100));
         register_ok_neuron(netuid, v_hot, v_cold, 0);
         SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
-            &v_hot, &v_cold, netuid, 10_000,
+            &v_hot,
+            &v_cold,
+            netuid,
+            10_000.into(),
         );
         SubtensorModule::set_validator_permit_for_uid(netuid, 0, true);
         SubtensorModule::set_max_allowed_validators(netuid, 1);
@@ -3730,7 +3748,10 @@ fn test_epoch_does_not_mask_outside_window_but_masks_inside() {
         let (old_hot, old_cold) = (U256::from(2001), U256::from(2101));
         register_ok_neuron(netuid, old_hot, old_cold, 0);
         SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
-            &old_hot, &old_cold, netuid, 1_000,
+            &old_hot,
+            &old_cold,
+            netuid,
+            1_000.into(),
         );
 
         /* let first commit expire for UID‑1 */
@@ -3748,13 +3769,19 @@ fn test_epoch_does_not_mask_outside_window_but_masks_inside() {
         let (mid_hot, mid_cold) = (U256::from(2002), U256::from(2102));
         register_ok_neuron(netuid, mid_hot, mid_cold, 0);
         SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
-            &mid_hot, &mid_cold, netuid, 1_000,
+            &mid_hot,
+            &mid_cold,
+            netuid,
+            1_000.into(),
         );
 
         let (new_hot, new_cold) = (U256::from(2003), U256::from(2103));
         register_ok_neuron(netuid, new_hot, new_cold, 0);
         SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
-            &new_hot, &new_cold, netuid, 1_000,
+            &new_hot,
+            &new_cold,
+            netuid,
+            1_000.into(),
         );
 
         run_to_block(System::block_number() + 1); // avoid out‑dated
@@ -3771,7 +3798,7 @@ fn test_epoch_does_not_mask_outside_window_but_masks_inside() {
         ));
         SubtensorModule::set_commit_reveal_weights_enabled(netuid, true);
 
-        SubtensorModule::epoch(netuid, 1_000);
+        SubtensorModule::epoch(netuid, 1_000.into());
 
         assert!(
             SubtensorModule::get_rank_for_uid(netuid, 1) > 0,

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -13,7 +13,7 @@ use frame_support::{
     weights::Weight,
 };
 
-use crate::migrations::{migrate_crv3_commits_add_block::OldCRV3WeightCommits, migrate_storage};
+use crate::migrations::migrate_storage;
 use frame_system::Config;
 use pallet_drand::types::RoundNumber;
 use scale_info::prelude::collections::VecDeque;
@@ -1020,10 +1020,10 @@ fn test_migrate_crv3_commits_add_block() {
 
         let old_queue: VecDeque<_> = VecDeque::from(vec![(who, ciphertext.clone(), round)]);
 
-        OldCRV3WeightCommits::<Test>::insert(netuid, epoch, old_queue.clone());
+        CRV3WeightCommits::<Test>::insert(netuid, epoch, old_queue.clone());
 
         // Sanity: entry decodes under old alias
-        assert_eq!(OldCRV3WeightCommits::<Test>::get(netuid, epoch), old_queue);
+        assert_eq!(CRV3WeightCommits::<Test>::get(netuid, epoch), old_queue);
 
         assert!(
             !HasMigrationRun::<Test>::get(MIG_NAME.to_vec()),
@@ -1048,11 +1048,11 @@ fn test_migrate_crv3_commits_add_block() {
 
         // Old storage must be empty (drained)
         assert!(
-            OldCRV3WeightCommits::<Test>::get(netuid, epoch).is_empty(),
+            CRV3WeightCommits::<Test>::get(netuid, epoch).is_empty(),
             "old queue should have been drained"
         );
 
-        let new_q = CRV3WeightCommits::<Test>::get(netuid, epoch);
+        let new_q = CRV3WeightCommitsV2::<Test>::get(netuid, epoch);
         assert_eq!(new_q.len(), 1, "exactly one migrated element expected");
 
         let (who2, commit_block, cipher2, round2) = new_q.front().cloned().unwrap();

--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -1047,3 +1047,16 @@ pub(crate) fn last_event() -> RuntimeEvent {
 pub fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
     frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
+
+#[allow(dead_code)]
+pub fn commit_dummy(who: U256, netuid: NetUid) {
+    SubtensorModule::set_weights_set_rate_limit(netuid, 0);
+
+    // any 32‑byte value is fine; hash is never opened
+    let hash = sp_core::H256::from_low_u64_be(0xDEAD_BEEF);
+    assert_ok!(SubtensorModule::do_commit_weights(
+        RuntimeOrigin::signed(who),
+        netuid,
+        hash
+    ));
+}

--- a/pallets/subtensor/src/tests/weights.rs
+++ b/pallets/subtensor/src/tests/weights.rs
@@ -5042,8 +5042,8 @@ fn test_do_commit_crv3_weights_success() {
         let commits = CRV3WeightCommits::<Test>::get(netuid, cur_epoch);
         assert_eq!(commits.len(), 1);
         assert_eq!(commits[0].0, hotkey);
-        assert_eq!(commits[0].1, commit_data);
-        assert_eq!(commits[0].2, reveal_round);
+        assert_eq!(commits[0].2, commit_data);
+        assert_eq!(commits[0].3, reveal_round);
     });
 }
 
@@ -5918,7 +5918,7 @@ fn test_reveal_crv3_commits_removes_past_epoch_commits() {
                 netuid,
                 *epoch,
                 |commits| -> DispatchResult {
-                    commits.push_back((hotkey, bounded_commit_data, reveal_round));
+                    commits.push_back((hotkey, current_block, bounded_commit_data, reveal_round));
                     Ok(())
                 }
             ));

--- a/pallets/subtensor/src/tests/weights.rs
+++ b/pallets/subtensor/src/tests/weights.rs
@@ -5039,7 +5039,7 @@ fn test_do_commit_crv3_weights_success() {
 
         let cur_epoch =
             SubtensorModule::get_epoch_index(netuid, SubtensorModule::get_current_block_as_u64());
-        let commits = CRV3WeightCommits::<Test>::get(netuid, cur_epoch);
+        let commits = CRV3WeightCommitsV2::<Test>::get(netuid, cur_epoch);
         assert_eq!(commits.len(), 1);
         assert_eq!(commits[0].0, hotkey);
         assert_eq!(commits[0].2, commit_data);
@@ -5879,7 +5879,7 @@ fn test_multiple_commits_by_same_hotkey_within_limit() {
 
         let cur_epoch =
             SubtensorModule::get_epoch_index(netuid, SubtensorModule::get_current_block_as_u64());
-        let commits = CRV3WeightCommits::<Test>::get(netuid, cur_epoch);
+        let commits = CRV3WeightCommitsV2::<Test>::get(netuid, cur_epoch);
         assert_eq!(
             commits.len(),
             10,
@@ -5914,7 +5914,7 @@ fn test_reveal_crv3_commits_removes_past_epoch_commits() {
                 .clone()
                 .try_into()
                 .expect("Failed to convert commit data into bounded vector");
-            assert_ok!(CRV3WeightCommits::<Test>::try_mutate(
+            assert_ok!(CRV3WeightCommitsV2::<Test>::try_mutate(
                 netuid,
                 *epoch,
                 |commits| -> DispatchResult {
@@ -5925,7 +5925,7 @@ fn test_reveal_crv3_commits_removes_past_epoch_commits() {
         }
 
         for epoch in &past_epochs {
-            let commits = CRV3WeightCommits::<Test>::get(netuid, *epoch);
+            let commits = CRV3WeightCommitsV2::<Test>::get(netuid, *epoch);
             assert!(
                 !commits.is_empty(),
                 "Expected commits to be present for past epoch {}",
@@ -5936,7 +5936,7 @@ fn test_reveal_crv3_commits_removes_past_epoch_commits() {
         assert_ok!(SubtensorModule::reveal_crv3_commits(netuid));
 
         for epoch in &past_epochs {
-            let commits = CRV3WeightCommits::<Test>::get(netuid, *epoch);
+            let commits = CRV3WeightCommitsV2::<Test>::get(netuid, *epoch);
             assert!(
                 commits.is_empty(),
                 "Expected commits for past epoch {} to be removed",
@@ -5944,7 +5944,7 @@ fn test_reveal_crv3_commits_removes_past_epoch_commits() {
             );
         }
 
-        let current_epoch_commits = CRV3WeightCommits::<Test>::get(netuid, current_epoch);
+        let current_epoch_commits = CRV3WeightCommitsV2::<Test>::get(netuid, current_epoch);
         assert!(
             current_epoch_commits.is_empty(),
             "Expected no commits for current epoch {}",
@@ -6134,7 +6134,7 @@ fn test_reveal_crv3_commits_multiple_valid_commits_all_processed() {
             netuid,
             SubtensorModule::get_current_block_as_u64(),
         );
-        let commits = CRV3WeightCommits::<Test>::get(netuid, cur_epoch);
+        let commits = CRV3WeightCommitsV2::<Test>::get(netuid, cur_epoch);
         assert!(
             commits.is_empty(),
             "Expected no commits left in storage after reveal"
@@ -6321,7 +6321,7 @@ fn test_reveal_crv3_commits_max_neurons() {
             netuid,
             SubtensorModule::get_current_block_as_u64(),
         );
-        let commits = CRV3WeightCommits::<Test>::get(netuid, cur_epoch);
+        let commits = CRV3WeightCommitsV2::<Test>::get(netuid, cur_epoch);
         assert!(
             commits.is_empty(),
             "Expected no commits left in storage after reveal"


### PR DESCRIPTION
## Description
Commit-Block-Based Commit-Reveal Weight Masking for Deregistered UIDs

Weights are masked whenever a validator still has an unrevealed commit whose commit_block predates the target miner’s latest registration block.