### PR TITLE
Fix docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,8 +72,6 @@ services:
       - --no-mdns
       - --bootnodes=/dns/bootnode.test.finney.opentensor.ai/tcp/30333/p2p/12D3KooWPM4mLcKJGtyVtkggqdG84zWrd7Rij6PGQDoijh1X86Vr
       - --sync=warp
-      - --reserved-nodes=/dns/bootnode.test.finney.opentensor.ai/tcp/30333/p2p/12D3KooWPM4mLcKJGtyVtkggqdG84zWrd7Rij6PGQDoijh1X86Vr
-      - --reserved-only
       - --database paritydb
       - --db-cache 4096
       - --trie-cache-size 2048
@@ -91,5 +89,3 @@ services:
       - --no-mdns
       - --bootnodes=/dns/bootnode.test.finney.opentensor.ai/tcp/30333/p2p/12D3KooWPM4mLcKJGtyVtkggqdG84zWrd7Rij6PGQDoijh1X86Vr
       - --pruning=archive
-      - --reserved-nodes=/dns/bootnode.test.finney.opentensor.ai/tcp/30333/p2p/12D3KooWPM4mLcKJGtyVtkggqdG84zWrd7Rij6PGQDoijh1X86Vr
-      - --reserved-only


### PR DESCRIPTION
## Description
This PR removes invalid parameters for testnets from `docker-compose.yml`: 
- reserved-only
- reserved-nodes

These parameters forbid other connections to testnet nodes which is not correct for the regular usage. 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules