### PR TITLE
Fix insufficient liquidity issue

### DIFF
--- a/pallets/subtensor/src/tests/staking.rs
+++ b/pallets/subtensor/src/tests/staking.rs
@@ -763,6 +763,67 @@ fn test_add_stake_insufficient_liquidity() {
     });
 }
 
+/// cargo test --package pallet-subtensor --lib -- tests::staking::test_add_stake_insufficient_liquidity_one_side_ok --exact --show-output
+#[test]
+fn test_add_stake_insufficient_liquidity_one_side_ok() {
+    new_test_ext(1).execute_with(|| {
+        let subnet_owner_coldkey = U256::from(1001);
+        let subnet_owner_hotkey = U256::from(1002);
+        let hotkey = U256::from(2);
+        let coldkey = U256::from(3);
+        let amount_staked = DefaultMinStake::<Test>::get() * 10;
+
+        let netuid = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
+        SubtensorModule::create_account_if_non_existent(&coldkey, &hotkey);
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey, amount_staked);
+
+        // Set the liquidity at lowest possible value so that all staking requests fail
+        let reserve_alpha = u64::from(mock::SwapMinimumReserve::get());
+        let reserve_tao = u64::from(mock::SwapMinimumReserve::get()) - 1;
+        mock::setup_reserves(netuid, reserve_tao, reserve_alpha.into());
+
+        // Check the error
+        assert_ok!(SubtensorModule::add_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            amount_staked
+        ));
+    });
+}
+
+/// cargo test --package pallet-subtensor --lib -- tests::staking::test_add_stake_insufficient_liquidity_one_side_fail --exact --show-output
+#[test]
+fn test_add_stake_insufficient_liquidity_one_side_fail() {
+    new_test_ext(1).execute_with(|| {
+        let subnet_owner_coldkey = U256::from(1001);
+        let subnet_owner_hotkey = U256::from(1002);
+        let hotkey = U256::from(2);
+        let coldkey = U256::from(3);
+        let amount_staked = DefaultMinStake::<Test>::get() * 10;
+
+        let netuid = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
+        SubtensorModule::create_account_if_non_existent(&coldkey, &hotkey);
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey, amount_staked);
+
+        // Set the liquidity at lowest possible value so that all staking requests fail
+        let reserve_alpha = u64::from(mock::SwapMinimumReserve::get()) - 1;
+        let reserve_tao = u64::from(mock::SwapMinimumReserve::get());
+        mock::setup_reserves(netuid, reserve_tao, reserve_alpha.into());
+
+        // Check the error
+        assert_noop!(
+            SubtensorModule::add_stake(
+                RuntimeOrigin::signed(coldkey),
+                hotkey,
+                netuid,
+                amount_staked
+            ),
+            Error::<Test>::InsufficientLiquidity
+        );
+    });
+}
+
 #[test]
 fn test_remove_stake_insufficient_liquidity() {
     new_test_ext(1).execute_with(|| {

--- a/pallets/swap/src/pallet/impls.rs
+++ b/pallets/swap/src/pallet/impls.rs
@@ -465,12 +465,17 @@ impl<T: Config> Pallet<T> {
         limit_sqrt_price: SqrtPrice,
         drop_fees: bool,
     ) -> Result<SwapResult, Error<T>> {
-        ensure!(
-            T::SubnetInfo::tao_reserve(netuid.into()) >= T::MinimumReserve::get().get()
-                && u64::from(T::SubnetInfo::alpha_reserve(netuid.into()))
+        match order_type {
+            OrderType::Buy => ensure!(
+                u64::from(T::SubnetInfo::alpha_reserve(netuid.into()))
                     >= T::MinimumReserve::get().get(),
-            Error::<T>::ReservesTooLow
-        );
+                Error::<T>::ReservesTooLow
+            ),
+            OrderType::Sell => ensure!(
+                T::SubnetInfo::tao_reserve(netuid.into()) >= T::MinimumReserve::get().get(),
+                Error::<T>::ReservesTooLow
+            ),
+        }
 
         Self::maybe_initialize_v3(netuid)?;
 


### PR DESCRIPTION
## Description

Fix insufficient liquidity issue when liquidity is insufficient only on one side (TAO for add_stake and Alpha for remove_stake).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

