### PR TITLE
Fix v3 emissions on low prices

### DIFF
--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -629,6 +629,7 @@ impl<T: Config> Pallet<T> {
         netuid: NetUid,
         tao: u64,
         price_limit: u64,
+        drop_fees: bool,
     ) -> Result<SwapResult, DispatchError> {
         // Step 1: Get the mechanism type for the subnet (0 for Stable, 1 for Dynamic)
         let mechanism_id: u16 = SubnetMechanism::<T>::get(netuid);
@@ -638,7 +639,7 @@ impl<T: Config> Pallet<T> {
                 OrderType::Buy,
                 tao,
                 price_limit,
-                false,
+                drop_fees,
                 false,
             )?;
             let alpha_decrease =
@@ -821,7 +822,7 @@ impl<T: Config> Pallet<T> {
         set_limit: bool,
     ) -> Result<AlphaCurrency, DispatchError> {
         // Swap the tao to alpha.
-        let swap_result = Self::swap_tao_for_alpha(netuid, tao, price_limit)?;
+        let swap_result = Self::swap_tao_for_alpha(netuid, tao, price_limit, false)?;
 
         ensure!(swap_result.amount_paid_out > 0, Error::<T>::AmountTooLow);
 

--- a/pallets/subtensor/src/subnets/registration.rs
+++ b/pallets/subtensor/src/subnets/registration.rs
@@ -141,9 +141,13 @@ impl<T: Config> Pallet<T> {
             Self::remove_balance_from_coldkey_account(&coldkey, registration_cost)?;
 
         // Tokens are swapped and then burned.
-        let burned_alpha =
-            Self::swap_tao_for_alpha(netuid, actual_burn_amount, T::SwapInterface::max_price())?
-                .amount_paid_out;
+        let burned_alpha = Self::swap_tao_for_alpha(
+            netuid,
+            actual_burn_amount,
+            T::SwapInterface::max_price(),
+            false,
+        )?
+        .amount_paid_out;
         SubnetAlphaOut::<T>::mutate(netuid, |total| {
             *total = total.saturating_sub(burned_alpha.into())
         });

--- a/pallets/subtensor/src/tests/children.rs
+++ b/pallets/subtensor/src/tests/children.rs
@@ -3031,6 +3031,7 @@ fn test_parent_child_chain_emission() {
                 netuid,
                 total_tao.to_num::<u64>(),
                 <Test as Config>::SwapInterface::max_price(),
+                false,
             )
             .unwrap()
             .amount_paid_out,

--- a/pallets/subtensor/src/tests/staking.rs
+++ b/pallets/subtensor/src/tests/staking.rs
@@ -565,7 +565,7 @@ fn test_add_stake_partial_below_min_stake_fails() {
         mock::setup_reserves(netuid, amount * 10, (amount * 10).into());
 
         // Force the swap to initialize
-        SubtensorModule::swap_tao_for_alpha(netuid, 0, 1_000_000_000_000).unwrap();
+        SubtensorModule::swap_tao_for_alpha(netuid, 0, 1_000_000_000_000, false).unwrap();
 
         // Get the current price (should be 1.0)
         let current_price =
@@ -3306,7 +3306,7 @@ fn test_max_amount_add_dynamic() {
             SubnetAlphaIn::<Test>::insert(netuid, alpha_in);
 
             // Force the swap to initialize
-            SubtensorModule::swap_tao_for_alpha(netuid, 0, 1_000_000_000_000).unwrap();
+            SubtensorModule::swap_tao_for_alpha(netuid, 0, 1_000_000_000_000, false).unwrap();
 
             if !alpha_in.is_zero() {
                 let expected_price = U96F32::from_num(tao_in) / U96F32::from_num(alpha_in);
@@ -5705,7 +5705,7 @@ fn test_large_swap() {
         pallet_subtensor_swap::EnabledUserLiquidity::<Test>::insert(NetUid::from(netuid), true);
 
         // Force the swap to initialize
-        SubtensorModule::swap_tao_for_alpha(netuid, 0, 1_000_000_000_000).unwrap();
+        SubtensorModule::swap_tao_for_alpha(netuid, 0, 1_000_000_000_000, false).unwrap();
 
         setup_positions(netuid.into());
 

--- a/pallets/subtensor/src/tests/staking2.rs
+++ b/pallets/subtensor/src/tests/staking2.rs
@@ -39,6 +39,7 @@ fn test_stake_base_case() {
                 netuid,
                 tao_to_swap,
                 <Test as Config>::SwapInterface::max_price(),
+                false,
             )
             .unwrap()
             .amount_paid_out,


### PR DESCRIPTION
## Description

When subnet price is low, the blockstep will buy Alpha instead of selling root alpha.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
