### PR TITLE
Subsidized emission: root alpha is being burned

### DIFF
--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -224,6 +224,26 @@ impl<T: Config> Pallet<T> {
                     PendingRootDivs::<T>::mutate(*netuid_i, |total| {
                         *total = total.saturating_add(root_tao);
                     });
+                }         
+                // Accumulate alpha emission in pending.
+                PendingAlphaSwapped::<T>::mutate(*netuid_i, |total| {
+                    *total = total.saturating_add(tou64!(root_alpha).into());
+                });
+                // Accumulate alpha emission in pending.
+                PendingEmission::<T>::mutate(*netuid_i, |total| {
+                    *total = total.saturating_add(tou64!(pending_alpha).into());
+                });
+            }
+            else{
+                //subsidized.  
+                //No emissions to root. Root alpha shifted to PendingEmission
+                //This will push all validator emissions for this block to alpha holders
+                PendingEmission::<T>::mutate(*netuid_i, |total| {
+                    *total = total.saturating_add(tou64!(root_alpha).into());
+                }
+                // Accumulate alpha emission in pending.
+                PendingEmission::<T>::mutate(*netuid_i, |total| {
+                    *total = total.saturating_add(tou64!(pending_alpha).into());
                 }
             }
             // Accumulate alpha emission in pending.


### PR DESCRIPTION
## Description
The chain update on July 29 added a new feature: root emission is disabled when the price is lower that tao emissions.
<img width="1342" height="568" alt="image" src="https://github.com/user-attachments/assets/f31f0ee8-dc3a-40e6-aa33-ba6d20bed2a5" />

The intention appears to have the alpha that was designated for root to be distributed to alpha stakeholders (the full 41% of validator earnings to alpha.)

In the code, it subsidized subnets still have PendingSwapped incremented.  This PendingSwapped is never allocated back to pending_validator_alpha - in fact it is still subtracted.  This results in the root alpha being burned.

The fix is in the if !subsidized call on line 214.

If it is not subsidized (root divs are paid):

PendingAlphaSwapped (alpha that is going to root)  is increased by root_alpha
PendingEmission (alpha to miners & alpha holders) is increased by pending_alpha

if it IS subsidized (no root divs are paid):
PendingEmission (alpha to miners & alpha holders) is increased by root_alpha and by pending_alpha
This pushes all of the root emission and alpha emission to alpha stakeholders.


## Related Issue(s)

- Closes #[issue number]

## Type of Change


- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist



- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.