### PR TITLE
Fix invalid check in `get_stake_fee` runtime call

### DIFF
--- a/pallets/subtensor/src/rpc_info/stake_info.rs
+++ b/pallets/subtensor/src/rpc_info/stake_info.rs
@@ -124,7 +124,8 @@ impl<T: Config> Pallet<T> {
         _destination_coldkey_account: T::AccountId,
         amount: u64,
     ) -> u64 {
-        if destination == origin {
+        // if same subnet, no fee
+        if origin.clone().map(|v| v.1) == destination.clone().map(|v| v.1) {
             0_u64
         } else {
             let netuid = destination.or(origin).map(|v| v.1).unwrap_or_default();


### PR DESCRIPTION
## Description
https://github.com/opentensor/subtensor/blob/c779f4cdc6479248f3f93999a0f3edfd65ea2d0b/pallets/subtensor/src/rpc_info/stake_info.rs#L120-L134

Currently, we check that both the origin/destination netuid and origin/destination hotkey match when only the netuid should be checked.

## Related Issue(s)

- Closes #1907 

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

n/a

## Additional Notes

n/a