### PR TITLE
fix alpha_in emission calculations

### DIFF
--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -84,7 +84,6 @@ impl<T: Config> Pallet<T> {
             );
             if price_i < tao_in_ratio {
                 tao_in_i = price_i.saturating_mul(U96F32::saturating_from_num(block_emission));
-                alpha_in_i = alpha_emission_i;
                 let difference_tao: U96F32 = default_tao_in_i.saturating_sub(tao_in_i);
                 // Difference becomes buy.
                 let buy_swap_result = Self::swap_tao_for_alpha(
@@ -102,9 +101,10 @@ impl<T: Config> Pallet<T> {
                 is_subsidized.insert(*netuid_i, true);
             } else {
                 tao_in_i = default_tao_in_i;
-                alpha_in_i = tao_in_i.safe_div_or(price_i, alpha_emission_i);
                 is_subsidized.insert(*netuid_i, false);
             }
+            
+            alpha_in_i = tao_in_i.safe_div_or(price_i, block_emission);
             log::debug!("alpha_in_i: {:?}", alpha_in_i);
 
             // Get alpha_out.


### PR DESCRIPTION
## Description
This fix aims to fix an issue (#1909) - while also simplifying the codebase.

old line 87 is incorrect.  after the tao halving the alpha_in_i must max out at block_emission (0.5). If 1.0 alpha were emitted, the tao/alpha emission would not be even, causing a liquidity imbalance and a change in price.

modeled in a spreadsheet - at the tao halvings, an incorrect amount of alpha_in is emitted.
<img width="976" height="744" alt="image" src="https://github.com/user-attachments/assets/75e7f27c-8b3c-4d14-872b-e05528be7a43" />
https://docs.google.com/spreadsheets/d/1i4tn0IYaVhvBu8xT1IjiP4U7uuFzsOdD4awjKWckH-k/edit?usp=sharing



we could have changed line 87 to 

```
alpha_in_i = block_emission;
```
to resolve this.

but there is an error in line 105 as well
```
alpha_in_i = tao_in_i.safe_div_or(price_i, alpha_emission_i);
```

This needs to read:
```
alpha_in_i = tao_in_i.safe_div_or(price_i, block_emission);
```
or on a divide by zero, we'll add too much alpha_in into the liquidity pool.


Taking a step back - lets look at line 105 in context of subsidy.
when the subsidy is in place:
`tao_in_i = price_i*block_emission`

so we can rewrite line 105 (removing the safe div for the example:
`alpha_in_i = (tao_in_i)/(price_i)`

to:
`alpha_in_i = (price_i*block_emission)/(price_i)`
canceling the `price_i`
`alpha_in_i = block_emission`

Since line 87 and line 105 both return the same value, 

I added line 107 to account for both options.

alpha_in_i = tao_in_i.safe_div_or(price_i, block_emission);

With the alpha_in_i calcualted in just one place - we simplify the code.

 This also resolves the issue of using alpha_emission_i instead of block_emission.


## Related Issue(s)

- Closes #1909 

## Type of Change


- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

no breaking change.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.