### PR TITLE
Staking jobs with DRAND sorting

### DIFF
--- a/pallets/admin-utils/src/tests/mock.rs
+++ b/pallets/admin-utils/src/tests/mock.rs
@@ -396,6 +396,7 @@ impl pallet_drand::Config for Test {
     type Verifier = pallet_drand::verifier::QuicknetVerifier;
     type UnsignedPriority = ConstU64<{ 1 << 20 }>;
     type HttpFetchTimeout = ConstU64<1_000>;
+    type OnPulseReceived = ();
 }
 
 impl frame_system::offchain::SigningTypes for Test {

--- a/pallets/admin-utils/src/tests/mock.rs
+++ b/pallets/admin-utils/src/tests/mock.rs
@@ -8,6 +8,7 @@ use frame_support::{
 };
 use frame_system::{self as system, offchain::CreateTransactionBase};
 use frame_system::{EnsureNever, EnsureRoot, limits};
+use pallet_subtensor::EvmOriginHelper;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_consensus_grandpa::AuthorityList as GrandpaAuthorityList;
 use sp_core::U256;
@@ -28,7 +29,7 @@ frame_support::construct_runtime!(
         System: frame_system = 1,
         Balances: pallet_balances = 2,
         AdminUtils: crate = 3,
-        SubtensorModule: pallet_subtensor::{Pallet, Call, Storage, Event<T>, Error<T>} = 4,
+        SubtensorModule: pallet_subtensor::{Pallet, Call, Storage, Event<T>, Error<T>, Origin<T>} = 4,
         Scheduler: pallet_scheduler::{Pallet, Call, Storage, Event<T>} = 5,
         Drand: pallet_drand::{Pallet, Call, Storage, Event<T>} = 6,
         Grandpa: pallet_grandpa = 7,
@@ -151,8 +152,15 @@ parameter_types! {
     pub const LeaseDividendsDistributionInterval: u32 = 100; // 100 blocks
 }
 
+impl EvmOriginHelper<RuntimeOrigin, AccountId> for () {
+    fn make_evm_origin(_: AccountId) -> RuntimeOrigin {
+        RuntimeOrigin::none()
+    }
+}
 impl pallet_subtensor::Config for Test {
+    type EvmOriginHelper = ();
     type RuntimeEvent = RuntimeEvent;
+    type RuntimeOrigin = RuntimeOrigin;
     type RuntimeCall = RuntimeCall;
     type Currency = Balances;
     type InitialIssuance = InitialIssuance;

--- a/pallets/commitments/src/mock.rs
+++ b/pallets/commitments/src/mock.rs
@@ -123,6 +123,7 @@ impl pallet_drand::Config for Test {
     type Verifier = pallet_drand::verifier::QuicknetVerifier;
     type UnsignedPriority = ConstU64<{ 1 << 20 }>;
     type HttpFetchTimeout = ConstU64<1_000>;
+    type OnPulseReceived = ();
 }
 
 pub mod test_crypto {

--- a/pallets/drand/src/mock.rs
+++ b/pallets/drand/src/mock.rs
@@ -102,6 +102,7 @@ impl pallet_drand_bridge::Config for Test {
     type Verifier = QuicknetVerifier;
     type UnsignedPriority = UnsignedPriority;
     type HttpFetchTimeout = ConstU64<1_000>;
+    type OnPulseReceived = ();
 }
 
 // Build genesis storage according to the mock runtime.

--- a/pallets/subtensor/src/benchmarks.rs
+++ b/pallets/subtensor/src/benchmarks.rs
@@ -1738,4 +1738,60 @@ mod pallet_benchmarks {
         #[extrinsic_call]
         _(RawOrigin::Signed(coldkey.clone()), hotkey.clone(), netuid, amount_unstaked.into())
     }
+
+    #[benchmark]
+    fn remove_stake_full_limit_aggregate() {
+        let netuid = NetUid::from(1);
+        let tempo: u16 = 1;
+        let seed: u32 = 1;
+
+        // Set our total stake to 1000 TAO
+        Subtensor::<T>::increase_total_stake(1_000_000_000_000);
+
+        Subtensor::<T>::init_new_network(netuid, tempo);
+        Subtensor::<T>::set_network_registration_allowed(netuid, true);
+        SubtokenEnabled::<T>::insert(netuid, true);
+
+        Subtensor::<T>::set_max_allowed_uids(netuid, 4096);
+        assert_eq!(Subtensor::<T>::get_max_allowed_uids(netuid), 4096);
+
+        let coldkey: T::AccountId = account("Test", 0, seed);
+        let hotkey: T::AccountId = account("Alice", 0, seed);
+        Subtensor::<T>::set_burn(netuid, 1);
+
+        let limit: u64 = 1_000_000_000;
+        let tao_reserve = 150_000_000_000_u64;
+        let alpha_in = AlphaCurrency::from(100_000_000_000);
+        SubnetTAO::<T>::insert(netuid, tao_reserve);
+        SubnetAlphaIn::<T>::insert(netuid, alpha_in);
+
+        let wallet_bal = 1000000u32.into();
+        Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), wallet_bal);
+
+        assert_ok!(Subtensor::<T>::do_burned_registration(
+            RawOrigin::Signed(coldkey.clone()).into(),
+            netuid,
+            hotkey.clone()
+        ));
+
+        let u64_staked_amt = 100_000_000_000;
+        Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), u64_staked_amt);
+
+        assert_ok!(Subtensor::<T>::add_stake(
+            RawOrigin::Signed(coldkey.clone()).into(),
+            hotkey.clone(),
+            netuid,
+            u64_staked_amt
+        ));
+
+        StakingOperationRateLimiter::<T>::remove((hotkey.clone(), coldkey.clone(), netuid));
+
+        #[extrinsic_call]
+        _(
+            RawOrigin::Signed(coldkey.clone()),
+            hotkey.clone(),
+            netuid,
+            Some(limit),
+        );
+    }
 }

--- a/pallets/subtensor/src/benchmarks.rs
+++ b/pallets/subtensor/src/benchmarks.rs
@@ -1892,7 +1892,7 @@ mod pallet_benchmarks {
             alpha_to_move,
         );
     }
-    
+
     #[benchmark]
     fn transfer_stake_aggregate() {
         let coldkey: T::AccountId = whitelisted_caller();

--- a/pallets/subtensor/src/benchmarks.rs
+++ b/pallets/subtensor/src/benchmarks.rs
@@ -1598,4 +1598,144 @@ mod pallet_benchmarks {
 
         assert_eq!(TokenSymbol::<T>::get(netuid), new_symbol);
     }
+
+    #[benchmark]
+    fn add_stake_aggregate() {
+        let netuid: NetUid = 1u16.into();
+        let tempo: u16 = 1;
+        let seed: u32 = 1;
+
+        Subtensor::<T>::init_new_network(netuid, tempo);
+        Subtensor::<T>::set_burn(netuid, 1);
+        Subtensor::<T>::set_network_registration_allowed(netuid, true);
+        SubtokenEnabled::<T>::insert(netuid, true);
+        Subtensor::<T>::set_max_allowed_uids(netuid, 4096);
+        assert_eq!(Subtensor::<T>::get_max_allowed_uids(netuid), 4096);
+
+        let coldkey: T::AccountId = account("Test", 0, seed);
+        let hotkey: T::AccountId = account("Alice", 0, seed);
+
+        let amount: u64 = 6000000;
+        let amount_to_be_staked = 1000000000u64;
+        Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), amount_to_be_staked);
+
+        assert_ok!(Subtensor::<T>::do_burned_registration(RawOrigin::Signed(coldkey.clone()).into(), netuid, hotkey.clone()));
+
+        #[extrinsic_call]
+        _(RawOrigin::Signed( coldkey.clone() ), hotkey, netuid, amount);
+    }
+    
+    #[benchmark]
+    fn add_stake_limit_aggregate() {
+        let netuid: NetUid = 1u16.into();
+        let tempo: u16 = 1;
+        let seed: u32 = 1;
+    
+        Subtensor::<T>::init_new_network(netuid, tempo);
+        Subtensor::<T>::set_burn(netuid, 1);
+        Subtensor::<T>::set_network_registration_allowed(netuid, true);
+        Subtensor::<T>::set_max_allowed_uids(netuid, 4096);
+        SubtokenEnabled::<T>::insert(netuid, true);
+    
+        let coldkey: T::AccountId = account("Test", 0, seed);
+        let hotkey: T::AccountId = account("Alice", 0, seed);
+    
+        let amount = 900_000_000_000;
+        let limit: u64 = 6_000_000_000;
+        let amount_to_be_staked = 440_000_000_000;
+        Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), amount);
+    
+        let tao_reserve = 150_000_000_000_u64;
+        let alpha_in: AlphaCurrency = 100_000_000_000_u64.into();
+        SubnetTAO::<T>::insert(netuid, tao_reserve);
+        SubnetAlphaIn::<T>::insert(netuid, alpha_in);
+    
+        assert_ok!(Subtensor::<T>::do_burned_registration(RawOrigin::Signed(coldkey.clone()).into(), netuid, hotkey.clone()));
+    
+        #[extrinsic_call]
+        _(RawOrigin::Signed( coldkey.clone() ), hotkey, netuid, amount_to_be_staked, limit, false)
+    }
+
+    #[benchmark]
+    fn remove_stake_limit_aggregate() {
+        let netuid: NetUid = 1u16.into();
+        let tempo: u16 = 1;
+        let seed: u32 = 1;
+
+        // Set our total stake to 1000 TAO
+        Subtensor::<T>::increase_total_stake(1_000_000_000_000);
+
+        Subtensor::<T>::init_new_network(netuid, tempo);
+        Subtensor::<T>::set_network_registration_allowed(netuid, true);
+        SubtokenEnabled::<T>::insert(netuid, true);
+        Subtensor::<T>::set_max_allowed_uids(netuid, 4096);
+        assert_eq!(Subtensor::<T>::get_max_allowed_uids(netuid), 4096);
+
+        let coldkey: T::AccountId = account("Test", 0, seed);
+        let hotkey: T::AccountId = account("Alice", 0, seed);
+        Subtensor::<T>::set_burn(netuid, 1);
+
+        let limit: u64 = 1_000_000_000;
+        let tao_reserve = 150_000_000_000_u64;
+        let alpha_in: AlphaCurrency = 100_000_000_000_u64.into();
+        SubnetTAO::<T>::insert(netuid, tao_reserve);
+        SubnetAlphaIn::<T>::insert(netuid, alpha_in);
+
+        let wallet_bal = 1000000u32.into();
+        Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), wallet_bal);
+
+        assert_ok!(Subtensor::<T>::do_burned_registration(RawOrigin::Signed(coldkey.clone()).into(), netuid, hotkey.clone()));
+
+        let u64_staked_amt = 100_000_000_000;
+        Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), u64_staked_amt);
+
+        assert_ok!(Subtensor::<T>::add_stake(RawOrigin::Signed( coldkey.clone() ).into() , hotkey.clone(), netuid, u64_staked_amt));
+
+        let amount_unstaked: u64 = 30_000_000_000;
+
+        // Remove stake limit for benchmark
+        StakingOperationRateLimiter::<T>::remove((hotkey.clone(), coldkey.clone(), netuid));
+     
+        #[extrinsic_call]
+        _(RawOrigin::Signed(coldkey.clone()), hotkey.clone(), netuid, amount_unstaked.into(), limit, false)
+    }
+
+    #[benchmark]
+    fn remove_stake_aggregate() {
+        let netuid: NetUid = 1u16.into();
+        let tempo: u16 = 1;
+        let seed: u32 = 1;
+
+        // Set our total stake to 1000 TAO
+        Subtensor::<T>::increase_total_stake(1_000_000_000_000);
+
+        Subtensor::<T>::init_new_network(netuid, tempo);
+        Subtensor::<T>::set_network_registration_allowed(netuid, true);
+        SubtokenEnabled::<T>::insert(netuid, true);
+        Subtensor::<T>::set_max_allowed_uids(netuid, 4096);
+        assert_eq!(Subtensor::<T>::get_max_allowed_uids(netuid), 4096);
+
+        let coldkey: T::AccountId = account("Test", 0, seed);
+        let hotkey: T::AccountId = account("Alice", 0, seed);
+        Subtensor::<T>::set_burn(netuid, 1);
+
+        let wallet_bal = 1000000u32.into();
+        Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), wallet_bal);
+
+        assert_ok!(Subtensor::<T>::do_burned_registration(RawOrigin::Signed(coldkey.clone()).into(), netuid, hotkey.clone()));
+
+        // Stake 10% of our current total staked TAO
+        let u64_staked_amt = 100_000_000_000;
+        Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), u64_staked_amt);
+
+        assert_ok!( Subtensor::<T>::add_stake(RawOrigin::Signed( coldkey.clone() ).into() , hotkey.clone(), netuid, u64_staked_amt));
+
+        let amount_unstaked: u64 = 600000;
+
+        // Remove stake limit for benchmark
+        StakingOperationRateLimiter::<T>::remove((hotkey.clone(), coldkey.clone(), netuid));
+
+        #[extrinsic_call]
+        _(RawOrigin::Signed(coldkey.clone()), hotkey.clone(), netuid, amount_unstaked.into())
+    }
 }

--- a/pallets/subtensor/src/benchmarks.rs
+++ b/pallets/subtensor/src/benchmarks.rs
@@ -1619,41 +1619,56 @@ mod pallet_benchmarks {
         let amount_to_be_staked = 1000000000u64;
         Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), amount_to_be_staked);
 
-        assert_ok!(Subtensor::<T>::do_burned_registration(RawOrigin::Signed(coldkey.clone()).into(), netuid, hotkey.clone()));
+        assert_ok!(Subtensor::<T>::do_burned_registration(
+            RawOrigin::Signed(coldkey.clone()).into(),
+            netuid,
+            hotkey.clone()
+        ));
 
         #[extrinsic_call]
-        _(RawOrigin::Signed( coldkey.clone() ), hotkey, netuid, amount);
+        _(RawOrigin::Signed(coldkey.clone()), hotkey, netuid, amount);
     }
-    
+
     #[benchmark]
     fn add_stake_limit_aggregate() {
         let netuid: NetUid = 1u16.into();
         let tempo: u16 = 1;
         let seed: u32 = 1;
-    
+
         Subtensor::<T>::init_new_network(netuid, tempo);
         Subtensor::<T>::set_burn(netuid, 1);
         Subtensor::<T>::set_network_registration_allowed(netuid, true);
         Subtensor::<T>::set_max_allowed_uids(netuid, 4096);
         SubtokenEnabled::<T>::insert(netuid, true);
-    
+
         let coldkey: T::AccountId = account("Test", 0, seed);
         let hotkey: T::AccountId = account("Alice", 0, seed);
-    
+
         let amount = 900_000_000_000;
         let limit: u64 = 6_000_000_000;
         let amount_to_be_staked = 440_000_000_000;
         Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), amount);
-    
+
         let tao_reserve = 150_000_000_000_u64;
         let alpha_in: AlphaCurrency = 100_000_000_000_u64.into();
         SubnetTAO::<T>::insert(netuid, tao_reserve);
         SubnetAlphaIn::<T>::insert(netuid, alpha_in);
-    
-        assert_ok!(Subtensor::<T>::do_burned_registration(RawOrigin::Signed(coldkey.clone()).into(), netuid, hotkey.clone()));
-    
+
+        assert_ok!(Subtensor::<T>::do_burned_registration(
+            RawOrigin::Signed(coldkey.clone()).into(),
+            netuid,
+            hotkey.clone()
+        ));
+
         #[extrinsic_call]
-        _(RawOrigin::Signed( coldkey.clone() ), hotkey, netuid, amount_to_be_staked, limit, false)
+        _(
+            RawOrigin::Signed(coldkey.clone()),
+            hotkey,
+            netuid,
+            amount_to_be_staked,
+            limit,
+            false,
+        )
     }
 
     #[benchmark]
@@ -1684,20 +1699,36 @@ mod pallet_benchmarks {
         let wallet_bal = 1000000u32.into();
         Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), wallet_bal);
 
-        assert_ok!(Subtensor::<T>::do_burned_registration(RawOrigin::Signed(coldkey.clone()).into(), netuid, hotkey.clone()));
+        assert_ok!(Subtensor::<T>::do_burned_registration(
+            RawOrigin::Signed(coldkey.clone()).into(),
+            netuid,
+            hotkey.clone()
+        ));
 
         let u64_staked_amt = 100_000_000_000;
         Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), u64_staked_amt);
 
-        assert_ok!(Subtensor::<T>::add_stake(RawOrigin::Signed( coldkey.clone() ).into() , hotkey.clone(), netuid, u64_staked_amt));
+        assert_ok!(Subtensor::<T>::add_stake(
+            RawOrigin::Signed(coldkey.clone()).into(),
+            hotkey.clone(),
+            netuid,
+            u64_staked_amt
+        ));
 
         let amount_unstaked: u64 = 30_000_000_000;
 
         // Remove stake limit for benchmark
         StakingOperationRateLimiter::<T>::remove((hotkey.clone(), coldkey.clone(), netuid));
-     
+
         #[extrinsic_call]
-        _(RawOrigin::Signed(coldkey.clone()), hotkey.clone(), netuid, amount_unstaked.into(), limit, false)
+        _(
+            RawOrigin::Signed(coldkey.clone()),
+            hotkey.clone(),
+            netuid,
+            amount_unstaked.into(),
+            limit,
+            false,
+        )
     }
 
     #[benchmark]
@@ -1722,13 +1753,22 @@ mod pallet_benchmarks {
         let wallet_bal = 1000000u32.into();
         Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), wallet_bal);
 
-        assert_ok!(Subtensor::<T>::do_burned_registration(RawOrigin::Signed(coldkey.clone()).into(), netuid, hotkey.clone()));
+        assert_ok!(Subtensor::<T>::do_burned_registration(
+            RawOrigin::Signed(coldkey.clone()).into(),
+            netuid,
+            hotkey.clone()
+        ));
 
         // Stake 10% of our current total staked TAO
         let u64_staked_amt = 100_000_000_000;
         Subtensor::<T>::add_balance_to_coldkey_account(&coldkey.clone(), u64_staked_amt);
 
-        assert_ok!( Subtensor::<T>::add_stake(RawOrigin::Signed( coldkey.clone() ).into() , hotkey.clone(), netuid, u64_staked_amt));
+        assert_ok!(Subtensor::<T>::add_stake(
+            RawOrigin::Signed(coldkey.clone()).into(),
+            hotkey.clone(),
+            netuid,
+            u64_staked_amt
+        ));
 
         let amount_unstaked: u64 = 600000;
 
@@ -1736,7 +1776,12 @@ mod pallet_benchmarks {
         StakingOperationRateLimiter::<T>::remove((hotkey.clone(), coldkey.clone(), netuid));
 
         #[extrinsic_call]
-        _(RawOrigin::Signed(coldkey.clone()), hotkey.clone(), netuid, amount_unstaked.into())
+        _(
+            RawOrigin::Signed(coldkey.clone()),
+            hotkey.clone(),
+            netuid,
+            amount_unstaked.into(),
+        )
     }
 
     #[benchmark]

--- a/pallets/subtensor/src/benchmarks.rs
+++ b/pallets/subtensor/src/benchmarks.rs
@@ -508,7 +508,7 @@ mod pallet_benchmarks {
         let block_number: u64 = Subtensor::<T>::get_current_block_as_u64();
         let (nonce, work) =
             Subtensor::<T>::create_work_for_block_number(netuid, block_number, 3, &hotkey);
-        let origin = T::RuntimeOrigin::from(RawOrigin::Signed(hotkey.clone()));
+        let origin = OriginFor::<T>::from(RawOrigin::Signed(hotkey.clone()));
         assert_ok!(Subtensor::<T>::register(
             origin.clone(),
             netuid,

--- a/pallets/subtensor/src/coinbase/reveal_commits.rs
+++ b/pallets/subtensor/src/coinbase/reveal_commits.rs
@@ -133,7 +133,7 @@ impl<T: Config> Pallet<T> {
             };
 
             if let Err(e) = Self::do_set_weights(
-                T::RuntimeOrigin::signed(who.clone()),
+                OriginFor::<T>::signed(who.clone()),
                 netuid,
                 payload.uids,
                 payload.values,

--- a/pallets/subtensor/src/coinbase/root.rs
+++ b/pallets/subtensor/src/coinbase/root.rs
@@ -82,7 +82,7 @@ impl<T: Config> Pallet<T> {
     /// # Returns:
     /// * 'DispatchResult': A result type indicating success or failure of the registration.
     ///
-    pub fn do_root_register(origin: T::RuntimeOrigin, hotkey: T::AccountId) -> DispatchResult {
+    pub fn do_root_register(origin: OriginFor<T>, hotkey: T::AccountId) -> DispatchResult {
         // --- 0. Get the unique identifier (UID) for the root network.
         let current_block_number: u64 = Self::get_current_block_as_u64();
         ensure!(
@@ -218,7 +218,7 @@ impl<T: Config> Pallet<T> {
     // # Returns:
     // * 'DispatchResult': A result type indicating success or failure of the registration.
     //
-    pub fn do_adjust_senate(origin: T::RuntimeOrigin, hotkey: T::AccountId) -> DispatchResult {
+    pub fn do_adjust_senate(origin: OriginFor<T>, hotkey: T::AccountId) -> DispatchResult {
         ensure!(
             Self::if_subnet_exist(NetUid::ROOT),
             Error::<T>::RootNetworkDoesNotExist
@@ -325,7 +325,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn do_vote_root(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         hotkey: &T::AccountId,
         proposal: T::Hash,
         index: u32,
@@ -373,7 +373,7 @@ impl<T: Config> Pallet<T> {
     /// Facilitates the removal of a user's subnetwork.
     ///
     /// # Args:
-    /// * 'origin': ('T::RuntimeOrigin'): The calling origin. Must be signed.
+    /// * 'origin': ('OriginFor<T>'): The calling origin. Must be signed.
     /// * 'netuid': ('u16'): The unique identifier of the network to be removed.
     ///
     /// # Event:

--- a/pallets/subtensor/src/epoch/run_epoch.rs
+++ b/pallets/subtensor/src/epoch/run_epoch.rs
@@ -1375,7 +1375,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn do_set_alpha_values(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         netuid: NetUid,
         alpha_low: u16,
         alpha_high: u16,

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -373,6 +373,21 @@ pub mod pallet {
             /// Hotkey account
             hotkey: AccountId,
         },
+        /// Represents a job for "move_stake" operation
+        MoveStake {
+            /// Coldkey account
+            coldkey: AccountId,
+            /// Origin hotkey account
+            origin_hotkey: AccountId,
+            /// Destination hotkey account
+            destination_hotkey: AccountId,
+            /// Origin subnet UID
+            origin_netuid: NetUid,
+            /// Destination subnet UID
+            destination_netuid: NetUid,
+            /// Alpha
+            alpha_amount: AlphaCurrency,
+        },
     }
 
     impl<AccountId: Clone> StakeJob<AccountId> {
@@ -385,6 +400,7 @@ pub mod pallet {
                 StakeJob::RemoveStakeLimit { coldkey, .. } => coldkey.clone(),
                 StakeJob::UnstakeAll { coldkey, .. } => coldkey.clone(),
                 StakeJob::UnstakeAllAlpha { coldkey, .. } => coldkey.clone(),
+                StakeJob::MoveStake { coldkey, .. } => coldkey.clone(),
             }
         }
     }

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -448,6 +448,24 @@ pub mod pallet {
             destination_netuid: NetUid,
             /// Alpha
             alpha_amount: AlphaCurrency,
+        },        
+        /// Represents a job for "swap_stake_limit" operation
+        SwapStakeLimit {
+            /// Coldkey account
+            coldkey: AccountId,
+            /// Hotkey account
+            hotkey: AccountId,
+            /// Origin subnet UID
+            origin_netuid: NetUid,
+            /// Destination subnet UID
+            destination_netuid: NetUid,
+            /// Alpha
+            alpha_amount: AlphaCurrency,
+            /// The limit price
+            limit_price: u64,
+            /// Allows partial execution of the amount. If set to false, this becomes
+            /// fill or kill type or order.
+            allow_partial: bool,
         },
     }
 
@@ -464,6 +482,7 @@ pub mod pallet {
                 StakeJob::MoveStake { coldkey, .. } => coldkey.clone(),
                 StakeJob::TransferStake { origin_coldkey, .. } => origin_coldkey.clone(),
                 StakeJob::SwapStake { coldkey, .. } => coldkey.clone(),
+                StakeJob::SwapStakeLimit { coldkey, .. } => coldkey.clone(),
             }
         }
     }

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -403,6 +403,19 @@ pub mod pallet {
             /// Alpha
             alpha_amount: AlphaCurrency,
         },
+        /// Represents a job for "swap_stake" operation
+        SwapStake {
+            /// Coldkey account
+            coldkey: AccountId,
+            /// Hotkey account
+            hotkey: AccountId,
+            /// Origin subnet UID
+            origin_netuid: NetUid,
+            /// Destination subnet UID
+            destination_netuid: NetUid,
+            /// Alpha
+            alpha_amount: AlphaCurrency,
+        },
     }
 
     impl<AccountId: Clone> StakeJob<AccountId> {
@@ -417,6 +430,7 @@ pub mod pallet {
                 StakeJob::UnstakeAllAlpha { coldkey, .. } => coldkey.clone(),
                 StakeJob::MoveStake { coldkey, .. } => coldkey.clone(),
                 StakeJob::TransferStake { origin_coldkey, .. } => origin_coldkey.clone(),
+                StakeJob::SwapStake { coldkey, .. } => coldkey.clone(),
             }
         }
     }

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -388,6 +388,21 @@ pub mod pallet {
             /// Alpha
             alpha_amount: AlphaCurrency,
         },
+        /// Represents a job for "transfer_stake" operation
+        TransferStake {
+            /// Origin coldkey account
+            origin_coldkey: AccountId,
+            /// Destinatino coldkey account
+            destination_coldkey: AccountId,
+            /// Hotkey account
+            hotkey: AccountId,
+            /// Origin subnet UID
+            origin_netuid: NetUid,
+            /// Destination subnet UID
+            destination_netuid: NetUid,
+            /// Alpha
+            alpha_amount: AlphaCurrency,
+        },
     }
 
     impl<AccountId: Clone> StakeJob<AccountId> {
@@ -401,6 +416,7 @@ pub mod pallet {
                 StakeJob::UnstakeAll { coldkey, .. } => coldkey.clone(),
                 StakeJob::UnstakeAllAlpha { coldkey, .. } => coldkey.clone(),
                 StakeJob::MoveStake { coldkey, .. } => coldkey.clone(),
+                StakeJob::TransferStake { origin_coldkey, .. } => origin_coldkey.clone(),
             }
         }
     }

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -325,7 +325,7 @@ pub mod pallet {
             /// Subnet ID
             netuid: NetUid,
             /// Alpha value
-            alpha_unstaked: u64,
+            alpha_unstaked: AlphaCurrency,
         },
         /// Represents a job for "add_stake_limit" operation
         AddStakeLimit {
@@ -352,7 +352,7 @@ pub mod pallet {
             /// Subnet ID
             netuid: NetUid,
             /// The amount of stake to be added to the hotkey staking account.
-            alpha_unstaked: u64,
+            alpha_unstaked: AlphaCurrency,
             /// The limit price
             limit_price: u64,
             /// Allows partial execution of the amount. If set to false, this becomes
@@ -373,6 +373,20 @@ pub mod pallet {
             /// Hotkey account
             hotkey: AccountId,
         },
+    }
+
+    impl<AccountId: Clone> StakeJob<AccountId> {
+        /// Extracts coldkey from the stake job
+        pub fn coldkey(&self) -> AccountId {
+            match self {
+                StakeJob::AddStake { coldkey, .. } => coldkey.clone(),
+                StakeJob::RemoveStake { coldkey, .. } => coldkey.clone(),
+                StakeJob::AddStakeLimit { coldkey, .. } => coldkey.clone(),
+                StakeJob::RemoveStakeLimit { coldkey, .. } => coldkey.clone(),
+                StakeJob::UnstakeAll { coldkey, .. } => coldkey.clone(),
+                StakeJob::UnstakeAllAlpha { coldkey, .. } => coldkey.clone(),
+            }
+        }
     }
 
     /// ============================

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -302,6 +302,79 @@ pub mod pallet {
         pub additional: Vec<u8>,
     }
 
+    /// Data structure for stake related jobs.
+    #[derive(Encode, Decode, TypeInfo, Clone, PartialEq, Eq, Debug)]
+    pub enum StakeJob<AccountId> {
+        /// Represents a job for "add_stake" operation
+        AddStake {
+            /// Hotkey account
+            hotkey: AccountId,
+            /// Coldkey account
+            coldkey: AccountId,
+            /// Subnet ID
+            netuid: NetUid,
+            /// The amount of stake to be added to the hotkey staking account.
+            stake_to_be_added: u64,
+        },
+        /// Represents a job for "remove_stake" operation
+        RemoveStake {
+            /// Hotkey account
+            hotkey: AccountId,
+            /// Coldkey account
+            coldkey: AccountId,
+            /// Subnet ID
+            netuid: NetUid,
+            /// Alpha value
+            alpha_unstaked: u64,
+        },
+        /// Represents a job for "add_stake_limit" operation
+        AddStakeLimit {
+            /// Coldkey account
+            coldkey: AccountId,
+            /// Hotkey account
+            hotkey: AccountId,
+            /// Subnet ID
+            netuid: NetUid,
+            /// The amount of stake to be added to the hotkey staking account.
+            stake_to_be_added: u64,
+            /// The limit price expressed in units of RAO per one Alpha.
+            limit_price: u64,
+            /// Allows partial execution of the amount. If set to false, this becomes
+            /// fill or kill type or order.
+            allow_partial: bool,
+        },
+        /// Represents a job for "remove_stake_limit" operation
+        RemoveStakeLimit {
+            /// Coldkey account
+            coldkey: AccountId,
+            /// Hotkey account
+            hotkey: AccountId,
+            /// Subnet ID
+            netuid: NetUid,
+            /// The amount of stake to be added to the hotkey staking account.
+            alpha_unstaked: u64,
+            /// The limit price
+            limit_price: u64,
+            /// Allows partial execution of the amount. If set to false, this becomes
+            /// fill or kill type or order.
+            allow_partial: bool,
+        },
+        /// Represents a job for "unstake_all" operation
+        UnstakeAll {
+            /// Coldkey account
+            coldkey: AccountId,
+            /// Hotkey account
+            hotkey: AccountId,
+        },
+        /// Represents a job for "unstake_all_alpha" operation
+        UnstakeAllAlpha {
+            /// Coldkey account
+            coldkey: AccountId,
+            /// Hotkey account
+            hotkey: AccountId,
+        },
+    }
+
     /// ============================
     /// ==== Staking + Accounts ====
     /// ============================
@@ -892,6 +965,17 @@ pub mod pallet {
         u64,
         ValueQuery,
         DefaultZeroU64<T>,
+    >;
+
+    #[pallet::storage]
+    pub type StakeJobs<T: Config> = StorageDoubleMap<
+        _,
+        Blake2_128Concat,
+        BlockNumberFor<T>, // first key: current block number
+        Twox64Concat,
+        u64, // second key: unique job ID
+        StakeJob<T::AccountId>,
+        OptionQuery,
     >;
 
     #[pallet::storage]

--- a/pallets/subtensor/src/macros/config.rs
+++ b/pallets/subtensor/src/macros/config.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::crate_in_macro_def)]
 
 use frame_support::pallet_macros::pallet_section;
+
 /// A [`pallet_section`] that defines the errors for a pallet.
 /// This can later be imported into the pallet using [`import_section`].
 #[pallet_section]
@@ -13,9 +14,16 @@ mod config {
     pub trait Config:
         frame_system::Config + pallet_drand::Config + pallet_crowdloan::Config
     {
+        /// Helps create EVM origin by account ID
+        type EvmOriginHelper: EvmOriginHelper<<Self as frame_system::Config>::RuntimeOrigin, Self::AccountId>;
+
+        /// Custom runtime origin for EVM
+        type RuntimeOrigin: From<<Self as frame_system::Config>::RuntimeOrigin>
+            + Into<Result<crate::pallet::Origin<Self>, <Self as Config>::RuntimeOrigin>>;
+
         /// call type
         type RuntimeCall: Parameter
-            + Dispatchable<RuntimeOrigin = Self::RuntimeOrigin>
+            + Dispatchable<RuntimeOrigin = OriginFor<Self>>
             + From<Call<Self>>
             + IsType<<Self as frame_system::Config>::RuntimeCall>
             + From<frame_system::Call<Self>>;
@@ -25,11 +33,11 @@ mod config {
 
         /// A sudo-able call.
         type SudoRuntimeCall: Parameter
-            + UnfilteredDispatchable<RuntimeOrigin = Self::RuntimeOrigin>
+            + UnfilteredDispatchable<RuntimeOrigin = OriginFor<Self>>
             + GetDispatchInfo;
 
         /// Origin checking for council majority
-        type CouncilOrigin: EnsureOrigin<Self::RuntimeOrigin>;
+        type CouncilOrigin: EnsureOrigin<<Self as frame_system::Config>::RuntimeOrigin>;
 
         ///  Currency type that will be used to place deposits on neurons
         type Currency: fungible::Balanced<Self::AccountId, Balance = u64>

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2303,5 +2303,29 @@ mod dispatches {
                 alpha_amount,
             )
         }
+
+        /// Transfers a specified amount of stake from one coldkey to another, optionally across subnets,
+        /// while keeping the same hotkey.
+        #[pallet::call_index(121)]
+        #[pallet::weight((Weight::from_parts(154_800_000, 0)
+        .saturating_add(T::DbWeight::get().reads(13_u64))
+        .saturating_add(T::DbWeight::get().writes(6_u64)), DispatchClass::Operational, Pays::Yes))]
+        pub fn transfer_stake_aggregate(
+            origin: T::RuntimeOrigin,
+            destination_coldkey: T::AccountId,
+            hotkey: T::AccountId,
+            origin_netuid: NetUid,
+            destination_netuid: NetUid,
+            alpha_amount: AlphaCurrency,
+        ) -> DispatchResult {
+            Self::do_transfer_stake_aggregate(
+                origin,
+                destination_coldkey,
+                hotkey,
+                origin_netuid,
+                destination_netuid,
+                alpha_amount,
+            )
+        }
     }
 }

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2451,7 +2451,7 @@ mod dispatches {
         ) -> DispatchResult {
             let account_id = crate::ensure_evm_origin(<T as Config>::RuntimeOrigin::from(origin))?;
             let verified_evm_origin = RawOrigin::Signed(account_id);
-            
+
             Self::do_move_stake(
                 verified_evm_origin.into(),
                 origin_hotkey,
@@ -2477,7 +2477,7 @@ mod dispatches {
         ) -> DispatchResult {
             let account_id = crate::ensure_evm_origin(<T as Config>::RuntimeOrigin::from(origin))?;
             let verified_evm_origin = RawOrigin::Signed(account_id);
-            
+
             Self::do_transfer_stake(
                 verified_evm_origin.into(),
                 destination_coldkey,
@@ -2488,32 +2488,21 @@ mod dispatches {
             )
         }
 
-        /// swap_stake with EVM origin
+        /// remove_stake_full_limit with EVM origin
         #[pallet::call_index(129)]
-        #[pallet::weight((
-            Weight::from_parts(351_300_000, 0)
-            .saturating_add(T::DbWeight::get().reads(32))
-            .saturating_add(T::DbWeight::get().writes(17)),
-            DispatchClass::Operational,
-            Pays::Yes
-        ))]
-        pub fn swap_stake(
+        #[pallet::weight((Weight::from_parts(398_000_000, 10142)
+			.saturating_add(T::DbWeight::get().reads(30_u64))
+			.saturating_add(T::DbWeight::get().writes(14_u64)), DispatchClass::Normal, Pays::Yes))]
+        pub fn remove_stake_full_limit_evm(
             origin: OriginFor<T>,
             hotkey: T::AccountId,
-            origin_netuid: NetUid,
-            destination_netuid: NetUid,
-            alpha_amount: AlphaCurrency,
+            netuid: NetUid,
+            limit_price: Option<u64>,
         ) -> DispatchResult {
             let account_id = crate::ensure_evm_origin(<T as Config>::RuntimeOrigin::from(origin))?;
             let verified_evm_origin = RawOrigin::Signed(account_id);
-            
-            Self::do_swap_stake(
-                verified_evm_origin.into(),
-                hotkey,
-                origin_netuid,
-                destination_netuid,
-                alpha_amount,
-            )
+
+            Self::do_remove_stake_full_limit(verified_evm_origin.into(), hotkey, netuid, limit_price)
         }
     }
 }

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -156,7 +156,7 @@ mod dispatches {
 		.saturating_add(T::DbWeight::get().reads(7))
 		.saturating_add(T::DbWeight::get().writes(2)), DispatchClass::Normal, Pays::No))]
         pub fn commit_weights(
-            origin: T::RuntimeOrigin,
+            origin: OriginFor<T>,
             netuid: NetUid,
             commit_hash: H256,
         ) -> DispatchResult {
@@ -239,7 +239,7 @@ mod dispatches {
 		.saturating_add(T::DbWeight::get().reads(16))
 		.saturating_add(T::DbWeight::get().writes(2)), DispatchClass::Normal, Pays::No))]
         pub fn reveal_weights(
-            origin: T::RuntimeOrigin,
+            origin: OriginFor<T>,
             netuid: NetUid,
             uids: Vec<u16>,
             values: Vec<u16>,
@@ -283,7 +283,7 @@ mod dispatches {
 		.saturating_add(T::DbWeight::get().reads(6_u64))
 		.saturating_add(T::DbWeight::get().writes(2)), DispatchClass::Normal, Pays::No))]
         pub fn commit_crv3_weights(
-            origin: T::RuntimeOrigin,
+            origin: OriginFor<T>,
             netuid: NetUid,
             commit: BoundedVec<u8, ConstU32<MAX_CRV3_COMMIT_SIZE_BYTES>>,
             reveal_round: u64,
@@ -335,7 +335,7 @@ mod dispatches {
 		.saturating_add(T::DbWeight::get().reads(16))
 		.saturating_add(T::DbWeight::get().writes(2_u64)), DispatchClass::Normal, Pays::No))]
         pub fn batch_reveal_weights(
-            origin: T::RuntimeOrigin,
+            origin: OriginFor<T>,
             netuid: NetUid,
             uids_list: Vec<Vec<u16>>,
             values_list: Vec<Vec<u16>>,
@@ -1285,7 +1285,7 @@ mod dispatches {
 		.saturating_add(T::DbWeight::get().reads(6))
 		.saturating_add(T::DbWeight::get().writes(31)), DispatchClass::Operational, Pays::Yes))]
         pub fn set_children(
-            origin: T::RuntimeOrigin,
+            origin: OriginFor<T>,
             hotkey: T::AccountId,
             netuid: NetUid,
             children: Vec<(u64, T::AccountId)>,
@@ -1641,7 +1641,7 @@ mod dispatches {
         .saturating_add(T::DbWeight::get().reads(15_u64))
         .saturating_add(T::DbWeight::get().writes(7_u64)), DispatchClass::Operational, Pays::Yes))]
         pub fn move_stake(
-            origin: T::RuntimeOrigin,
+            origin: OriginFor<T>,
             origin_hotkey: T::AccountId,
             destination_hotkey: T::AccountId,
             origin_netuid: NetUid,
@@ -1684,7 +1684,7 @@ mod dispatches {
         .saturating_add(T::DbWeight::get().reads(13_u64))
         .saturating_add(T::DbWeight::get().writes(6_u64)), DispatchClass::Operational, Pays::Yes))]
         pub fn transfer_stake(
-            origin: T::RuntimeOrigin,
+            origin: OriginFor<T>,
             destination_coldkey: T::AccountId,
             hotkey: T::AccountId,
             origin_netuid: NetUid,
@@ -1729,7 +1729,7 @@ mod dispatches {
             Pays::Yes
         ))]
         pub fn swap_stake(
-            origin: T::RuntimeOrigin,
+            origin: OriginFor<T>,
             hotkey: T::AccountId,
             origin_netuid: NetUid,
             destination_netuid: NetUid,
@@ -1902,7 +1902,7 @@ mod dispatches {
             Pays::Yes
         ))]
         pub fn swap_stake_limit(
-            origin: T::RuntimeOrigin,
+            origin: OriginFor<T>,
             hotkey: T::AccountId,
             origin_netuid: NetUid,
             destination_netuid: NetUid,
@@ -1935,10 +1935,7 @@ mod dispatches {
             DispatchClass::Operational,
             Pays::Yes
         ))]
-        pub fn try_associate_hotkey(
-            origin: T::RuntimeOrigin,
-            hotkey: T::AccountId,
-        ) -> DispatchResult {
+        pub fn try_associate_hotkey(origin: OriginFor<T>, hotkey: T::AccountId) -> DispatchResult {
             let coldkey = ensure_signed(origin)?;
 
             let _ = Self::do_try_associate_hotkey(&coldkey, &hotkey);
@@ -1960,7 +1957,7 @@ mod dispatches {
             DispatchClass::Operational,
             Pays::Yes
         ))]
-        pub fn start_call(origin: T::RuntimeOrigin, netuid: NetUid) -> DispatchResult {
+        pub fn start_call(origin: OriginFor<T>, netuid: NetUid) -> DispatchResult {
             Self::do_start_call(origin, netuid)?;
             Ok(())
         }
@@ -1999,7 +1996,7 @@ mod dispatches {
             Pays::Yes
         ))]
         pub fn associate_evm_key(
-            origin: T::RuntimeOrigin,
+            origin: OriginFor<T>,
             netuid: NetUid,
             evm_key: H160,
             block_number: u64,
@@ -2025,7 +2022,7 @@ mod dispatches {
             Pays::Yes
         ))]
         pub fn recycle_alpha(
-            origin: T::RuntimeOrigin,
+            origin: OriginFor<T>,
             hotkey: T::AccountId,
             amount: AlphaCurrency,
             netuid: NetUid,
@@ -2050,7 +2047,7 @@ mod dispatches {
             Pays::Yes
         ))]
         pub fn burn_alpha(
-            origin: T::RuntimeOrigin,
+            origin: OriginFor<T>,
             hotkey: T::AccountId,
             amount: AlphaCurrency,
             netuid: NetUid,
@@ -2079,7 +2076,7 @@ mod dispatches {
 			.saturating_add(T::DbWeight::get().reads(30_u64))
 			.saturating_add(T::DbWeight::get().writes(14_u64)), DispatchClass::Normal, Pays::Yes))]
         pub fn remove_stake_full_limit(
-            origin: T::RuntimeOrigin,
+            origin: OriginFor<T>,
             hotkey: T::AccountId,
             netuid: NetUid,
             limit_price: Option<u64>,
@@ -2106,7 +2103,7 @@ mod dispatches {
         #[pallet::call_index(110)]
         #[pallet::weight(SubnetLeasingWeightInfo::<T>::do_register_leased_network(T::MaxContributors::get()))]
         pub fn register_leased_network(
-            origin: T::RuntimeOrigin,
+            origin: OriginFor<T>,
             emissions_share: Percent,
             end_block: Option<BlockNumberFor<T>>,
         ) -> DispatchResultWithPostInfo {
@@ -2132,7 +2129,7 @@ mod dispatches {
         #[pallet::call_index(111)]
         #[pallet::weight(SubnetLeasingWeightInfo::<T>::do_terminate_lease(T::MaxContributors::get()))]
         pub fn terminate_lease(
-            origin: T::RuntimeOrigin,
+            origin: OriginFor<T>,
             lease_id: LeaseId,
             hotkey: T::AccountId,
         ) -> DispatchResultWithPostInfo {
@@ -2273,7 +2270,7 @@ mod dispatches {
 			.saturating_add(T::DbWeight::get().reads(30_u64))
 			.saturating_add(T::DbWeight::get().writes(14_u64)), DispatchClass::Normal, Pays::Yes))]
         pub fn remove_stake_full_limit_aggregate(
-            origin: T::RuntimeOrigin,
+            origin: OriginFor<T>,
             hotkey: T::AccountId,
             netuid: NetUid,
             limit_price: Option<u64>,
@@ -2287,7 +2284,7 @@ mod dispatches {
         .saturating_add(T::DbWeight::get().reads(15_u64))
         .saturating_add(T::DbWeight::get().writes(7_u64)), DispatchClass::Operational, Pays::Yes))]
         pub fn move_stake_aggregate(
-            origin: T::RuntimeOrigin,
+            origin: OriginFor<T>,
             origin_hotkey: T::AccountId,
             destination_hotkey: T::AccountId,
             origin_netuid: NetUid,
@@ -2338,7 +2335,7 @@ mod dispatches {
             Pays::Yes
         ))]
         pub fn swap_stake_aggregate(
-            origin: T::RuntimeOrigin,
+            origin: OriginFor<T>,
             hotkey: T::AccountId,
             origin_netuid: NetUid,
             destination_netuid: NetUid,
@@ -2351,6 +2348,23 @@ mod dispatches {
                 destination_netuid,
                 alpha_amount,
             )
+        }
+
+        /// add_stake with EVM origin
+        #[pallet::call_index(123)]
+        #[pallet::weight((Weight::from_parts(345_500_000, 0)
+		.saturating_add(T::DbWeight::get().reads(26))
+		.saturating_add(T::DbWeight::get().writes(15)), DispatchClass::Normal, Pays::Yes))]
+        pub fn add_stake_evm(
+            origin: OriginFor<T>,
+            hotkey: T::AccountId,
+            netuid: NetUid,
+            amount_staked: u64,
+        ) -> DispatchResult {
+            let account_id = crate::ensure_evm_origin(<T as Config>::RuntimeOrigin::from(origin))?;
+            let checked_evm_origin = RawOrigin::Signed(account_id);
+
+            Self::do_add_stake(checked_evm_origin.into(), hotkey, netuid, amount_staked)
         }
     }
 }

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2370,8 +2370,8 @@ mod dispatches {
         /// remove_stake with EVM origin
         #[pallet::call_index(124)]
         #[pallet::weight((Weight::from_parts(196_800_000, 0)
-		.saturating_add(T::DbWeight::get().reads(19))
-		.saturating_add(T::DbWeight::get().writes(10)), DispatchClass::Normal, Pays::Yes))]
+        .saturating_add(T::DbWeight::get().reads(19))
+        .saturating_add(T::DbWeight::get().writes(10)), DispatchClass::Normal, Pays::Yes))]
         pub fn remove_stake_evm(
             origin: OriginFor<T>,
             hotkey: T::AccountId,
@@ -2382,6 +2382,58 @@ mod dispatches {
             let verified_evm_origin = RawOrigin::Signed(account_id);
 
             Self::do_remove_stake(verified_evm_origin.into(), hotkey, netuid, amount_unstaked)
+        }
+
+        /// add_stake_limit with EVM origin
+        #[pallet::call_index(125)]
+        #[pallet::weight((Weight::from_parts(402_800_000, 0)
+        .saturating_add(T::DbWeight::get().reads(26))
+        .saturating_add(T::DbWeight::get().writes(15)), DispatchClass::Normal, Pays::Yes))]
+        pub fn add_stake_limit_evm(
+            origin: OriginFor<T>,
+            hotkey: T::AccountId,
+            netuid: NetUid,
+            amount_staked: u64,
+            limit_price: u64,
+            allow_partial: bool,
+        ) -> DispatchResult {
+            let account_id = crate::ensure_evm_origin(<T as Config>::RuntimeOrigin::from(origin))?;
+            let verified_evm_origin = RawOrigin::Signed(account_id);
+
+            Self::do_add_stake_limit(
+                verified_evm_origin.into(),
+                hotkey,
+                netuid,
+                amount_staked,
+                limit_price,
+                allow_partial,
+            )
+        }
+
+        /// remove_stake_limit with EVM origin
+        #[pallet::call_index(126)]
+        #[pallet::weight((Weight::from_parts(403_800_000, 0)
+            .saturating_add(T::DbWeight::get().reads(30))
+            .saturating_add(T::DbWeight::get().writes(14)), DispatchClass::Normal, Pays::Yes))]
+        pub fn remove_stake_limit_evm(
+            origin: OriginFor<T>,
+            hotkey: T::AccountId,
+            netuid: NetUid,
+            amount_unstaked: AlphaCurrency,
+            limit_price: u64,
+            allow_partial: bool,
+        ) -> DispatchResult {
+            let account_id = crate::ensure_evm_origin(<T as Config>::RuntimeOrigin::from(origin))?;
+            let verified_evm_origin = RawOrigin::Signed(account_id);
+
+            Self::do_remove_stake_limit(
+                verified_evm_origin.into(),
+                hotkey,
+                netuid,
+                amount_unstaked,
+                limit_price,
+                allow_partial,
+            )
         }
     }
 }

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2266,5 +2266,19 @@ mod dispatches {
         ) -> DispatchResult {
             Self::do_unstake_all_alpha_aggregate(origin, hotkey)
         }
+
+        /// Remove the full stake from the subnet with the price limit. 
+        #[pallet::call_index(119)]
+        #[pallet::weight((Weight::from_parts(398_000_000, 10142)
+			.saturating_add(T::DbWeight::get().reads(30_u64))
+			.saturating_add(T::DbWeight::get().writes(14_u64)), DispatchClass::Normal, Pays::Yes))]
+        pub fn remove_stake_full_limit_aggregate(
+            origin: T::RuntimeOrigin,
+            hotkey: T::AccountId,
+            netuid: NetUid,
+            limit_price: Option<u64>,
+        ) -> DispatchResult {
+            Self::do_remove_stake_full_limit_aggregate(origin, hotkey, netuid, limit_price)
+        }
     }
 }

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2435,5 +2435,85 @@ mod dispatches {
                 allow_partial,
             )
         }
+
+        /// move_stake with EVM origin
+        #[pallet::call_index(127)]
+        #[pallet::weight((Weight::from_parts(157_100_000, 0)
+        .saturating_add(T::DbWeight::get().reads(15_u64))
+        .saturating_add(T::DbWeight::get().writes(7_u64)), DispatchClass::Operational, Pays::Yes))]
+        pub fn move_stake_evm(
+            origin: OriginFor<T>,
+            origin_hotkey: T::AccountId,
+            destination_hotkey: T::AccountId,
+            origin_netuid: NetUid,
+            destination_netuid: NetUid,
+            alpha_amount: AlphaCurrency,
+        ) -> DispatchResult {
+            let account_id = crate::ensure_evm_origin(<T as Config>::RuntimeOrigin::from(origin))?;
+            let verified_evm_origin = RawOrigin::Signed(account_id);
+            
+            Self::do_move_stake(
+                verified_evm_origin.into(),
+                origin_hotkey,
+                destination_hotkey,
+                origin_netuid,
+                destination_netuid,
+                alpha_amount,
+            )
+        }
+
+        /// transfer_stake with EVM origin
+        #[pallet::call_index(128)]
+        #[pallet::weight((Weight::from_parts(154_800_000, 0)
+        .saturating_add(T::DbWeight::get().reads(13_u64))
+        .saturating_add(T::DbWeight::get().writes(6_u64)), DispatchClass::Operational, Pays::Yes))]
+        pub fn transfer_stake_evm(
+            origin: OriginFor<T>,
+            destination_coldkey: T::AccountId,
+            hotkey: T::AccountId,
+            origin_netuid: NetUid,
+            destination_netuid: NetUid,
+            alpha_amount: AlphaCurrency,
+        ) -> DispatchResult {
+            let account_id = crate::ensure_evm_origin(<T as Config>::RuntimeOrigin::from(origin))?;
+            let verified_evm_origin = RawOrigin::Signed(account_id);
+            
+            Self::do_transfer_stake(
+                verified_evm_origin.into(),
+                destination_coldkey,
+                hotkey,
+                origin_netuid,
+                destination_netuid,
+                alpha_amount,
+            )
+        }
+
+        /// swap_stake with EVM origin
+        #[pallet::call_index(129)]
+        #[pallet::weight((
+            Weight::from_parts(351_300_000, 0)
+            .saturating_add(T::DbWeight::get().reads(32))
+            .saturating_add(T::DbWeight::get().writes(17)),
+            DispatchClass::Operational,
+            Pays::Yes
+        ))]
+        pub fn swap_stake(
+            origin: OriginFor<T>,
+            hotkey: T::AccountId,
+            origin_netuid: NetUid,
+            destination_netuid: NetUid,
+            alpha_amount: AlphaCurrency,
+        ) -> DispatchResult {
+            let account_id = crate::ensure_evm_origin(<T as Config>::RuntimeOrigin::from(origin))?;
+            let verified_evm_origin = RawOrigin::Signed(account_id);
+            
+            Self::do_swap_stake(
+                verified_evm_origin.into(),
+                hotkey,
+                origin_netuid,
+                destination_netuid,
+                alpha_amount,
+            )
+        }
     }
 }

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2308,7 +2308,7 @@ mod dispatches {
         .saturating_add(T::DbWeight::get().reads(13_u64))
         .saturating_add(T::DbWeight::get().writes(6_u64)), DispatchClass::Operational, Pays::Yes))]
         pub fn transfer_stake_aggregate(
-            origin: T::RuntimeOrigin,
+            origin: OriginFor<T>,
             destination_coldkey: T::AccountId,
             hotkey: T::AccountId,
             origin_netuid: NetUid,

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2504,5 +2504,34 @@ mod dispatches {
 
             Self::do_remove_stake_full_limit(verified_evm_origin.into(), hotkey, netuid, limit_price)
         }
+
+        /// Aggregated version of swap_stake_limit
+        #[pallet::call_index(130)]
+        #[pallet::weight((
+            Weight::from_parts(426_500_000, 0)
+            .saturating_add(T::DbWeight::get().reads(32))
+            .saturating_add(T::DbWeight::get().writes(17)),
+            DispatchClass::Operational,
+            Pays::Yes
+        ))]
+        pub fn swap_stake_limit_aggregate(
+            origin: OriginFor<T>,
+            hotkey: T::AccountId,
+            origin_netuid: NetUid,
+            destination_netuid: NetUid,
+            alpha_amount: AlphaCurrency,
+            limit_price: u64,
+            allow_partial: bool,
+        ) -> DispatchResult {
+            Self::do_swap_stake_limit_aggregate(
+                origin,
+                hotkey,
+                origin_netuid,
+                destination_netuid,
+                alpha_amount,
+                limit_price,
+                allow_partial,
+            )
+        }
     }
 }

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2175,5 +2175,96 @@ mod dispatches {
             Self::deposit_event(Event::SymbolUpdated { netuid, symbol });
             Ok(())
         }
+
+        /// Add stake. The operation is postponed.
+        #[pallet::call_index(113)]
+        #[pallet::weight((Weight::from_parts(99_000_000, 5127)
+        .saturating_add(T::DbWeight::get().reads(14_u64))
+        .saturating_add(T::DbWeight::get().writes(12_u64)), DispatchClass::Normal, Pays::No))]
+        pub fn add_stake_aggregate(
+            origin: OriginFor<T>,
+            hotkey: T::AccountId,
+            netuid: NetUid,
+            amount_staked: u64,
+        ) -> DispatchResult {
+            Self::do_add_stake_aggregate(origin, hotkey, netuid, amount_staked)
+        }
+
+        /// Remove stake. The operation is postponed.
+        #[pallet::call_index(114)]
+        #[pallet::weight((Weight::from_parts(129_000_000, 10163)
+        .saturating_add(T::DbWeight::get().reads(19_u64))
+        .saturating_add(T::DbWeight::get().writes(12_u64)), DispatchClass::Normal, Pays::No))]
+        pub fn remove_stake_aggregate(
+            origin: OriginFor<T>,
+            hotkey: T::AccountId,
+            netuid: NetUid,
+            amount_unstaked: AlphaCurrency,
+        ) -> DispatchResult {
+            Self::do_remove_stake_aggregate(origin, hotkey, netuid, amount_unstaked)
+        }
+
+        /// Add stake with price limit. The operation is postponed.
+        #[pallet::call_index(115)]
+        #[pallet::weight((Weight::from_parts(99_000_000, 5127)
+        .saturating_add(T::DbWeight::get().reads(14_u64))
+        .saturating_add(T::DbWeight::get().writes(12_u64)), DispatchClass::Normal, Pays::No))]
+        pub fn add_stake_limit_aggregate(
+            origin: OriginFor<T>,
+            hotkey: T::AccountId,
+            netuid: NetUid,
+            amount_staked: u64,
+            limit_price: u64,
+            allow_partial: bool,
+        ) -> DispatchResult {
+            Self::do_add_stake_limit_aggregate(
+                origin,
+                hotkey,
+                netuid,
+                amount_staked,
+                limit_price,
+                allow_partial,
+            )
+        }
+
+        /// Remove stake with price limit. The operation is postponed.
+        #[pallet::call_index(116)]
+        #[pallet::weight((Weight::from_parts(129_000_000, 10163)
+        .saturating_add(T::DbWeight::get().reads(19_u64))
+        .saturating_add(T::DbWeight::get().writes(12_u64)), DispatchClass::Normal, Pays::No))]
+        pub fn remove_stake_limit_aggregate(
+            origin: OriginFor<T>,
+            hotkey: T::AccountId,
+            netuid: NetUid,
+            amount_unstaked: AlphaCurrency,
+            limit_price: u64,
+            allow_partial: bool,
+        ) -> DispatchResult {
+            Self::do_remove_stake_limit_aggregate(
+                origin,
+                hotkey,
+                netuid,
+                amount_unstaked,
+                limit_price,
+                allow_partial,
+            )
+        }
+
+        /// Unstake all subnets. The operation is postponed.
+        #[pallet::call_index(117)]
+        #[pallet::weight((Weight::from_parts(3_000_000, 0).saturating_add(T::DbWeight::get().writes(1)), DispatchClass::Operational, Pays::No))]
+        pub fn unstake_all_aggregate(origin: OriginFor<T>, hotkey: T::AccountId) -> DispatchResult {
+            Self::do_unstake_all_aggregate(origin, hotkey)
+        }
+
+        /// Unstake all alpha from subnets. The operation is postponed.
+        #[pallet::call_index(118)]
+        #[pallet::weight((Weight::from_parts(3_000_000, 0).saturating_add(T::DbWeight::get().writes(1)), DispatchClass::Operational, Pays::No))]
+        pub fn unstake_all_alpha_aggregate(
+            origin: OriginFor<T>,
+            hotkey: T::AccountId,
+        ) -> DispatchResult {
+            Self::do_unstake_all_alpha_aggregate(origin, hotkey)
+        }
     }
 }

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2267,7 +2267,7 @@ mod dispatches {
             Self::do_unstake_all_alpha_aggregate(origin, hotkey)
         }
 
-        /// Remove the full stake from the subnet with the price limit. 
+        /// Remove the full stake from the subnet with the price limit.
         #[pallet::call_index(119)]
         #[pallet::weight((Weight::from_parts(398_000_000, 10142)
 			.saturating_add(T::DbWeight::get().reads(30_u64))
@@ -2279,6 +2279,29 @@ mod dispatches {
             limit_price: Option<u64>,
         ) -> DispatchResult {
             Self::do_remove_stake_full_limit_aggregate(origin, hotkey, netuid, limit_price)
+        }
+
+        /// Move stake between subnets.
+        #[pallet::call_index(120)]
+        #[pallet::weight((Weight::from_parts(157_100_000, 0)
+        .saturating_add(T::DbWeight::get().reads(15_u64))
+        .saturating_add(T::DbWeight::get().writes(7_u64)), DispatchClass::Operational, Pays::Yes))]
+        pub fn move_stake_aggregate(
+            origin: T::RuntimeOrigin,
+            origin_hotkey: T::AccountId,
+            destination_hotkey: T::AccountId,
+            origin_netuid: NetUid,
+            destination_netuid: NetUid,
+            alpha_amount: AlphaCurrency,
+        ) -> DispatchResult {
+            Self::do_move_stake_aggregate(
+                origin,
+                origin_hotkey,
+                destination_hotkey,
+                origin_netuid,
+                destination_netuid,
+                alpha_amount,
+            )
         }
     }
 }

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2327,5 +2327,30 @@ mod dispatches {
                 alpha_amount,
             )
         }
+
+        /// Swaps a specified amount of stake from one subnet to another, while keeping the same coldkey and hotkey.
+        #[pallet::call_index(122)]
+        #[pallet::weight((
+            Weight::from_parts(351_300_000, 0)
+            .saturating_add(T::DbWeight::get().reads(32))
+            .saturating_add(T::DbWeight::get().writes(17)),
+            DispatchClass::Operational,
+            Pays::Yes
+        ))]
+        pub fn swap_stake_aggregate(
+            origin: T::RuntimeOrigin,
+            hotkey: T::AccountId,
+            origin_netuid: NetUid,
+            destination_netuid: NetUid,
+            alpha_amount: AlphaCurrency,
+        ) -> DispatchResult {
+            Self::do_swap_stake_aggregate(
+                origin,
+                hotkey,
+                origin_netuid,
+                destination_netuid,
+                alpha_amount,
+            )
+        }
     }
 }

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2362,9 +2362,26 @@ mod dispatches {
             amount_staked: u64,
         ) -> DispatchResult {
             let account_id = crate::ensure_evm_origin(<T as Config>::RuntimeOrigin::from(origin))?;
-            let checked_evm_origin = RawOrigin::Signed(account_id);
+            let verified_evm_origin = RawOrigin::Signed(account_id);
 
-            Self::do_add_stake(checked_evm_origin.into(), hotkey, netuid, amount_staked)
+            Self::do_add_stake(verified_evm_origin.into(), hotkey, netuid, amount_staked)
+        }
+
+        /// remove_stake with EVM origin
+        #[pallet::call_index(124)]
+        #[pallet::weight((Weight::from_parts(196_800_000, 0)
+		.saturating_add(T::DbWeight::get().reads(19))
+		.saturating_add(T::DbWeight::get().writes(10)), DispatchClass::Normal, Pays::Yes))]
+        pub fn remove_stake_evm(
+            origin: OriginFor<T>,
+            hotkey: T::AccountId,
+            netuid: NetUid,
+            amount_unstaked: AlphaCurrency,
+        ) -> DispatchResult {
+            let account_id = crate::ensure_evm_origin(<T as Config>::RuntimeOrigin::from(origin))?;
+            let verified_evm_origin = RawOrigin::Signed(account_id);
+
+            Self::do_remove_stake(verified_evm_origin.into(), hotkey, netuid, amount_unstaked)
         }
     }
 }

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2180,7 +2180,7 @@ mod dispatches {
         #[pallet::call_index(113)]
         #[pallet::weight((Weight::from_parts(99_000_000, 5127)
         .saturating_add(T::DbWeight::get().reads(14_u64))
-        .saturating_add(T::DbWeight::get().writes(12_u64)), DispatchClass::Normal, Pays::No))]
+        .saturating_add(T::DbWeight::get().writes(12_u64)), DispatchClass::Normal, Pays::Yes))]
         pub fn add_stake_aggregate(
             origin: OriginFor<T>,
             hotkey: T::AccountId,
@@ -2194,7 +2194,7 @@ mod dispatches {
         #[pallet::call_index(114)]
         #[pallet::weight((Weight::from_parts(129_000_000, 10163)
         .saturating_add(T::DbWeight::get().reads(19_u64))
-        .saturating_add(T::DbWeight::get().writes(12_u64)), DispatchClass::Normal, Pays::No))]
+        .saturating_add(T::DbWeight::get().writes(12_u64)), DispatchClass::Normal, Pays::Yes))]
         pub fn remove_stake_aggregate(
             origin: OriginFor<T>,
             hotkey: T::AccountId,
@@ -2208,7 +2208,7 @@ mod dispatches {
         #[pallet::call_index(115)]
         #[pallet::weight((Weight::from_parts(99_000_000, 5127)
         .saturating_add(T::DbWeight::get().reads(14_u64))
-        .saturating_add(T::DbWeight::get().writes(12_u64)), DispatchClass::Normal, Pays::No))]
+        .saturating_add(T::DbWeight::get().writes(12_u64)), DispatchClass::Normal, Pays::Yes))]
         pub fn add_stake_limit_aggregate(
             origin: OriginFor<T>,
             hotkey: T::AccountId,
@@ -2231,7 +2231,7 @@ mod dispatches {
         #[pallet::call_index(116)]
         #[pallet::weight((Weight::from_parts(129_000_000, 10163)
         .saturating_add(T::DbWeight::get().reads(19_u64))
-        .saturating_add(T::DbWeight::get().writes(12_u64)), DispatchClass::Normal, Pays::No))]
+        .saturating_add(T::DbWeight::get().writes(12_u64)), DispatchClass::Normal, Pays::Yes))]
         pub fn remove_stake_limit_aggregate(
             origin: OriginFor<T>,
             hotkey: T::AccountId,
@@ -2252,14 +2252,14 @@ mod dispatches {
 
         /// Unstake all subnets. The operation is postponed.
         #[pallet::call_index(117)]
-        #[pallet::weight((Weight::from_parts(3_000_000, 0).saturating_add(T::DbWeight::get().writes(1)), DispatchClass::Operational, Pays::No))]
+        #[pallet::weight((Weight::from_parts(3_000_000, 0).saturating_add(T::DbWeight::get().writes(1)), DispatchClass::Operational, Pays::Yes))]
         pub fn unstake_all_aggregate(origin: OriginFor<T>, hotkey: T::AccountId) -> DispatchResult {
             Self::do_unstake_all_aggregate(origin, hotkey)
         }
 
         /// Unstake all alpha from subnets. The operation is postponed.
         #[pallet::call_index(118)]
-        #[pallet::weight((Weight::from_parts(3_000_000, 0).saturating_add(T::DbWeight::get().writes(1)), DispatchClass::Operational, Pays::No))]
+        #[pallet::weight((Weight::from_parts(3_000_000, 0).saturating_add(T::DbWeight::get().writes(1)), DispatchClass::Operational, Pays::Yes))]
         pub fn unstake_all_alpha_aggregate(
             origin: OriginFor<T>,
             hotkey: T::AccountId,

--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -380,5 +380,30 @@ mod events {
             /// The symbol that has been updated.
             symbol: Vec<u8>,
         },
+
+        /// stake has been transferred from the coldkey account onto the hotkey staking account (at the end of the block)
+        AggregatedStakeAdded(T::AccountId, T::AccountId, u16, u64),
+        /// adding aggregated stake has failed
+        FailedToAddAggregatedStake(T::AccountId, T::AccountId, u16, u64),
+        /// limited stake has been transferred from the coldkey account onto the hotkey staking account (at the end of the block)
+        AggregatedLimitedStakeAdded(T::AccountId, T::AccountId, u16, u64, u64, bool),
+        /// adding limited aggregated stake has failed
+        FailedToAddAggregatedLimitedStake(T::AccountId, T::AccountId, u16, u64, u64, bool),
+        /// stake has been removed from the hotkey staking account into the coldkey account (at the end of the block).
+        AggregatedStakeRemoved(T::AccountId, T::AccountId, u16, u64),
+        /// removing aggregated stake has failed
+        FailedToRemoveAggregatedStake(T::AccountId, T::AccountId, u16, u64),
+        /// aggregated limited stake has been removed from the hotkey staking account into the coldkey account (at the end of the block).
+        AggregatedLimitedStakeRemoved(T::AccountId, T::AccountId, u16, u64, u64, bool),
+        /// removing limited aggregated stake has failed
+        FailedToRemoveAggregatedLimitedStake(T::AccountId, T::AccountId, u16, u64, u64, bool),
+        ///  aggregated unstake_all operation has succeeded
+        AggregatedUnstakeAllSucceeded(T::AccountId, T::AccountId),
+        /// aggregated unstake_all operation has failed
+        AggregatedUnstakeAllFailed(T::AccountId, T::AccountId),
+        ///  aggregated unstake_all_alpha operation has succeeded
+        AggregatedUnstakeAllAlphaSucceeded(T::AccountId, T::AccountId),
+        /// aggregated unstake_all_alpha operation has failed
+        AggregatedUnstakeAllAlphaFailed(T::AccountId, T::AccountId),
     }
 }

--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -513,5 +513,35 @@ mod events {
             /// the account ID of hotkey
             hotkey: T::AccountId,
         },
+        /// Aggregated version of `move_stake` executed successfully
+        AggregatedStakeMoved {
+            /// Coldkey account
+            coldkey: T::AccountId,
+            /// Origin hotkey account
+            origin_hotkey: T::AccountId,
+            /// Destination hotkey account
+            destination_hotkey: T::AccountId,
+            /// Origin subnet UID
+            origin_netuid: NetUid,
+            /// Destination subnet UID
+            destination_netuid: NetUid,
+            /// Alpha
+            alpha_amount: AlphaCurrency,
+        },
+        /// Aggregated version of `move_stake` executed successfully
+        FailedToMoveAggregatedStake {
+            /// Coldkey account
+            coldkey: T::AccountId,
+            /// Origin hotkey account
+            origin_hotkey: T::AccountId,
+            /// Destination hotkey account
+            destination_hotkey: T::AccountId,
+            /// Origin subnet UID
+            origin_netuid: NetUid,
+            /// Destination subnet UID
+            destination_netuid: NetUid,
+            /// Alpha
+            alpha_amount: AlphaCurrency,
+        },
     }
 }

--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -599,5 +599,39 @@ mod events {
             /// Alpha
             alpha_amount: AlphaCurrency,
         },
+        /// Aggregated version of `swap_stake_limit` executed successfully
+        AggregatedLimitedStakeSwapped {
+            /// Coldkey account
+            coldkey: T::AccountId,
+            /// Hotkey account
+            hotkey: T::AccountId,
+            /// Origin subnet UID
+            origin_netuid: NetUid,
+            /// Destination subnet UID
+            destination_netuid: NetUid,
+            /// Alpha
+            alpha_amount: AlphaCurrency,
+            /// price limit
+            limit_price: u64,
+            /// allow partial stake removal
+            allow_partial: bool,
+        },        
+        /// Aggregated version of `swap_stake_limit` executed successfully
+        FailedToSwapLimitedAggregatedStake {
+            /// Coldkey account
+            coldkey: T::AccountId,
+            /// Hotkey account
+            hotkey: T::AccountId,
+            /// Origin subnet UID
+            origin_netuid: NetUid,
+            /// Destination subnet UID
+            destination_netuid: NetUid,
+            /// Alpha
+            alpha_amount: AlphaCurrency,
+            /// price limit
+            limit_price: u64,
+            /// allow partial stake removal
+            allow_partial: bool,
+        },
     }
 }

--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -573,5 +573,31 @@ mod events {
             /// Alpha
             alpha_amount: AlphaCurrency,
         },
+        /// Aggregated version of `swap_stake` executed successfully
+        AggregatedStakeSwapped {
+            /// Coldkey account
+            coldkey: T::AccountId,
+            /// Hotkey account
+            hotkey: T::AccountId,
+            /// Origin subnet UID
+            origin_netuid: NetUid,
+            /// Destination subnet UID
+            destination_netuid: NetUid,
+            /// Alpha
+            alpha_amount: AlphaCurrency,
+        },
+        /// Aggregated version of `swap_stake` has failed
+        FailedToSwapAggregatedStake {
+            /// Coldkey account
+            coldkey: T::AccountId,
+            /// Hotkey account
+            hotkey: T::AccountId,
+            /// Origin subnet UID
+            origin_netuid: NetUid,
+            /// Destination subnet UID
+            destination_netuid: NetUid,
+            /// Alpha
+            alpha_amount: AlphaCurrency,
+        },
     }
 }

--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -528,7 +528,7 @@ mod events {
             /// Alpha
             alpha_amount: AlphaCurrency,
         },
-        /// Aggregated version of `move_stake` executed successfully
+        /// Aggregated version of `move_stake` has failed
         FailedToMoveAggregatedStake {
             /// Coldkey account
             coldkey: T::AccountId,
@@ -536,6 +536,36 @@ mod events {
             origin_hotkey: T::AccountId,
             /// Destination hotkey account
             destination_hotkey: T::AccountId,
+            /// Origin subnet UID
+            origin_netuid: NetUid,
+            /// Destination subnet UID
+            destination_netuid: NetUid,
+            /// Alpha
+            alpha_amount: AlphaCurrency,
+        },
+        /// Aggregated version of `transfer_stake` executed successfully
+        AggregatedStakeTransferred {
+            /// Origin coldkey account
+            origin_coldkey: T::AccountId,
+            /// Destination coldkey account
+            destination_coldkey: T::AccountId,
+            /// Hotkey account
+            hotkey: T::AccountId,
+            /// Origin subnet UID
+            origin_netuid: NetUid,
+            /// Destination subnet UID
+            destination_netuid: NetUid,
+            /// Alpha
+            alpha_amount: AlphaCurrency,
+        },
+        /// Aggregated version of `transfer_stake` has failed
+        FailedToTransferAggregatedStake {
+            /// Origin coldkey account
+            origin_coldkey: T::AccountId,
+            /// Destination coldkey account
+            destination_coldkey: T::AccountId,
+            /// Hotkey account
+            hotkey: T::AccountId,
             /// Origin subnet UID
             origin_netuid: NetUid,
             /// Destination subnet UID

--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -382,28 +382,136 @@ mod events {
         },
 
         /// stake has been transferred from the coldkey account onto the hotkey staking account (at the end of the block)
-        AggregatedStakeAdded(T::AccountId, T::AccountId, u16, u64),
+        AggregatedStakeAdded {
+            /// the account ID of coldkey
+            coldkey: T::AccountId,
+            /// the account ID of hotkey
+            hotkey: T::AccountId,
+            /// The subnet ID
+            netuid: NetUid,
+            /// Stake
+            stake_to_be_added: u64,
+        },
         /// adding aggregated stake has failed
-        FailedToAddAggregatedStake(T::AccountId, T::AccountId, u16, u64),
+        FailedToAddAggregatedStake {
+            /// the account ID of coldkey
+            coldkey: T::AccountId,
+            /// the account ID of hotkey
+            hotkey: T::AccountId,
+            /// The subnet ID
+            netuid: NetUid,
+            /// Stake
+            stake_to_be_added: u64,
+        },
         /// limited stake has been transferred from the coldkey account onto the hotkey staking account (at the end of the block)
-        AggregatedLimitedStakeAdded(T::AccountId, T::AccountId, u16, u64, u64, bool),
+        AggregatedLimitedStakeAdded {
+            /// the account ID of coldkey
+            coldkey: T::AccountId,
+            /// the account ID of hotkey
+            hotkey: T::AccountId,
+            /// The subnet ID
+            netuid: NetUid,
+            /// stake
+            stake_to_be_added: u64,
+            /// price limit
+            limit_price: u64,
+            /// allow partial stake removal
+            allow_partial: bool,
+        },
         /// adding limited aggregated stake has failed
-        FailedToAddAggregatedLimitedStake(T::AccountId, T::AccountId, u16, u64, u64, bool),
+        FailedToAddAggregatedLimitedStake {
+            /// the account ID of coldkey
+            coldkey: T::AccountId,
+            /// the account ID of hotkey
+            hotkey: T::AccountId,
+            /// The subnet ID
+            netuid: NetUid,
+            /// stake
+            stake_to_be_added: u64,
+            /// price limit
+            limit_price: u64,
+            /// allow partial stake removal
+            allow_partial: bool,
+        },
         /// stake has been removed from the hotkey staking account into the coldkey account (at the end of the block).
-        AggregatedStakeRemoved(T::AccountId, T::AccountId, u16, u64),
+        AggregatedStakeRemoved {
+            /// the account ID of coldkey
+            coldkey: T::AccountId,
+            /// the account ID of hotkey
+            hotkey: T::AccountId,
+            /// The subnet ID
+            netuid: NetUid,
+            /// alpha
+            alpha_unstaked: AlphaCurrency,
+        },
         /// removing aggregated stake has failed
-        FailedToRemoveAggregatedStake(T::AccountId, T::AccountId, u16, u64),
+        FailedToRemoveAggregatedStake {
+            /// the account ID of coldkey
+            coldkey: T::AccountId,
+            /// the account ID of hotkey
+            hotkey: T::AccountId,
+            /// The subnet ID
+            netuid: NetUid,
+            /// alpha
+            alpha_unstaked: AlphaCurrency,
+        },
         /// aggregated limited stake has been removed from the hotkey staking account into the coldkey account (at the end of the block).
-        AggregatedLimitedStakeRemoved(T::AccountId, T::AccountId, u16, u64, u64, bool),
+        AggregatedLimitedStakeRemoved {
+            /// the account ID of coldkey
+            coldkey: T::AccountId,
+            /// the account ID of hotkey
+            hotkey: T::AccountId,
+            /// The subnet ID
+            netuid: NetUid,
+            /// alpha
+            alpha_unstaked: AlphaCurrency,
+            /// price limit
+            limit_price: u64,
+            /// allow partial stake removal
+            allow_partial: bool,
+        },
         /// removing limited aggregated stake has failed
-        FailedToRemoveAggregatedLimitedStake(T::AccountId, T::AccountId, u16, u64, u64, bool),
+        FailedToRemoveAggregatedLimitedStake {
+            /// the account ID of coldkey
+            coldkey: T::AccountId,
+            /// the account ID of hotkey
+            hotkey: T::AccountId,
+            /// The subnet ID
+            netuid: NetUid,
+            /// alpha
+            alpha_unstaked: AlphaCurrency,
+            /// price limit
+            limit_price: u64,
+            /// allow partial stake removal
+            allow_partial: bool,
+        },
         ///  aggregated unstake_all operation has succeeded
-        AggregatedUnstakeAllSucceeded(T::AccountId, T::AccountId),
+        AggregatedUnstakeAllSucceeded {
+            /// the account ID of coldkey
+            coldkey: T::AccountId,
+            /// the account ID of hotkey
+            hotkey: T::AccountId,
+        },
         /// aggregated unstake_all operation has failed
-        AggregatedUnstakeAllFailed(T::AccountId, T::AccountId),
+        AggregatedUnstakeAllFailed {
+            /// the account ID of coldkey
+            coldkey: T::AccountId,
+            /// the account ID of hotkey
+            hotkey: T::AccountId,
+        },
         ///  aggregated unstake_all_alpha operation has succeeded
-        AggregatedUnstakeAllAlphaSucceeded(T::AccountId, T::AccountId),
+        AggregatedUnstakeAllAlphaSucceeded {
+            /// the account ID of coldkey
+            coldkey: T::AccountId,
+            /// the account ID of hotkey
+            hotkey: T::AccountId,
+        },
         /// aggregated unstake_all_alpha operation has failed
-        AggregatedUnstakeAllAlphaFailed(T::AccountId, T::AccountId),
+        AggregatedUnstakeAllAlphaFailed {
+            /// the account ID of coldkey
+            coldkey: T::AccountId,
+            /// the account ID of hotkey
+            hotkey: T::AccountId,
+        },
     }
 }

--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -43,10 +43,12 @@ mod hooks {
         // # Args:
         // 	* 'n': (BlockNumberFor<T>):
         // 		- The number of the block we are finalizing.
-        fn on_finalize(_block_number: BlockNumberFor<T>) {
+        fn on_finalize(block_number: BlockNumberFor<T>) {
             for _ in StakingOperationRateLimiter::<T>::drain() {
                 // Clear all entries each block
             }
+
+            Self::process_staking_jobs(block_number);
         }
 
         fn on_runtime_upgrade() -> frame_support::weights::Weight {

--- a/pallets/subtensor/src/staking/add_stake.rs
+++ b/pallets/subtensor/src/staking/add_stake.rs
@@ -38,7 +38,7 @@ impl<T: Config> Pallet<T> {
     ///     -  Thrown if key has hit transaction rate limit
     ///
     pub fn do_add_stake(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         hotkey: T::AccountId,
         netuid: NetUid,
         stake_to_be_added: u64,
@@ -125,7 +125,7 @@ impl<T: Config> Pallet<T> {
     ///     -  Thrown if key has hit transaction rate limit
     ///
     pub fn do_add_stake_limit(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         hotkey: T::AccountId,
         netuid: NetUid,
         stake_to_be_added: u64,
@@ -208,7 +208,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn do_add_stake_aggregate(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         hotkey: T::AccountId,
         netuid: NetUid,
         stake_to_be_added: u64,
@@ -244,7 +244,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn do_add_stake_limit_aggregate(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         hotkey: T::AccountId,
         netuid: NetUid,
         stake_to_be_added: u64,

--- a/pallets/subtensor/src/staking/decrease_take.rs
+++ b/pallets/subtensor/src/staking/decrease_take.rs
@@ -28,7 +28,7 @@ impl<T: Config> Pallet<T> {
     ///     - The delegate is setting a take which is not lower than the previous.
     ///
     pub fn do_decrease_take(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         hotkey: T::AccountId,
         take: u16,
     ) -> dispatch::DispatchResult {

--- a/pallets/subtensor/src/staking/increase_take.rs
+++ b/pallets/subtensor/src/staking/increase_take.rs
@@ -31,7 +31,7 @@ impl<T: Config> Pallet<T> {
     ///     - The delegate is setting a take which is not greater than the previous.
     ///
     pub fn do_increase_take(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         hotkey: T::AccountId,
         take: u16,
     ) -> dispatch::DispatchResult {

--- a/pallets/subtensor/src/staking/move_stake.rs
+++ b/pallets/subtensor/src/staking/move_stake.rs
@@ -575,4 +575,45 @@ impl<T: Config> Pallet<T> {
 
         Ok(())
     }
+
+    pub fn do_transfer_stake_aggregate(
+        origin: T::RuntimeOrigin,
+        destination_coldkey: T::AccountId,
+        hotkey: T::AccountId,
+        origin_netuid: NetUid,
+        destination_netuid: NetUid,
+        alpha_amount: AlphaCurrency,
+    ) -> dispatch::DispatchResult {
+        let coldkey = ensure_signed(origin)?;
+
+        // Consider the weight from on_finalize
+        if cfg!(feature = "runtime-benchmarks") && !cfg!(test) {
+            Self::do_transfer_stake(
+                crate::dispatch::RawOrigin::Signed(coldkey.clone()).into(),
+                destination_coldkey.clone(),
+                hotkey.clone(),
+                origin_netuid,
+                destination_netuid,
+                alpha_amount,
+            )?;
+        }
+
+        // Save the staking job for the on_finalize
+        let stake_job = StakeJob::TransferStake {
+            origin_coldkey: coldkey,
+            destination_coldkey,
+            hotkey,
+            origin_netuid,
+            destination_netuid,
+            alpha_amount,
+        };
+
+        let stake_job_id = NextStakeJobId::<T>::get();
+        let current_blocknumber = <frame_system::Pallet<T>>::block_number();
+
+        StakeJobs::<T>::insert(current_blocknumber, stake_job_id, stake_job);
+        NextStakeJobId::<T>::set(stake_job_id.saturating_add(1));
+
+        Ok(())
+    }
 }

--- a/pallets/subtensor/src/staking/move_stake.rs
+++ b/pallets/subtensor/src/staking/move_stake.rs
@@ -28,7 +28,7 @@ impl<T: Config> Pallet<T> {
     /// # Events
     /// Emits a `StakeMoved` event upon successful completion of the stake movement.
     pub fn do_move_stake(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         origin_hotkey: T::AccountId,
         destination_hotkey: T::AccountId,
         origin_netuid: NetUid,
@@ -123,7 +123,7 @@ impl<T: Config> Pallet<T> {
     /// # Events
     /// Emits a `StakeTransferred` event upon successful completion of the transfer.
     pub fn do_transfer_stake(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         destination_coldkey: T::AccountId,
         hotkey: T::AccountId,
         origin_netuid: NetUid,
@@ -195,7 +195,7 @@ impl<T: Config> Pallet<T> {
     /// # Events
     /// Emits a `StakeSwapped` event upon successful completion.
     pub fn do_swap_stake(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         hotkey: T::AccountId,
         origin_netuid: NetUid,
         destination_netuid: NetUid,
@@ -266,7 +266,7 @@ impl<T: Config> Pallet<T> {
     /// # Events
     /// Emits a `StakeSwapped` event upon successful completion.
     pub fn do_swap_stake_limit(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         hotkey: T::AccountId,
         origin_netuid: NetUid,
         destination_netuid: NetUid,
@@ -536,7 +536,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn do_move_stake_aggregate(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         origin_hotkey: T::AccountId,
         destination_hotkey: T::AccountId,
         origin_netuid: NetUid,
@@ -577,7 +577,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn do_transfer_stake_aggregate(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         destination_coldkey: T::AccountId,
         hotkey: T::AccountId,
         origin_netuid: NetUid,
@@ -618,7 +618,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn do_swap_stake_aggregate(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         hotkey: T::AccountId,
         origin_netuid: NetUid,
         destination_netuid: NetUid,

--- a/pallets/subtensor/src/staking/recycle_alpha.rs
+++ b/pallets/subtensor/src/staking/recycle_alpha.rs
@@ -16,7 +16,7 @@ impl<T: Config> Pallet<T> {
     ///
     /// * `DispatchResult` - Success or error
     pub(crate) fn do_recycle_alpha(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         hotkey: T::AccountId,
         amount: AlphaCurrency,
         netuid: NetUid,
@@ -82,7 +82,7 @@ impl<T: Config> Pallet<T> {
     ///
     /// * `DispatchResult` - Success or error
     pub(crate) fn do_burn_alpha(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         hotkey: T::AccountId,
         amount: AlphaCurrency,
         netuid: NetUid,

--- a/pallets/subtensor/src/staking/remove_stake.rs
+++ b/pallets/subtensor/src/staking/remove_stake.rs
@@ -440,4 +440,135 @@ impl<T: Config> Pallet<T> {
             Self::do_remove_stake(origin, hotkey, netuid, alpha_unstaked)
         }
     }
+
+    pub fn do_remove_stake_aggregate(
+        origin: T::RuntimeOrigin,
+        hotkey: T::AccountId,
+        netuid: NetUid,
+        alpha_unstaked: AlphaCurrency,
+    ) -> dispatch::DispatchResult {
+        // We check the transaction is signed by the caller and retrieve the T::AccountId coldkey information.
+        let coldkey = ensure_signed(origin)?;
+
+        // Consider the weight from on_finalize
+        if cfg!(feature = "runtime-benchmarks") && !cfg!(test) {
+            Self::do_remove_stake(
+                crate::dispatch::RawOrigin::Signed(coldkey.clone()).into(),
+                hotkey.clone(),
+                netuid,
+                alpha_unstaked,
+            )?;
+        }
+
+        // Save the staking job for the on_finalize
+        let stake_job = StakeJob::RemoveStake {
+            hotkey,
+            coldkey,
+            netuid,
+            alpha_unstaked,
+        };
+
+        let stake_job_id = NextStakeJobId::<T>::get();
+        let current_blocknumber = <frame_system::Pallet<T>>::block_number();
+
+        StakeJobs::<T>::insert(current_blocknumber, stake_job_id, stake_job);
+        NextStakeJobId::<T>::set(stake_job_id.saturating_add(1));
+
+        Ok(())
+    }
+
+    pub fn do_remove_stake_limit_aggregate(
+        origin: T::RuntimeOrigin,
+        hotkey: T::AccountId,
+        netuid: NetUid,
+        alpha_unstaked: AlphaCurrency,
+        limit_price: u64,
+        allow_partial: bool,
+    ) -> dispatch::DispatchResult {
+        let coldkey = ensure_signed(origin)?;
+
+        // Consider the weight from on_finalize
+        if cfg!(feature = "runtime-benchmarks") && !cfg!(test) {
+            Self::do_remove_stake_limit(
+                crate::dispatch::RawOrigin::Signed(coldkey.clone()).into(),
+                hotkey.clone(),
+                netuid,
+                alpha_unstaked,
+                limit_price,
+                allow_partial,
+            )?;
+        }
+
+        let stake_job = StakeJob::RemoveStakeLimit {
+            hotkey,
+            coldkey,
+            netuid,
+            alpha_unstaked,
+            limit_price,
+            allow_partial,
+        };
+
+        let stake_job_id = NextStakeJobId::<T>::get();
+        let current_blocknumber = <frame_system::Pallet<T>>::block_number();
+
+        StakeJobs::<T>::insert(current_blocknumber, stake_job_id, stake_job);
+        NextStakeJobId::<T>::set(stake_job_id.saturating_add(1));
+
+        // Done and ok.
+        Ok(())
+    }
+
+    pub fn do_unstake_all_aggregate(
+        origin: T::RuntimeOrigin,
+        hotkey: T::AccountId,
+    ) -> dispatch::DispatchResult {
+        // We check the transaction is signed by the caller and retrieve the T::AccountId coldkey information.
+        let coldkey = ensure_signed(origin)?;
+
+        // Consider the weight from on_finalize
+        if cfg!(feature = "runtime-benchmarks") && !cfg!(test) {
+            Self::do_unstake_all(
+                crate::dispatch::RawOrigin::Signed(coldkey.clone()).into(),
+                hotkey.clone(),
+            )?;
+        }
+
+        // Save the unstake_all job for the on_finalize
+        let stake_job = StakeJob::UnstakeAll { hotkey, coldkey };
+
+        let stake_job_id = NextStakeJobId::<T>::get();
+        let current_blocknumber = <frame_system::Pallet<T>>::block_number();
+
+        StakeJobs::<T>::insert(current_blocknumber, stake_job_id, stake_job);
+        NextStakeJobId::<T>::set(stake_job_id.saturating_add(1));
+
+        Ok(())
+    }
+
+    pub fn do_unstake_all_alpha_aggregate(
+        origin: T::RuntimeOrigin,
+        hotkey: T::AccountId,
+    ) -> dispatch::DispatchResult {
+        // We check the transaction is signed by the caller and retrieve the T::AccountId coldkey information.
+        let coldkey = ensure_signed(origin)?;
+
+        // Consider the weight from on_finalize
+        if cfg!(feature = "runtime-benchmarks") && !cfg!(test) {
+            Self::do_unstake_all_alpha(
+                crate::dispatch::RawOrigin::Signed(coldkey.clone()).into(),
+                hotkey.clone(),
+            )?;
+        }
+
+        // Save the unstake_all_alpha job for the on_finalize
+        let stake_job = StakeJob::UnstakeAllAlpha { hotkey, coldkey };
+
+        let stake_job_id = NextStakeJobId::<T>::get();
+        let current_blocknumber = <frame_system::Pallet<T>>::block_number();
+
+        StakeJobs::<T>::insert(current_blocknumber, stake_job_id, stake_job);
+        NextStakeJobId::<T>::set(stake_job_id.saturating_add(1));
+
+        Ok(())
+    }
 }

--- a/pallets/subtensor/src/staking/remove_stake.rs
+++ b/pallets/subtensor/src/staking/remove_stake.rs
@@ -37,7 +37,7 @@ impl<T: Config> Pallet<T> {
     ///     -  Thrown if key has hit transaction rate limit
     ///
     pub fn do_remove_stake(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         hotkey: T::AccountId,
         netuid: NetUid,
         alpha_unstaked: AlphaCurrency,
@@ -117,10 +117,7 @@ impl<T: Config> Pallet<T> {
     /// * 'TxRateLimitExceeded':
     ///     -  Thrown if key has hit transaction rate limit
     ///
-    pub fn do_unstake_all(
-        origin: T::RuntimeOrigin,
-        hotkey: T::AccountId,
-    ) -> dispatch::DispatchResult {
+    pub fn do_unstake_all(origin: OriginFor<T>, hotkey: T::AccountId) -> dispatch::DispatchResult {
         // 1. We check the transaction is signed by the caller and retrieve the T::AccountId coldkey information.
         let coldkey = ensure_signed(origin)?;
         log::debug!("do_unstake_all( origin:{:?} hotkey:{:?} )", coldkey, hotkey);
@@ -208,7 +205,7 @@ impl<T: Config> Pallet<T> {
     ///     -  Thrown if key has hit transaction rate limit
     ///
     pub fn do_unstake_all_alpha(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         hotkey: T::AccountId,
     ) -> dispatch::DispatchResult {
         // 1. We check the transaction is signed by the caller and retrieve the T::AccountId coldkey information.
@@ -327,7 +324,7 @@ impl<T: Config> Pallet<T> {
     ///     - Thrown if there is not enough stake on the hotkey to withdwraw this amount.
     ///
     pub fn do_remove_stake_limit(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         hotkey: T::AccountId,
         netuid: NetUid,
         alpha_unstaked: AlphaCurrency,
@@ -424,7 +421,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn do_remove_stake_full_limit(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         hotkey: T::AccountId,
         netuid: NetUid,
         limit_price: Option<u64>,
@@ -442,7 +439,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn do_remove_stake_full_limit_aggregate(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         hotkey: T::AccountId,
         netuid: NetUid,
         limit_price: Option<u64>,
@@ -467,7 +464,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn do_remove_stake_aggregate(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         hotkey: T::AccountId,
         netuid: NetUid,
         alpha_unstaked: AlphaCurrency,
@@ -503,7 +500,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn do_remove_stake_limit_aggregate(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         hotkey: T::AccountId,
         netuid: NetUid,
         alpha_unstaked: AlphaCurrency,
@@ -544,7 +541,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn do_unstake_all_aggregate(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         hotkey: T::AccountId,
     ) -> dispatch::DispatchResult {
         // We check the transaction is signed by the caller and retrieve the T::AccountId coldkey information.
@@ -571,7 +568,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn do_unstake_all_alpha_aggregate(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         hotkey: T::AccountId,
     ) -> dispatch::DispatchResult {
         // We check the transaction is signed by the caller and retrieve the T::AccountId coldkey information.

--- a/pallets/subtensor/src/staking/remove_stake.rs
+++ b/pallets/subtensor/src/staking/remove_stake.rs
@@ -440,7 +440,7 @@ impl<T: Config> Pallet<T> {
             Self::do_remove_stake(origin, hotkey, netuid, alpha_unstaked)
         }
     }
-    
+
     pub fn do_remove_stake_full_limit_aggregate(
         origin: T::RuntimeOrigin,
         hotkey: T::AccountId,
@@ -453,7 +453,14 @@ impl<T: Config> Pallet<T> {
             Self::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
 
         if let Some(limit_price) = limit_price {
-            Self::do_remove_stake_limit_aggregate(origin, hotkey, netuid, alpha_unstaked, limit_price, false)
+            Self::do_remove_stake_limit_aggregate(
+                origin,
+                hotkey,
+                netuid,
+                alpha_unstaked,
+                limit_price,
+                false,
+            )
         } else {
             Self::do_remove_stake_aggregate(origin, hotkey, netuid, alpha_unstaked)
         }

--- a/pallets/subtensor/src/staking/remove_stake.rs
+++ b/pallets/subtensor/src/staking/remove_stake.rs
@@ -440,6 +440,24 @@ impl<T: Config> Pallet<T> {
             Self::do_remove_stake(origin, hotkey, netuid, alpha_unstaked)
         }
     }
+    
+    pub fn do_remove_stake_full_limit_aggregate(
+        origin: T::RuntimeOrigin,
+        hotkey: T::AccountId,
+        netuid: NetUid,
+        limit_price: Option<u64>,
+    ) -> DispatchResult {
+        let coldkey = ensure_signed(origin.clone())?;
+
+        let alpha_unstaked =
+            Self::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
+
+        if let Some(limit_price) = limit_price {
+            Self::do_remove_stake_limit_aggregate(origin, hotkey, netuid, alpha_unstaked, limit_price, false)
+        } else {
+            Self::do_remove_stake_aggregate(origin, hotkey, netuid, alpha_unstaked)
+        }
+    }
 
     pub fn do_remove_stake_aggregate(
         origin: T::RuntimeOrigin,

--- a/pallets/subtensor/src/staking/set_children.rs
+++ b/pallets/subtensor/src/staking/set_children.rs
@@ -35,7 +35,7 @@ impl<T: Config> Pallet<T> {
     ///     - Too many children in request
     ///
     pub fn do_schedule_children(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         hotkey: T::AccountId,
         netuid: NetUid,
         children: Vec<(u64, T::AccountId)>,

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -1309,7 +1309,7 @@ impl<T: Config> Pallet<T> {
     }
 
     // Process staking job for on_finalize() hook.
-    pub(crate) fn process_staking_jobs(_current_block_number: BlockNumberFor<T>) {
+    pub fn process_staking_jobs(_current_block_number: BlockNumberFor<T>) {
         let stake_jobs = StakeJobs::<T>::drain().collect::<Vec<_>>();
 
         // Sort jobs by job type
@@ -1356,7 +1356,7 @@ impl<T: Config> Pallet<T> {
             }
             _ => sp_std::cmp::Ordering::Equal, // unreachable
         });
-        
+
         // TODO: add other extrinsics
 
         // direct job order
@@ -1397,7 +1397,7 @@ impl<T: Config> Pallet<T> {
                                 stake_to_be_added,
                                 err
                             );
-                            // TODO: 
+                            // TODO:
                             // Self::deposit_event(Event::FailedToAddAggregatedStake(
                             //     coldkey,
                             //     hotkey,
@@ -1405,7 +1405,7 @@ impl<T: Config> Pallet<T> {
                             //     stake_to_be_added,
                             // ));
                         } else {
-                            // TODO: 
+                            // TODO:
                             // Self::deposit_event(Event::AggregatedStakeAdded(
                             //     coldkey,
                             //     hotkey,

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -3,6 +3,7 @@ use frame_support::traits::Randomness;
 use frame_system::pallet_prelude::BlockNumberFor;
 use safe_math::*;
 use share_pool::{SharePool, SharePoolDataOperations};
+use sp_core::blake2_128;
 use sp_std::ops::Neg;
 use substrate_fixed::types::{I64F64, I96F32, U64F64, U96F32};
 use subtensor_runtime_common::{AlphaCurrency, Currency, NetUid};
@@ -1341,7 +1342,8 @@ impl<T: Config> Pallet<T> {
             T::Hash,
             BlockNumberFor<T>,
         >>::random(b"staking_ops");
-        let first_byte = randomness.as_ref().first().unwrap_or(&0);
+        let random_hash = blake2_128(randomness.as_ref());
+        let first_byte = random_hash.as_ref().first().unwrap_or(&0);
         // Extract the first bit
         let altered_order = (*first_byte & 0b10000000) != 0;
 

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -1340,83 +1340,245 @@ impl<T: Config> Pallet<T> {
         let altered_order = (*first_byte & 0b10000000) != 0;
 
         // Ascending sort by coldkey
-
-        add_stake.sort_by(|a, b| match (a, b) {
-            (
-                StakeJob::AddStake { coldkey: a_key, .. },
-                StakeJob::AddStake { coldkey: b_key, .. },
-            ) => {
-                let direct_order = b_key.cmp(a_key); // descending
-
-                if altered_order {
-                    direct_order.reverse()
-                } else {
-                    direct_order
-                }
+        let compare_coldkeys = |a_key: &T::AccountId, b_key: &T::AccountId| {
+            let direct_order = a_key.cmp(b_key);
+            if altered_order {
+                direct_order.reverse()
+            } else {
+                direct_order
             }
-            _ => sp_std::cmp::Ordering::Equal, // unreachable
-        });
+        };
 
-        // TODO: add other extrinsics
+        remove_stake_limit.sort_by(|a, b| compare_coldkeys(&a.coldkey(), &b.coldkey()));
+        remove_stake.sort_by(|a, b| compare_coldkeys(&a.coldkey(), &b.coldkey()));
+        unstake_all.sort_by(|a, b| compare_coldkeys(&a.coldkey(), &b.coldkey()));
+        unstake_all_aplha.sort_by(|a, b| compare_coldkeys(&a.coldkey(), &b.coldkey()));
+        add_stake_limit.sort_by(|a, b| compare_coldkeys(&a.coldkey(), &b.coldkey()));
+        add_stake.sort_by(|a, b| compare_coldkeys(&a.coldkey(), &b.coldkey()));
 
-        // direct job order
-        let mut job_batches = vec![
-            remove_stake_limit,
+        let job_batches = vec![
+            add_stake,
+            add_stake_limit,
             remove_stake,
+            remove_stake_limit,
             unstake_all,
             unstake_all_aplha,
-            add_stake_limit,
-            add_stake,
         ];
-        if altered_order {
-            job_batches.reverse();
-        }
 
         for jobs in job_batches.into_iter() {
             for job in jobs.into_iter() {
-                match job {
-                    StakeJob::AddStake {
-                        hotkey,
+                Self::process_single_staking_job(job);
+            }
+        }
+    }
+
+    fn process_single_staking_job(job: StakeJob<T::AccountId>) {
+        match job {
+            StakeJob::RemoveStakeLimit {
+                hotkey,
+                coldkey,
+                netuid,
+                alpha_unstaked,
+                limit_price,
+                allow_partial,
+            } => {
+                let result = Self::do_remove_stake_limit(
+                    dispatch::RawOrigin::Signed(coldkey.clone()).into(),
+                    hotkey.clone(),
+                    netuid,
+                    alpha_unstaked,
+                    limit_price,
+                    allow_partial,
+                );
+
+                if let Err(err) = result {
+                    log::debug!(
+                        "Failed to remove aggregated limited stake: {:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}",
                         coldkey,
+                        hotkey,
+                        netuid,
+                        alpha_unstaked,
+                        limit_price,
+                        allow_partial,
+                        err
+                    );
+                    Self::deposit_event(Event::FailedToRemoveAggregatedLimitedStake {
+                        coldkey,
+                        hotkey,
+                        netuid,
+                        alpha_unstaked,
+                        limit_price,
+                        allow_partial,
+                    });
+                } else {
+                    Self::deposit_event(Event::AggregatedLimitedStakeRemoved {
+                        coldkey,
+                        hotkey,
+                        netuid,
+                        alpha_unstaked,
+                        limit_price,
+                        allow_partial,
+                    });
+                }
+            }
+            StakeJob::RemoveStake {
+                coldkey,
+                hotkey,
+                netuid,
+                alpha_unstaked,
+            } => {
+                let result = Self::do_remove_stake(
+                    dispatch::RawOrigin::Signed(coldkey.clone()).into(),
+                    hotkey.clone(),
+                    netuid,
+                    alpha_unstaked,
+                );
+
+                if let Err(err) = result {
+                    log::debug!(
+                        "Failed to remove aggregated stake: {:?}, {:?}, {:?}, {:?}, {:?}",
+                        coldkey,
+                        hotkey,
+                        netuid,
+                        alpha_unstaked,
+                        err
+                    );
+                    Self::deposit_event(Event::FailedToRemoveAggregatedStake {
+                        coldkey,
+                        hotkey,
+                        netuid,
+                        alpha_unstaked,
+                    });
+                } else {
+                    Self::deposit_event(Event::AggregatedStakeRemoved {
+                        coldkey,
+                        hotkey,
+                        netuid,
+                        alpha_unstaked,
+                    });
+                }
+            }
+            StakeJob::UnstakeAll { hotkey, coldkey } => {
+                let result = Self::do_unstake_all(
+                    dispatch::RawOrigin::Signed(coldkey.clone()).into(),
+                    hotkey.clone(),
+                );
+
+                if let Err(err) = result {
+                    log::debug!(
+                        "Failed to unstake all: {:?}, {:?}, {:?}",
+                        coldkey,
+                        hotkey,
+                        err
+                    );
+                    Self::deposit_event(Event::AggregatedUnstakeAllFailed { coldkey, hotkey });
+                } else {
+                    Self::deposit_event(Event::AggregatedUnstakeAllSucceeded { coldkey, hotkey });
+                }
+            }
+            StakeJob::UnstakeAllAlpha { hotkey, coldkey } => {
+                let result = Self::do_unstake_all_alpha(
+                    dispatch::RawOrigin::Signed(coldkey.clone()).into(),
+                    hotkey.clone(),
+                );
+
+                if let Err(err) = result {
+                    log::debug!(
+                        "Failed to unstake all alpha: {:?}, {:?}, {:?}",
+                        coldkey,
+                        hotkey,
+                        err
+                    );
+                    Self::deposit_event(Event::AggregatedUnstakeAllAlphaFailed { coldkey, hotkey });
+                } else {
+                    Self::deposit_event(Event::AggregatedUnstakeAllAlphaSucceeded {
+                        coldkey,
+                        hotkey,
+                    });
+                }
+            }
+            StakeJob::AddStakeLimit {
+                hotkey,
+                coldkey,
+                netuid,
+                stake_to_be_added,
+                limit_price,
+                allow_partial,
+            } => {
+                let result = Self::do_add_stake_limit(
+                    dispatch::RawOrigin::Signed(coldkey.clone()).into(),
+                    hotkey.clone(),
+                    netuid,
+                    stake_to_be_added,
+                    limit_price,
+                    allow_partial,
+                );
+
+                if let Err(err) = result {
+                    log::debug!(
+                        "Failed to add aggregated limited stake: {:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}",
+                        coldkey,
+                        hotkey,
                         netuid,
                         stake_to_be_added,
-                    } => {
-                        let result = Self::do_add_stake(
-                            dispatch::RawOrigin::Signed(coldkey.clone()).into(),
-                            hotkey.clone(),
-                            netuid,
-                            stake_to_be_added,
-                        );
+                        limit_price,
+                        allow_partial,
+                        err
+                    );
+                    Self::deposit_event(Event::FailedToAddAggregatedLimitedStake {
+                        coldkey,
+                        hotkey,
+                        netuid,
+                        stake_to_be_added,
+                        limit_price,
+                        allow_partial,
+                    });
+                } else {
+                    Self::deposit_event(Event::AggregatedLimitedStakeAdded {
+                        coldkey,
+                        hotkey,
+                        netuid,
+                        stake_to_be_added,
+                        limit_price,
+                        allow_partial,
+                    });
+                }
+            }
+            StakeJob::AddStake {
+                hotkey,
+                coldkey,
+                netuid,
+                stake_to_be_added,
+            } => {
+                let result = Self::do_add_stake(
+                    dispatch::RawOrigin::Signed(coldkey.clone()).into(),
+                    hotkey.clone(),
+                    netuid,
+                    stake_to_be_added,
+                );
 
-                        if let Err(err) = result {
-                            log::debug!(
-                                "Failed to add aggregated stake: {:?}, {:?}, {:?}, {:?}, {:?}",
-                                coldkey,
-                                hotkey,
-                                netuid,
-                                stake_to_be_added,
-                                err
-                            );
-                            // TODO:
-                            // Self::deposit_event(Event::FailedToAddAggregatedStake(
-                            //     coldkey,
-                            //     hotkey,
-                            //     netuid,
-                            //     stake_to_be_added,
-                            // ));
-                        } else {
-                            // TODO:
-                            // Self::deposit_event(Event::AggregatedStakeAdded(
-                            //     coldkey,
-                            //     hotkey,
-                            //     netuid,
-                            //     stake_to_be_added,
-                            // ));
-                        }
-                    }
-                    _ => {
-                        // TODO: implement other extrinsics
-                    }
+                if let Err(err) = result {
+                    log::debug!(
+                        "Failed to add aggregated stake: {:?}, {:?}, {:?}, {:?}, {:?}",
+                        coldkey,
+                        hotkey,
+                        netuid,
+                        stake_to_be_added,
+                        err
+                    );
+                    Self::deposit_event(Event::FailedToAddAggregatedStake {
+                        coldkey,
+                        hotkey,
+                        netuid,
+                        stake_to_be_added,
+                    });
+                } else {
+                    Self::deposit_event(Event::AggregatedStakeAdded {
+                        coldkey,
+                        hotkey,
+                        netuid,
+                        stake_to_be_added,
+                    });
                 }
             }
         }

--- a/pallets/subtensor/src/subnets/leasing.rs
+++ b/pallets/subtensor/src/subnets/leasing.rs
@@ -67,7 +67,7 @@ impl<T: Config> Pallet<T> {
     ///
     /// The leftover cap is refunded to the contributors and the beneficiary.
     pub fn do_register_leased_network(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         emissions_share: Percent,
         end_block: Option<BlockNumberFor<T>>,
     ) -> DispatchResultWithPostInfo {
@@ -191,7 +191,7 @@ impl<T: Config> Pallet<T> {
     /// The beneficiary can terminate the lease after the end block has passed and get the subnet ownership.
     /// The subnet is transferred to the beneficiary and the lease is removed from storage.
     pub fn do_terminate_lease(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         lease_id: LeaseId,
         hotkey: T::AccountId,
     ) -> DispatchResultWithPostInfo {

--- a/pallets/subtensor/src/subnets/registration.rs
+++ b/pallets/subtensor/src/subnets/registration.rs
@@ -65,7 +65,7 @@ impl<T: Config> Pallet<T> {
     ///     - The hotkey is already registered on this network.
     ///
     pub fn do_burned_registration(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         netuid: NetUid,
         hotkey: T::AccountId,
     ) -> DispatchResult {
@@ -222,7 +222,7 @@ impl<T: Config> Pallet<T> {
     ///     - The seal is incorrect.
     ///
     pub fn do_registration(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         netuid: NetUid,
         block_number: u64,
         nonce: u64,
@@ -349,7 +349,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn do_faucet(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         block_number: u64,
         nonce: u64,
         work: Vec<u8>,

--- a/pallets/subtensor/src/subnets/serving.rs
+++ b/pallets/subtensor/src/subnets/serving.rs
@@ -56,7 +56,7 @@ impl<T: Config> Pallet<T> {
     ///     - Attempting to set prometheus information withing the rate limit min.
     ///
     pub fn do_serve_axon(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         netuid: NetUid,
         version: u32,
         ip: u128,
@@ -160,7 +160,7 @@ impl<T: Config> Pallet<T> {
     ///     - Attempting to set prometheus information withing the rate limit min.
     ///
     pub fn do_serve_prometheus(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         netuid: NetUid,
         version: u32,
         ip: u128,

--- a/pallets/subtensor/src/subnets/subnet.rs
+++ b/pallets/subtensor/src/subnets/subnet.rs
@@ -101,7 +101,7 @@ impl<T: Config> Pallet<T> {
     /// Facilitates user registration of a new subnetwork.
     ///
     /// # Args:
-    /// * 'origin': ('T::RuntimeOrigin'): The calling origin. Must be signed.
+    /// * 'origin': ('OriginFor<T>'): The calling origin. Must be signed.
     /// * `identity` (`Option<SubnetIdentityOfV3>`): Optional identity to be associated with the new subnetwork.
     ///
     /// # Event:
@@ -115,7 +115,7 @@ impl<T: Config> Pallet<T> {
     /// * `SubnetIdentityRemoved(netuid)`: Emitted when the identity of a removed network is also deleted.
     ///
     pub fn do_register_network(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         hotkey: &T::AccountId,
         mechid: u16,
         identity: Option<SubnetIdentityOfV3>,
@@ -333,7 +333,7 @@ impl<T: Config> Pallet<T> {
     /// # Returns
     ///
     /// * `DispatchResult`: A result indicating the success or failure of the operation.
-    pub fn do_start_call(origin: T::RuntimeOrigin, netuid: NetUid) -> DispatchResult {
+    pub fn do_start_call(origin: OriginFor<T>, netuid: NetUid) -> DispatchResult {
         ensure!(
             Self::if_subnet_exist(netuid),
             Error::<T>::SubNetworkDoesNotExist
@@ -394,7 +394,7 @@ impl<T: Config> Pallet<T> {
     /// # Rate Limiting
     /// This function is rate-limited to one call per subnet per interval (e.g., one week).
     pub fn do_set_sn_owner_hotkey(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         netuid: NetUid,
         hotkey: &T::AccountId,
     ) -> DispatchResult {

--- a/pallets/subtensor/src/subnets/weights.rs
+++ b/pallets/subtensor/src/subnets/weights.rs
@@ -40,7 +40,7 @@ impl<T: Config> Pallet<T> {
     /// * `WeightsCommitted`:
     ///   - Emitted upon successfully storing the weight hash.
     pub fn do_commit_weights(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         netuid: NetUid,
         commit_hash: H256,
     ) -> DispatchResult {
@@ -138,7 +138,7 @@ impl<T: Config> Pallet<T> {
     ///    - Emitted when the lengths of the input vectors are not equal.
     ///
     pub fn do_batch_commit_weights(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         netuids: Vec<Compact<NetUid>>,
         commit_hashes: Vec<H256>,
     ) -> dispatch::DispatchResult {
@@ -228,7 +228,7 @@ impl<T: Config> Pallet<T> {
     /// * `WeightsCommitted`:
     ///   - Emitted upon successfully storing the weight hash.
     pub fn do_commit_crv3_weights(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         netuid: NetUid,
         commit: BoundedVec<u8, ConstU32<MAX_CRV3_COMMIT_SIZE_BYTES>>,
         reveal_round: u64,
@@ -338,7 +338,7 @@ impl<T: Config> Pallet<T> {
     /// * `InvalidRevealCommitHashNotMatch`:
     ///   - The revealed hash does not match any committed hash.
     pub fn do_reveal_weights(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         netuid: NetUid,
         uids: Vec<u16>,
         values: Vec<u16>,
@@ -479,7 +479,7 @@ impl<T: Config> Pallet<T> {
     /// * `InputLengthsUnequal`:
     ///   - The input vectors are of mismatched lengths.
     pub fn do_batch_reveal_weights(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         netuid: NetUid,
         uids_list: Vec<Vec<u16>>,
         values_list: Vec<Vec<u16>>,
@@ -675,7 +675,7 @@ impl<T: Config> Pallet<T> {
     ///    - Attempting to set weights with max value exceeding limit.
     ///
     pub fn do_set_weights(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         netuid: NetUid,
         uids: Vec<u16>,
         values: Vec<u16>,
@@ -826,7 +826,7 @@ impl<T: Config> Pallet<T> {
     ///    - Emitted when the lengths of the input vectors are not equal.
     ///
     pub fn do_batch_set_weights(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         netuids: Vec<Compact<NetUid>>,
         weights: Vec<Vec<(Compact<u16>, Compact<u16>)>>,
         version_keys: Vec<Compact<u64>>,

--- a/pallets/subtensor/src/swap/swap_hotkey.rs
+++ b/pallets/subtensor/src/swap/swap_hotkey.rs
@@ -26,7 +26,7 @@ impl<T: Config> Pallet<T> {
     /// * `HotKeyAlreadyRegisteredInSubNet` - If the new hotkey is already registered in the subnet.
     /// * `NotEnoughBalanceToPaySwapHotKey` - If there is not enough balance to pay for the swap.
     pub fn do_swap_hotkey(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         old_hotkey: &T::AccountId,
         new_hotkey: &T::AccountId,
         netuid: Option<NetUid>,

--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -40,7 +40,7 @@ frame_support::construct_runtime!(
         TriumvirateMembers: pallet_membership::<Instance1>::{Pallet, Call, Storage, Event<T>, Config<T>} = 4,
         Senate: pallet_collective::<Instance2>::{Pallet, Call, Storage, Origin<T>, Event<T>, Config<T>} = 5,
         SenateMembers: pallet_membership::<Instance2>::{Pallet, Call, Storage, Event<T>, Config<T>} = 6,
-        SubtensorModule: crate::{Pallet, Call, Storage, Event<T>} = 7,
+        SubtensorModule: crate::{Pallet, Call, Storage, Event<T>, Origin<T>} = 7,
         Utility: pallet_utility::{Pallet, Call, Storage, Event} = 8,
         Scheduler: pallet_scheduler::{Pallet, Call, Storage, Event<T>} = 9,
         Preimage: pallet_preimage::{Pallet, Call, Storage, Event<T>} = 10,
@@ -384,7 +384,19 @@ impl pallet_membership::Config<SenateMembership> for Test {
     type WeightInfo = pallet_membership::weights::SubstrateWeight<Test>;
 }
 
+pub struct OriginHelper;
+
+impl EvmOriginHelper<RuntimeOrigin, AccountId> for OriginHelper {
+    fn make_evm_origin(account_id: AccountId) -> RuntimeOrigin {
+        RuntimeOrigin::from(Origin::Evm { account_id })
+    }
+}
+
 impl crate::Config for Test {
+    // type EvmOrigin = EvmOrigin<Self>;
+    type RuntimeOrigin = RuntimeOrigin;
+
+    type EvmOriginHelper = OriginHelper;
     type RuntimeEvent = RuntimeEvent;
     type RuntimeCall = RuntimeCall;
     type Currency = Balances;

--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -616,6 +616,7 @@ impl pallet_drand::Config for Test {
     type Verifier = pallet_drand::verifier::QuicknetVerifier;
     type UnsignedPriority = ConstU64<{ 1 << 20 }>;
     type HttpFetchTimeout = ConstU64<1_000>;
+    type OnPulseReceived = ();
 }
 
 impl frame_system::offchain::SigningTypes for Test {

--- a/pallets/subtensor/src/tests/move_stake.rs
+++ b/pallets/subtensor/src/tests/move_stake.rs
@@ -2393,3 +2393,53 @@ fn test_do_swap_aggregate_fail() {
         }));
     });
 }
+
+#[test]
+fn test_swap_stake_limits_succeeds() {
+    new_test_ext(1).execute_with(|| {
+        let subnet_owner_coldkey = U256::from(1001);
+        let subnet_owner_hotkey = U256::from(1002);
+        let netuid = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
+        let netuid2 = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
+
+        let origin_coldkey = U256::from(1);
+        let hotkey = U256::from(3);
+        let stake_amount = DefaultMinStake::<Test>::get() * 10;
+
+        SubtensorModule::create_account_if_non_existent(&origin_coldkey, &hotkey);
+        SubtensorModule::stake_into_subnet(
+            &hotkey,
+            &origin_coldkey,
+            netuid,
+            stake_amount,
+            <Test as Config>::SwapInterface::max_price(),
+            false,
+        )
+            .unwrap();
+        let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey,
+            &origin_coldkey,
+            netuid,
+        );
+
+        assert_ok!(SubtensorModule::do_swap_stake(
+            RuntimeOrigin::signed(origin_coldkey),
+            hotkey,
+            netuid,
+            netuid2,
+            alpha
+        ),);
+
+        assert!(!StakingOperationRateLimiter::<Test>::contains_key((
+            hotkey,
+            origin_coldkey,
+            netuid
+        )));
+
+        assert!(StakingOperationRateLimiter::<Test>::contains_key((
+            hotkey,
+            origin_coldkey,
+            netuid2
+        )));
+    });
+}

--- a/pallets/subtensor/src/tests/staking.rs
+++ b/pallets/subtensor/src/tests/staking.rs
@@ -5766,3 +5766,112 @@ fn test_stake_rate_limits() {
         )));
     });
 }
+
+#[test]
+fn test_add_stake_aggregate_ok_no_emission() {
+    new_test_ext(1).execute_with(|| {
+        let hotkey_account_id = U256::from(533453);
+        let coldkey_account_id = U256::from(55453);
+        let amount = DefaultMinStake::<Test>::get() * 10;
+
+        //add network
+        let netuid = add_dynamic_network(&hotkey_account_id, &coldkey_account_id);
+
+        // Give it some $$$ in his coldkey balance
+        SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, amount);
+
+        // Check we have zero staked before transfer
+        assert_eq!(
+            SubtensorModule::get_total_stake_for_hotkey(&hotkey_account_id),
+            0
+        );
+
+        // Also total stake should be equal to the network initial lock
+        assert_eq!(
+            SubtensorModule::get_total_stake(),
+            SubtensorModule::get_network_min_lock()
+        );
+
+        // Transfer to hotkey account, and check if the result is ok
+        assert_ok!(SubtensorModule::add_stake_aggregate(
+            RuntimeOrigin::signed(coldkey_account_id),
+            hotkey_account_id,
+            netuid,
+            amount
+        ));
+
+        // Ensure that extrinsic call doesn't change the stake.
+        assert_eq!(
+            SubtensorModule::get_total_stake(),
+            SubtensorModule::get_network_min_lock()
+        );
+
+        // Check for the block delay
+        run_to_block_ext(2, true);
+
+        let approx_fee =
+            <Test as pallet::Config>::SwapInterface::approx_fee_amount(netuid.into(), amount);
+
+        // Check if stake has increased
+        assert_abs_diff_eq!(
+            SubtensorModule::get_total_stake_for_hotkey(&hotkey_account_id),
+            amount + approx_fee,
+            epsilon = amount / 1000,
+        );
+
+        // Check if balance has decreased
+        assert_eq!(SubtensorModule::get_coldkey_balance(&coldkey_account_id), 1);
+
+        // Check if total stake has increased accordingly.
+        assert_eq!(
+            SubtensorModule::get_total_stake(),
+            amount + SubtensorModule::get_network_min_lock()
+        );
+
+        // Check that event was emitted.
+        assert!(System::events().iter().any(|e| {
+            matches!(
+                &e.event,
+                RuntimeEvent::SubtensorModule(Event::StakeAdded { .. })
+            )
+        }));
+
+        // Check that event was emitted.
+        assert!(System::events().iter().any(|e| {
+            matches!(
+                &e.event,
+                RuntimeEvent::SubtensorModule(Event::AggregatedStakeAdded { .. })
+            )
+        }));
+    });
+}
+
+#[test]
+fn test_add_stake_aggregate_failed() {
+    new_test_ext(1).execute_with(|| {
+        let hotkey_account_id = U256::from(533453);
+        let coldkey_account_id = U256::from(55453);
+        let amount = DefaultMinStake::<Test>::get() * 100;
+        //add network
+        let netuid = add_dynamic_network(&hotkey_account_id, &coldkey_account_id);
+
+        // Transfer to hotkey account, and check if the result is ok
+        assert_ok!(SubtensorModule::add_stake_aggregate(
+            RuntimeOrigin::signed(coldkey_account_id),
+            hotkey_account_id,
+            netuid,
+            amount
+        ));
+
+        // Enable on_finalize code to run
+        run_to_block_ext(2, true);
+
+        // Check that event was emitted.
+        assert!(System::events().iter().any(|e| {
+            matches!(
+                &e.event,
+                RuntimeEvent::SubtensorModule(Event::FailedToAddAggregatedStake { .. })
+            )
+        }));
+    });
+}

--- a/pallets/subtensor/src/tests/staking.rs
+++ b/pallets/subtensor/src/tests/staking.rs
@@ -6564,4 +6564,3 @@ fn test_remove_stake_full_limit_aggregate_ok() {
         assert_abs_diff_eq!(new_balance, 9_086_000_000, epsilon = 1_000_000);
     });
 }
-

--- a/pallets/subtensor/src/utils/evm.rs
+++ b/pallets/subtensor/src/utils/evm.rs
@@ -42,7 +42,7 @@ impl<T: Config> Pallet<T> {
     /// * `block_number` - The block number used in the `signature`.
     /// * `signature` - A signed message by the `evm_key` containing the `hotkey` and the hashed `block_number`.
     pub fn do_associate_evm_key(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         netuid: NetUid,
         evm_key: H160,
         block_number: u64,

--- a/pallets/subtensor/src/utils/identity.rs
+++ b/pallets/subtensor/src/utils/identity.rs
@@ -25,7 +25,7 @@ impl<T: Config> Pallet<T> {
     ///
     /// Returns `Ok(())` if the identity is successfully set, otherwise returns an error.
     pub fn do_set_identity(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         name: Vec<u8>,
         url: Vec<u8>,
         github_repo: Vec<u8>,
@@ -96,7 +96,7 @@ impl<T: Config> Pallet<T> {
     ///
     /// Returns `Ok(())` if the subnet identity is successfully set, otherwise returns an error.
     pub fn do_set_subnet_identity(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         netuid: NetUid,
         subnet_name: Vec<u8>,
         github_repo: Vec<u8>,

--- a/pallets/subtensor/src/utils/misc.rs
+++ b/pallets/subtensor/src/utils/misc.rs
@@ -12,7 +12,7 @@ use subtensor_runtime_common::{AlphaCurrency, NetUid};
 
 impl<T: Config> Pallet<T> {
     pub fn ensure_subnet_owner_or_root(
-        o: T::RuntimeOrigin,
+        o: OriginFor<T>,
         netuid: NetUid,
     ) -> Result<(), DispatchError> {
         let coldkey = ensure_signed_or_root(o);
@@ -24,7 +24,7 @@ impl<T: Config> Pallet<T> {
         }
     }
 
-    pub fn ensure_subnet_owner(o: T::RuntimeOrigin, netuid: NetUid) -> Result<(), DispatchError> {
+    pub fn ensure_subnet_owner(o: OriginFor<T>, netuid: NetUid) -> Result<(), DispatchError> {
         let coldkey = ensure_signed(o);
         match coldkey {
             Ok(who) if SubnetOwner::<T>::get(netuid) == who => Ok(()),
@@ -653,7 +653,7 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn do_set_senate_required_stake_perc(
-        origin: T::RuntimeOrigin,
+        origin: OriginFor<T>,
         required_percent: u64,
     ) -> DispatchResult {
         ensure_root(origin)?;

--- a/precompiles/src/staking.rs
+++ b/precompiles/src/staking.rs
@@ -346,7 +346,7 @@ where
         let limit_price = limit_price_rao.unique_saturated_into();
         let hotkey = R::AccountId::from(address.0);
         let netuid = try_u16_from_u256(netuid)?;
-        let call = pallet_subtensor::Call::<R>::add_stake_limit {
+        let call = pallet_subtensor::Call::<R>::add_stake_limit_evm {
             hotkey,
             netuid: netuid.into(),
             amount_staked,
@@ -354,7 +354,9 @@ where
             allow_partial,
         };
 
-        handle.try_dispatch_runtime_call::<R, _>(call, RawOrigin::Signed(account_id))
+        let evm_origin = R::EvmOriginHelper::make_evm_origin(account_id);
+
+        handle.try_dispatch_runtime_call_with_custom_origin::<R, _>(call, evm_origin)
     }
 
     #[precompile::public("removeStakeLimit(bytes32,uint256,uint256,bool,uint256)")]
@@ -371,15 +373,16 @@ where
         let netuid = try_u16_from_u256(netuid)?;
         let amount_unstaked: u64 = amount_alpha.unique_saturated_into();
         let limit_price = limit_price_rao.unique_saturated_into();
-        let call = pallet_subtensor::Call::<R>::remove_stake_limit {
+        let call = pallet_subtensor::Call::<R>::remove_stake_limit_evm {
             hotkey,
             netuid: netuid.into(),
             amount_unstaked: amount_unstaked.into(),
             limit_price,
             allow_partial,
         };
+        let evm_origin = R::EvmOriginHelper::make_evm_origin(account_id);
 
-        handle.try_dispatch_runtime_call::<R, _>(call, RawOrigin::Signed(account_id))
+        handle.try_dispatch_runtime_call_with_custom_origin::<R, _>(call, evm_origin)
     }
 }
 

--- a/precompiles/src/staking.rs
+++ b/precompiles/src/staking.rs
@@ -179,7 +179,7 @@ where
         let origin_netuid = try_u16_from_u256(origin_netuid)?;
         let destination_netuid = try_u16_from_u256(destination_netuid)?;
         let alpha_amount: u64 = amount_alpha.unique_saturated_into();
-        let call = pallet_subtensor::Call::<R>::move_stake {
+        let call = pallet_subtensor::Call::<R>::move_stake_evm {
             origin_hotkey,
             destination_hotkey,
             origin_netuid: origin_netuid.into(),
@@ -187,7 +187,9 @@ where
             alpha_amount: alpha_amount.into(),
         };
 
-        handle.try_dispatch_runtime_call::<R, _>(call, RawOrigin::Signed(account_id))
+        let evm_origin = R::EvmOriginHelper::make_evm_origin(account_id);
+
+        handle.try_dispatch_runtime_call_with_custom_origin::<R, _>(call, evm_origin)
     }
 
     #[precompile::public("transferStake(bytes32,bytes32,uint256,uint256,uint256)")]
@@ -205,7 +207,7 @@ where
         let origin_netuid = try_u16_from_u256(origin_netuid)?;
         let destination_netuid = try_u16_from_u256(destination_netuid)?;
         let alpha_amount: u64 = amount_alpha.unique_saturated_into();
-        let call = pallet_subtensor::Call::<R>::transfer_stake {
+        let call = pallet_subtensor::Call::<R>::transfer_stake_evm {
             destination_coldkey,
             hotkey,
             origin_netuid: origin_netuid.into(),
@@ -213,7 +215,9 @@ where
             alpha_amount: alpha_amount.into(),
         };
 
-        handle.try_dispatch_runtime_call::<R, _>(call, RawOrigin::Signed(account_id))
+        let evm_origin = R::EvmOriginHelper::make_evm_origin(account_id);
+
+        handle.try_dispatch_runtime_call_with_custom_origin::<R, _>(call, evm_origin)
     }
 
     #[precompile::public("getTotalColdkeyStake(bytes32)")]

--- a/precompiles/src/staking.rs
+++ b/precompiles/src/staking.rs
@@ -135,13 +135,15 @@ where
         let account_id = handle.caller_account_id::<R>();
         let hotkey = R::AccountId::from(hotkey.0);
         let netuid = try_u16_from_u256(netuid)?;
-        let call = pallet_subtensor::Call::<R>::remove_stake_full_limit {
+        let call = pallet_subtensor::Call::<R>::remove_stake_full_limit_evm {
             hotkey,
             netuid: netuid.into(),
             limit_price,
         };
 
-        handle.try_dispatch_runtime_call::<R, _>(call, RawOrigin::Signed(account_id))
+        let evm_origin = R::EvmOriginHelper::make_evm_origin(account_id);
+
+        handle.try_dispatch_runtime_call_with_custom_origin::<R, _>(call, evm_origin)
     }
 
     #[precompile::public("removeStakeFull(bytes32,uint256)")]

--- a/precompiles/src/staking.rs
+++ b/precompiles/src/staking.rs
@@ -115,13 +115,15 @@ where
         let hotkey = R::AccountId::from(address.0);
         let netuid = try_u16_from_u256(netuid)?;
         let amount_unstaked: u64 = amount_alpha.unique_saturated_into();
-        let call = pallet_subtensor::Call::<R>::remove_stake {
+        let call = pallet_subtensor::Call::<R>::remove_stake_evm {
             hotkey,
             netuid: netuid.into(),
             amount_unstaked: amount_unstaked.into(),
         };
 
-        handle.try_dispatch_runtime_call::<R, _>(call, RawOrigin::Signed(account_id))
+        let evm_origin = R::EvmOriginHelper::make_evm_origin(account_id);
+
+        handle.try_dispatch_runtime_call_with_custom_origin::<R, _>(call, evm_origin)
     }
 
     fn call_remove_stake_full_limit(

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -104,6 +104,15 @@ use pallet_evm::{
     Account as EVMAccount, BalanceConverter, EvmBalance, FeeCalculator, Runner, SubstrateBalance,
 };
 
+pub struct StakingJobsOnDrandPulse;
+impl OnPulseReceived for StakingJobsOnDrandPulse {
+    fn on_pulse_received(_: RoundNumber) {
+        pallet_subtensor::pallet::Pallet::<Runtime>::process_staking_jobs(
+            frame_system::pallet::Pallet::<Runtime>::block_number(),
+        );
+    }
+}
+
 // Drand
 impl pallet_drand::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
@@ -111,6 +120,8 @@ impl pallet_drand::Config for Runtime {
     type Verifier = pallet_drand::verifier::QuicknetVerifier;
     type UnsignedPriority = ConstU64<{ 1 << 20 }>;
     type HttpFetchTimeout = ConstU64<1_000>;
+    // Warning: ensure the weight is calculated correctly when changing this parameter.
+    type OnPulseReceived = StakingJobsOnDrandPulse;
 }
 
 impl frame_system::offchain::SigningTypes for Runtime {
@@ -1311,6 +1322,8 @@ impl pallet_subtensor_swap::Config for Runtime {
     type WeightInfo = pallet_subtensor_swap::weights::DefaultWeight<Runtime>;
 }
 
+use pallet_drand::OnPulseReceived;
+use pallet_drand::types::RoundNumber;
 use sp_runtime::BoundedVec;
 
 pub struct AuraPalletIntrf;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -542,7 +542,7 @@ impl CanVote<AccountId> for CanVoteToTriumvirate {
     }
 }
 
-use pallet_subtensor::{CollectiveInterface, MemberManagement, ProxyInterface};
+use pallet_subtensor::{CollectiveInterface, EvmOriginHelper, MemberManagement, ProxyInterface};
 pub struct ManageSenateMembers;
 impl MemberManagement<AccountId> for ManageSenateMembers {
     fn add_member(account: &AccountId) -> DispatchResultWithPostInfo {
@@ -1226,7 +1226,17 @@ parameter_types! {
     pub const LeaseDividendsDistributionInterval: BlockNumber = 100; // 100 blocks
 }
 
+pub struct OriginHelper;
+
+impl EvmOriginHelper<RuntimeOrigin, AccountId> for OriginHelper {
+    fn make_evm_origin(account_id: AccountId) -> RuntimeOrigin {
+        RuntimeOrigin::from(pallet_subtensor::Origin::Evm { account_id })
+    }
+}
+
 impl pallet_subtensor::Config for Runtime {
+    type EvmOriginHelper = OriginHelper;
+    type RuntimeOrigin = RuntimeOrigin;
     type RuntimeEvent = RuntimeEvent;
     type RuntimeCall = RuntimeCall;
     type SudoRuntimeCall = RuntimeCall;


### PR DESCRIPTION
## Description
This PR reintroduces staking jobs for all staking operations. All staking operations will be delayed until the end of the block or the next DRAND pulse. The jobs within each type (like add_stake jobs) will be sorted using the last DRAND pulse randomness. 

Affected extrinsics:
 - add_stake
 - add_stake_limit
 - remove_stake
 - remove_stake_limit
 - remove_stake_full_limit (creates either remove_stake or remove_stake_limit staking job)
 - unstake_all
 - unstake_all_alpha
 - swap_stake
 - move_stake
 - transfer_stake


Comment: swap_stake, move_stake and transfer_stake will be likely modified using `transactional::with_transaction` as suggested by @gztensor 


## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules