### PR TITLE
Set Oldest Stored Round

### DIFF
--- a/pallets/drand/src/benchmarking.rs
+++ b/pallets/drand/src/benchmarking.rs
@@ -79,5 +79,15 @@ mod benchmarks {
         assert_eq!(Pulses::<T>::get(p.round), Some(p));
     }
 
+    #[benchmark]
+    fn set_oldest_stored_round() {
+        let oldest_stored_round: u64 = 10;
+
+        #[extrinsic_call]
+        set_oldest_stored_round(RawOrigin::Root, oldest_stored_round);
+
+        assert_eq!(OldestStoredRound::<T>::get(), oldest_stored_round);
+    }
+
     impl_benchmark_test_suite!(Drand, crate::mock::new_test_ext(), crate::mock::Test);
 }

--- a/pallets/drand/src/lib.rs
+++ b/pallets/drand/src/lib.rs
@@ -425,9 +425,9 @@ pub mod pallet {
 
         /// allows the root user to set the oldest stored round
         #[pallet::call_index(2)]
-        #[pallet::weight(Weight::from_parts(9_878_000, 0)
+        #[pallet::weight(Weight::from_parts(5_630_000, 0)
         .saturating_add(T::DbWeight::get().reads(0_u64))
-        .saturating_add(T::DbWeight::get().writes(2_u64)))]
+        .saturating_add(T::DbWeight::get().writes(1_u64)))]
         pub fn set_oldest_stored_round(origin: OriginFor<T>, oldest_round: u64) -> DispatchResult {
             ensure_root(origin)?;
             OldestStoredRound::<T>::put(oldest_round);

--- a/pallets/drand/src/lib.rs
+++ b/pallets/drand/src/lib.rs
@@ -278,11 +278,12 @@ pub mod pallet {
             }
         }
         fn on_runtime_upgrade() -> frame_support::weights::Weight {
-            let weight = frame_support::weights::Weight::from_parts(0, 0);
+            /*let weight = */
+            frame_support::weights::Weight::from_parts(0, 0) /*;*/
 
             //weight = weight.saturating_add(migrations::migrate_set_oldest_round::<T>());
 
-            weight
+            //weight
         }
     }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -218,7 +218,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 300,
+    spec_version: 301,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
This PR:
- Adds the sudo extrinsic `set_oldest_stored_round` 
- Disables the migration to set the oldest stored round