### PR TITLE
Fix updating root and stable subnets counters on stakes and unstakes

### DIFF
--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -572,53 +572,54 @@ impl<T: Config> Pallet<T> {
     ) -> Result<SwapResult, DispatchError> {
         // Step 1: Get the mechanism type for the subnet (0 for Stable, 1 for Dynamic)
         let mechanism_id: u16 = SubnetMechanism::<T>::get(netuid);
-        if mechanism_id == 1 {
-            let swap_result = T::SwapInterface::swap(
+        let swap_result = if mechanism_id == 1 {
+            T::SwapInterface::swap(
                 netuid.into(),
                 OrderType::Buy,
                 tao.into(),
                 price_limit.into(),
                 drop_fees,
                 false,
-            )?;
-            let alpha_decrease =
-                AlphaCurrency::from(swap_result.alpha_reserve_delta.unsigned_abs());
-
-            // Decrease Alpha reserves.
-            Self::decrease_provided_alpha_reserve(netuid.into(), alpha_decrease);
-
-            // Increase Alpha outstanding.
-            SubnetAlphaOut::<T>::mutate(netuid, |total| {
-                *total = total.saturating_add(swap_result.amount_paid_out.into());
-            });
-
-            // Increase only the protocol TAO reserve. We only use the sum of
-            // (SubnetTAO + SubnetTaoProvided) in tao_reserve(), so it is irrelevant
-            // which one to increase.
-            SubnetTAO::<T>::mutate(netuid, |total| {
-                *total = total.saturating_add((swap_result.tao_reserve_delta as u64).into());
-            });
-
-            // Increase Total Tao reserves.
-            TotalStake::<T>::mutate(|total| *total = total.saturating_add(tao));
-
-            // Increase total subnet TAO volume.
-            SubnetVolume::<T>::mutate(netuid, |total| {
-                *total = total.saturating_add(tao.to_u64() as u128);
-            });
-
-            // Return the alpha received.
-            Ok(swap_result)
+            )?
         } else {
+            let abs_delta: u64 = tao.into();
+
             // Step 3.b.1: Stable mechanism, just return the value 1:1
-            Ok(SwapResult {
+            SwapResult {
                 amount_paid_in: tao.into(),
                 amount_paid_out: tao.into(),
                 fee_paid: 0,
-                tao_reserve_delta: 0,
-                alpha_reserve_delta: 0,
-            })
-        }
+                tao_reserve_delta: abs_delta as i64,
+                alpha_reserve_delta: (abs_delta as i64).neg(),
+            }
+        };
+
+        let alpha_decrease = AlphaCurrency::from(swap_result.alpha_reserve_delta.unsigned_abs());
+
+        // Decrease Alpha reserves.
+        Self::decrease_provided_alpha_reserve(netuid.into(), alpha_decrease);
+
+        // Increase Alpha outstanding.
+        SubnetAlphaOut::<T>::mutate(netuid, |total| {
+            *total = total.saturating_add(swap_result.amount_paid_out.into());
+        });
+
+        // Increase only the protocol TAO reserve. We only use the sum of
+        // (SubnetTAO + SubnetTaoProvided) in tao_reserve(), so it is irrelevant
+        // which one to increase.
+        SubnetTAO::<T>::mutate(netuid, |total| {
+            *total = total.saturating_add((swap_result.tao_reserve_delta as u64).into());
+        });
+
+        // Increase Total Tao reserves.
+        TotalStake::<T>::mutate(|total| *total = total.saturating_add(tao));
+
+        // Increase total subnet TAO volume.
+        SubnetVolume::<T>::mutate(netuid, |total| {
+            *total = total.saturating_add(tao.to_u64() as u128);
+        });
+
+        Ok(swap_result)
     }
 
     /// Swaps a subnet's Alpha token for TAO.
@@ -633,62 +634,64 @@ impl<T: Config> Pallet<T> {
         // Step 1: Get the mechanism type for the subnet (0 for Stable, 1 for Dynamic)
         let mechanism_id: u16 = SubnetMechanism::<T>::get(netuid);
         // Step 2: Swap alpha and attain tao
-        if mechanism_id == 1 {
-            let swap_result = T::SwapInterface::swap(
+        let swap_result = if mechanism_id == 1 {
+            T::SwapInterface::swap(
                 netuid.into(),
                 OrderType::Sell,
                 alpha.into(),
                 price_limit.into(),
                 drop_fees,
                 false,
-            )?;
-
-            // Increase only the protocol Alpha reserve. We only use the sum of
-            // (SubnetAlphaIn + SubnetAlphaInProvided) in alpha_reserve(), so it is irrelevant
-            // which one to increase.
-            SubnetAlphaIn::<T>::mutate(netuid, |total| {
-                *total = total.saturating_add((swap_result.alpha_reserve_delta as u64).into());
-            });
-
-            // Decrease Alpha outstanding.
-            // TODO: Deprecate, not accurate in v3 anymore
-            SubnetAlphaOut::<T>::mutate(netuid, |total| {
-                *total = total.saturating_sub((swap_result.alpha_reserve_delta as u64).into());
-            });
-
-            // Decrease tao reserves.
-            Self::decrease_provided_tao_reserve(
-                netuid.into(),
-                swap_result
-                    .tao_reserve_delta
-                    .abs()
-                    .try_into()
-                    .unwrap_or(0)
-                    .into(),
-            );
-
-            // Reduce total TAO reserves.
-            TotalStake::<T>::mutate(|total| {
-                *total = total.saturating_sub(swap_result.amount_paid_out.into())
-            });
-
-            // Increase total subnet TAO volume.
-            SubnetVolume::<T>::mutate(netuid, |total| {
-                *total = total.saturating_add(swap_result.amount_paid_out.into())
-            });
-
-            // Return the tao received.
-            Ok(swap_result)
+            )?
         } else {
+            let abs_delta: u64 = alpha.into();
+
             // Step 3.b.1: Stable mechanism, just return the value 1:1
-            Ok(SwapResult {
+            SwapResult {
                 amount_paid_in: alpha.into(),
                 amount_paid_out: alpha.into(),
                 fee_paid: 0,
-                tao_reserve_delta: 0,
-                alpha_reserve_delta: 0,
-            })
-        }
+                tao_reserve_delta: (abs_delta as i64).neg(),
+                alpha_reserve_delta: abs_delta as i64,
+            }
+        };
+
+        // Increase only the protocol Alpha reserve. We only use the sum of
+        // (SubnetAlphaIn + SubnetAlphaInProvided) in alpha_reserve(), so it is irrelevant
+        // which one to increase.
+        SubnetAlphaIn::<T>::mutate(netuid, |total| {
+            *total = total.saturating_add((swap_result.alpha_reserve_delta as u64).into());
+        });
+
+        // Decrease Alpha outstanding.
+        // TODO: Deprecate, not accurate in v3 anymore
+        SubnetAlphaOut::<T>::mutate(netuid, |total| {
+            *total = total.saturating_sub((swap_result.alpha_reserve_delta as u64).into());
+        });
+
+        // Decrease tao reserves.
+        Self::decrease_provided_tao_reserve(
+            netuid.into(),
+            swap_result
+                .tao_reserve_delta
+                .abs()
+                .try_into()
+                .unwrap_or(0)
+                .into(),
+        );
+
+        // Reduce total TAO reserves.
+        TotalStake::<T>::mutate(|total| {
+            *total = total.saturating_sub(swap_result.amount_paid_out.into())
+        });
+
+        // Increase total subnet TAO volume.
+        SubnetVolume::<T>::mutate(netuid, |total| {
+            *total = total.saturating_add(swap_result.amount_paid_out.into())
+        });
+
+        // Return the tao received.
+        Ok(swap_result)
     }
 
     /// Unstakes alpha from a subnet for a given hotkey and coldkey pair.

--- a/pallets/transaction-fee/src/lib.rs
+++ b/pallets/transaction-fee/src/lib.rs
@@ -160,8 +160,6 @@ where
         alpha_vec: &[(AccountIdOf<T>, NetUid)],
         tao_amount: u64,
     ) {
-        log::error("====== Withdrawing alpha fees");
-
         if alpha_vec.is_empty() {
             return;
         }

--- a/pallets/transaction-fee/src/lib.rs
+++ b/pallets/transaction-fee/src/lib.rs
@@ -160,6 +160,8 @@ where
         alpha_vec: &[(AccountIdOf<T>, NetUid)],
         tao_amount: u64,
     ) {
+        log::error("====== Withdrawing alpha fees");
+
         if alpha_vec.is_empty() {
             return;
         }


### PR DESCRIPTION
## Description

Fix updating root and stable subnet counters (TotalStake, SubnetTAO, SubnetAlphaIn, SubnetAlphaOut, SubnetVolume) when staking and unstaking.

## Related Issue(s)

- Partially addresses #1911 , need a migration after this PR is deployed for the full fix.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

