### PR TITLE
Ignore zero alpha stake in `clear_small_nomination_if_required`

### DIFF
--- a/pallets/subtensor/src/staking/helpers.rs
+++ b/pallets/subtensor/src/staking/helpers.rs
@@ -184,7 +184,7 @@ impl<T: Config> Pallet<T> {
     ) {
         // Verify if the account is a nominator account by checking ownership of the hotkey by the coldkey.
         if !Self::coldkey_owns_hotkey(coldkey, hotkey) {
-            // If the stake is below the minimum required, it's considered a small nomination and needs to be cleared.
+            // If the stake is non-zero and below the minimum required, it's considered a small nomination and needs to be cleared.
             // Log if the stake is below the minimum required
             let alpha_stake =
                 Self::get_stake_for_hotkey_and_coldkey_on_subnet(hotkey, coldkey, netuid);
@@ -192,7 +192,7 @@ impl<T: Config> Pallet<T> {
                 U96F32::saturating_from_num(Self::get_nominator_min_required_stake())
                     .safe_div(T::SwapInterface::current_alpha_price(netuid))
                     .saturating_to_num::<u64>();
-            if alpha_stake < min_alpha_stake.into() {
+            if alpha_stake > 0.into() && alpha_stake < min_alpha_stake.into() {
                 // Log the clearing of a small nomination
                 // Remove the stake from the nominator account. (this is a more forceful unstake operation which )
                 // Actually deletes the staking account.


### PR DESCRIPTION
## Description
`clear_small_nomination_if_required` now validates that `alpha_stake > 0` before it proceeds to clear the small nomination. This fixes the issue where the function would emit unnecessary `StakeRemoved` and `Deposit` events with zero values.


## Related Issue(s)

- Closes #1950

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.