### PR TITLE
Fix liquidity positions limit.

### DIFF
--- a/pallets/swap/src/pallet/impls.rs
+++ b/pallets/swap/src/pallet/impls.rs
@@ -885,7 +885,7 @@ impl<T: Config> Pallet<T> {
         liquidity: u64,
     ) -> Result<(Position<T>, u64, u64), Error<T>> {
         ensure!(
-            Self::count_positions(netuid, coldkey_account_id) <= T::MaxPositions::get() as usize,
+            Self::count_positions(netuid, coldkey_account_id) < T::MaxPositions::get() as usize,
             Error::<T>::MaxPositionsExceeded
         );
 

--- a/pallets/swap/src/pallet/tests.rs
+++ b/pallets/swap/src/pallet/tests.rs
@@ -343,6 +343,40 @@ fn test_add_liquidity_basic() {
 }
 
 #[test]
+fn test_add_liquidity_max_limit_enforced() {
+    new_test_ext().execute_with(|| {
+        let netuid = NetUid::from(1);
+        let liquidity = 2_000_000_000_u64;
+        assert_ok!(Pallet::<Test>::maybe_initialize_v3(netuid));
+
+        let limit = MaxPositions::get() as usize;
+
+        for _ in 0..limit {
+            Pallet::<Test>::do_add_liquidity(
+                netuid,
+                &OK_COLDKEY_ACCOUNT_ID,
+                &OK_HOTKEY_ACCOUNT_ID,
+                TickIndex::MIN,
+                TickIndex::MAX,
+                liquidity,
+            )
+            .unwrap();
+        }
+
+        let test_result = Pallet::<Test>::do_add_liquidity(
+            netuid,
+            &OK_COLDKEY_ACCOUNT_ID,
+            &OK_HOTKEY_ACCOUNT_ID,
+            TickIndex::MIN,
+            TickIndex::MAX,
+            liquidity,
+        );
+
+        assert_err!(test_result, Error::<Test>::MaxPositionsExceeded);
+    });
+}
+
+#[test]
 fn test_add_liquidity_out_of_bounds() {
     new_test_ext().execute_with(|| {
         [


### PR DESCRIPTION
## Description

This PR fixes a minor issue with the liquidity limit. It moves the limit from (LIMIT + 1) to just LIMIT when adding a new liquidity position. 

## Type of Change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
