### PR TITLE
do not update (singular) BlockEmission for every subnet

### DIFF
--- a/pallets/subtensor/src/coinbase/block_emission.rs
+++ b/pallets/subtensor/src/coinbase/block_emission.rs
@@ -98,7 +98,13 @@ impl<T: Config> Pallet<T> {
     ///
     pub fn get_block_emission() -> Result<TaoCurrency, &'static str> {
         // Convert the total issuance to a fixed-point number for calculation.
-        Self::get_block_emission_for_issuance(Self::get_total_issuance().into()).map(Into::into)
+        let block_emission =
+            Self::get_block_emission_for_issuance(Self::get_total_issuance().into());
+        let block_emission_u64: u64 = block_emission.unwrap_or(0);
+        if BlockEmission::<T>::get() != block_emission_u64 {
+            BlockEmission::<T>::put(block_emission_u64);
+        }
+        block_emission.map(Into::into)
     }
 
     /// Returns the block emission for an issuance value.
@@ -144,9 +150,6 @@ impl<T: Config> Pallet<T> {
             .saturating_mul(I96F32::saturating_from_num(DefaultBlockEmission::<T>::get()));
         // Convert to u64
         let block_emission_u64: u64 = block_emission.saturating_to_num::<u64>();
-        if BlockEmission::<T>::get() != block_emission_u64 {
-            BlockEmission::<T>::put(block_emission_u64);
-        }
         Ok(block_emission_u64)
     }
 }


### PR DESCRIPTION
do not update (singular) BlockEmission for every subnet but only on fetching Tao block emission

## Description

BlockEmission is updated in a utility function, which is very clearly the wrong place

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional Notes

This is actively being discussed in discord channel refactor-run_coinbase