### PR TITLE
Upgrade docker container build instance type

### DIFF
--- a/.github/workflows/docker-localnet.yml
+++ b/.github/workflows/docker-localnet.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: [self-hosted, type-ccx33]
+    runs-on: [self-hosted, type-ccx53, type-ccx43, type-ccx33]
 
     steps:
       - name: Determine Docker tag and ref

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: [self-hosted, type-ccx33]
+    runs-on: [self-hosted, type-ccx53, type-ccx43, type-ccx33]
 
     steps:
       - name: Determine Docker tag and ref

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -120,9 +120,9 @@ mod dispatches {
         /// 	- On failure for each failed item in the batch.
         ///
         #[pallet::call_index(80)]
-        #[pallet::weight((Weight::from_parts(95_160_000, 0)
-        .saturating_add(T::DbWeight::get().reads(14))
-        .saturating_add(T::DbWeight::get().writes(2)), DispatchClass::Normal, Pays::No))]
+        #[pallet::weight((Weight::from_parts(19_330_000, 0)
+        .saturating_add(T::DbWeight::get().reads(1_u64))
+        .saturating_add(T::DbWeight::get().writes(0_u64)), DispatchClass::Normal, Pays::No))]
         pub fn batch_set_weights(
             origin: OriginFor<T>,
             netuids: Vec<Compact<NetUid>>,


### PR DESCRIPTION
## Description
Docker builds on ARM were taking so long they were timing out due to emulation overhead. Bumping instance type to compensate until we can split back into dedicated jobs for both platforms.


## Related Issue(s)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.