### PR TITLE
childkey tax rate

### DIFF
--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -1682,6 +1682,17 @@ pub mod pallet {
             pallet_subtensor::Pallet::<T>::set_owner_immune_neuron_limit(netuid, immune_neurons)?;
             Ok(())
         }
+
+        #[pallet::call_index(73)]
+        #[pallet::weight(Weight::from_parts(15_000_000, 0))]
+        pub fn sudo_set_childkey_tax_rate(
+            origin: OriginFor<T>,
+            childkey_tax_rate: u16,
+        ) -> DispatchResult {
+            ensure_root(origin)?;
+            pallet_subtensor::Pallet::<T>::set_childkey_tax_rate(childkey_tax_rate)?;
+            Ok(())
+        }
     }
 }
 

--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -1683,6 +1683,7 @@ pub mod pallet {
             Ok(())
         }
 
+        /// Sets the childkey tax rate
         #[pallet::call_index(73)]
         #[pallet::weight(Weight::from_parts(15_000_000, 0))]
         pub fn sudo_set_childkey_tax_rate(

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1483,9 +1483,9 @@ pub mod pallet {
         StorageMap<_, Identity, NetUid, u16, ValueQuery, DefaultImmuneOwnerUidsLimit<T>>;
 
     #[pallet::type_value]
-    /// Default value for childkey tax rate
+    /// Default value for childkey tax rate, 18%
     pub fn DefaultChildkeyTaxRate<T: Config>() -> u16 {
-        18
+        11_796
     }
     #[pallet::storage]
     pub type ChildkeyTaxRate<T> = StorageValue<_, u16, ValueQuery, DefaultChildkeyTaxRate<T>>;

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1482,6 +1482,14 @@ pub mod pallet {
     pub type ImmuneOwnerUidsLimit<T> =
         StorageMap<_, Identity, NetUid, u16, ValueQuery, DefaultImmuneOwnerUidsLimit<T>>;
 
+    #[pallet::type_value]
+    /// Default value for childkey tax rate
+    pub fn DefaultChildkeyTaxRate<T: Config>() -> u16 {
+        18
+    }
+    #[pallet::storage]
+    pub type ChildkeyTaxRate<T> = StorageValue<_, u16, ValueQuery, DefaultChildkeyTaxRate<T>>;
+
     /// =======================================
     /// ==== Subnetwork Consensus Storage  ====
     /// =======================================

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -120,9 +120,9 @@ mod dispatches {
         /// 	- On failure for each failed item in the batch.
         ///
         #[pallet::call_index(80)]
-        #[pallet::weight((Weight::from_parts(19_330_000, 0)
-        .saturating_add(T::DbWeight::get().reads(1_u64))
-        .saturating_add(T::DbWeight::get().writes(0_u64)), DispatchClass::Normal, Pays::No))]
+        #[pallet::weight((Weight::from_parts(94_830_000, 0)
+        .saturating_add(T::DbWeight::get().reads(14_u64))
+        .saturating_add(T::DbWeight::get().writes(2_u64)), DispatchClass::Normal, Pays::No))]
         pub fn batch_set_weights(
             origin: OriginFor<T>,
             netuids: Vec<Compact<NetUid>>,

--- a/pallets/subtensor/src/utils/misc.rs
+++ b/pallets/subtensor/src/utils/misc.rs
@@ -829,4 +829,28 @@ impl<T: Config> Pallet<T> {
         ImmuneOwnerUidsLimit::<T>::insert(netuid, limit);
         Ok(())
     }
+
+    /// Get the childkey tax rate
+    ///
+    /// # Returns
+    /// - `u16` - The childkey tax rate.
+    pub fn get_childkey_tax_rate() -> u16 {
+        ChildkeyTaxRate::<T>::get()
+    }
+
+    /// Set the childkey tax rate
+    ///
+    /// # Arguments
+    ///
+    /// * `childkey_tax_rate` - The new childkey tax rate.
+    ///
+    /// # Returns
+    /// - `Ok(())` on success.
+    /// - `Err(Error::<T>::InvalidValue)` if `childkey_tax_rate` is outside `[0, 100]`.
+    pub fn set_childkey_tax_rate(childkey_tax_rate: u16) -> DispatchResult {
+        ensure!(childkey_tax_rate <= 100, Error::<T>::InvalidValue);
+
+        ChildkeyTaxRate::<T>::set(childkey_tax_rate);
+        Ok(())
+    }
 }

--- a/pallets/subtensor/src/utils/misc.rs
+++ b/pallets/subtensor/src/utils/misc.rs
@@ -848,8 +848,6 @@ impl<T: Config> Pallet<T> {
     /// - `Ok(())` on success.
     /// - `Err(Error::<T>::InvalidValue)` if `childkey_tax_rate` is outside `[0, 100]`.
     pub fn set_childkey_tax_rate(childkey_tax_rate: u16) -> DispatchResult {
-        ensure!(childkey_tax_rate <= 100, Error::<T>::InvalidValue);
-
         ChildkeyTaxRate::<T>::set(childkey_tax_rate);
         Ok(())
     }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -220,7 +220,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 307,
+    spec_version: 308,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
CHK Tax Rate is a recycle fee applied to all CHKs outside of the same cold key
New sudo global param for setting CHK Tax Rate
Default CHK Tax Rate set to 18% (meaning 18% recycle fee applied to all CHKs outside of the same cold key)
Validators can still set CHK Take, which functions as it does now, but applies net of the tax (ie. after the recycle fee is taken)
Separate PR from the one force enabling CR4/BT9.9.2+, but to be included in the same merge as a one-two-punch against WC/CHK.


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.