### PR TITLE
become delegate deprecated, fix e2e test

### DIFF
--- a/evm-tests/src/subtensor.ts
+++ b/evm-tests/src/subtensor.ts
@@ -268,15 +268,6 @@ export async function setMinDelegateTake(api: TypedApi<typeof devnet>, minDelega
     assert.equal(minDelegateTake, await api.query.SubtensorModule.MinDelegateTake.getValue())
 }
 
-export async function becomeDelegate(api: TypedApi<typeof devnet>, ss58Address: string, keypair: KeyPair) {
-    const signer = getSignerFromKeypair(keypair)
-
-    const tx = api.tx.SubtensorModule.become_delegate({
-        hotkey: ss58Address
-    })
-    await waitForTransactionWithRetry(api, tx, signer)
-}
-
 export async function addStake(api: TypedApi<typeof devnet>, netuid: number, ss58Address: string, amount_staked: bigint, keypair: KeyPair) {
     const signer = getSignerFromKeypair(keypair)
     let tx = api.tx.SubtensorModule.add_stake({

--- a/evm-tests/test/staking.precompile.reward.test.ts
+++ b/evm-tests/test/staking.precompile.reward.test.ts
@@ -7,7 +7,7 @@ import { tao } from "../src/balance-math"
 import {
     forceSetBalanceToSs58Address, addNewSubnetwork, burnedRegister,
     setTxRateLimit, setTempo, setWeightsSetRateLimit, setSubnetOwnerCut, setMaxAllowedUids,
-    setMinDelegateTake, becomeDelegate, setActivityCutoff, addStake, setWeight, rootRegister,
+    setMinDelegateTake, setActivityCutoff, addStake, setWeight, rootRegister,
     startCall
 } from "../src/subtensor"
 
@@ -52,8 +52,6 @@ describe("Test neuron precompile reward", () => {
         await setActivityCutoff(api, netuid, 65535)
         await setMaxAllowedUids(api, netuid, 65535)
         await setMinDelegateTake(api, 0)
-        await becomeDelegate(api, convertPublicKeyToSs58(validator.publicKey), coldkey)
-        await becomeDelegate(api, convertPublicKeyToSs58(miner.publicKey), coldkey)
     })
 
     it("Staker receives rewards", async () => {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -220,7 +220,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 307,
+    spec_version: 308,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
extrinsic become_delegate is deprecated, remove it from e2e test.


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.