### PR TITLE
LP Dissolution validator selection

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -9,7 +9,7 @@ use runtime_common::prod_or_fast;
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_runtime::{
-    MultiSignature,
+    MultiSignature, Vec,
     traits::{IdentifyAccount, Verify},
 };
 use subtensor_macros::freeze_struct;
@@ -175,6 +175,9 @@ pub trait SubnetInfo<AccountId> {
     fn mechanism(netuid: NetUid) -> u16;
     fn is_owner(account_id: &AccountId, netuid: NetUid) -> bool;
     fn is_subtoken_enabled(netuid: NetUid) -> bool;
+    fn get_validator_trust(netuid: NetUid) -> Vec<u16>;
+    fn get_validator_permit(netuid: NetUid) -> Vec<bool>;
+    fn hotkey_of_uid(netuid: NetUid, uid: u16) -> Option<AccountId>;
 }
 
 pub trait BalanceOps<AccountId> {

--- a/pallets/subtensor/src/coinbase/root.rs
+++ b/pallets/subtensor/src/coinbase/root.rs
@@ -375,6 +375,7 @@ impl<T: Config> Pallet<T> {
         // 2. --- Perform the cleanup before removing the network.
         T::SwapInterface::dissolve_all_liquidity_providers(netuid)?;
         Self::destroy_alpha_in_out_stakes(netuid)?;
+        T::SwapInterface::clear_protocol_liquidity(netuid)?;
         T::CommitmentsInterface::purge_netuid(netuid);
 
         // 3. --- Remove the network

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -2146,6 +2146,18 @@ impl<T: Config + pallet_balances::Config<Balance = u64>>
     fn is_subtoken_enabled(netuid: NetUid) -> bool {
         SubtokenEnabled::<T>::get(netuid)
     }
+
+    fn get_validator_trust(netuid: NetUid) -> Vec<u16> {
+        ValidatorTrust::<T>::get(netuid)
+    }
+
+    fn get_validator_permit(netuid: NetUid) -> Vec<bool> {
+        ValidatorPermit::<T>::get(netuid)
+    }
+
+    fn hotkey_of_uid(netuid: NetUid, uid: u16) -> Option<T::AccountId> {
+        Keys::<T>::try_get(netuid, uid).ok()
+    }
 }
 
 impl<T: Config + pallet_balances::Config<Balance = u64>>

--- a/pallets/swap-interface/src/lib.rs
+++ b/pallets/swap-interface/src/lib.rs
@@ -36,6 +36,7 @@ pub trait SwapHandler<AccountId> {
     fn is_user_liquidity_enabled(netuid: NetUid) -> bool;
     fn dissolve_all_liquidity_providers(netuid: NetUid) -> DispatchResult;
     fn toggle_user_liquidity(netuid: NetUid, enabled: bool);
+    fn clear_protocol_liquidity(netuid: NetUid) -> DispatchResult;
 }
 
 #[derive(Debug, PartialEq)]

--- a/pallets/swap/src/mock.rs
+++ b/pallets/swap/src/mock.rs
@@ -120,6 +120,26 @@ impl SubnetInfo<AccountId> for MockLiquidityProvider {
     fn is_subtoken_enabled(netuid: NetUid) -> bool {
         netuid.inner() != SUBTOKEN_DISABLED_NETUID
     }
+
+    fn get_validator_trust(netuid: NetUid) -> Vec<u16> {
+        match netuid.into() {
+            123u16 => vec![4000, 3000, 2000, 1000],
+            WRAPPING_FEES_NETUID => vec![8000, 7000, 6000, 5000],
+            _ => vec![1000, 800, 600, 400],
+        }
+    }
+
+    fn get_validator_permit(netuid: NetUid) -> Vec<bool> {
+        match netuid.into() {
+            123u16 => vec![true, true, false, true],
+            WRAPPING_FEES_NETUID => vec![true, true, true, true],
+            _ => vec![true, true, true, true],
+        }
+    }
+
+    fn hotkey_of_uid(_netuid: NetUid, uid: u16) -> Option<AccountId> {
+        Some(uid as AccountId)
+    }
 }
 
 pub struct MockBalanceOps;

--- a/pallets/swap/src/pallet/impls.rs
+++ b/pallets/swap/src/pallet/impls.rs
@@ -1280,7 +1280,6 @@ impl<T: Config> Pallet<T> {
 
                             // 2) Convert ALL α withdrawn (principal + fees) to τ and refund τ to user.
                             if alpha_total_from_pool > AlphaCurrency::ZERO {
-                                // α → τ via AMM swap (sell α). Drop trading fees on forced dissolve.
                                 let sell_amount: u64 = alpha_total_from_pool.into();
 
                                 if let Some(limit_sqrt_price) = compute_limit() {
@@ -1293,7 +1292,6 @@ impl<T: Config> Pallet<T> {
                                         false,
                                     ) {
                                         Ok(sres) => {
-                                            // Credit τ output to the user.
                                             let tao_out: TaoCurrency = sres.amount_paid_out.into();
                                             if tao_out > TaoCurrency::ZERO {
                                                 T::BalanceOps::increase_balance(&owner, tao_out);
@@ -1302,8 +1300,6 @@ impl<T: Config> Pallet<T> {
                                             }
                                         }
                                         Err(e) => {
-                                            // Could not convert α -> τ; log and continue dissolving others.
-                                            // (No α is credited to the user; α already removed from pool is effectively burned.)
                                             log::debug!(
                                                 "dissolve_all_lp: α→τ swap failed on dissolve: netuid={:?}, owner={:?}, pos_id={:?}, α={:?}, err={:?}",
                                                 netuid,
@@ -1324,7 +1320,6 @@ impl<T: Config> Pallet<T> {
                                     );
                                 }
 
-                                // Provided‑α reserve (user‑provided liquidity) decreased by what left the pool.
                                 T::BalanceOps::decrease_provided_alpha_reserve(
                                     netuid,
                                     alpha_total_from_pool,
@@ -1344,7 +1339,6 @@ impl<T: Config> Pallet<T> {
                         }
                     }
                     Err(e) => {
-                        // Keep dissolving other positions even if this one fails.
                         log::debug!(
                             "dissolve_all_lp: force-close failed: netuid={:?}, owner={:?}, pos_id={:?}, err={:?}",
                             netuid,

--- a/pallets/swap/src/pallet/impls.rs
+++ b/pallets/swap/src/pallet/impls.rs
@@ -1286,7 +1286,7 @@ impl<T: Config> Pallet<T> {
                                 T::BalanceOps::increase_stake(
                                     &owner,
                                     &validator_hotkey,
-                                    netuid,
+                                    NetUid::ROOT,
                                     alpha_total_from_pool,
                                 )?;
 

--- a/pallets/swap/src/pallet/impls.rs
+++ b/pallets/swap/src/pallet/impls.rs
@@ -1241,11 +1241,10 @@ impl<T: Config> Pallet<T> {
             let permit: Vec<bool> = T::SubnetInfo::get_validator_permit(netuid.into());
 
             if trust.len() != permit.len() {
+                let trust_len = trust.len();
+                let permit_len = permit.len();
                 log::debug!(
-                    "dissolve_all_lp: ValidatorTrust/Permit length mismatch: netuid={:?}, trust_len={}, permit_len={}",
-                    netuid,
-                    trust.len(),
-                    permit.len()
+                    "dissolve_all_lp: ValidatorTrust/Permit length mismatch: netuid={netuid:?}, trust_len={trust_len}, permit_len={permit_len}"
                 );
                 return Err(sp_runtime::DispatchError::Other(
                     "validator_meta_len_mismatch",
@@ -1280,12 +1279,9 @@ impl<T: Config> Pallet<T> {
                             if alpha_total_from_pool > AlphaCurrency::ZERO {
                                 burned_alpha = burned_alpha.saturating_add(alpha_total_from_pool);
                             }
+                            let tao = rm.tao;
                             log::debug!(
-                                "dissolve_all_lp: burned protocol pos: netuid={:?}, pos_id={:?}, τ={:?}, α_total={:?}",
-                                netuid,
-                                pos_id,
-                                rm.tao,
-                                alpha_total_from_pool
+                                "dissolve_all_lp: burned protocol pos: netuid={netuid:?}, pos_id={pos_id:?}, τ={tao:?}, α_total={alpha_total_from_pool:?}"
                             );
                         } else {
                             // ---------------- USER: refund τ and convert α → τ ----------------
@@ -1318,23 +1314,14 @@ impl<T: Config> Pallet<T> {
                                         user_staked_alpha.saturating_add(alpha_total_from_pool);
 
                                     log::debug!(
-                                        "dissolve_all_lp: user dissolved & staked α: netuid={:?}, owner={:?}, pos_id={:?}, α_staked={:?}, target_uid={}",
-                                        netuid,
-                                        owner,
-                                        pos_id,
-                                        alpha_total_from_pool,
-                                        target_uid
+                                        "dissolve_all_lp: user dissolved & staked α: netuid={netuid:?}, owner={owner:?}, pos_id={pos_id:?}, α_staked={alpha_total_from_pool:?}, target_uid={target_uid}"
                                     );
                                 } else {
                                     // No permitted validators; burn to avoid balance drift.
                                     burned_alpha =
                                         burned_alpha.saturating_add(alpha_total_from_pool);
                                     log::debug!(
-                                        "dissolve_all_lp: no permitted validators; α burned: netuid={:?}, owner={:?}, pos_id={:?}, α_total={:?}",
-                                        netuid,
-                                        owner,
-                                        pos_id,
-                                        alpha_total_from_pool
+                                        "dissolve_all_lp: no permitted validators; α burned: netuid={netuid:?}, owner={owner:?}, pos_id={pos_id:?}, α_total={alpha_total_from_pool:?}"
                                     );
                                 }
 
@@ -1347,11 +1334,7 @@ impl<T: Config> Pallet<T> {
                     }
                     Err(e) => {
                         log::debug!(
-                            "dissolve_all_lp: force-close failed: netuid={:?}, owner={:?}, pos_id={:?}, err={:?}",
-                            netuid,
-                            owner,
-                            pos_id,
-                            e
+                            "dissolve_all_lp: force-close failed: netuid={netuid:?}, owner={owner:?}, pos_id={pos_id:?}, err={e:?}"
                         );
                         continue;
                     }
@@ -1380,12 +1363,7 @@ impl<T: Config> Pallet<T> {
             EnabledUserLiquidity::<T>::remove(netuid);
 
             log::debug!(
-                "dissolve_all_liquidity_providers: netuid={:?}, users_refunded_total_τ={:?}, users_staked_total_α={:?}; protocol_burned: τ={:?}, α={:?}; state cleared",
-                netuid,
-                user_refunded_tao,
-                user_staked_alpha,
-                burned_tao,
-                burned_alpha
+                "dissolve_all_liquidity_providers: netuid={netuid:?}, users_refunded_total_τ={user_refunded_tao:?}, users_staked_total_α={user_staked_alpha:?}; protocol_burned: τ={burned_tao:?}, α={burned_alpha:?}; state cleared"
             );
 
             return Ok(());
@@ -1413,8 +1391,7 @@ impl<T: Config> Pallet<T> {
         EnabledUserLiquidity::<T>::remove(netuid);
 
         log::debug!(
-            "dissolve_all_liquidity_providers: netuid={:?}, mode=V2-or-nonV3, state_cleared",
-            netuid
+            "dissolve_all_liquidity_providers: netuid={netuid:?}, mode=V2-or-nonV3, state_cleared"
         );
 
         Ok(())

--- a/pallets/swap/src/pallet/impls.rs
+++ b/pallets/swap/src/pallet/impls.rs
@@ -1286,7 +1286,7 @@ impl<T: Config> Pallet<T> {
                                 T::BalanceOps::increase_stake(
                                     &owner,
                                     &validator_hotkey,
-                                    NetUid::ROOT,
+                                    netuid,
                                     alpha_total_from_pool,
                                 )?;
 

--- a/pallets/swap/src/pallet/impls.rs
+++ b/pallets/swap/src/pallet/impls.rs
@@ -1243,17 +1243,6 @@ impl<T: Config> Pallet<T> {
             let trust: Vec<u16> = T::SubnetInfo::get_validator_trust(netuid.into());
             let permit: Vec<bool> = T::SubnetInfo::get_validator_permit(netuid.into());
 
-            if trust.len() != permit.len() {
-                let trust_len = trust.len();
-                let permit_len = permit.len();
-                log::debug!(
-                    "dissolve_all_lp: ValidatorTrust/Permit length mismatch: netuid={netuid:?}, trust_len={trust_len}, permit_len={permit_len}"
-                );
-                return Err(sp_runtime::DispatchError::Other(
-                    "validator_meta_len_mismatch",
-                ));
-            }
-
             // Helper: pick target validator uid, only among permitted validators, by highest trust.
             let pick_target_uid = |trust: &Vec<u16>, permit: &Vec<bool>| -> Option<u16> {
                 let mut best_uid: Option<usize> = None;

--- a/pallets/swap/src/pallet/tests.rs
+++ b/pallets/swap/src/pallet/tests.rs
@@ -1982,7 +1982,6 @@ fn test_swap_subtoken_disabled() {
     });
 }
 
-/// V3 path: protocol + user positions exist, fees accrued, everything must be removed.
 #[test]
 fn test_liquidate_v3_removes_positions_ticks_and_state() {
     new_test_ext().execute_with(|| {
@@ -1992,7 +1991,7 @@ fn test_liquidate_v3_removes_positions_ticks_and_state() {
         assert_ok!(Pallet::<Test>::maybe_initialize_v3(netuid));
         assert!(SwapV3Initialized::<Test>::get(netuid));
 
-        // Enable user LP (mock usually enables for 0..=100, but be explicit and consistent)
+        // Enable user LP
         assert_ok!(Swap::toggle_user_liquidity(
             RuntimeOrigin::root(),
             netuid.into(),
@@ -2041,14 +2040,14 @@ fn test_liquidate_v3_removes_positions_ticks_and_state() {
         assert!(Ticks::<Test>::get(netuid, TickIndex::MAX).is_some());
         assert!(CurrentLiquidity::<Test>::get(netuid) > 0);
 
-        // There should be some bitmap words (active ticks) after adding a position.
         let had_bitmap_words = TickIndexBitmapWords::<Test>::iter_prefix((netuid,))
             .next()
             .is_some();
         assert!(had_bitmap_words);
 
-        // ACT: Liquidate & reset swap state
+        // ACT: users-only liquidation then protocol clear
         assert_ok!(Pallet::<Test>::do_dissolve_all_liquidity_providers(netuid));
+        assert_ok!(Pallet::<Test>::do_clear_protocol_liquidity(netuid));
 
         // ASSERT: positions cleared (both user and protocol)
         assert_eq!(
@@ -2091,12 +2090,11 @@ fn test_liquidate_v3_removes_positions_ticks_and_state() {
     });
 }
 
-/// V3 path with user liquidity disabled at teardown: must still remove all positions and clear state.
+/// V3 path with user liquidity disabled at teardown:
+/// must still remove positions and clear state (after protocol clear).
 #[test]
 fn test_liquidate_v3_with_user_liquidity_disabled() {
     new_test_ext().execute_with(|| {
-        // Pick a netuid the mock treats as "disabled" by default (per your comment >100),
-        // then explicitly walk through enable -> add -> disable -> liquidate.
         let netuid = NetUid::from(101);
 
         assert_ok!(Pallet::<Test>::maybe_initialize_v3(netuid));
@@ -2125,15 +2123,16 @@ fn test_liquidate_v3_with_user_liquidity_disabled() {
         )
         .expect("add liquidity");
 
-        // Disable user LP *before* liquidation to validate that removal ignores this flag.
+        // Disable user LP *before* liquidation; removal must ignore this flag.
         assert_ok!(Swap::toggle_user_liquidity(
             RuntimeOrigin::root(),
             netuid.into(),
             false
         ));
 
-        // ACT
+        // Users-only dissolve, then clear protocol liquidity/state.
         assert_ok!(Pallet::<Test>::do_dissolve_all_liquidity_providers(netuid));
+        assert_ok!(Pallet::<Test>::do_clear_protocol_liquidity(netuid));
 
         // ASSERT: positions & ticks gone, state reset
         assert_eq!(
@@ -2158,7 +2157,7 @@ fn test_liquidate_v3_with_user_liquidity_disabled() {
         assert!(!FeeGlobalTao::<Test>::contains_key(netuid));
         assert!(!FeeGlobalAlpha::<Test>::contains_key(netuid));
 
-        // `EnabledUserLiquidity` is removed by liquidation.
+        // `EnabledUserLiquidity` is removed by protocol clear stage.
         assert!(!EnabledUserLiquidity::<Test>::contains_key(netuid));
     });
 }
@@ -2205,7 +2204,6 @@ fn test_liquidate_non_v3_uninitialized_ok_and_clears() {
     });
 }
 
-/// Idempotency: calling liquidation twice is safe (both V3 and non‑V3 flavors).
 #[test]
 fn test_liquidate_idempotent() {
     // V3 flavor
@@ -2230,10 +2228,13 @@ fn test_liquidate_idempotent() {
             123_456_789
         ));
 
-        // 1st liquidation
+        // Users-only liquidations are idempotent.
         assert_ok!(Pallet::<Test>::do_dissolve_all_liquidity_providers(netuid));
-        // 2nd liquidation (no state left) — must still succeed
         assert_ok!(Pallet::<Test>::do_dissolve_all_liquidity_providers(netuid));
+
+        // Now clear protocol liquidity/state—also idempotent.
+        assert_ok!(Pallet::<Test>::do_clear_protocol_liquidity(netuid));
+        assert_ok!(Pallet::<Test>::do_clear_protocol_liquidity(netuid));
 
         // State remains empty
         assert!(
@@ -2254,7 +2255,7 @@ fn test_liquidate_idempotent() {
     new_test_ext().execute_with(|| {
         let netuid = NetUid::from(8);
 
-        // Never initialize V3
+        // Never initialize V3; both calls no-op and succeed.
         assert_ok!(Pallet::<Test>::do_dissolve_all_liquidity_providers(netuid));
         assert_ok!(Pallet::<Test>::do_dissolve_all_liquidity_providers(netuid));
 
@@ -2286,7 +2287,7 @@ fn liquidate_v3_refunds_user_funds_and_clears_state() {
         ));
         assert_ok!(Pallet::<Test>::maybe_initialize_v3(netuid));
 
-        // Use distinct cold/hot to demonstrate alpha refund goes to (owner, owner).
+        // Use distinct cold/hot to demonstrate alpha refund/stake accounting.
         let cold = OK_COLDKEY_ACCOUNT_ID;
         let hot = OK_HOTKEY_ACCOUNT_ID;
 
@@ -2322,15 +2323,14 @@ fn liquidate_v3_refunds_user_funds_and_clears_state() {
         <Test as Config>::BalanceOps::increase_provided_tao_reserve(netuid.into(), tao_taken);
         <Test as Config>::BalanceOps::increase_provided_alpha_reserve(netuid.into(), alpha_taken);
 
-        // Liquidate everything on the subnet.
+        // Users‑only liquidation.
         assert_ok!(Pallet::<Test>::do_dissolve_all_liquidity_providers(netuid));
 
         // Expect balances restored to BEFORE snapshots (no swaps ran -> zero fees).
-        // TAO: we withdrew 'need_tao' above and liquidation refunded it, so we should be back to 'tao_before'.
         let tao_after = <Test as Config>::BalanceOps::tao_balance(&cold);
         assert_eq!(tao_after, tao_before, "TAO principal must be refunded");
 
-        // ALPHA: refund is credited to (coldkey=cold, hotkey=cold). Compare totals across both ledgers.
+        // ALPHA totals conserved to owner (distribution may differ).
         let alpha_after_hot =
             <Test as Config>::BalanceOps::alpha_balance(netuid.into(), &cold, &hot);
         let alpha_after_owner =
@@ -2338,8 +2338,11 @@ fn liquidate_v3_refunds_user_funds_and_clears_state() {
         let alpha_after_total = alpha_after_hot + alpha_after_owner;
         assert_eq!(
             alpha_after_total, alpha_before_total,
-            "ALPHA principal must be refunded to the account (may be credited to (owner, owner))"
+            "ALPHA principal must be refunded/staked for the account (check totals)"
         );
+
+        // Clear protocol liquidity and V3 state now.
+        assert_ok!(Pallet::<Test>::do_clear_protocol_liquidity(netuid));
 
         // User position(s) are gone and all V3 state cleared.
         assert_eq!(Pallet::<Test>::count_positions(netuid, &cold), 0);
@@ -2386,10 +2389,10 @@ fn refund_alpha_single_provider_exact() {
         .expect("decrease ALPHA");
         <Test as Config>::BalanceOps::increase_provided_alpha_reserve(netuid.into(), alpha_taken);
 
-        // --- Act: dissolve (calls refund_alpha inside).
+        // --- Act: users‑only dissolve.
         assert_ok!(Pallet::<Test>::do_dissolve_all_liquidity_providers(netuid));
 
-        // --- Assert: refunded back to the owner (may credit to (cold,cold)).
+        // --- Assert: total α conserved to owner (may be staked to validator).
         let alpha_after_hot =
             <Test as Config>::BalanceOps::alpha_balance(netuid.into(), &cold, &hot);
         let alpha_after_owner =
@@ -2397,8 +2400,11 @@ fn refund_alpha_single_provider_exact() {
         let alpha_after_total = alpha_after_hot + alpha_after_owner;
         assert_eq!(
             alpha_after_total, alpha_before_total,
-            "ALPHA principal must be conserved to the owner"
+            "ALPHA principal must be conserved to the account"
         );
+
+        // Clear protocol liquidity and V3 state now.
+        assert_ok!(Pallet::<Test>::do_clear_protocol_liquidity(netuid));
 
         // --- State is cleared.
         assert!(Ticks::<Test>::iter_prefix(netuid).next().is_none());
@@ -2593,7 +2599,6 @@ fn test_dissolve_v3_green_path_refund_tao_stake_alpha_and_clear_state() {
             <Test as Config>::BalanceOps::alpha_balance(netuid.into(), &cold, &validator_hotkey);
 
         let alpha_before_total = if validator_hotkey == hot {
-            // Avoid double counting when validator == user's hotkey.
             alpha_before_hot + alpha_before_owner
         } else {
             alpha_before_hot + alpha_before_owner + alpha_before_val
@@ -2635,13 +2640,10 @@ fn test_dissolve_v3_green_path_refund_tao_stake_alpha_and_clear_state() {
         );
 
         if validator_hotkey == hot {
-            // Net effect: user's hot ledger returns to its original balance.
             assert_eq!(
                 alpha_after_hot, alpha_before_hot,
                 "When validator == hotkey, user's hot ledger must net back to its original balance"
             );
-
-            // Totals without double-counting the same ledger.
             let alpha_after_total = alpha_after_hot + alpha_after_owner;
             assert_eq!(
                 alpha_after_total, alpha_before_total,
@@ -2659,13 +2661,11 @@ fn test_dissolve_v3_green_path_refund_tao_stake_alpha_and_clear_state() {
 
             let hot_loss = alpha_before_hot - alpha_after_hot;
             let val_gain = alpha_after_val - alpha_before_val;
-
             assert_eq!(
                 val_gain, hot_loss,
                 "α that left the user's hot ledger must equal α credited to the validator ledger"
             );
 
-            // Totals across distinct ledgers must be conserved.
             let alpha_after_total = alpha_after_hot + alpha_after_owner + alpha_after_val;
             assert_eq!(
                 alpha_after_total, alpha_before_total,
@@ -2673,9 +2673,10 @@ fn test_dissolve_v3_green_path_refund_tao_stake_alpha_and_clear_state() {
             );
         }
 
-        // --- Assert: All positions (user + protocol) removed and V3 state cleared ---
-        let protocol_id = Pallet::<Test>::protocol_account_id();
+        // Now clear protocol liquidity & state and assert full reset.
+        assert_ok!(Pallet::<Test>::do_clear_protocol_liquidity(netuid));
 
+        let protocol_id = Pallet::<Test>::protocol_account_id();
         assert_eq!(Pallet::<Test>::count_positions(netuid, &cold), 0);
         let prot_positions_after =
             Positions::<Test>::iter_prefix_values((netuid, protocol_id)).collect::<Vec<_>>();
@@ -2684,7 +2685,6 @@ fn test_dissolve_v3_green_path_refund_tao_stake_alpha_and_clear_state() {
             "protocol positions must be removed"
         );
 
-        // Ticks / liquidity / price / flags cleared
         assert!(Ticks::<Test>::iter_prefix(netuid).next().is_none());
         assert!(Ticks::<Test>::get(netuid, TickIndex::MIN).is_none());
         assert!(Ticks::<Test>::get(netuid, TickIndex::MAX).is_none());
@@ -2693,11 +2693,9 @@ fn test_dissolve_v3_green_path_refund_tao_stake_alpha_and_clear_state() {
         assert!(!AlphaSqrtPrice::<Test>::contains_key(netuid));
         assert!(!SwapV3Initialized::<Test>::contains_key(netuid));
 
-        // Fee globals cleared
         assert!(!FeeGlobalTao::<Test>::contains_key(netuid));
         assert!(!FeeGlobalAlpha::<Test>::contains_key(netuid));
 
-        // Active tick bitmap cleared
         assert!(
             TickIndexBitmapWords::<Test>::iter_prefix((netuid,))
                 .next()
@@ -2705,8 +2703,89 @@ fn test_dissolve_v3_green_path_refund_tao_stake_alpha_and_clear_state() {
             "active tick bitmap words must be cleared"
         );
 
+        assert!(!FeeRate::<Test>::contains_key(netuid));
+        assert!(!EnabledUserLiquidity::<Test>::contains_key(netuid));
+    });
+}
+
+#[test]
+fn test_clear_protocol_liquidity_green_path() {
+    new_test_ext().execute_with(|| {
+        // --- Arrange ---
+        let netuid = NetUid::from(55);
+
+        // Ensure the "user liquidity enabled" flag exists so we can verify it's removed later.
+        assert_ok!(Pallet::<Test>::toggle_user_liquidity(
+            RuntimeOrigin::root(),
+            netuid,
+            true
+        ));
+
+        // Initialize V3 state; this should set price/tick flags and create a protocol position.
+        assert_ok!(Pallet::<Test>::maybe_initialize_v3(netuid));
+        assert!(
+            SwapV3Initialized::<Test>::get(netuid),
+            "V3 must be initialized"
+        );
+
+        // Sanity: protocol positions exist before clearing.
+        let protocol_id = Pallet::<Test>::protocol_account_id();
+        let prot_positions_before =
+            Positions::<Test>::iter_prefix_values((netuid, protocol_id)).collect::<Vec<_>>();
+        assert!(
+            !prot_positions_before.is_empty(),
+            "protocol positions should exist after V3 init"
+        );
+
+        // --- Act ---
+        // Green path: just clear protocol liquidity and wipe all V3 state.
+        assert_ok!(Pallet::<Test>::do_clear_protocol_liquidity(netuid));
+
+        // --- Assert: all protocol positions removed ---
+        let prot_positions_after =
+            Positions::<Test>::iter_prefix_values((netuid, protocol_id)).collect::<Vec<_>>();
+        assert!(
+            prot_positions_after.is_empty(),
+            "protocol positions must be removed by do_clear_protocol_liquidity"
+        );
+
+        // --- Assert: V3 data wiped (idempotent even if some maps were empty) ---
+        // Ticks / active tick bitmap
+        assert!(Ticks::<Test>::iter_prefix(netuid).next().is_none());
+        assert!(
+            TickIndexBitmapWords::<Test>::iter_prefix((netuid,))
+                .next()
+                .is_none(),
+            "active tick bitmap words must be cleared"
+        );
+
+        // Fee globals
+        assert!(!FeeGlobalTao::<Test>::contains_key(netuid));
+        assert!(!FeeGlobalAlpha::<Test>::contains_key(netuid));
+
+        // Price / tick / liquidity / flags
+        assert!(!AlphaSqrtPrice::<Test>::contains_key(netuid));
+        assert!(!CurrentTick::<Test>::contains_key(netuid));
+        assert!(!CurrentLiquidity::<Test>::contains_key(netuid));
+        assert!(!SwapV3Initialized::<Test>::contains_key(netuid));
+
         // Knobs removed
         assert!(!FeeRate::<Test>::contains_key(netuid));
         assert!(!EnabledUserLiquidity::<Test>::contains_key(netuid));
+
+        // --- And it's idempotent ---
+        assert_ok!(Pallet::<Test>::do_clear_protocol_liquidity(netuid));
+        assert!(
+            Positions::<Test>::iter_prefix_values((netuid, protocol_id))
+                .next()
+                .is_none()
+        );
+        assert!(Ticks::<Test>::iter_prefix(netuid).next().is_none());
+        assert!(
+            TickIndexBitmapWords::<Test>::iter_prefix((netuid,))
+                .next()
+                .is_none()
+        );
+        assert!(!SwapV3Initialized::<Test>::contains_key(netuid));
     });
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -220,7 +220,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 319,
+    spec_version: 320,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -220,7 +220,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 318,
+    spec_version: 319,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
This PR modifies `do_dissolve_all_liquidity_providers` to select a validator with the highest vtrust when re-allocating alpha. Also doesn't remove protocol liquidity until after all user alpha stakes are dissolved. 