### PR TITLE
Fix/Use `netuid_index` in selective metagraph

### DIFF
--- a/pallets/subtensor/src/rpc_info/metagraph.rs
+++ b/pallets/subtensor/src/rpc_info/metagraph.rs
@@ -1453,7 +1453,7 @@ impl<T: Config> Pallet<T> {
             Some(SelectiveMetagraphIndex::Incentives) => SelectiveMetagraph {
                 netuid: netuid.into(),
                 incentives: Some(
-                    Incentive::<T>::get(NetUidStorageIndex::from(netuid_index))
+                    Incentive::<T>::get(netuid_index)
                         .into_iter()
                         .map(Compact::from)
                         .collect(),
@@ -1464,7 +1464,7 @@ impl<T: Config> Pallet<T> {
             Some(SelectiveMetagraphIndex::LastUpdate) => SelectiveMetagraph {
                 netuid: netuid.into(),
                 last_update: Some(
-                    LastUpdate::<T>::get(NetUidStorageIndex::from(netuid_index))
+                    LastUpdate::<T>::get(netuid_index)
                         .into_iter()
                         .map(Compact::from)
                         .collect(),

--- a/pallets/subtensor/src/rpc_info/metagraph.rs
+++ b/pallets/subtensor/src/rpc_info/metagraph.rs
@@ -1453,7 +1453,7 @@ impl<T: Config> Pallet<T> {
             Some(SelectiveMetagraphIndex::Incentives) => SelectiveMetagraph {
                 netuid: netuid.into(),
                 incentives: Some(
-                    Incentive::<T>::get(NetUidStorageIndex::from(netuid))
+                    Incentive::<T>::get(NetUidStorageIndex::from(netuid_index))
                         .into_iter()
                         .map(Compact::from)
                         .collect(),
@@ -1464,7 +1464,7 @@ impl<T: Config> Pallet<T> {
             Some(SelectiveMetagraphIndex::LastUpdate) => SelectiveMetagraph {
                 netuid: netuid.into(),
                 last_update: Some(
-                    LastUpdate::<T>::get(NetUidStorageIndex::from(netuid))
+                    LastUpdate::<T>::get(NetUidStorageIndex::from(netuid_index))
                         .into_iter()
                         .map(Compact::from)
                         .collect(),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -220,7 +220,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 318,
+    spec_version: 319,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
This PR fixes a bug where netuid was incorrectly used in the metagraph instead of `netuid_index`.