### PR TITLE
"Untrimming" of UIDs

### DIFF
--- a/evm-tests/src/subtensor.ts
+++ b/evm-tests/src/subtensor.ts
@@ -233,24 +233,6 @@ export async function setActivityCutoff(api: TypedApi<typeof devnet>, netuid: nu
     assert.equal(activityCutoff, await api.query.SubtensorModule.ActivityCutoff.getValue(netuid))
 }
 
-export async function setMaxAllowedUids(api: TypedApi<typeof devnet>, netuid: number, maxAllowedUids: number) {
-    const value = await api.query.SubtensorModule.MaxAllowedUids.getValue(netuid)
-    if (value === maxAllowedUids) {
-        return;
-    }
-
-    const alice = getAliceSigner()
-
-    const internalCall = api.tx.AdminUtils.sudo_set_max_allowed_uids({
-        netuid: netuid,
-        max_allowed_uids: maxAllowedUids
-    })
-    const tx = api.tx.Sudo.sudo({ call: internalCall.decodedCall })
-
-    await waitForTransactionWithRetry(api, tx, alice)
-    assert.equal(maxAllowedUids, await api.query.SubtensorModule.MaxAllowedUids.getValue(netuid))
-}
-
 export async function setMinDelegateTake(api: TypedApi<typeof devnet>, minDelegateTake: number) {
     const value = await api.query.SubtensorModule.MinDelegateTake.getValue()
     if (value === minDelegateTake) {

--- a/evm-tests/test/staking.precompile.reward.test.ts
+++ b/evm-tests/test/staking.precompile.reward.test.ts
@@ -6,7 +6,7 @@ import { convertPublicKeyToSs58 } from "../src/address-utils"
 import { tao } from "../src/balance-math"
 import {
     forceSetBalanceToSs58Address, addNewSubnetwork, burnedRegister,
-    setTxRateLimit, setTempo, setWeightsSetRateLimit, setSubnetOwnerCut, setMaxAllowedUids,
+    setTxRateLimit, setTempo, setWeightsSetRateLimit, setSubnetOwnerCut,
     setMinDelegateTake, setActivityCutoff, addStake, setWeight, rootRegister,
     startCall,
     disableAdminFreezeWindowAndOwnerHyperparamRateLimit
@@ -52,7 +52,6 @@ describe("Test neuron precompile reward", () => {
         await burnedRegister(api, netuid, convertPublicKeyToSs58(nominator.publicKey), coldkey)
         await setSubnetOwnerCut(api, 0)
         await setActivityCutoff(api, netuid, 65535)
-        await setMaxAllowedUids(api, netuid, 65535)
         await setMinDelegateTake(api, 0)
     })
 

--- a/pallets/admin-utils/src/benchmarking.rs
+++ b/pallets/admin-utils/src/benchmarking.rs
@@ -263,7 +263,7 @@ mod benchmarks {
         );
 
         #[extrinsic_call]
-		_(RawOrigin::Root, 1u16.into()/*netuid*/, 4097u16/*max_allowed_uids*/)/*sudo_set_max_allowed_uids*/;
+		_(RawOrigin::Root, 1u16.into()/*netuid*/, 2048u16/*max_allowed_uids*/)/*sudo_set_max_allowed_uids*/;
     }
 
     #[benchmark]

--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -527,8 +527,8 @@ pub mod pallet {
         /// It is only callable by the root account and subnet owner.
         /// The extrinsic will call the Subtensor pallet to set the maximum allowed UIDs for a subnet.
         #[pallet::call_index(15)]
-        #[pallet::weight(Weight::from_parts(18_800_000, 0)
-        .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(2_u64))
+        #[pallet::weight(Weight::from_parts(32_140_000, 0)
+        .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(5_u64))
         .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1_u64)))]
         pub fn sudo_set_max_allowed_uids(
             origin: OriginFor<T>,
@@ -837,7 +837,7 @@ pub mod pallet {
         /// It is only callable by the root account or subnet owner.
         /// The extrinsic will call the Subtensor pallet to set the difficulty.
         #[pallet::call_index(24)]
-        #[pallet::weight(Weight::from_parts(26_230_000, 0)
+        #[pallet::weight(Weight::from_parts(38_500_000, 0)
         .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(3_u64))
         .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1_u64)))]
         pub fn sudo_set_difficulty(

--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -545,11 +545,11 @@ pub mod pallet {
                 Error::<T>::SubnetDoesNotExist
             );
             ensure!(
-                max_allowed_uids > pallet_subtensor::Pallet::<T>::get_min_allowed_uids(netuid),
+                max_allowed_uids >= pallet_subtensor::Pallet::<T>::get_min_allowed_uids(netuid),
                 Error::<T>::MaxAllowedUidsLessThanMinAllowedUids
             );
             ensure!(
-                pallet_subtensor::Pallet::<T>::get_subnetwork_n(netuid) < max_allowed_uids,
+                pallet_subtensor::Pallet::<T>::get_subnetwork_n(netuid) <= max_allowed_uids,
                 Error::<T>::MaxAllowedUIdsLessThanCurrentUIds
             );
             ensure!(

--- a/pallets/admin-utils/src/tests/mock.rs
+++ b/pallets/admin-utils/src/tests/mock.rs
@@ -92,7 +92,7 @@ parameter_types! {
     pub const SelfOwnership: u64 = 2;
     pub const InitialImmunityPeriod: u16 = 2;
     pub const InitialMinAllowedUids: u16 = 2;
-    pub const InitialMaxAllowedUids: u16 = 4;
+    pub const InitialMaxAllowedUids: u16 = 16;
     pub const InitialBondsMovingAverage: u64 = 900_000;
     pub const InitialBondsPenalty: u16 = u16::MAX;
     pub const InitialBondsResetOn: bool = false;

--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -580,6 +580,40 @@ fn test_sudo_set_max_allowed_uids() {
             to_be_set
         ));
         assert_eq!(SubtensorModule::get_max_allowed_uids(netuid), to_be_set);
+
+        // Exact current case
+        assert_ok!(AdminUtils::sudo_set_max_allowed_uids(
+            <<Test as Config>::RuntimeOrigin>::root(),
+            netuid,
+            SubtensorModule::get_subnetwork_n(netuid)
+        ));
+        assert_eq!(
+            SubtensorModule::get_max_allowed_uids(netuid),
+            SubtensorModule::get_subnetwork_n(netuid)
+        );
+
+        // Lower bound case
+        SubtensorModule::set_min_allowed_uids(netuid, SubtensorModule::get_subnetwork_n(netuid));
+        assert_ok!(AdminUtils::sudo_set_max_allowed_uids(
+            <<Test as Config>::RuntimeOrigin>::root(),
+            netuid,
+            SubtensorModule::get_min_allowed_uids(netuid)
+        ));
+        assert_eq!(
+            SubtensorModule::get_max_allowed_uids(netuid),
+            SubtensorModule::get_min_allowed_uids(netuid)
+        );
+
+        // Upper bound case
+        assert_ok!(AdminUtils::sudo_set_max_allowed_uids(
+            <<Test as Config>::RuntimeOrigin>::root(),
+            netuid,
+            DefaultMaxAllowedUids::<Test>::get(),
+        ));
+        assert_eq!(
+            SubtensorModule::get_max_allowed_uids(netuid),
+            DefaultMaxAllowedUids::<Test>::get()
+        );
     });
 }
 

--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -513,69 +513,73 @@ fn test_sudo_set_min_allowed_weights() {
 fn test_sudo_set_max_allowed_uids() {
     new_test_ext().execute_with(|| {
         let netuid = NetUid::from(1);
-        let to_be_set: u16 = 10;
+        let to_be_set: u16 = 12;
         add_network(netuid, 10);
-        let init_value: u16 = SubtensorModule::get_max_allowed_uids(netuid);
-        assert_eq!(
+        MaxRegistrationsPerBlock::<Test>::insert(netuid, 256);
+        TargetRegistrationsPerInterval::<Test>::insert(netuid, 256);
+
+        // Register some neurons
+        for i in 0..=8 {
+            register_ok_neuron(netuid, U256::from(i * 1000), U256::from(i * 1000 + i), 0);
+        }
+
+        // Bad origin that is not root or subnet owner
+        assert_noop!(
             AdminUtils::sudo_set_max_allowed_uids(
-                <<Test as Config>::RuntimeOrigin>::signed(U256::from(0)),
+                <<Test as Config>::RuntimeOrigin>::signed(U256::from(42)),
                 netuid,
                 to_be_set
             ),
-            Err(DispatchError::BadOrigin)
+            DispatchError::BadOrigin
         );
-        assert_eq!(
+
+        // Random netuid that doesn't exist
+        assert_noop!(
             AdminUtils::sudo_set_max_allowed_uids(
                 <<Test as Config>::RuntimeOrigin>::root(),
-                netuid.next(),
+                NetUid::from(42),
                 to_be_set
             ),
-            Err(Error::<Test>::SubnetDoesNotExist.into())
+            Error::<Test>::SubnetDoesNotExist
         );
-        assert_eq!(SubtensorModule::get_max_allowed_uids(netuid), init_value);
+
+        // Trying to set max allowed uids less than min allowed uids
+        assert_noop!(
+            AdminUtils::sudo_set_max_allowed_uids(
+                <<Test as Config>::RuntimeOrigin>::root(),
+                netuid,
+                SubtensorModule::get_min_allowed_uids(netuid) - 1
+            ),
+            Error::<Test>::MaxAllowedUidsLessThanMinAllowedUids
+        );
+
+        // Trying to set max allowed uids less than current uids
+        assert_noop!(
+            AdminUtils::sudo_set_max_allowed_uids(
+                <<Test as Config>::RuntimeOrigin>::root(),
+                netuid,
+                SubtensorModule::get_subnetwork_n(netuid) - 1
+            ),
+            Error::<Test>::MaxAllowedUIdsLessThanCurrentUIds
+        );
+
+        // Trying to set max allowed uids greater than default max allowed uids
+        assert_noop!(
+            AdminUtils::sudo_set_max_allowed_uids(
+                <<Test as Config>::RuntimeOrigin>::root(),
+                netuid,
+                DefaultMaxAllowedUids::<Test>::get() + 1
+            ),
+            Error::<Test>::MaxAllowedUidsGreaterThanDefaultMaxAllowedUids
+        );
+
+        // Normal case
         assert_ok!(AdminUtils::sudo_set_max_allowed_uids(
             <<Test as Config>::RuntimeOrigin>::root(),
             netuid,
             to_be_set
         ));
         assert_eq!(SubtensorModule::get_max_allowed_uids(netuid), to_be_set);
-    });
-}
-
-#[test]
-fn test_sudo_set_and_decrease_max_allowed_uids() {
-    new_test_ext().execute_with(|| {
-        let netuid = NetUid::from(1);
-        let to_be_set: u16 = 10;
-        add_network(netuid, 10);
-        let init_value: u16 = SubtensorModule::get_max_allowed_uids(netuid);
-        assert_eq!(
-            AdminUtils::sudo_set_max_allowed_uids(
-                <<Test as Config>::RuntimeOrigin>::signed(U256::from(0)),
-                netuid,
-                to_be_set
-            ),
-            Err(DispatchError::BadOrigin)
-        );
-        assert_eq!(
-            AdminUtils::sudo_set_max_allowed_uids(
-                <<Test as Config>::RuntimeOrigin>::root(),
-                netuid.next(),
-                to_be_set
-            ),
-            Err(Error::<Test>::SubnetDoesNotExist.into())
-        );
-        assert_eq!(SubtensorModule::get_max_allowed_uids(netuid), init_value);
-        assert_ok!(AdminUtils::sudo_set_max_allowed_uids(
-            <<Test as Config>::RuntimeOrigin>::root(),
-            netuid,
-            to_be_set
-        ));
-        assert_ok!(AdminUtils::sudo_set_max_allowed_uids(
-            <<Test as Config>::RuntimeOrigin>::root(),
-            netuid,
-            to_be_set - 1
-        ));
     });
 }
 

--- a/pallets/subtensor/src/utils/rate_limiting.rs
+++ b/pallets/subtensor/src/utils/rate_limiting.rs
@@ -197,6 +197,7 @@ pub enum Hyperparameter {
     BondsResetEnabled = 22,
     ImmuneNeuronLimit = 23,
     RecycleOrBurn = 24,
+    MaxAllowedUids = 25,
 }
 
 impl<T: Config> Pallet<T> {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -223,7 +223,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 322,
+    spec_version: 323,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -223,7 +223,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 323,
+    spec_version: 324,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
Refactor the `sudo_set_max_allowed_uids` to make it possible to augment the maximum between bounds and never below the active number of UIDs (which would require trimming).


## Related Issue(s)

- Closes #2077 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.