### PR TITLE
Hotfix/trim uids renumber

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5209,15 +5209,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_executable"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baabb8b4867b26294d818bf3f651a454b6901431711abb96e296245888d6e8c4"
-dependencies = [
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5209,6 +5209,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_executable"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baabb8b4867b26294d818bf3f651a454b6901431711abb96e296245888d6e8c4"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -2631,6 +2631,13 @@ fn test_trim_to_max_allowed_uids() {
         // Actual number of neurons on the network updated after trimming
         assert_eq!(SubnetworkN::<Test>::get(netuid), new_max_n);
 
+        for i in 0..new_max_n {
+            let i = i as u16;
+            let hotkey = Keys::<Test>::get(netuid, i);
+            let uid = Uids::<Test>::get(netuid, hotkey);
+            assert_eq!(uid.unwrap(), i);
+        }
+
         // Non existent subnet
         assert_err!(
             AdminUtils::sudo_trim_to_max_allowed_uids(

--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -2492,33 +2492,33 @@ fn test_trim_to_max_allowed_uids() {
         BlockAtRegistration::<Test>::set(netuid, 6, now);
         BlockAtRegistration::<Test>::set(netuid, 11, now);
 
-        // Set some evm addresses
-        AssociatedEvmAddress::<Test>::insert(
-            netuid,
-            6,
-            (sp_core::H160::from_slice(b"12345678901234567890"), now),
-        );
-        AssociatedEvmAddress::<Test>::insert(
-            netuid,
-            11,
-            (sp_core::H160::from_slice(b"A2345678901234567890"), now),
-        );
-        AssociatedEvmAddress::<Test>::insert(
-            netuid,
-            7,
-            (sp_core::H160::from_slice(b"B2345678901234567890"), now),
-        );
-        AssociatedEvmAddress::<Test>::insert(
-            netuid,
-            14,
-            (sp_core::H160::from_slice(b"C2345678901234567890"), now),
-        );
-
         // And some temporally immune uids
         Keys::<Test>::insert(netuid, 7, sn_owner_hotkey1);
         Uids::<Test>::insert(netuid, sn_owner_hotkey1, 7);
         Keys::<Test>::insert(netuid, 14, sn_owner_hotkey2);
         Uids::<Test>::insert(netuid, sn_owner_hotkey2, 14);
+
+        // Set some evm addresses
+        AssociatedEvmAddress::<Test>::insert(
+            netuid,
+            6,
+            (sp_core::H160::from_slice(b"12345678901234567891"), now),
+        );
+        AssociatedEvmAddress::<Test>::insert(
+            netuid,
+            10,
+            (sp_core::H160::from_slice(b"12345678901234567892"), now),
+        );
+        AssociatedEvmAddress::<Test>::insert(
+            netuid,
+            12,
+            (sp_core::H160::from_slice(b"12345678901234567893"), now),
+        );
+        AssociatedEvmAddress::<Test>::insert(
+            netuid,
+            14,
+            (sp_core::H160::from_slice(b"12345678901234567894"), now),
+        );
 
         // Populate Weights and Bonds storage items to test trimming
         // Create weights and bonds that span across the range that will be trimmed
@@ -2660,6 +2660,16 @@ fn test_trim_to_max_allowed_uids() {
             let uid = Uids::<Test>::get(netuid, hotkey);
             assert_eq!(uid, Some(i));
         }
+
+        // EVM association have been remapped correctly (uids: 7 -> 2, 14 -> 7)
+        assert_eq!(
+            AssociatedEvmAddress::<Test>::get(netuid, 2),
+            Some((sp_core::H160::from_slice(b"12345678901234567891"), now))
+        );
+        assert_eq!(
+            AssociatedEvmAddress::<Test>::get(netuid, 7),
+            Some((sp_core::H160::from_slice(b"12345678901234567894"), now))
+        );
 
         // Non existent subnet
         assert_err!(

--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -2496,22 +2496,22 @@ fn test_trim_to_max_allowed_uids() {
         AssociatedEvmAddress::<Test>::insert(
             netuid,
             6,
-            (sp_core::H160::from_slice(b"0x12345678901234567890"), now),
+            (sp_core::H160::from_slice(b"12345678901234567890"), now),
         );
         AssociatedEvmAddress::<Test>::insert(
             netuid,
             11,
-            (sp_core::H160::from_slice(b"0xA2345678901234567890"), now),
+            (sp_core::H160::from_slice(b"A2345678901234567890"), now),
         );
         AssociatedEvmAddress::<Test>::insert(
             netuid,
             7,
-            (sp_core::H160::from_slice(b"0xB2345678901234567890"), now),
+            (sp_core::H160::from_slice(b"B2345678901234567890"), now),
         );
         AssociatedEvmAddress::<Test>::insert(
             netuid,
             14,
-            (sp_core::H160::from_slice(b"0xC2345678901234567890"), now),
+            (sp_core::H160::from_slice(b"C2345678901234567890"), now),
         );
 
         // And some temporally immune uids

--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -2492,6 +2492,28 @@ fn test_trim_to_max_allowed_uids() {
         BlockAtRegistration::<Test>::set(netuid, 6, now);
         BlockAtRegistration::<Test>::set(netuid, 11, now);
 
+        // Set some evm addresses
+        AssociatedEvmAddress::<Test>::insert(
+            netuid,
+            6,
+            (sp_core::H160::from_slice(b"0x12345678901234567890"), now),
+        );
+        AssociatedEvmAddress::<Test>::insert(
+            netuid,
+            11,
+            (sp_core::H160::from_slice(b"0xA2345678901234567890"), now),
+        );
+        AssociatedEvmAddress::<Test>::insert(
+            netuid,
+            7,
+            (sp_core::H160::from_slice(b"0xB2345678901234567890"), now),
+        );
+        AssociatedEvmAddress::<Test>::insert(
+            netuid,
+            14,
+            (sp_core::H160::from_slice(b"0xC2345678901234567890"), now),
+        );
+
         // And some temporally immune uids
         Keys::<Test>::insert(netuid, 7, sn_owner_hotkey1);
         Uids::<Test>::insert(netuid, sn_owner_hotkey1, 7);
@@ -2574,6 +2596,7 @@ fn test_trim_to_max_allowed_uids() {
         for uid in new_max_n..max_n {
             assert!(!Keys::<Test>::contains_key(netuid, uid));
             assert!(!BlockAtRegistration::<Test>::contains_key(netuid, uid));
+            assert!(!AssociatedEvmAddress::<Test>::contains_key(netuid, uid));
             for mecid in 0..mechanism_count.into() {
                 let netuid_index =
                     SubtensorModule::get_mechanism_storage_index(netuid, MechId::from(mecid));
@@ -2631,6 +2654,7 @@ fn test_trim_to_max_allowed_uids() {
         // Actual number of neurons on the network updated after trimming
         assert_eq!(SubnetworkN::<Test>::get(netuid), new_max_n);
 
+        // Uids match enumeration order
         for i in 0..new_max_n.into() {
             let hotkey = Keys::<Test>::get(netuid, i);
             let uid = Uids::<Test>::get(netuid, hotkey);

--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -2631,11 +2631,10 @@ fn test_trim_to_max_allowed_uids() {
         // Actual number of neurons on the network updated after trimming
         assert_eq!(SubnetworkN::<Test>::get(netuid), new_max_n);
 
-        for i in 0..new_max_n {
-            let i = i as u16;
+        for i in 0..new_max_n.into() {
             let hotkey = Keys::<Test>::get(netuid, i);
             let uid = Uids::<Test>::get(netuid, hotkey);
-            assert_eq!(uid.unwrap(), i);
+            assert_eq!(uid, Some(i));
         }
 
         // Non existent subnet

--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -2713,7 +2713,7 @@ fn test_trim_to_max_allowed_uids_too_many_immune() {
         MaxRegistrationsPerBlock::<Test>::insert(netuid, 256);
         TargetRegistrationsPerInterval::<Test>::insert(netuid, 256);
         ImmuneOwnerUidsLimit::<Test>::insert(netuid, 2);
-        MinAllowedUids::<Test>::set(netuid, 4);
+        MinAllowedUids::<Test>::set(netuid, 2);
 
         // Add 5 neurons
         let max_n = 5;
@@ -2751,7 +2751,7 @@ fn test_trim_to_max_allowed_uids_too_many_immune() {
                 netuid,
                 4
             ),
-            pallet_subtensor::Error::<Test>::InvalidValue
+            pallet_subtensor::Error::<Test>::TrimmingWouldExceedMaxImmunePercentage
         );
 
         // Try to trim to 3 UIDs - this should also fail because 4/3 > 80% immune (>= 80%)
@@ -2761,7 +2761,7 @@ fn test_trim_to_max_allowed_uids_too_many_immune() {
                 netuid,
                 3
             ),
-            pallet_subtensor::Error::<Test>::InvalidValue
+            pallet_subtensor::Error::<Test>::TrimmingWouldExceedMaxImmunePercentage
         );
 
         // Now test a scenario where trimming should succeed
@@ -2772,10 +2772,6 @@ fn test_trim_to_max_allowed_uids_too_many_immune() {
         Keys::<Test>::remove(netuid, uid_to_remove);
         Uids::<Test>::remove(netuid, hotkey_to_remove);
         BlockAtRegistration::<Test>::remove(netuid, uid_to_remove);
-
-        // Now we have 3 immune out of 4 total UIDs
-        // Try to trim to 3 UIDs - this should succeed because 3/3 = 100% immune, but that's exactly 80%
-        // Wait, 100% is > 80%, so this should fail. Let me test with a scenario where we have fewer immune UIDs
 
         // Remove another immune UID to make it 2 immune out of 3 total
         let uid_to_remove2 = 2;

--- a/pallets/subtensor/src/macros/errors.rs
+++ b/pallets/subtensor/src/macros/errors.rs
@@ -254,5 +254,9 @@ mod errors {
         SubnetLimitReached,
         /// Insufficient funds to meet the subnet lock cost
         CannotAffordLockCost,
+        /// exceeded the rate limit for associating an EVM key.
+        EvmKeyAssociateRateLimitExceeded,
+        /// The UID map for the subnet could not be cleared
+        UidMapCouldNotBeCleared
     }
 }

--- a/pallets/subtensor/src/macros/errors.rs
+++ b/pallets/subtensor/src/macros/errors.rs
@@ -257,6 +257,8 @@ mod errors {
         /// exceeded the rate limit for associating an EVM key.
         EvmKeyAssociateRateLimitExceeded,
         /// The UID map for the subnet could not be cleared
-        UidMapCouldNotBeCleared
+        UidMapCouldNotBeCleared,
+        /// Trimming would exceed the max immune neurons percentage
+        TrimmingWouldExceedMaxImmunePercentage,
     }
 }

--- a/pallets/subtensor/src/subnets/uids.rs
+++ b/pallets/subtensor/src/subnets/uids.rs
@@ -209,6 +209,7 @@ impl<T: Config> Pallet<T> {
                     #[allow(unknown_lints)]
                     Keys::<T>::remove(netuid, neuron_uid);
                     BlockAtRegistration::<T>::remove(netuid, neuron_uid);
+                    AssociatedEvmAddress::<T>::remove(netuid, neuron_uid);
                     for mecid in 0..mechanisms_count {
                         let netuid_index = Self::get_mechanism_storage_index(netuid, mecid.into());
                         Weights::<T>::remove(netuid_index, neuron_uid);
@@ -315,6 +316,7 @@ impl<T: Config> Pallet<T> {
 
                 // Swap uid specific storage items to new compressed positions
                 Keys::<T>::swap(netuid, old_neuron_uid, netuid, new_neuron_uid);
+                AssociatedEvmAddress::<T>::swap(netuid, old_neuron_uid, netuid, new_neuron_uid);
                 BlockAtRegistration::<T>::swap(netuid, old_neuron_uid, netuid, new_neuron_uid);
 
                 for mecid in 0..mechanisms_count {

--- a/pallets/subtensor/src/subnets/uids.rs
+++ b/pallets/subtensor/src/subnets/uids.rs
@@ -361,7 +361,7 @@ impl<T: Config> Pallet<T> {
             );
 
             // Insert the new UIDs
-            for (old_uid, new_uid) in &old_to_new_uid {
+            for new_uid in old_to_new_uid.values() {
                 // Get the hotkey using Keys map and new UID.
                 let hotkey = Keys::<T>::get(netuid, *new_uid as u16);
                 Uids::<T>::insert(netuid, hotkey, *new_uid as u16);

--- a/pallets/subtensor/src/subnets/uids.rs
+++ b/pallets/subtensor/src/subnets/uids.rs
@@ -162,7 +162,7 @@ impl<T: Config> Pallet<T> {
             let immune_percentage = Percent::from_rational(immune_count, max_n);
             ensure!(
                 immune_percentage < T::MaxImmuneUidsPercentage::get(),
-                Error::<T>::InvalidValue
+                Error::<T>::TrimmingWouldExceedMaxImmunePercentage
             );
 
             // Get all emissions with their UIDs and sort by emission (descending)

--- a/pallets/subtensor/src/subnets/uids.rs
+++ b/pallets/subtensor/src/subnets/uids.rs
@@ -352,6 +352,21 @@ impl<T: Config> Pallet<T> {
                 }
             }
 
+            // Clear the UID map for the subnet
+            let clear_result = Uids::<T>::clear_prefix(netuid, u32::MAX, None);
+            // Shouldn't happen, but possible.
+            ensure!(
+                clear_result.maybe_cursor.is_none(),
+                Error::<T>::UidMapCouldNotBeCleared
+            );
+
+            // Insert the new UIDs
+            for (old_uid, new_uid) in &old_to_new_uid {
+                // Get the hotkey using Keys map and new UID.
+                let hotkey = Keys::<T>::get(netuid, *new_uid as u16);
+                Uids::<T>::insert(netuid, hotkey, *new_uid as u16);
+            }
+
             // Update the subnet's uid count to reflect the new maximum
             SubnetworkN::<T>::insert(netuid, max_n);
         }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -220,7 +220,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-	spec_version: 321,
+    spec_version: 321,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -220,7 +220,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 320,
+	spec_version: 321,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
Fixes two issues with the trim UIDs feature.  
- makes the `UIDs` map match the order of the swapped neurons.
- swaps `AssociatedEvmAddress` during trim

See: #2085 

## Related Issue(s)

- Closes #2083 
- Closes #2086 

- replaces #2085 

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.