### PR TITLE
always include the netuid in selective metagraph

### DIFF
--- a/pallets/subtensor/src/rpc_info/metagraph.rs
+++ b/pallets/subtensor/src/rpc_info/metagraph.rs
@@ -870,13 +870,13 @@ impl<T: Config> Pallet<T> {
         } else {
             let mut result = SelectiveMetagraph::default();
 
-            // always include netuid even the metagraph_indexes doesn't contain it
-            result.netuid = netuid.into();
-
             for index in metagraph_indexes.iter() {
                 let value = Self::get_single_selective_mechagraph(netuid, mecid, *index);
                 result.merge_value(&value, *index as usize);
             }
+            // always include netuid even the metagraph_indexes doesn't contain it
+            result.netuid = netuid.into();
+
             Some(result)
         }
     }

--- a/pallets/subtensor/src/rpc_info/metagraph.rs
+++ b/pallets/subtensor/src/rpc_info/metagraph.rs
@@ -870,7 +870,7 @@ impl<T: Config> Pallet<T> {
         } else {
             let mut result = SelectiveMetagraph::default();
 
-            // alwayseven the metagraph_indexes doesn't contain it
+            // always include netuid even the metagraph_indexes doesn't contain it
             result.netuid = netuid.into();
 
             for index in metagraph_indexes.iter() {

--- a/pallets/subtensor/src/rpc_info/metagraph.rs
+++ b/pallets/subtensor/src/rpc_info/metagraph.rs
@@ -870,22 +870,8 @@ impl<T: Config> Pallet<T> {
         } else {
             let mut result = SelectiveMetagraph::default();
 
+            // alwayseven the metagraph_indexes doesn't contain it
             result.netuid = netuid.into();
-            let netuid_in_metagraph_index =
-                SelectiveMetagraphIndex::from_index(SelectiveMetagraphIndex::Netuid as usize);
-
-            // always include netuid even the metagraph_indexes doesn't contain it
-            if let Some(netuid_in_metagraph_index) = netuid_in_metagraph_index {
-                let netuid_in_metagraph_index = netuid_in_metagraph_index as u16;
-                if !metagraph_indexes.contains(&netuid_in_metagraph_index) {
-                    let value = Self::get_single_selective_mechagraph(
-                        netuid,
-                        mecid,
-                        netuid_in_metagraph_index,
-                    );
-                    result.merge_value(&value, netuid_in_metagraph_index as usize);
-                }
-            }
 
             for index in metagraph_indexes.iter() {
                 let value = Self::get_single_selective_mechagraph(netuid, mecid, *index);

--- a/pallets/subtensor/src/rpc_info/metagraph.rs
+++ b/pallets/subtensor/src/rpc_info/metagraph.rs
@@ -869,6 +869,8 @@ impl<T: Config> Pallet<T> {
             None
         } else {
             let mut result = SelectiveMetagraph::default();
+
+            result.netuid = netuid.into();
             let netuid_in_metagraph_index =
                 SelectiveMetagraphIndex::from_index(SelectiveMetagraphIndex::Netuid as usize);
 

--- a/pallets/subtensor/src/rpc_info/metagraph.rs
+++ b/pallets/subtensor/src/rpc_info/metagraph.rs
@@ -869,6 +869,18 @@ impl<T: Config> Pallet<T> {
             None
         } else {
             let mut result = SelectiveMetagraph::default();
+            let netuid_index =
+                SelectiveMetagraphIndex::from_index(SelectiveMetagraphIndex::Netuid as usize);
+
+            // always include netuid even the metagraph_indexes doesn't contain it
+            if let Some(netuid_index) = netuid_index {
+                let netuid_index = netuid_index as u16;
+                if !metagraph_indexes.contains(&netuid_index) {
+                    let value = Self::get_single_selective_mechagraph(netuid, mecid, netuid_index);
+                    result.merge_value(&value, netuid_index as usize);
+                }
+            }
+
             for index in metagraph_indexes.iter() {
                 let value = Self::get_single_selective_mechagraph(netuid, mecid, *index);
                 result.merge_value(&value, *index as usize);

--- a/pallets/subtensor/src/rpc_info/metagraph.rs
+++ b/pallets/subtensor/src/rpc_info/metagraph.rs
@@ -869,15 +869,19 @@ impl<T: Config> Pallet<T> {
             None
         } else {
             let mut result = SelectiveMetagraph::default();
-            let netuid_index =
+            let netuid_in_metagraph_index =
                 SelectiveMetagraphIndex::from_index(SelectiveMetagraphIndex::Netuid as usize);
 
             // always include netuid even the metagraph_indexes doesn't contain it
-            if let Some(netuid_index) = netuid_index {
-                let netuid_index = netuid_index as u16;
-                if !metagraph_indexes.contains(&netuid_index) {
-                    let value = Self::get_single_selective_mechagraph(netuid, mecid, netuid_index);
-                    result.merge_value(&value, netuid_index as usize);
+            if let Some(netuid_in_metagraph_index) = netuid_in_metagraph_index {
+                let netuid_in_metagraph_index = netuid_in_metagraph_index as u16;
+                if !metagraph_indexes.contains(&netuid_in_metagraph_index) {
+                    let value = Self::get_single_selective_mechagraph(
+                        netuid,
+                        mecid,
+                        netuid_in_metagraph_index,
+                    );
+                    result.merge_value(&value, netuid_in_metagraph_index as usize);
                 }
             }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -223,7 +223,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 324,
+    spec_version: 325,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
should put the netuid into the result of selective metagraph, instead of returning the default value 0.
no matter the index is selected or not.

## Related Issue(s)

- Closes #2089 

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.