### PR TITLE
Upgrade Polkadot SDK to stable2506-2

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -44,5 +44,6 @@ jobs:
       - name: cargo audit
         run: |
           cargo audit --ignore RUSTSEC-2023-0091 \
+                      --ignore RUSTSEC-2024-0438 \
                       --ignore RUSTSEC-2025-0009 \
-                      --ignore RUSTSEC-2024-0438
+                      --ignore RUSTSEC-2025-0055

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,17 +73,6 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.16",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -508,7 +497,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "ark-ff 0.5.0",
  "ark-poly 0.5.0",
  "ark-serialize 0.5.0",
@@ -743,7 +732,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
  "ark-std 0.5.0",
@@ -4174,19 +4163,6 @@ dependencies = [
 
 [[package]]
 name = "ethbloom"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
-dependencies = [
- "crunchy",
- "fixed-hash",
- "impl-rlp 0.3.0",
- "impl-serde 0.4.0",
- "tiny-keccak",
-]
-
-[[package]]
-name = "ethbloom"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c321610643004cf908ec0f5f2aa0d8f1f8e14b540562a2887a1111ff1ecbf7b"
@@ -4194,8 +4170,8 @@ dependencies = [
  "crunchy",
  "fixed-hash",
  "impl-codec 0.7.1",
- "impl-rlp 0.4.0",
- "impl-serde 0.5.0",
+ "impl-rlp",
+ "impl-serde",
  "scale-info",
  "tiny-keccak",
 ]
@@ -4207,7 +4183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ee371ebb7479ed3258617557ab0b3247e741075cb6b02b820d188f68da44441"
 dependencies = [
  "bytes",
- "ethereum-types 0.15.1",
+ "ethereum-types",
  "hash-db",
  "hash256-std-hasher",
  "k256",
@@ -4229,29 +4205,15 @@ dependencies = [
 
 [[package]]
 name = "ethereum-types"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
-dependencies = [
- "ethbloom 0.13.0",
- "fixed-hash",
- "impl-rlp 0.3.0",
- "impl-serde 0.4.0",
- "primitive-types 0.12.2",
- "uint 0.9.5",
-]
-
-[[package]]
-name = "ethereum-types"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ab15ed80916029f878e0267c3a9f92b67df55e79af370bf66199059ae2b4ee3"
 dependencies = [
- "ethbloom 0.14.1",
+ "ethbloom",
  "fixed-hash",
  "impl-codec 0.7.1",
- "impl-rlp 0.4.0",
- "impl-serde 0.5.0",
+ "impl-rlp",
+ "impl-serde",
  "primitive-types 0.13.1",
  "scale-info",
  "uint 0.10.0",
@@ -4569,7 +4531,7 @@ version = "2.0.0-dev"
 source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "ethereum",
- "ethereum-types 0.15.1",
+ "ethereum-types",
  "evm",
  "fc-api",
  "fc-mapping-sync",
@@ -4620,7 +4582,7 @@ version = "1.1.0-dev"
 source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "ethereum",
- "ethereum-types 0.15.1",
+ "ethereum-types",
  "jsonrpsee",
  "rlp 0.6.1",
  "rustc-hex",
@@ -4635,7 +4597,7 @@ version = "1.0.0-dev"
 source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "ethereum",
- "ethereum-types 0.15.1",
+ "ethereum-types",
  "fp-rpc",
  "fp-storage",
  "parity-scale-codec",
@@ -4827,7 +4789,7 @@ version = "1.0.0-dev"
 source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "hex",
- "impl-serde 0.5.0",
+ "impl-serde",
  "libsecp256k1",
  "log",
  "parity-scale-codec",
@@ -4856,7 +4818,7 @@ version = "1.0.0-dev"
 source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "ethereum",
- "ethereum-types 0.15.1",
+ "ethereum-types",
  "fp-evm",
  "frame-support",
  "parity-scale-codec",
@@ -4884,7 +4846,7 @@ version = "3.0.0-dev"
 source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "ethereum",
- "ethereum-types 0.15.1",
+ "ethereum-types",
  "fp-evm",
  "parity-scale-codec",
  "scale-info",
@@ -5729,9 +5691,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -5739,7 +5698,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
 ]
 
 [[package]]
@@ -5748,7 +5707,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "allocator-api2",
  "serde",
 ]
@@ -6367,29 +6326,11 @@ dependencies = [
 
 [[package]]
 name = "impl-rlp"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
-dependencies = [
- "rlp 0.5.2",
-]
-
-[[package]]
-name = "impl-rlp"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54ed8ad1f3877f7e775b8cbf30ed1bd3209a95401817f19a0eb4402d13f8cf90"
 dependencies = [
  "rlp 0.6.1",
-]
-
-[[package]]
-name = "impl-serde"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -7572,15 +7513,6 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lru"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
-dependencies = [
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "lru"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a83fb7698b3643a0e34f9ae6f2e8f0178c0fd42f8b59d493aa271ff3a5bf21"
@@ -8100,14 +8032,16 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.15.6"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
 dependencies = [
  "matrixmultiply",
  "num-complex",
  "num-integer",
  "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
  "rawpointer",
 ]
 
@@ -8318,6 +8252,7 @@ name = "node-subtensor-runtime"
 version = "4.0.0-dev"
 dependencies = [
  "ark-serialize 0.4.2",
+ "ethereum",
  "fp-account",
  "fp-evm",
  "fp-rpc",
@@ -9660,7 +9595,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "ethereum",
- "ethereum-types 0.15.1",
+ "ethereum-types",
  "evm",
  "fp-consensus",
  "fp-ethereum",
@@ -10333,7 +10268,7 @@ dependencies = [
  "derive_more 0.99.20",
  "environmental",
  "ethereum-standards",
- "ethereum-types 0.15.1",
+ "ethereum-types",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -10729,9 +10664,8 @@ dependencies = [
  "pallet-subtensor-utility",
  "pallet-transaction-payment",
  "parity-scale-codec",
- "parity-util-mem",
  "polkadot-runtime-common",
- "rand 0.8.5",
+ "rand 0.9.2",
  "rand_chacha 0.3.1",
  "safe-math",
  "scale-info",
@@ -11242,35 +11176,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "parity-util-mem"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d32c34f4f5ca7f9196001c0aba5a1f9a5a12382c8944b8b0f90233282d1e8f8"
-dependencies = [
- "cfg-if",
- "ethereum-types 0.14.1",
- "hashbrown 0.12.3",
- "impl-trait-for-tuples",
- "lru 0.8.1",
- "parity-util-mem-derive",
- "parking_lot 0.12.4",
- "primitive-types 0.12.2",
- "smallvec",
- "winapi",
-]
-
-[[package]]
-name = "parity-util-mem-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
-dependencies = [
- "proc-macro2",
- "syn 1.0.109",
- "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -13067,6 +12972,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13172,8 +13086,6 @@ checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
  "impl-codec 0.6.0",
- "impl-rlp 0.3.0",
- "impl-serde 0.4.0",
  "uint 0.9.5",
 ]
 
@@ -13186,8 +13098,8 @@ dependencies = [
  "fixed-hash",
  "impl-codec 0.7.1",
  "impl-num-traits",
- "impl-rlp 0.4.0",
- "impl-serde 0.5.0",
+ "impl-rlp",
+ "impl-serde",
  "scale-info",
  "uint 0.10.0",
 ]
@@ -14808,7 +14720,7 @@ name = "sc-consensus-grandpa"
 version = "0.36.0"
 source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "array-bytes 6.2.3",
  "async-trait",
  "dyn-clone",
@@ -15111,7 +15023,7 @@ name = "sc-network-gossip"
 version = "0.51.0"
 source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "futures",
  "futures-timer",
  "log",
@@ -15824,7 +15736,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "356285bbf17bea63d9e52e96bd18f039672ac92b55b8cb997d6162a2a37d1649"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "cfg-if",
  "hashbrown 0.13.2",
 ]
@@ -16930,7 +16842,7 @@ dependencies = [
  "futures",
  "hash-db",
  "hash256-std-hasher",
- "impl-serde 0.5.0",
+ "impl-serde",
  "itertools 0.11.0",
  "k256",
  "libsecp256k1",
@@ -17351,7 +17263,7 @@ name = "sp-storage"
 version = "22.0.0"
 source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "impl-serde 0.5.0",
+ "impl-serde",
  "parity-scale-codec",
  "ref-cast",
  "serde",
@@ -17409,7 +17321,7 @@ name = "sp-trie"
 version = "40.0.0"
 source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "foldhash 0.1.5",
  "hash-db",
  "hashbrown 0.15.5",
@@ -17434,7 +17346,7 @@ name = "sp-version"
 version = "40.0.0"
 source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "impl-serde 0.5.0",
+ "impl-serde",
  "parity-scale-codec",
  "parity-wasm",
  "scale-info",
@@ -18027,7 +17939,7 @@ dependencies = [
 name = "subtensor-macros"
 version = "0.1.0"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -18219,7 +18131,7 @@ dependencies = [
  "frame-metadata 20.0.0",
  "hashbrown 0.14.5",
  "hex",
- "impl-serde 0.5.0",
+ "impl-serde",
  "keccak-hash",
  "parity-scale-codec",
  "primitive-types 0.13.1",
@@ -18294,7 +18206,7 @@ dependencies = [
  "frame-metadata 20.0.0",
  "futures",
  "hex",
- "impl-serde 0.5.0",
+ "impl-serde",
  "jsonrpsee",
  "parity-scale-codec",
  "primitive-types 0.13.1",
@@ -19613,7 +19525,7 @@ version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c128c039340ffd50d4195c3f8ce31aac357f06804cfc494c8b9508d4b30dca4"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "hashbrown 0.14.5",
  "string-interner",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3636,7 +3636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.106",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -10665,7 +10665,7 @@ dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
  "polkadot-runtime-common",
- "rand 0.9.2",
+ "rand 0.8.5",
  "rand_chacha 0.3.1",
  "safe-math",
  "scale-info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,11 +23,11 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
- "gimli 0.31.1",
+ "gimli 0.32.3",
 ]
 
 [[package]]
@@ -112,28 +112,27 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-core"
-version = "0.8.25"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d8bcce99ad10fe02640cfaec1c6bc809b837c783c1d52906aa5af66e2a196f6"
+checksum = "575053cea24ea8cb7e775e39d5c53c33b19cfd0ca1cf6c0fd653f3d8c682095f"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
- "alloy-primitives",
+ "alloy-primitives 1.4.0",
  "alloy-rlp",
  "alloy-sol-types",
 ]
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.8.25"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb8e762aefd39a397ff485bc86df673465c4ad3ec8819cc60833a8a3ba5cdc87"
+checksum = "a6c2905bafc2df7ccd32ca3af13f0b0d82f2e2ff9dfbeb12196c0d978d5c0deb"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives",
+ "alloy-primitives 1.4.0",
  "alloy-sol-type-parser",
  "alloy-sol-types",
- "const-hex",
  "itoa",
  "serde",
  "serde_json",
@@ -142,11 +141,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.8.25"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6beff64ad0aa6ad1019a3db26fef565aefeb011736150ab73ed3366c3cfd1b"
+checksum = "a2acb6637a9c0e1cdf8971e0ced8f3fa34c04c5e9dccf6bb184f6a64fe0e37d8"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 1.4.0",
  "alloy-sol-type-parser",
  "serde",
  "serde_json",
@@ -163,15 +162,41 @@ dependencies = [
  "cfg-if",
  "const-hex",
  "derive_more 2.0.1",
- "foldhash",
- "hashbrown 0.15.4",
- "indexmap 2.10.0",
+ "foldhash 0.1.5",
+ "indexmap 2.11.4",
  "itoa",
  "k256",
  "keccak-asm",
  "paste",
  "proptest",
  "rand 0.8.5",
+ "ruint",
+ "rustc-hash 2.1.1",
+ "serde",
+ "sha3",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b77f7d5e60ad8ae6bd2200b8097919712a07a6db622a4b201e7ead6166f02e5"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more 2.0.1",
+ "foldhash 0.2.0",
+ "hashbrown 0.16.0",
+ "indexmap 2.11.4",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "paste",
+ "proptest",
+ "rand 0.9.2",
  "ruint",
  "rustc-hash 2.1.1",
  "serde",
@@ -191,41 +216,41 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.25"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10ae8e9a91d328ae954c22542415303919aabe976fe7a92eb06db1b68fd59f2"
+checksum = "78c84c3637bee9b5c4a4d2b93360ee16553d299c3b932712353caf1cea76d0e6"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.25"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83ad5da86c127751bc607c174d6c9fe9b85ef0889a9ca0c641735d77d4f98f26"
+checksum = "a882aa4e1790063362434b9b40d358942b188477ac1c44cfb8a52816ffc0cc17"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
- "indexmap 2.10.0",
+ "indexmap 2.11.4",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "syn-solidity",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.25"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3d30f0d3f9ba3b7686f3ff1de9ee312647aac705604417a2f40c604f409a9e"
+checksum = "18e5772107f9bb265d8d8c86e0733937bb20d0857ea5425b1b6ddf51a9804042"
 dependencies = [
  "const-hex",
  "dunce",
@@ -233,15 +258,15 @@ dependencies = [
  "macro-string",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.8.25"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d162f8524adfdfb0e4bd0505c734c985f3e2474eb022af32eef0d52a4f3935c"
+checksum = "e188b939aa4793edfaaa099cb1be4e620036a775b4bdf24fdc56f1cd6fd45890"
 dependencies = [
  "serde",
  "winnow",
@@ -249,14 +274,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.25"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d43d5e60466a440230c07761aa67671d4719d46f43be8ea6e7ed334d8db4a9ab"
+checksum = "c3c8a9a909872097caffc05df134e5ef2253a1cdb56d3a9cf0052a042ac763f9"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives",
+ "alloy-primitives 1.4.0",
  "alloy-sol-macro",
- "const-hex",
  "serde",
 ]
 
@@ -265,12 +289,6 @@ name = "always-assert"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4436e0292ab1bb631b42973c61205e704475fe8126af845c8d923c0996328127"
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -283,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -298,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
@@ -313,29 +331,29 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "approx"
@@ -357,7 +375,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -497,7 +515,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "itertools 0.13.0",
  "num-bigint",
  "num-integer",
@@ -652,7 +670,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -690,7 +708,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -731,7 +749,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -792,6 +810,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-scale"
+version = "0.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985c81a9c7b23a72f62b7b20686d5326d2a9956806f37de9ee35cb1238faf0c0"
+dependencies = [
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "parity-scale-codec",
+ "scale-info",
+]
+
+[[package]]
 name = "ark-serialize"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,7 +875,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -931,6 +961,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5dde061bd34119e902bbb2d9b90c5692635cf59fb91d582c2b68043f1b8293"
 
 [[package]]
+name = "array-bytes"
+version = "9.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27d55334c98d756b32dcceb60248647ab34f027690f87f9a362fd292676ee927"
+dependencies = [
+ "smallvec",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,7 +1019,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "time",
 ]
 
@@ -991,7 +1031,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "synstructure 0.13.2",
 ]
 
@@ -1003,7 +1043,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "synstructure 0.13.2",
 ]
 
@@ -1015,7 +1055,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1026,19 +1066,24 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "assets-common"
-version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.22.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "cumulus-primitives-core",
+ "ethereum-standards",
  "frame-support",
+ "frame-system",
  "impl-trait-for-tuples",
  "pallet-asset-conversion",
  "pallet-assets",
+ "pallet-revive",
+ "pallet-revive-uapi",
  "pallet-xcm",
  "parachains-common",
  "parity-scale-codec",
  "scale-info",
  "sp-api",
+ "sp-core",
  "sp-runtime",
  "staging-xcm",
  "staging-xcm-builder",
@@ -1071,9 +1116,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
+checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -1097,9 +1142,9 @@ dependencies = [
 
 [[package]]
 name = "async-fs"
-version = "2.1.3"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f7e37c0ed80b2a977691c47dae8625cfb21e205827106c64f7c588766b2e50"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
 dependencies = [
  "async-lock 3.4.1",
  "blocking",
@@ -1128,20 +1173,20 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
- "async-lock 3.4.1",
+ "autocfg",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
  "futures-lite 2.6.1",
  "parking",
- "polling 3.10.0",
- "rustix 1.0.8",
+ "polling 3.11.0",
+ "rustix 1.1.2",
  "slab",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -1181,7 +1226,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
 dependencies = [
- "async-io 2.5.0",
+ "async-io 2.6.0",
  "blocking",
  "futures-lite 2.6.1",
 ]
@@ -1205,12 +1250,12 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
 dependencies = [
  "async-channel 2.5.0",
- "async-io 2.5.0",
+ "async-io 2.6.0",
  "async-lock 3.4.1",
  "async-signal",
  "async-task",
@@ -1218,25 +1263,25 @@ dependencies = [
  "cfg-if",
  "event-listener 5.4.1",
  "futures-lite 2.6.1",
- "rustix 1.0.8",
+ "rustix 1.1.2",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f567af260ef69e1d52c2b560ce0ea230763e6fbb9214a85d768760a920e3e3c1"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
 dependencies = [
- "async-io 2.5.0",
+ "async-io 2.6.0",
  "async-lock 3.4.1",
  "atomic-waker",
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -1247,13 +1292,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1322,7 +1367,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1333,17 +1378,17 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
- "addr2line 0.24.2",
+ "addr2line 0.25.1",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.36.7",
+ "object 0.37.3",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -1357,6 +1402,16 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base256emoji"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e9430d9a245a77c92176e649af6e275f20839a48389859d1661e9a128d077c"
+dependencies = [
+ "const-str",
+ "match-lookup",
+]
 
 [[package]]
 name = "base58"
@@ -1391,7 +1446,7 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 [[package]]
 name = "binary-merkle-tree"
 version = "16.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "hash-db",
  "log",
@@ -1425,7 +1480,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1511,9 +1566,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "bitvec"
@@ -1627,6 +1682,17 @@ dependencies = [
 
 [[package]]
 name = "bounded-collections"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca548b6163b872067dc5eb82fd130c56881435e30367d2073594a3d9744120dd"
+dependencies = [
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+]
+
+[[package]]
+name = "bounded-collections"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ad8a0bed7827f0b07a5d23cec2e58cc02038a99e4ca81616cb2bb2025f804d"
@@ -1648,8 +1714,8 @@ dependencies = [
 
 [[package]]
 name = "bp-header-chain"
-version = "0.20.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.21.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
@@ -1665,8 +1731,8 @@ dependencies = [
 
 [[package]]
 name = "bp-messages"
-version = "0.20.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.21.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -1681,8 +1747,8 @@ dependencies = [
 
 [[package]]
 name = "bp-parachains"
-version = "0.20.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.21.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -1698,8 +1764,8 @@ dependencies = [
 
 [[package]]
 name = "bp-polkadot-core"
-version = "0.20.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.21.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1714,8 +1780,8 @@ dependencies = [
 
 [[package]]
 name = "bp-relayers"
-version = "0.20.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.21.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1732,8 +1798,8 @@ dependencies = [
 
 [[package]]
 name = "bp-runtime"
-version = "0.20.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.21.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1755,8 +1821,8 @@ dependencies = [
 
 [[package]]
 name = "bp-test-utils"
-version = "0.20.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.21.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -1775,8 +1841,8 @@ dependencies = [
 
 [[package]]
 name = "bp-xcm-bridge-hub"
-version = "0.6.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.7.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1792,8 +1858,8 @@ dependencies = [
 
 [[package]]
 name = "bp-xcm-bridge-hub-router"
-version = "0.17.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.18.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1804,8 +1870,8 @@ dependencies = [
 
 [[package]]
 name = "bridge-hub-common"
-version = "0.13.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.14.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1823,8 +1889,8 @@ dependencies = [
 
 [[package]]
 name = "bridge-runtime-common"
-version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.22.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1891,9 +1957,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
 
 [[package]]
 name = "byteorder"
@@ -1932,11 +1998,11 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.10"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da45bc31171d8d6960122e222a67740df867c1dd53b4d51caa297084c185cab"
+checksum = "276a59bf2b2c967788139340c9f0c5b12d7fd6630315c15c217e559de85d2609"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1956,7 +2022,7 @@ checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.26",
+ "semver 1.0.27",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -1970,10 +2036,11 @@ checksum = "fd6c0e7b807d60291f42f33f58480c0bfafe28ed08286446f45e463728cf9c1c"
 
 [[package]]
 name = "cc"
-version = "1.2.31"
+version = "1.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a42d84bb6b69d3a8b3eaacf0d88f179e1929695e1ad012b6cf64d9caaa5fd2"
+checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -2005,9 +2072,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cfg_aliases"
@@ -2057,14 +2124,14 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -2127,9 +2194,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.42"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2137,9 +2204,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.42"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2150,14 +2217,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.41"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2206,7 +2273,7 @@ dependencies = [
  "nom",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2227,9 +2294,9 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "7.1.4"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
+checksum = "b03b7db8e0b4b2fdad6c551e634134e99ec000e5c8c3b6856c65e8bbaded7a3b"
 dependencies = [
  "unicode-segmentation",
  "unicode-width",
@@ -2265,15 +2332,14 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.14.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e22e0ed40b96a48d3db274f72fd365bd78f67af39b6bbd47e8a15e1c6207ff"
+checksum = "b6407bff74dea37e0fa3dc1c1c974e5d46405f0c987bf9997a0762adce71eda6"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "hex",
  "proptest",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2301,6 +2367,12 @@ dependencies = [
  "once_cell",
  "tiny-keccak",
 ]
+
+[[package]]
+name = "const-str"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
 
 [[package]]
 name = "const_format"
@@ -2648,9 +2720,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cumulus-client-bootnodes"
+version = "0.2.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
+dependencies = [
+ "array-bytes 6.2.3",
+ "async-channel 1.9.0",
+ "cumulus-client-network",
+ "cumulus-primitives-core",
+ "cumulus-relay-chain-interface",
+ "futures",
+ "hex",
+ "ip_network",
+ "log",
+ "num-traits",
+ "parachains-common",
+ "parity-scale-codec",
+ "prost 0.12.6",
+ "prost-build",
+ "sc-network",
+ "sc-service",
+ "sp-consensus-babe",
+ "sp-runtime",
+ "tokio",
+]
+
+[[package]]
 name = "cumulus-client-cli"
-version = "0.22.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.24.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -2666,8 +2764,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-collator"
-version = "0.22.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.24.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -2689,8 +2787,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-consensus-aura"
-version = "0.22.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.24.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -2736,13 +2834,14 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-consensus-common"
-version = "0.22.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.24.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
+ "cumulus-relay-chain-streams",
  "dyn-clone",
  "futures",
  "log",
@@ -2751,6 +2850,7 @@ dependencies = [
  "sc-client-api",
  "sc-consensus",
  "sc-consensus-babe",
+ "sc-network",
  "schnellru",
  "sp-blockchain",
  "sp-consensus",
@@ -2766,8 +2866,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-consensus-proposer"
-version = "0.19.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.20.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2781,8 +2881,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
-version = "0.22.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.24.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -2804,8 +2904,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-network"
-version = "0.22.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.24.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -2818,6 +2918,7 @@ dependencies = [
  "polkadot-parachain-primitives",
  "polkadot-primitives",
  "sc-client-api",
+ "sc-network",
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
@@ -2830,8 +2931,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-parachain-inherent"
-version = "0.16.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.18.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2840,22 +2941,24 @@ dependencies = [
  "cumulus-test-relay-sproof-builder",
  "parity-scale-codec",
  "sc-client-api",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8)",
+ "sc-consensus-babe",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234)",
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
- "sp-storage 22.0.0",
+ "sp-storage",
  "tracing",
 ]
 
 [[package]]
 name = "cumulus-client-pov-recovery"
-version = "0.22.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.24.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
+ "cumulus-relay-chain-streams",
  "futures",
  "futures-timer",
  "parity-scale-codec",
@@ -2866,6 +2969,7 @@ dependencies = [
  "rand 0.8.5",
  "sc-client-api",
  "sc-consensus",
+ "sc-network",
  "sp-api",
  "sp-consensus",
  "sp-maybe-compressed-blob",
@@ -2876,9 +2980,10 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-service"
-version = "0.23.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.25.1"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
+ "async-channel 1.9.0",
  "cumulus-client-cli",
  "cumulus-client-collator",
  "cumulus-client-consensus-common",
@@ -2889,8 +2994,10 @@ dependencies = [
  "cumulus-relay-chain-inprocess-interface",
  "cumulus-relay-chain-interface",
  "cumulus-relay-chain-minimal-node",
+ "cumulus-relay-chain-streams",
  "futures",
  "polkadot-primitives",
+ "prometheus",
  "sc-client-api",
  "sc-consensus",
  "sc-network",
@@ -2913,8 +3020,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-aura-ext"
-version = "0.20.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.21.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -2930,8 +3037,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-dmp-queue"
-version = "0.20.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.21.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "cumulus-primitives-core",
  "frame-benchmarking",
@@ -2947,8 +3054,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-parachain-system"
-version = "0.20.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.21.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -2959,6 +3066,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "hashbrown 0.15.5",
  "impl-trait-for-tuples",
  "log",
  "pallet-message-queue",
@@ -2966,8 +3074,9 @@ dependencies = [
  "polkadot-parachain-primitives",
  "polkadot-runtime-parachains",
  "scale-info",
+ "sp-consensus-babe",
  "sp-core",
- "sp-externalities 0.30.0",
+ "sp-externalities",
  "sp-inherents",
  "sp-io",
  "sp-runtime",
@@ -2983,18 +3092,18 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
-version = "21.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "22.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3006,8 +3115,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-solo-to-para"
-version = "0.20.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.21.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -3021,8 +3130,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-weight-reclaim"
-version = "0.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.3.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "derive-where",
@@ -3040,8 +3149,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-xcm"
-version = "0.19.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.20.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3055,10 +3164,11 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
-version = "0.20.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.21.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "bounded-collections",
+ "approx",
+ "bounded-collections 0.2.4",
  "cumulus-primitives-core",
  "frame-benchmarking",
  "frame-support",
@@ -3079,8 +3189,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-ping"
-version = "0.20.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.21.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-primitives-core",
@@ -3094,8 +3204,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-aura"
-version = "0.17.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.18.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -3103,8 +3213,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-core"
-version = "0.18.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.19.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -3115,12 +3225,13 @@ dependencies = [
  "sp-runtime",
  "sp-trie",
  "staging-xcm",
+ "tracing",
 ]
 
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
-version = "0.18.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.19.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3133,18 +3244,18 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
-version = "0.12.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.13.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "sp-externalities 0.30.0",
- "sp-runtime-interface 29.0.1",
+ "sp-externalities",
+ "sp-runtime-interface",
  "sp-trie",
 ]
 
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
-version = "11.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "12.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -3160,8 +3271,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-utility"
-version = "0.20.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.21.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3177,18 +3288,22 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
-version = "0.23.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.25.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
+ "async-channel 1.9.0",
  "async-trait",
+ "cumulus-client-bootnodes",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
  "futures",
  "futures-timer",
  "polkadot-cli",
+ "polkadot-primitives",
  "polkadot-service",
  "sc-cli",
  "sc-client-api",
+ "sc-network",
  "sc-sysinfo",
  "sc-telemetry",
  "sc-tracing",
@@ -3201,8 +3316,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-interface"
-version = "0.22.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.24.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3211,6 +3326,7 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-overseer",
  "sc-client-api",
+ "sc-network",
  "sp-api",
  "sp-blockchain",
  "sp-state-machine",
@@ -3220,11 +3336,13 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
-version = "0.23.2"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.25.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.3",
+ "async-channel 1.9.0",
  "async-trait",
+ "cumulus-client-bootnodes",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
  "cumulus-relay-chain-rpc-interface",
@@ -3254,8 +3372,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
-version = "0.22.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.24.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3270,6 +3388,7 @@ dependencies = [
  "prometheus",
  "rand 0.8.5",
  "sc-client-api",
+ "sc-network",
  "sc-rpc-api",
  "sc-service",
  "schnellru",
@@ -3282,7 +3401,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-state-machine",
- "sp-storage 22.0.0",
+ "sp-storage",
  "sp-version",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
@@ -3293,9 +3412,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "cumulus-relay-chain-streams"
+version = "0.2.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
+dependencies = [
+ "cumulus-relay-chain-interface",
+ "futures",
+ "polkadot-node-subsystem",
+ "polkadot-primitives",
+ "sp-api",
+ "sp-consensus",
+ "tracing",
+]
+
+[[package]]
 name = "cumulus-test-relay-sproof-builder"
-version = "0.19.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.20.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -3329,7 +3462,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3347,64 +3480,65 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.161"
+version = "1.0.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3523cc02ad831111491dd64b27ad999f1ae189986728e477604e61b81f828df"
+checksum = "4e9c4fe7f2f5dc5c62871a1b43992d197da6fa1394656a94276ac2894a90a6fe"
 dependencies = [
  "cc",
+ "cxx-build",
  "cxxbridge-cmd",
  "cxxbridge-flags",
  "cxxbridge-macro",
- "foldhash",
+ "foldhash 0.2.0",
  "link-cplusplus",
 ]
 
 [[package]]
 name = "cxx-build"
-version = "1.0.161"
+version = "1.0.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212b754247a6f07b10fa626628c157593f0abf640a3dd04cce2760eca970f909"
+checksum = "b5cf2909d37d80633ddd208676fc27c2608a7f035fff69c882421168038b26dd"
 dependencies = [
  "cc",
  "codespan-reporting",
- "indexmap 2.10.0",
+ "indexmap 2.11.4",
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "cxxbridge-cmd"
-version = "1.0.161"
+version = "1.0.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f426a20413ec2e742520ba6837c9324b55ffac24ead47491a6e29f933c5b135a"
+checksum = "077f5ee3d3bfd8d27f83208fdaa96ddd50af7f096c77077cc4b94da10bfacefd"
 dependencies = [
  "clap",
  "codespan-reporting",
- "indexmap 2.10.0",
+ "indexmap 2.11.4",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.161"
+version = "1.0.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258b6069020b4e5da6415df94a50ee4f586a6c38b037a180e940a43d06a070d"
+checksum = "b0108748615125b9f2e915dfafdffcbdabbca9b15102834f6d7e9a768f2f2864"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.161"
+version = "1.0.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dec184b52be5008d6eaf7e62fc1802caf1ad1227d11b3b7df2c409c7ffc3f4"
+checksum = "e6e896681ef9b8dc462cfa6961d61909704bde0984b30bcb4082fe102b478890"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.4",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3413,8 +3547,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -3428,7 +3572,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.104",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3437,9 +3595,20 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3478,7 +3647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3488,6 +3657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -3521,9 +3691,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
 dependencies = [
  "powerfmt",
 ]
@@ -3547,18 +3717,18 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "derive-where"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510c292c8cf384b1a340b816a9a6cf2599eb8f566a44949024af88418000c50b"
+checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3571,7 +3741,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3600,8 +3770,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
- "unicode-xid",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3612,7 +3781,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "unicode-xid",
 ]
 
@@ -3705,7 +3874,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3729,7 +3898,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.104",
+ "syn 2.0.106",
  "termcolor",
  "toml 0.8.23",
  "walkdir",
@@ -3783,7 +3952,7 @@ checksum = "7e8671d54058979a37a26f3511fbf8d198ba1aa35ffb202c42587d918d77213a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3834,16 +4003,17 @@ dependencies = [
 
 [[package]]
 name = "ed25519-zebra"
-version = "4.0.3"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d9ce6874da5d4415896cd45ffbc4d1cfc0c4f9c079427bd870742c30f2f65a9"
+checksum = "0017d969298eec91e3db7a2985a8cab4df6341d86e6f3a6f5878b13fb7846bc9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "hashbrown 0.14.5",
- "hex",
+ "hashbrown 0.15.5",
+ "pkcs8",
  "rand_core 0.6.4",
  "sha2 0.10.9",
+ "subtle 2.6.1",
  "zeroize",
 ]
 
@@ -3856,7 +4026,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3903,7 +4073,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3923,7 +4093,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3943,7 +4113,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3954,7 +4124,17 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
 ]
 
 [[package]]
@@ -3984,22 +4164,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "ethabi-decode"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52029c4087f9f01108f851d0d02df9c21feb5660a19713466724b7f95bd2d773"
-dependencies = [
- "ethereum-types 0.15.1",
- "tiny-keccak",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -4032,19 +4202,29 @@ dependencies = [
 
 [[package]]
 name = "ethereum"
-version = "0.15.0"
-source = "git+https://github.com/rust-ethereum/ethereum?rev=bbb544622208ef6e9890a2dbc224248f6dd13318#bbb544622208ef6e9890a2dbc224248f6dd13318"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee371ebb7479ed3258617557ab0b3247e741075cb6b02b820d188f68da44441"
 dependencies = [
  "bytes",
  "ethereum-types 0.15.1",
  "hash-db",
  "hash256-std-hasher",
+ "k256",
  "parity-scale-codec",
  "rlp 0.6.1",
  "scale-info",
  "serde",
  "sha3",
  "trie-root",
+]
+
+[[package]]
+name = "ethereum-standards"
+version = "0.1.1"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
+dependencies = [
+ "alloy-core",
 ]
 
 [[package]]
@@ -4117,8 +4297,9 @@ dependencies = [
 
 [[package]]
 name = "evm"
-version = "0.42.0"
-source = "git+https://github.com/rust-ethereum/evm?rev=6ca5a72bc8942f4860137155dd9033526fd362a5#6ca5a72bc8942f4860137155dd9033526fd362a5"
+version = "0.43.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b54f188e7563c1702ecefdef92c8b2c4be8941b84a50684907a747f87121aace"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -4137,8 +4318,9 @@ dependencies = [
 
 [[package]]
 name = "evm-core"
-version = "0.42.0"
-source = "git+https://github.com/rust-ethereum/evm?rev=6ca5a72bc8942f4860137155dd9033526fd362a5#6ca5a72bc8942f4860137155dd9033526fd362a5"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ef956f8cc0c25a2d8be1dea7d659782b7c5f201f7e8057878f2051eec78350"
 dependencies = [
  "parity-scale-codec",
  "primitive-types 0.13.1",
@@ -4148,8 +4330,9 @@ dependencies = [
 
 [[package]]
 name = "evm-gasometer"
-version = "0.42.0"
-source = "git+https://github.com/rust-ethereum/evm?rev=6ca5a72bc8942f4860137155dd9033526fd362a5#6ca5a72bc8942f4860137155dd9033526fd362a5"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54aa0327b242bad8dd83ba524effd1d798e9102ff592910dfdded79c6bde4ff3"
 dependencies = [
  "environmental",
  "evm-core",
@@ -4159,8 +4342,9 @@ dependencies = [
 
 [[package]]
 name = "evm-runtime"
-version = "0.42.0"
-source = "git+https://github.com/rust-ethereum/evm?rev=6ca5a72bc8942f4860137155dd9033526fd362a5#6ca5a72bc8942f4860137155dd9033526fd362a5"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf22109a8f12b6d9ae60475584c80f2c9d48cf12427eac651b69ce14e5b95666"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -4190,7 +4374,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4259,17 +4443,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb42427514b063d97ce21d5199f36c0c307d981434a6be32582bc79fe5bd2303"
 dependencies = [
  "expander",
- "indexmap 2.10.0",
- "proc-macro-crate 3.3.0",
+ "indexmap 2.11.4",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "fc-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "async-trait",
  "fp-storage",
@@ -4281,7 +4465,7 @@ dependencies = [
 [[package]]
 name = "fc-aura"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "fc-rpc",
  "fp-storage",
@@ -4297,7 +4481,7 @@ dependencies = [
 [[package]]
 name = "fc-babe"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "fc-rpc",
  "sc-client-api",
@@ -4313,7 +4497,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "async-trait",
  "fp-consensus",
@@ -4323,13 +4507,13 @@ dependencies = [
  "sp-block-builder",
  "sp-consensus",
  "sp-runtime",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "async-trait",
  "ethereum",
@@ -4359,7 +4543,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "fc-db",
  "fc-storage",
@@ -4382,7 +4566,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -4418,22 +4602,22 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-externalities 0.30.0",
+ "sp-externalities",
  "sp-inherents",
  "sp-io",
  "sp-runtime",
  "sp-state-machine",
- "sp-storage 22.0.0",
+ "sp-storage",
  "sp-trie",
  "substrate-prometheus-endpoint",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tokio",
 ]
 
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -4442,13 +4626,13 @@ dependencies = [
  "rustc-hex",
  "serde",
  "serde_json",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234)",
 ]
 
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -4459,7 +4643,7 @@ dependencies = [
  "sp-api",
  "sp-io",
  "sp-runtime",
- "sp-storage 22.0.0",
+ "sp-storage",
 ]
 
 [[package]]
@@ -4510,14 +4694,14 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.25"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
 dependencies = [
  "cfg-if",
  "libc",
  "libredox",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4535,6 +4719,12 @@ dependencies = [
  "parking_lot 0.12.4",
  "scale-info",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
 name = "fixed-hash"
@@ -4584,6 +4774,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4601,16 +4797,16 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "parity-scale-codec",
 ]
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -4628,7 +4824,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "hex",
  "impl-serde 0.5.0",
@@ -4640,14 +4836,13 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-runtime-interface 29.0.1",
  "staging-xcm",
 ]
 
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -4658,7 +4853,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -4670,7 +4865,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "environmental",
  "evm",
@@ -4686,7 +4881,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -4702,7 +4897,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4714,7 +4909,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -4728,8 +4923,8 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "frame-benchmarking"
-version = "40.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.1"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -4745,24 +4940,26 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-runtime-interface 29.0.1",
- "sp-storage 22.0.0",
+ "sp-runtime-interface",
+ "sp-storage",
  "static_assertions",
 ]
 
 [[package]]
 name = "frame-benchmarking-cli"
-version = "47.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "49.1.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "Inflector",
- "array-bytes",
+ "array-bytes 6.2.3",
  "chrono",
  "clap",
  "comfy-table",
  "cumulus-client-parachain-inherent",
  "cumulus-primitives-proof-size-hostfunction",
+ "env_filter",
  "frame-benchmarking",
+ "frame-storage-access-test-runtime",
  "frame-support",
  "frame-system",
  "gethostname",
@@ -4781,6 +4978,8 @@ dependencies = [
  "sc-client-api",
  "sc-client-db",
  "sc-executor",
+ "sc-executor-common",
+ "sc-executor-wasmtime",
  "sc-runtime-utilities",
  "sc-service",
  "sc-sysinfo",
@@ -4791,19 +4990,20 @@ dependencies = [
  "sp-blockchain",
  "sp-core",
  "sp-database",
- "sp-externalities 0.30.0",
+ "sp-externalities",
  "sp-genesis-builder",
  "sp-inherents",
  "sp-io",
  "sp-keystore",
  "sp-runtime",
+ "sp-runtime-interface",
  "sp-state-machine",
- "sp-storage 22.0.0",
+ "sp-storage",
  "sp-timestamp",
  "sp-transaction-pool",
  "sp-trie",
  "sp-version",
- "sp-wasm-interface 21.0.1",
+ "sp-wasm-interface",
  "subxt",
  "subxt-signer",
  "thiserror 1.0.69",
@@ -4812,8 +5012,8 @@ dependencies = [
 
 [[package]]
 name = "frame-benchmarking-pallet-pov"
-version = "30.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "31.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4826,13 +5026,13 @@ dependencies = [
 
 [[package]]
 name = "frame-decode"
-version = "0.5.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6027a409bac4fe95b4d107f965fcdbc252fc89d884a360d076b3070b6128c094"
+checksum = "a7cb8796f93fa038f979a014234d632e9688a120e745f936e2635123c77537f7"
 dependencies = [
- "frame-metadata 17.0.0",
+ "frame-metadata 21.0.0",
  "parity-scale-codec",
- "scale-decode 0.14.0",
+ "scale-decode",
  "scale-info",
  "scale-type-resolver",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4841,18 +5041,18 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "16.1.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "frame-election-provider-support"
-version = "40.1.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -4863,12 +5063,13 @@ dependencies = [
  "sp-core",
  "sp-npos-elections",
  "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
 name = "frame-executive"
-version = "40.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.1"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -4880,19 +5081,7 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-tracing 17.1.0",
-]
-
-[[package]]
-name = "frame-metadata"
-version = "17.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701bac17e9b55e0f95067c428ebcb46496587f08e8cf4ccc0fe5903bea10dbb8"
-dependencies = [
- "cfg-if",
- "parity-scale-codec",
- "scale-info",
- "serde",
+ "sp-tracing",
 ]
 
 [[package]]
@@ -4908,11 +5097,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "frame-metadata-hash-extension"
-version = "0.8.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+name = "frame-metadata"
+version = "21.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20dfd1d7eae1d94e32e869e2fb272d81f52dd8db57820a373adb83ea24d7d862"
 dependencies = [
- "array-bytes",
+ "cfg-if",
+ "parity-scale-codec",
+ "scale-info",
+]
+
+[[package]]
+name = "frame-metadata"
+version = "23.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c26fcb0454397c522c05fdad5380c4e622f8a875638af33bff5a320d1fc965"
+dependencies = [
+ "cfg-if",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+]
+
+[[package]]
+name = "frame-metadata-hash-extension"
+version = "0.9.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
+dependencies = [
+ "array-bytes 6.2.3",
  "const-hex",
  "docify",
  "frame-support",
@@ -4924,17 +5136,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "frame-storage-access-test-runtime"
+version = "0.2.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
+dependencies = [
+ "cumulus-pallet-parachain-system",
+ "parity-scale-codec",
+ "sp-core",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-trie",
+ "substrate-wasm-builder",
+]
+
+[[package]]
 name = "frame-support"
-version = "40.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "aquamarine",
- "array-bytes",
+ "array-bytes 6.2.3",
  "binary-merkle-tree",
  "bitflags 1.3.2",
  "docify",
  "environmental",
- "frame-metadata 20.0.0",
+ "frame-metadata 23.0.0",
  "frame-support-procedural",
  "impl-trait-for-tuples",
  "k256",
@@ -4958,7 +5184,7 @@ dependencies = [
  "sp-staking",
  "sp-state-machine",
  "sp-std",
- "sp-tracing 17.1.0",
+ "sp-tracing",
  "sp-trie",
  "sp-weights",
  "tt-call",
@@ -4966,8 +5192,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural"
-version = "33.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "34.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -4980,8 +5206,8 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8)",
- "syn 2.0.104",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234)",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4991,22 +5217,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3363df38464c47a73eb521a4f648bfcc7537a82d70347ef8af3f73b6d019e910"
 dependencies = [
  "frame-support-procedural-tools-derive 11.0.0",
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-support-procedural-tools-derive 12.0.0",
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5017,23 +5243,23 @@ checksum = "68672b9ec6fe72d259d3879dc212c5e42e977588cdac830c76f54d9f492aeb58"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "frame-system"
-version = "40.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "cfg-if",
  "docify",
@@ -5051,8 +5277,8 @@ dependencies = [
 
 [[package]]
 name = "frame-system-benchmarking"
-version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5065,8 +5291,8 @@ dependencies = [
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
-version = "36.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "37.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -5075,8 +5301,8 @@ dependencies = [
 
 [[package]]
 name = "frame-try-runtime"
-version = "0.46.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.47.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5225,7 +5451,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5285,20 +5511,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generator"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d18470a76cb7f8ff746cf1f7470914f900252ec36bbc40b569d74b1258446827"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "log",
- "rustversion",
- "windows 0.61.3",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5351,7 +5563,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -5397,10 +5609,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.2"
+name = "gimli"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "governor"
@@ -5445,7 +5663,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.10.0",
+ "indexmap 2.11.4",
  "slab",
  "tokio",
  "tokio-util",
@@ -5454,9 +5672,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -5464,7 +5682,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.10.0",
+ "indexmap 2.11.4",
  "slab",
  "tokio",
  "tokio-util",
@@ -5537,13 +5755,22 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+dependencies = [
+ "foldhash 0.2.0",
  "serde",
 ]
 
@@ -5562,7 +5789,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -5662,7 +5889,7 @@ dependencies = [
  "once_cell",
  "rand 0.9.2",
  "ring 0.17.14",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tinyvec",
  "tokio",
  "tracing",
@@ -5706,7 +5933,7 @@ dependencies = [
  "rand 0.9.2",
  "resolv-conf",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
 ]
@@ -5820,9 +6047,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "humantime-serde"
@@ -5860,20 +6087,22 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
- "h2 0.4.11",
+ "futures-core",
+ "h2 0.4.12",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -5886,7 +6115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.3.1",
- "hyper 1.6.0",
+ "hyper 1.7.0",
  "hyper-util",
  "log",
  "rustls",
@@ -5899,9 +6128,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -5909,7 +6138,7 @@ dependencies = [
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
- "hyper 1.6.0",
+ "hyper 1.7.0",
  "libc",
  "pin-project-lite",
  "socket2 0.6.0",
@@ -5920,9 +6149,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -5930,7 +6159,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.1",
 ]
 
 [[package]]
@@ -6036,9 +6265,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -6071,7 +6300,7 @@ version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdf9d64cfcf380606e64f9a0bcf493616b65331199f984151a6fa11a7b3cde38"
 dependencies = [
- "async-io 2.5.0",
+ "async-io 2.6.0",
  "core-foundation 0.9.4",
  "fnv",
  "futures",
@@ -6180,7 +6409,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -6215,13 +6444,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.16.0",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -6270,11 +6500,11 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "cfg-if",
  "libc",
 ]
@@ -6404,9 +6634,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom 0.3.3",
  "libc",
@@ -6414,9 +6644,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -6494,10 +6724,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e65763c942dfc9358146571911b0cd1c361c2d63e2d2305622d40d36376ca80"
 dependencies = [
  "heck 0.5.0",
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -6510,7 +6740,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper 1.7.0",
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -6662,18 +6892,18 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libloading"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -6821,7 +7051,7 @@ dependencies = [
  "quick-protobuf",
  "rand 0.8.5",
  "sha2 0.10.9",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tracing",
  "zeroize",
 ]
@@ -7015,7 +7245,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -7103,16 +7333,16 @@ dependencies = [
  "thiserror 1.0.69",
  "tracing",
  "yamux 0.12.1",
- "yamux 0.13.6",
+ "yamux 0.13.7",
 ]
 
 [[package]]
 name = "libredox"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "libc",
  "redox_syscall 0.5.17",
 ]
@@ -7204,9 +7434,9 @@ dependencies = [
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6f6da007f968f9def0d65a05b187e2960183de70c160204ecfccf0ee330212"
+checksum = "7f78c730aaa7d0b9336a299029ea49f9ee53b0ed06e9202e8cb7db9bae7b8c82"
 dependencies = [
  "cc",
 ]
@@ -7255,9 +7485,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lioness"
@@ -7291,7 +7521,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "hickory-resolver 0.25.2",
- "indexmap 2.10.0",
+ "indexmap 2.11.4",
  "libc",
  "mockall",
  "multiaddr 0.17.1",
@@ -7308,7 +7538,7 @@ dependencies = [
  "smallvec",
  "snow",
  "socket2 0.5.10",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
@@ -7319,7 +7549,7 @@ dependencies = [
  "url",
  "x25519-dalek",
  "x509-parser 0.17.0",
- "yamux 0.13.6",
+ "yamux 0.13.7",
  "yasna",
  "zeroize",
 ]
@@ -7336,22 +7566,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
-
-[[package]]
-name = "loom"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
-dependencies = [
- "cfg-if",
- "generator",
- "scoped-tls",
- "tracing",
- "tracing-subscriber 0.3.19",
-]
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lru"
@@ -7374,7 +7591,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -7428,7 +7645,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -7440,7 +7657,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -7454,7 +7671,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -7465,7 +7682,7 @@ checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -7476,16 +7693,27 @@ checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "match-lookup"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1265724d8cb29dbbc2b0f06fffb8bf1a8c0cf73a78eede9ba73a4a66c52a981e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -7500,17 +7728,17 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memfd"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
 dependencies = [
- "rustix 0.38.44",
+ "rustix 1.1.2",
 ]
 
 [[package]]
@@ -7524,9 +7752,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483758ad303d734cec05e5c12b41d7e93e6a6390c5e9dae6bdeb7c1259012d28"
+checksum = "843a98750cd611cc2965a8213b53b43e715f13c37a9e096c6408e69990961db7"
 dependencies = [
  "libc",
 ]
@@ -7542,24 +7770,26 @@ dependencies = [
 
 [[package]]
 name = "memory-db"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808b50db46293432a45e63bc15ea51e0ab4c0a1647b8eb114e31a3e698dd6fbe"
+checksum = "7e300c54e3239a86f9c61cc63ab0f03862eb40b1c6e065dc6fd6ceaeff6da93d"
 dependencies = [
+ "foldhash 0.1.5",
  "hash-db",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
 name = "merkleized-metadata"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc9b7ac0ce054412d9a85ff39bac27aec27483b06cef8756b57d9c29d448d081"
+checksum = "b3e3e3f549d27d2dc054372f320ddf68045a833fab490563ff70d4cf1b9d91ea"
 dependencies = [
- "array-bytes",
+ "array-bytes 9.3.0",
  "blake3",
- "frame-metadata 20.0.0",
+ "frame-metadata 23.0.0",
  "parity-scale-codec",
- "scale-decode 0.13.1",
+ "scale-decode",
  "scale-info",
 ]
 
@@ -7628,8 +7858,8 @@ dependencies = [
 
 [[package]]
 name = "mmr-gadget"
-version = "44.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "46.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "futures",
  "log",
@@ -7647,8 +7877,8 @@ dependencies = [
 
 [[package]]
 name = "mmr-rpc"
-version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -7683,25 +7913,24 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "moka"
-version = "0.12.10"
+version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9321642ca94a4282428e6ea4af8cc2ca4eac48ac7a6a4ea8f33f76d0ce70926"
+checksum = "8261cd88c312e0004c1d51baad2980c66528dfdb2bee62003e643a4d8f86b077"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
  "crossbeam-utils",
- "loom",
+ "equivalent",
  "parking_lot 0.12.4",
  "portable-atomic",
  "rustc_version 0.4.1",
  "smallvec",
  "tagptr",
- "thiserror 1.0.69",
  "uuid",
 ]
 
@@ -7751,11 +7980,12 @@ dependencies = [
 
 [[package]]
 name = "multibase"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3539ec3c1f04ac9748a260728e855f261b4977f5c3406612c884564f329404"
+checksum = "8694bb4835f452b0e3bb06dbebb1d6fc5385b6ca1caf2e55fd165c042390ec77"
 dependencies = [
  "base-x",
+ "base256emoji",
  "data-encoding",
  "data-encoding-macro",
 ]
@@ -7929,7 +8159,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -7947,13 +8177,13 @@ dependencies = [
 
 [[package]]
 name = "network-interface"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862f41f1276e7148fb597fc55ed8666423bebe045199a1298c3515a73ec5cdd9"
+checksum = "07709a6d4eba90ab10ec170a0530b3aafc81cb8a2d380e4423ae41fc55fe5745"
 dependencies = [
  "cc",
  "libc",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "winapi",
 ]
 
@@ -7974,7 +8204,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
@@ -8018,7 +8248,7 @@ dependencies = [
  "hex",
  "jsonrpsee",
  "log",
- "memmap2 0.9.7",
+ "memmap2 0.9.8",
  "node-subtensor-runtime",
  "num-traits",
  "pallet-commitments",
@@ -8028,7 +8258,7 @@ dependencies = [
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc",
  "pallet-transaction-payment-rpc-runtime-api",
- "polkadot-sdk 2503.0.1",
+ "polkadot-sdk",
  "sc-basic-authorship",
  "sc-chain-spec",
  "sc-chain-spec-derive",
@@ -8065,7 +8295,7 @@ dependencies = [
  "sp-consensus-grandpa",
  "sp-consensus-slots",
  "sp-core",
- "sp-crypto-ec-utils 0.15.0",
+ "sp-crypto-ec-utils",
  "sp-inherents",
  "sp-io",
  "sp-keyring",
@@ -8176,8 +8406,8 @@ dependencies = [
  "sp-session",
  "sp-staking",
  "sp-std",
- "sp-storage 22.0.0",
- "sp-tracing 17.1.0",
+ "sp-storage",
+ "sp-tracing",
  "sp-transaction-pool",
  "sp-version",
  "substrate-fixed",
@@ -8189,7 +8419,7 @@ dependencies = [
  "subtensor-swap-interface",
  "subtensor-transaction-fee",
  "tle",
- "w3f-bls",
+ "w3f-bls 0.1.3",
 ]
 
 [[package]]
@@ -8227,13 +8457,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.46.0"
+name = "ntapi"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
 dependencies = [
- "overload",
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8283,7 +8521,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -8363,10 +8601,10 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -8386,6 +8624,15 @@ name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -8442,7 +8689,7 @@ version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -8459,7 +8706,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -8510,20 +8757,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43dfaf083aef571385fccfdc3a2f8ede8d0a1863160455d4f2b014d8f7d04a3f"
 dependencies = [
  "expander",
- "indexmap 2.10.0",
+ "indexmap 2.11.4",
  "itertools 0.11.0",
  "petgraph 0.6.5",
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pallet-admin-utils"
@@ -8550,7 +8791,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "sp-tracing 17.1.0",
+ "sp-tracing",
  "sp-weights",
  "substrate-fixed",
  "subtensor-macros",
@@ -8560,10 +8801,10 @@ dependencies = [
 
 [[package]]
 name = "pallet-alliance"
-version = "39.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "40.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.3",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -8573,15 +8814,15 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234)",
  "sp-io",
  "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-asset-conversion"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "23.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8598,8 +8839,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-conversion-ops"
-version = "0.8.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.9.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8616,8 +8857,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-conversion-tx-payment"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "23.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8631,8 +8872,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-rate"
-version = "19.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "20.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8645,8 +8886,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-rewards"
-version = "0.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.3.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8663,8 +8904,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-tx-payment"
-version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8673,21 +8914,22 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
  "sp-io",
  "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-assets"
-version = "42.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "43.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
+ "ethereum-standards",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
  "log",
+ "pallet-revive",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -8696,8 +8938,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-assets-freezer"
-version = "0.7.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.8.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "log",
  "pallet-assets",
@@ -8708,8 +8950,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-assets-holder"
-version = "0.2.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.3.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8723,8 +8965,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-atomic-swap"
-version = "40.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -8733,8 +8975,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-aura"
-version = "39.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "40.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8749,8 +8991,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-authority-discovery"
-version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8764,8 +9006,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-authorship"
-version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8777,8 +9019,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-babe"
-version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8800,8 +9042,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-bags-list"
-version = "39.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "40.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "aquamarine",
  "docify",
@@ -8816,13 +9058,13 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-tracing 17.1.0",
+ "sp-tracing",
 ]
 
 [[package]]
 name = "pallet-balances"
-version = "41.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "42.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8838,7 +9080,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -8851,8 +9093,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-beefy"
-version = "41.1.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "42.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8870,10 +9112,10 @@ dependencies = [
 
 [[package]]
 name = "pallet-beefy-mmr"
-version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "42.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.3",
  "binary-merkle-tree",
  "frame-benchmarking",
  "frame-support",
@@ -8895,8 +9137,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-bounties"
-version = "39.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "40.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8912,8 +9154,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-bridge-grandpa"
-version = "0.20.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.21.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -8931,8 +9173,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-bridge-messages"
-version = "0.20.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.21.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -8950,8 +9192,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-bridge-parachains"
-version = "0.20.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.21.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -8970,8 +9212,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-bridge-relayers"
-version = "0.20.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.21.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -8993,8 +9235,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-broker"
-version = "0.19.2"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.20.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -9011,8 +9253,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-child-bounties"
-version = "39.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "40.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9029,8 +9271,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-collator-selection"
-version = "21.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "22.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9048,8 +9290,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-collective"
-version = "40.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9065,8 +9307,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-collective-content"
-version = "0.18.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.19.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9101,13 +9343,13 @@ dependencies = [
  "subtensor-macros",
  "subtensor-runtime-common",
  "tle",
- "w3f-bls",
+ "w3f-bls 0.1.3",
 ]
 
 [[package]]
 name = "pallet-contracts"
-version = "40.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -9137,8 +9379,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-contracts-mock-network"
-version = "17.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "18.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9159,7 +9401,7 @@ dependencies = [
  "sp-io",
  "sp-keystore",
  "sp-runtime",
- "sp-tracing 17.1.0",
+ "sp-tracing",
  "staging-xcm",
  "staging-xcm-builder",
  "staging-xcm-executor",
@@ -9169,17 +9411,17 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "23.0.3"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "pallet-contracts-uapi"
 version = "14.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -9189,8 +9431,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-conviction-voting"
-version = "40.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -9205,8 +9447,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-core-fellowship"
-version = "24.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "25.0.1"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9242,8 +9484,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-delegated-staking"
-version = "7.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "8.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9257,8 +9499,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-democracy"
-version = "40.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9274,8 +9516,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-dev-mode"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "23.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9318,20 +9560,58 @@ dependencies = [
  "sp-std",
  "subtensor-macros",
  "tle",
- "w3f-bls",
+ "w3f-bls 0.1.3",
 ]
 
 [[package]]
-name = "pallet-election-provider-multi-phase"
-version = "39.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+name = "pallet-dummy-dim"
+version = "0.2.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+]
+
+[[package]]
+name = "pallet-election-provider-multi-block"
+version = "0.2.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-support",
  "frame-system",
  "log",
- "pallet-election-provider-support-benchmarking",
+ "parity-scale-codec",
+ "rand 0.8.5",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-npos-elections",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-election-provider-multi-phase"
+version = "40.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
+dependencies = [
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
+ "log",
  "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",
@@ -9345,8 +9625,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
-version = "39.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "40.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9358,8 +9638,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-elections-phragmen"
-version = "41.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "42.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9377,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -9400,10 +9680,11 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "environmental",
+ "ethereum",
  "evm",
  "fp-account",
  "fp-evm",
@@ -9424,7 +9705,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9435,7 +9716,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -9445,7 +9726,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -9457,7 +9738,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "fp-evm",
  "num",
@@ -9466,7 +9747,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -9475,7 +9756,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "fp-evm",
  "ripemd",
@@ -9484,8 +9765,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-fast-unstake"
-version = "39.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "40.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9502,8 +9783,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-glutton"
-version = "26.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "27.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "blake2 0.10.6",
  "frame-benchmarking",
@@ -9520,8 +9801,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-grandpa"
-version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9543,7 +9824,7 @@ dependencies = [
 [[package]]
 name = "pallet-hotfix-sufficients"
 version = "1.0.0"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9557,8 +9838,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-identity"
-version = "40.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -9573,8 +9854,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-im-online"
-version = "39.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "40.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9592,8 +9873,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-indices"
-version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9607,8 +9888,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
-version = "28.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "29.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9618,8 +9899,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-lottery"
-version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9631,8 +9912,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-membership"
-version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9647,8 +9928,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-message-queue"
-version = "43.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "44.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -9666,8 +9947,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-meta-tx"
-version = "0.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.3.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9684,8 +9965,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-migrations"
-version = "10.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "11.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9703,8 +9984,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-mixnet"
-version = "0.16.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.17.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9717,8 +9998,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-mmr"
-version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9729,8 +10010,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-multisig"
-version = "40.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9740,24 +10021,21 @@ dependencies = [
 
 [[package]]
 name = "pallet-nft-fractionalization"
-version = "23.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
  "log",
  "pallet-assets",
  "pallet-nfts",
  "parity-scale-codec",
+ "polkadot-sdk-frame",
  "scale-info",
- "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-nfts"
-version = "34.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "35.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -9773,8 +10051,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-nis"
-version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9783,8 +10061,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-node-authorization"
-version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9794,8 +10072,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-nomination-pools"
-version = "38.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "39.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9807,13 +10085,13 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-staking",
- "sp-tracing 17.1.0",
+ "sp-tracing",
 ]
 
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
-version = "38.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "39.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9826,14 +10104,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-runtime-interface 29.0.1",
+ "sp-runtime-interface",
  "sp-staking",
 ]
 
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
-version = "36.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "37.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -9842,8 +10120,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-offences"
-version = "39.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "40.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9857,8 +10135,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-offences-benchmarking"
-version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9879,24 +10157,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-paged-list"
-version = "0.18.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+name = "pallet-origin-restriction"
+version = "0.2.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "docify",
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "log",
+ "pallet-transaction-payment",
  "parity-scale-codec",
  "scale-info",
+ "sp-arithmetic",
  "sp-core",
  "sp-io",
  "sp-runtime",
 ]
 
 [[package]]
+name = "pallet-paged-list"
+version = "0.19.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
+dependencies = [
+ "docify",
+ "parity-scale-codec",
+ "polkadot-sdk-frame",
+ "scale-info",
+]
+
+[[package]]
 name = "pallet-parameters"
-version = "0.11.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.12.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9911,9 +10203,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-people"
+version = "0.2.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "verifiable",
+]
+
+[[package]]
 name = "pallet-preimage"
-version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9928,8 +10238,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-proxy"
-version = "40.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9938,8 +10248,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-ranked-collective"
-version = "40.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9956,22 +10266,18 @@ dependencies = [
 
 [[package]]
 name = "pallet-recovery"
-version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
  "parity-scale-codec",
+ "polkadot-sdk-frame",
  "scale-info",
- "sp-io",
- "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-referenda"
-version = "40.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -10005,8 +10311,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-remark"
-version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10020,13 +10326,13 @@ dependencies = [
 
 [[package]]
 name = "pallet-revive"
-version = "0.6.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.7.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "alloy-core",
  "derive_more 0.99.20",
  "environmental",
- "ethabi-decode",
+ "ethereum-standards",
  "ethereum-types 0.15.1",
  "frame-benchmarking",
  "frame-support",
@@ -10060,16 +10366,14 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "staging-xcm",
- "staging-xcm-builder",
  "substrate-bn",
  "subxt-signer",
 ]
 
 [[package]]
 name = "pallet-revive-fixtures"
-version = "0.3.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.4.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -10081,48 +10385,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-revive-mock-network"
-version = "0.5.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
-dependencies = [
- "frame-support",
- "frame-system",
- "pallet-assets",
- "pallet-balances",
- "pallet-message-queue",
- "pallet-revive",
- "pallet-revive-uapi",
- "pallet-timestamp",
- "pallet-xcm",
- "parity-scale-codec",
- "polkadot-parachain-primitives",
- "polkadot-primitives",
- "polkadot-runtime-parachains",
- "scale-info",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-tracing 17.1.0",
- "staging-xcm",
- "staging-xcm-builder",
- "staging-xcm-executor",
- "xcm-simulator",
-]
-
-[[package]]
 name = "pallet-revive-proc-macro"
 version = "0.3.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "pallet-revive-uapi"
-version = "0.4.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.5.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bitflags 1.3.2",
  "pallet-revive-proc-macro",
@@ -10133,8 +10408,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-root-offences"
-version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "38.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10142,46 +10417,42 @@ dependencies = [
  "pallet-staking",
  "parity-scale-codec",
  "scale-info",
+ "sp-core",
  "sp-runtime",
  "sp-staking",
 ]
 
 [[package]]
 name = "pallet-root-testing"
-version = "16.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "17.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
  "sp-io",
  "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-safe-mode"
-version = "21.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "22.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "docify",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
  "pallet-balances",
  "pallet-proxy",
  "pallet-utility",
  "parity-scale-codec",
+ "polkadot-sdk-frame",
  "scale-info",
- "sp-arithmetic",
- "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-salary"
-version = "25.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "26.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "log",
  "pallet-ranked-collective",
@@ -10192,8 +10463,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-scheduler"
-version = "41.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "42.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10209,8 +10480,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-scored-pool"
-version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10222,8 +10493,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-session"
-version = "40.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10243,8 +10514,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-session-benchmarking"
-version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10259,8 +10530,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-skip-feeless-payment"
-version = "15.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "16.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10271,8 +10542,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-society"
-version = "40.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10288,8 +10559,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking"
-version = "40.1.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10309,20 +10580,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-staking-async"
+version = "0.2.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
+dependencies = [
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-staking-async-rc-client",
+ "parity-scale-codec",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "scale-info",
+ "serde",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
+]
+
+[[package]]
+name = "pallet-staking-async-ah-client"
+version = "0.2.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-authorship",
+ "pallet-session",
+ "pallet-staking-async-rc-client",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-runtime",
+ "sp-staking",
+]
+
+[[package]]
+name = "pallet-staking-async-rc-client"
+version = "0.2.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-runtime",
+ "sp-staking",
+ "staging-xcm",
+]
+
+[[package]]
 name = "pallet-staking-reward-curve"
 version = "12.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "pallet-staking-reward-fn"
-version = "22.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "23.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -10330,8 +10660,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-runtime-api"
-version = "26.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "27.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10340,8 +10670,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-state-trie-migration"
-version = "44.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "46.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10356,8 +10686,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-statement"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "23.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10413,14 +10743,14 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "sp-tracing 17.1.0",
+ "sp-tracing",
  "sp-version",
  "substrate-fixed",
  "subtensor-macros",
  "subtensor-runtime-common",
  "subtensor-swap-interface",
  "tle",
- "w3f-bls",
+ "w3f-bls 0.1.3",
 ]
 
 [[package]]
@@ -10456,7 +10786,7 @@ dependencies = [
 name = "pallet-subtensor-swap"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "approx",
  "frame-benchmarking",
  "frame-support",
@@ -10472,7 +10802,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "sp-tracing 17.1.0",
+ "sp-tracing",
  "substrate-fixed",
  "subtensor-macros",
  "subtensor-runtime-common",
@@ -10528,8 +10858,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-sudo"
-version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10543,8 +10873,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-timestamp"
-version = "39.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "40.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10554,16 +10884,15 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-inherents",
- "sp-io",
  "sp-runtime",
- "sp-storage 22.0.0",
+ "sp-storage",
  "sp-timestamp",
 ]
 
 [[package]]
 name = "pallet-tips"
-version = "39.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "40.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10580,8 +10909,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10589,15 +10918,14 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
  "sp-io",
  "sp-runtime",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
-version = "43.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "44.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -10612,8 +10940,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -10624,10 +10952,10 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-storage"
-version = "39.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "40.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.3",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -10643,8 +10971,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-treasury"
-version = "39.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "40.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10662,13 +10990,10 @@ dependencies = [
 
 [[package]]
 name = "pallet-tx-pause"
-version = "21.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "22.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "docify",
- "pallet-balances",
- "pallet-proxy",
- "pallet-utility",
  "parity-scale-codec",
  "polkadot-sdk-frame",
  "scale-info",
@@ -10676,8 +11001,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-uniques"
-version = "40.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10690,8 +11015,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-utility"
-version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10705,15 +11030,14 @@ dependencies = [
 
 [[package]]
 name = "pallet-verify-signature"
-version = "0.3.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.4.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-weights",
@@ -10721,8 +11045,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-vesting"
-version = "40.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10735,8 +11059,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-whitelist"
-version = "39.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "40.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10745,14 +11069,17 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm"
-version = "19.1.2"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "20.1.3"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "bounded-collections",
+ "bounded-collections 0.2.4",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "hex-literal",
  "pallet-balances",
+ "pallet-revive",
+ "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -10768,8 +11095,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-benchmarks"
-version = "20.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "21.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10785,8 +11112,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-bridge-hub"
-version = "0.16.3"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.17.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -10807,8 +11134,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-bridge-hub-router"
-version = "0.18.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.19.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-benchmarking",
@@ -10816,6 +11143,7 @@ dependencies = [
  "frame-system",
  "log",
  "parity-scale-codec",
+ "polkadot-runtime-parachains",
  "scale-info",
  "sp-core",
  "sp-runtime",
@@ -10826,8 +11154,8 @@ dependencies = [
 
 [[package]]
 name = "parachains-common"
-version = "21.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "22.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -10910,10 +11238,10 @@ version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -11056,27 +11384,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "percent-encoding"
-version = "2.3.1"
+name = "pem-rfc7468"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
+checksum = "21e0a3a33733faeaf8651dfee72dd0f388f0c8e5ad496a3478fa5a922f49cfa8"
 dependencies = [
  "memchr",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
+checksum = "bc58706f770acb1dbd0973e6530a3cff4746fb721207feb3a8a6064cd0b6c663"
 dependencies = [
  "pest",
  "pest_generator",
@@ -11084,22 +11421,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
+checksum = "6d4f36811dfe07f7b8573462465d5cb8965fffc2e71ae377a33aecf14c2c9a2f"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
+checksum = "42919b05089acbd0a5dcd5405fb304d17d1053847b81163d09c4ad18ce8e8420"
 dependencies = [
  "pest",
  "sha2 0.10.9",
@@ -11112,7 +11449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 2.10.0",
+ "indexmap 2.11.4",
 ]
 
 [[package]]
@@ -11122,7 +11459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset 0.5.7",
- "indexmap 2.10.0",
+ "indexmap 2.11.4",
 ]
 
 [[package]]
@@ -11142,7 +11479,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -11186,8 +11523,8 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polkadot-approval-distribution"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "futures",
  "futures-timer",
@@ -11204,8 +11541,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "futures",
  "futures-timer",
@@ -11219,8 +11556,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-distribution"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "fatality",
  "futures",
@@ -11242,8 +11579,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-recovery"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "fatality",
@@ -11275,8 +11612,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-cli"
-version = "23.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "25.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -11299,8 +11636,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-collator-protocol"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bitvec",
  "fatality",
@@ -11322,8 +11659,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-core-primitives"
-version = "17.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "18.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11333,13 +11670,13 @@ dependencies = [
 
 [[package]]
 name = "polkadot-dispute-distribution"
-version = "22.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "fatality",
  "futures",
  "futures-timer",
- "indexmap 2.10.0",
+ "indexmap 2.11.4",
  "parity-scale-codec",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
@@ -11355,8 +11692,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-erasure-coding"
-version = "19.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "20.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -11369,8 +11706,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-gossip-support"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.1"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "futures",
  "futures-timer",
@@ -11383,15 +11720,15 @@ dependencies = [
  "sc-network",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234)",
  "sp-keystore",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-network-bridge"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -11413,8 +11750,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-collation-generation"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -11431,8 +11768,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-approval-voting"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -11463,8 +11800,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-approval-voting-parallel"
-version = "0.5.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.7.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "futures",
@@ -11487,8 +11824,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-av-store"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bitvec",
  "futures",
@@ -11506,8 +11843,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-backing"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bitvec",
  "fatality",
@@ -11527,8 +11864,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -11542,8 +11879,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-candidate-validation"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "futures",
@@ -11564,8 +11901,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-api"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -11578,8 +11915,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-selection"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "futures",
  "futures-timer",
@@ -11594,8 +11931,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
-version = "22.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "fatality",
  "futures",
@@ -11612,8 +11949,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "futures",
@@ -11629,8 +11966,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
-version = "21.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "23.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "fatality",
  "futures",
@@ -11643,8 +11980,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-provisioner"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bitvec",
  "fatality",
@@ -11660,11 +11997,11 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "always-assert",
- "array-bytes",
+ "array-bytes 6.2.3",
  "futures",
  "futures-timer",
  "parity-scale-codec",
@@ -11688,8 +12025,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf-checker"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -11701,8 +12038,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf-common"
-version = "19.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "20.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "cpu-time",
  "futures",
@@ -11717,18 +12054,18 @@ dependencies = [
  "sc-executor-wasmtime",
  "seccompiler",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8)",
- "sp-externalities 0.30.0",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234)",
+ "sp-externalities",
  "sp-io",
- "sp-tracing 17.1.0",
+ "sp-tracing",
  "thiserror 1.0.69",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-runtime-api"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -11742,8 +12079,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-metrics"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bs58",
  "futures",
@@ -11759,8 +12096,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-network-protocol"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -11784,8 +12121,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-primitives"
-version = "19.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "20.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -11808,8 +12145,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
@@ -11817,8 +12154,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-types"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "derive_more 0.99.20",
@@ -11845,8 +12182,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-util"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.1"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "fatality",
  "futures",
@@ -11865,7 +12202,7 @@ dependencies = [
  "polkadot-primitives",
  "prioritized-metered-channel",
  "rand 0.8.5",
- "sc-client-api",
+ "sc-keystore",
  "schnellru",
  "sp-application-crypto",
  "sp-core",
@@ -11876,12 +12213,13 @@ dependencies = [
 
 [[package]]
 name = "polkadot-omni-node-lib"
-version = "0.5.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.7.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "clap",
  "color-print",
+ "cumulus-client-bootnodes",
  "cumulus-client-cli",
  "cumulus-client-collator",
  "cumulus-client-consensus-aura",
@@ -11918,11 +12256,15 @@ dependencies = [
  "sc-consensus",
  "sc-consensus-manual-seal",
  "sc-executor",
+ "sc-keystore",
  "sc-network",
+ "sc-network-statement",
+ "sc-network-sync",
  "sc-offchain",
  "sc-rpc",
  "sc-runtime-utilities",
  "sc-service",
+ "sc-statement-store",
  "sc-sysinfo",
  "sc-telemetry",
  "sc-tracing",
@@ -11936,14 +12278,14 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-aura",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8)",
  "sp-genesis-builder",
  "sp-inherents",
  "sp-keystore",
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-storage 22.0.0",
+ "sp-statement-store",
+ "sp-storage",
  "sp-timestamp",
  "sp-transaction-pool",
  "sp-version",
@@ -11957,8 +12299,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-overseer"
-version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "futures",
@@ -11977,10 +12319,10 @@ dependencies = [
 
 [[package]]
 name = "polkadot-parachain-primitives"
-version = "16.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "17.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "bounded-collections",
+ "bounded-collections 0.2.4",
  "derive_more 0.99.20",
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -11993,10 +12335,11 @@ dependencies = [
 
 [[package]]
 name = "polkadot-primitives"
-version = "18.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "19.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bitvec",
+ "bounded-collections 0.2.4",
  "hex-literal",
  "log",
  "parity-scale-codec",
@@ -12021,8 +12364,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-rpc"
-version = "23.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "25.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -12054,8 +12397,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-common"
-version = "19.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "20.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -12104,24 +12447,25 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-metrics"
-version = "20.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "21.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bs58",
  "frame-benchmarking",
  "parity-scale-codec",
  "polkadot-primitives",
- "sp-tracing 17.1.0",
+ "sp-tracing",
 ]
 
 [[package]]
 name = "polkadot-runtime-parachains"
-version = "19.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "20.0.2"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
  "frame-benchmarking",
+ "frame-election-provider-support",
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
@@ -12163,17 +12507,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-sdk"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb819108697967452fa6d8d96ab4c0d48cbaa423b3156499dcb24f1cf95d6775"
-dependencies = [
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "polkadot-sdk"
-version = "2503.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "2506.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "assets-common",
  "bridge-hub-common",
@@ -12235,6 +12570,8 @@ dependencies = [
  "pallet-delegated-staking",
  "pallet-democracy",
  "pallet-dev-mode",
+ "pallet-dummy-dim",
+ "pallet-election-provider-multi-block",
  "pallet-election-provider-multi-phase",
  "pallet-election-provider-support-benchmarking",
  "pallet-elections-phragmen",
@@ -12261,8 +12598,10 @@ dependencies = [
  "pallet-nomination-pools-benchmarking",
  "pallet-offences",
  "pallet-offences-benchmarking",
+ "pallet-origin-restriction",
  "pallet-paged-list",
  "pallet-parameters",
+ "pallet-people",
  "pallet-preimage",
  "pallet-proxy",
  "pallet-ranked-collective",
@@ -12270,7 +12609,6 @@ dependencies = [
  "pallet-referenda",
  "pallet-remark",
  "pallet-revive",
- "pallet-revive-mock-network",
  "pallet-root-offences",
  "pallet-root-testing",
  "pallet-safe-mode",
@@ -12282,6 +12620,9 @@ dependencies = [
  "pallet-skip-feeless-payment",
  "pallet-society",
  "pallet-staking",
+ "pallet-staking-async",
+ "pallet-staking-async-ah-client",
+ "pallet-staking-async-rc-client",
  "pallet-state-trie-migration",
  "pallet-statement",
  "pallet-sudo",
@@ -12324,8 +12665,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-sdk-frame"
-version = "0.9.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.10.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -12352,15 +12693,15 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-storage 22.0.0",
+ "sp-storage",
  "sp-transaction-pool",
  "sp-version",
 ]
 
 [[package]]
 name = "polkadot-service"
-version = "23.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "25.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -12467,15 +12808,13 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-distribution"
-version = "22.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "arrayvec 0.7.6",
  "bitvec",
  "fatality",
  "futures",
  "futures-timer",
- "indexmap 2.10.0",
  "parity-scale-codec",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
@@ -12483,32 +12822,18 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "sp-keystore",
- "sp-staking",
  "thiserror 1.0.69",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-statement-table"
-version = "19.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "20.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
  "tracing-gum",
-]
-
-[[package]]
-name = "polkavm"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd044ab1d3b11567ab6b98ca71259a992b4034220d5972988a0e96518e5d343d"
-dependencies = [
- "libc",
- "log",
- "polkavm-assembler 0.18.0",
- "polkavm-common 0.18.0",
- "polkavm-linux-raw 0.18.0",
 ]
 
 [[package]]
@@ -12525,12 +12850,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "polkavm-assembler"
-version = "0.18.0"
+name = "polkavm"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaad38dc420bfed79e6f731471c973ce5ff5e47ab403e63cf40358fef8a6368f"
+checksum = "f2a01db119bb3a86572c0641ba6e7c9786fbd2ac89c25b43b688c4e353787526"
 dependencies = [
+ "libc",
  "log",
+ "polkavm-assembler 0.24.0",
+ "polkavm-common 0.24.0",
+ "polkavm-linux-raw 0.24.0",
 ]
 
 [[package]]
@@ -12543,13 +12872,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "polkavm-common"
-version = "0.18.0"
+name = "polkavm-assembler"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31ff33982a807d8567645d4784b9b5d7ab87bcb494f534a57cadd9012688e102"
+checksum = "eea6105f3f344abe0bf0151d67b3de6f5d24353f2393355ecf3f5f6e06d7fd0b"
 dependencies = [
  "log",
- "polkavm-assembler 0.18.0",
 ]
 
 [[package]]
@@ -12565,17 +12893,12 @@ dependencies = [
 
 [[package]]
 name = "polkavm-common"
-version = "0.26.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a5794b695626ba70d29e66e3f4f4835767452a6723f3a0bc20884b07088fe8"
-
-[[package]]
-name = "polkavm-derive"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2eb703f3b6404c13228402e98a5eae063fd16b8f58afe334073ec105ee4117e"
+checksum = "d91ed9e5af472f729fcf3b3c1cf17508ddbb3505259dd6e2ee0fb5a29e105d22"
 dependencies = [
- "polkavm-derive-impl-macro 0.18.0",
+ "log",
+ "polkavm-assembler 0.24.0",
 ]
 
 [[package]]
@@ -12589,23 +12912,11 @@ dependencies = [
 
 [[package]]
 name = "polkavm-derive"
-version = "0.26.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95282a203ae1f6828a04ff334145c3f6dc718bba6d3959805d273358b45eab93"
+checksum = "176144f8661117ea95fa7cf868c9a62d6b143e8a2ebcb7582464c3faade8669a"
 dependencies = [
- "polkavm-derive-impl-macro 0.26.0",
-]
-
-[[package]]
-name = "polkavm-derive-impl"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f2116a92e6e96220a398930f4c8a6cda1264206f3e2034fc9982bfd93f261f7"
-dependencies = [
- "polkavm-common 0.18.0",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
+ "polkavm-derive-impl-macro 0.24.0",
 ]
 
 [[package]]
@@ -12617,29 +12928,19 @@ dependencies = [
  "polkavm-common 0.21.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "polkavm-derive-impl"
-version = "0.26.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6069dc7995cde6e612b868a02ce48b54397c6d2582bd1b97b63aabbe962cd779"
+checksum = "c5a21844afdfcc10c92b9ef288ccb926211af27478d1730fcd55e4aec710179d"
 dependencies = [
- "polkavm-common 0.26.0",
+ "polkavm-common 0.24.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "polkavm-derive-impl-macro"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c16669ddc7433e34c1007d31080b80901e3e8e523cb9d4b441c3910cf9294b"
-dependencies = [
- "polkavm-derive-impl 0.18.1",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -12649,33 +12950,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36837f6b7edfd6f4498f8d25d81da16cf03bd6992c3e56f3d477dfc90f4fefca"
 dependencies = [
  "polkavm-derive-impl 0.21.0",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "polkavm-derive-impl-macro"
-version = "0.26.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581d34cafec741dc5ffafbb341933c205b6457f3d76257a9d99fb56687219c91"
+checksum = "ba0ef0f17ad81413ea1ca5b1b67553aedf5650c88269b673d3ba015c83bc2651"
 dependencies = [
- "polkavm-derive-impl 0.26.0",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "polkavm-linker"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9bfe793b094d9ea5c99b7c43ba46e277b0f8f48f4bbfdbabf8d3ebf701a4bd3"
-dependencies = [
- "dirs",
- "gimli 0.31.1",
- "hashbrown 0.14.5",
- "log",
- "object 0.36.7",
- "polkavm-common 0.18.0",
- "regalloc2 0.9.3",
- "rustc-demangle",
+ "polkavm-derive-impl 0.24.0",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -12695,16 +12980,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "polkavm-linux-raw"
-version = "0.18.0"
+name = "polkavm-linker"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23eff02c070c70f31878a3d915e88a914ecf3e153741e2fb572dde28cce20fde"
+checksum = "06c95a521a1331024ebe5823ffdfba9ea6df40b934b0804049d5171887579806"
+dependencies = [
+ "dirs",
+ "gimli 0.31.1",
+ "hashbrown 0.14.5",
+ "log",
+ "object 0.36.7",
+ "polkavm-common 0.24.0",
+ "regalloc2 0.9.3",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "polkavm-linux-raw"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be6cd1d48c5e7814d287a3e12a339386a5dfa2f3ac72f932335f4cf56467f1b3"
+
+[[package]]
+name = "polkavm-linux-raw"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec0b13e26ec7234dba213ca17118c70c562809bdce0eefe84f92613d5c8da26"
 
 [[package]]
 name = "polling"
@@ -12724,16 +13025,16 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bd19146350fe804f7cb2669c851c03d69da628803dab0d98018142aaa5d829"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi 0.5.2",
  "pin-project-lite",
- "rustix 1.0.8",
- "windows-sys 0.60.2",
+ "rustix 1.1.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -12767,9 +13068,9 @@ checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "zerovec",
 ]
@@ -12792,7 +13093,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils"
 version = "0.1.0"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "environmental",
  "evm",
@@ -12816,15 +13117,15 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/opentensor/frontier?rev=830e61f370d88f7ace1c5a5659dd58db75a19844#830e61f370d88f7ace1c5a5659dd58db75a19844"
+source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
 dependencies = [
  "case",
  "num_enum",
  "prettyplease",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8)",
- "syn 2.0.104",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234)",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -12855,12 +13156,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.36"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -12919,11 +13220,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.23.6",
 ]
 
 [[package]]
@@ -12969,7 +13270,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -12980,14 +13281,14 @@ checksum = "75eea531cfcd120e0851a3f8aed42c4841f78c889eefafd96339c72677ae42c3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -13007,8 +13308,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8)",
- "syn 2.0.104",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234)",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -13045,24 +13346,24 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
+checksum = "2bb0be07becd10686a0bb407298fb425360a5c44a663774406340c59a22de4ce"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "lazy_static",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -13104,7 +13405,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types",
  "regex",
- "syn 2.0.104",
+ "syn 2.0.106",
  "tempfile",
 ]
 
@@ -13118,7 +13419,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -13131,7 +13432,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -13197,9 +13498,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
  "cfg_aliases 0.2.1",
@@ -13209,8 +13510,8 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
- "thiserror 2.0.12",
+ "socket2 0.6.0",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "web-time",
@@ -13218,9 +13519,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.12"
+version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "bytes",
  "getrandom 0.3.3",
@@ -13231,7 +13532,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tinyvec",
  "tracing",
  "web-time",
@@ -13239,23 +13540,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
@@ -13281,7 +13582,6 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
- "serde",
 ]
 
 [[package]]
@@ -13292,6 +13592,7 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+ "serde",
 ]
 
 [[package]]
@@ -13330,6 +13631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
+ "serde",
 ]
 
 [[package]]
@@ -13362,11 +13664,11 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.5.0"
+version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -13377,9 +13679,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -13387,9 +13689,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -13422,7 +13724,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -13450,22 +13752,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -13495,53 +13797,38 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.1.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "resolv-conf"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
+checksum = "6b3789b30bd25ba102de4beabd95d21ac45b69b1be7d14522bab988c526d6799"
 
 [[package]]
 name = "rfc6979"
@@ -13620,7 +13907,7 @@ checksum = "652db34deaaa57929e10ca18e5454a32cb0efc351ae80d320334bbf907b908b3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -13635,8 +13922,8 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime"
-version = "22.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.1"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -13721,7 +14008,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-storage 22.0.0",
+ "sp-storage",
  "sp-transaction-pool",
  "sp-version",
  "staging-xcm",
@@ -13733,8 +14020,8 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime-constants"
-version = "20.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "21.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -13794,13 +14081,14 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecb38f82477f20c5c3d62ef52d7c4e536e38ea9b73fb570a20c5cae0e14bcf6"
+checksum = "a68df0380e5c9d20ce49534f292a36a7514ae21350726efe1865bdb1fa91d278"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
+ "ark-ff 0.5.0",
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
@@ -13814,7 +14102,7 @@ dependencies = [
  "rand 0.9.2",
  "rlp 0.5.2",
  "ruint-macro",
- "serde",
+ "serde_core",
  "valuable",
  "zeroize",
 ]
@@ -13873,7 +14161,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.26",
+ "semver 1.0.27",
 ]
 
 [[package]]
@@ -13919,7 +14207,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -13928,28 +14216,28 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.31"
+version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
  "log",
  "once_cell",
  "ring 0.17.14",
  "rustls-pki-types",
- "rustls-webpki 0.103.4",
+ "rustls-webpki 0.103.7",
  "subtle 2.6.1",
  "zeroize",
 ]
@@ -13963,7 +14251,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.2.0",
+ "security-framework 3.5.1",
 ]
 
 [[package]]
@@ -13990,8 +14278,8 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.4",
- "security-framework 3.2.0",
+ "rustls-webpki 0.103.7",
+ "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
  "windows-sys 0.59.0",
@@ -14015,9 +14303,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
 dependencies = [
  "ring 0.17.14",
  "rustls-pki-types",
@@ -14026,9 +14314,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
@@ -14128,19 +14416,19 @@ dependencies = [
 
 [[package]]
 name = "sc-allocator"
-version = "31.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "32.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "log",
  "sp-core",
- "sp-wasm-interface 21.0.1",
+ "sp-wasm-interface",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-authority-discovery"
-version = "0.49.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.51.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "futures",
@@ -14155,6 +14443,8 @@ dependencies = [
  "sc-client-api",
  "sc-network",
  "sc-network-types",
+ "serde",
+ "serde_json",
  "sp-api",
  "sp-authority-discovery",
  "sp-blockchain",
@@ -14163,12 +14453,13 @@ dependencies = [
  "sp-runtime",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]
 name = "sc-basic-authorship"
-version = "0.49.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.50.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "futures",
  "log",
@@ -14188,8 +14479,8 @@ dependencies = [
 
 [[package]]
 name = "sc-block-builder"
-version = "0.44.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.45.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -14203,13 +14494,13 @@ dependencies = [
 
 [[package]]
 name = "sc-chain-spec"
-version = "42.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "44.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.3",
  "clap",
  "docify",
- "memmap2 0.9.7",
+ "memmap2 0.9.8",
  "parity-scale-codec",
  "sc-chain-spec-derive",
  "sc-client-api",
@@ -14220,31 +14511,31 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234)",
  "sp-genesis-builder",
  "sp-io",
  "sp-runtime",
  "sp-state-machine",
- "sp-tracing 17.1.0",
+ "sp-tracing",
 ]
 
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "sc-cli"
-version = "0.51.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.53.1"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.3",
  "chrono",
  "clap",
  "fdlimit",
@@ -14283,8 +14574,8 @@ dependencies = [
 
 [[package]]
 name = "sc-client-api"
-version = "39.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "40.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "fnv",
  "futures",
@@ -14299,18 +14590,18 @@ dependencies = [
  "sp-consensus",
  "sp-core",
  "sp-database",
- "sp-externalities 0.30.0",
+ "sp-externalities",
  "sp-runtime",
  "sp-state-machine",
- "sp-storage 22.0.0",
+ "sp-storage",
  "sp-trie",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-client-db"
-version = "0.46.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.47.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -14331,12 +14622,14 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-trie",
+ "substrate-prometheus-endpoint",
+ "sysinfo",
 ]
 
 [[package]]
 name = "sc-consensus"
-version = "0.48.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.50.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "futures",
@@ -14358,8 +14651,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-aura"
-version = "0.49.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.51.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "futures",
@@ -14387,8 +14680,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-babe"
-version = "0.49.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.51.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -14413,7 +14706,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-slots",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234)",
  "sp-inherents",
  "sp-keystore",
  "sp-runtime",
@@ -14423,8 +14716,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-babe-rpc"
-version = "0.49.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.51.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -14445,10 +14738,10 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-beefy"
-version = "28.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "30.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.3",
  "async-channel 1.9.0",
  "async-trait",
  "futures",
@@ -14479,8 +14772,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-beefy-rpc"
-version = "28.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "30.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -14499,8 +14792,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-epochs"
-version = "0.48.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.50.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -14512,11 +14805,11 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-grandpa"
-version = "0.34.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.36.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "ahash 0.8.12",
- "array-bytes",
+ "array-bytes 6.2.3",
  "async-trait",
  "dyn-clone",
  "finality-grandpa",
@@ -14547,7 +14840,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234)",
  "sp-keystore",
  "sp-runtime",
  "substrate-prometheus-endpoint",
@@ -14556,8 +14849,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-grandpa-rpc"
-version = "0.34.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.36.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -14576,8 +14869,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-manual-seal"
-version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.52.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -14611,8 +14904,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.48.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.50.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "futures",
@@ -14634,8 +14927,8 @@ dependencies = [
 
 [[package]]
 name = "sc-executor"
-version = "0.42.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.43.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.4",
@@ -14645,44 +14938,44 @@ dependencies = [
  "schnellru",
  "sp-api",
  "sp-core",
- "sp-externalities 0.30.0",
+ "sp-externalities",
  "sp-io",
  "sp-panic-handler",
- "sp-runtime-interface 29.0.1",
+ "sp-runtime-interface",
  "sp-trie",
  "sp-version",
- "sp-wasm-interface 21.0.1",
+ "sp-wasm-interface",
  "tracing",
 ]
 
 [[package]]
 name = "sc-executor-common"
-version = "0.38.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.39.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "polkavm 0.18.0",
+ "polkavm 0.24.0",
  "sc-allocator",
  "sp-maybe-compressed-blob",
- "sp-wasm-interface 21.0.1",
+ "sp-wasm-interface",
  "thiserror 1.0.69",
  "wasm-instrument",
 ]
 
 [[package]]
 name = "sc-executor-polkavm"
-version = "0.35.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.36.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "log",
- "polkavm 0.18.0",
+ "polkavm 0.24.0",
  "sc-executor-common",
- "sp-wasm-interface 21.0.1",
+ "sp-wasm-interface",
 ]
 
 [[package]]
 name = "sc-executor-wasmtime"
-version = "0.38.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.39.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "anyhow",
  "log",
@@ -14690,15 +14983,15 @@ dependencies = [
  "rustix 0.36.17",
  "sc-allocator",
  "sc-executor-common",
- "sp-runtime-interface 29.0.1",
- "sp-wasm-interface 21.0.1",
+ "sp-runtime-interface",
+ "sp-wasm-interface",
  "wasmtime",
 ]
 
 [[package]]
 name = "sc-informant"
-version = "0.48.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.50.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "console",
  "futures",
@@ -14713,10 +15006,10 @@ dependencies = [
 
 [[package]]
 name = "sc-keystore"
-version = "35.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "36.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.3",
  "parking_lot 0.12.4",
  "serde_json",
  "sp-application-crypto",
@@ -14727,10 +15020,10 @@ dependencies = [
 
 [[package]]
 name = "sc-mixnet"
-version = "0.19.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.21.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.3",
  "arrayvec 0.7.6",
  "blake2 0.10.6",
  "bytes",
@@ -14755,10 +15048,10 @@ dependencies = [
 
 [[package]]
 name = "sc-network"
-version = "0.49.2"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.51.1"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.3",
  "async-channel 1.9.0",
  "async-trait",
  "asynchronous-codec 0.6.2",
@@ -14805,8 +15098,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network-common"
-version = "0.48.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.49.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -14815,8 +15108,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network-gossip"
-version = "0.49.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.51.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "ahash 0.8.12",
  "futures",
@@ -14834,10 +15127,10 @@ dependencies = [
 
 [[package]]
 name = "sc-network-light"
-version = "0.48.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.50.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.3",
  "async-channel 1.9.0",
  "futures",
  "log",
@@ -14854,11 +15147,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "sc-network-sync"
-version = "0.48.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+name = "sc-network-statement"
+version = "0.33.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.3",
+ "async-channel 1.9.0",
+ "futures",
+ "log",
+ "parity-scale-codec",
+ "sc-network",
+ "sc-network-common",
+ "sc-network-sync",
+ "sc-network-types",
+ "sp-consensus",
+ "sp-runtime",
+ "sp-statement-store",
+ "substrate-prometheus-endpoint",
+]
+
+[[package]]
+name = "sc-network-sync"
+version = "0.50.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
+dependencies = [
+ "array-bytes 6.2.3",
  "async-channel 1.9.0",
  "async-trait",
  "fork-tree",
@@ -14890,10 +15203,10 @@ dependencies = [
 
 [[package]]
 name = "sc-network-transactions"
-version = "0.48.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.50.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.3",
  "futures",
  "log",
  "parity-scale-codec",
@@ -14909,8 +15222,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network-types"
-version = "0.15.4"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.17.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bs58",
  "bytes",
@@ -14922,21 +15235,23 @@ dependencies = [
  "multiaddr 0.18.2",
  "multihash 0.19.3",
  "rand 0.8.5",
+ "serde",
+ "serde_with",
  "thiserror 1.0.69",
  "zeroize",
 ]
 
 [[package]]
 name = "sc-offchain"
-version = "44.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "46.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bytes",
  "fnv",
  "futures",
  "futures-timer",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper 1.7.0",
  "hyper-rustls",
  "hyper-util",
  "num_cpus",
@@ -14952,7 +15267,7 @@ dependencies = [
  "sc-utils",
  "sp-api",
  "sp-core",
- "sp-externalities 0.30.0",
+ "sp-externalities",
  "sp-keystore",
  "sp-offchain",
  "sp-runtime",
@@ -14963,7 +15278,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.20.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -14971,8 +15286,8 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc"
-version = "44.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "46.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -15003,8 +15318,8 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.48.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.50.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -15023,8 +15338,8 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-server"
-version = "21.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "23.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -15032,7 +15347,7 @@ dependencies = [
  "governor",
  "http 1.3.1",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper 1.7.0",
  "ip_network",
  "jsonrpsee",
  "log",
@@ -15047,10 +15362,10 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-spec-v2"
-version = "0.49.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.51.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.3",
  "futures",
  "futures-util",
  "hex",
@@ -15072,6 +15387,7 @@ dependencies = [
  "sp-rpc",
  "sp-runtime",
  "sp-version",
+ "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
@@ -15079,23 +15395,23 @@ dependencies = [
 
 [[package]]
 name = "sc-runtime-utilities"
-version = "0.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.3.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
  "sc-executor-common",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234)",
  "sp-state-machine",
- "sp-wasm-interface 21.0.1",
+ "sp-wasm-interface",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "sc-service"
-version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.52.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "directories",
@@ -15137,12 +15453,12 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-externalities 0.30.0",
+ "sp-externalities",
  "sp-keystore",
  "sp-runtime",
  "sp-session",
  "sp-state-machine",
- "sp-storage 22.0.0",
+ "sp-storage",
  "sp-transaction-pool",
  "sp-transaction-storage-proof",
  "sp-trie",
@@ -15158,8 +15474,8 @@ dependencies = [
 
 [[package]]
 name = "sc-state-db"
-version = "0.38.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.39.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -15168,9 +15484,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sc-statement-store"
+version = "22.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
+dependencies = [
+ "log",
+ "parity-db",
+ "parking_lot 0.12.4",
+ "sc-client-api",
+ "sc-keystore",
+ "sp-api",
+ "sp-blockchain",
+ "sp-core",
+ "sp-runtime",
+ "sp-statement-store",
+ "substrate-prometheus-endpoint",
+ "tokio",
+]
+
+[[package]]
 name = "sc-storage-monitor"
-version = "0.24.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.25.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "clap",
  "fs4",
@@ -15182,8 +15517,8 @@ dependencies = [
 
 [[package]]
 name = "sc-sync-state-rpc"
-version = "0.49.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.51.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -15201,8 +15536,8 @@ dependencies = [
 
 [[package]]
 name = "sc-sysinfo"
-version = "42.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "43.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "derive_more 0.99.20",
  "futures",
@@ -15215,14 +15550,14 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234)",
  "sp-io",
 ]
 
 [[package]]
 name = "sc-telemetry"
-version = "28.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "29.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "chrono",
  "futures",
@@ -15240,8 +15575,8 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "39.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "40.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "chrono",
  "console",
@@ -15259,36 +15594,35 @@ dependencies = [
  "sp-core",
  "sp-rpc",
  "sp-runtime",
- "sp-tracing 17.1.0",
+ "sp-tracing",
  "thiserror 1.0.69",
  "tracing",
  "tracing-log",
- "tracing-subscriber 0.3.19",
+ "tracing-subscriber 0.3.20",
 ]
 
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "sc-transaction-pool"
-version = "39.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "40.1.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
- "indexmap 2.10.0",
+ "indexmap 2.11.4",
  "itertools 0.11.0",
  "linked-hash-map",
- "log",
  "parity-scale-codec",
  "parking_lot 0.12.4",
  "sc-client-api",
@@ -15298,9 +15632,9 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234)",
  "sp-runtime",
- "sp-tracing 17.1.0",
+ "sp-tracing",
  "sp-transaction-pool",
  "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
@@ -15311,12 +15645,12 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool-api"
-version = "39.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "40.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "futures",
- "indexmap 2.10.0",
+ "indexmap 2.11.4",
  "log",
  "parity-scale-codec",
  "serde",
@@ -15328,8 +15662,8 @@ dependencies = [
 
 [[package]]
 name = "sc-utils"
-version = "18.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "19.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -15342,9 +15676,9 @@ dependencies = [
 
 [[package]]
 name = "scale-bits"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57b1e7f6b65ed1f04e79a85a57d755ad56d76fdf1e9bddcc9ae14f71fcdcf54"
+checksum = "27243ab0d2d6235072b017839c5f0cd1a3b1ce45c0f7a715363b0c7d36c76c94"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -15354,70 +15688,57 @@ dependencies = [
 
 [[package]]
 name = "scale-decode"
-version = "0.13.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e98f3262c250d90e700bb802eb704e1f841e03331c2eb815e46516c4edbf5b27"
+checksum = "4d78196772d25b90a98046794ce0fe2588b39ebdfbdc1e45b4c6c85dd43bebad"
 dependencies = [
- "derive_more 0.99.20",
- "parity-scale-codec",
- "scale-bits",
- "scale-type-resolver",
- "smallvec",
-]
-
-[[package]]
-name = "scale-decode"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ae9cc099ae85ff28820210732b00f019546f36f33225f509fe25d5816864a0"
-dependencies = [
- "derive_more 1.0.0",
  "parity-scale-codec",
  "primitive-types 0.13.1",
  "scale-bits",
  "scale-decode-derive",
  "scale-type-resolver",
  "smallvec",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "scale-decode-derive"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed9401effa946b493f9f84dc03714cca98119b230497df6f3df6b84a2b03648"
+checksum = "2f4b54a1211260718b92832b661025d1f1a4b6930fbadd6908e00edd265fa5f7"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "scale-encode"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9271284d05d0749c40771c46180ce89905fd95aa72a2a2fddb4b7c0aa424db"
+checksum = "64901733157f9d25ef86843bd783eda439fac7efb0ad5a615d12d2cf3a29464b"
 dependencies = [
- "derive_more 1.0.0",
  "parity-scale-codec",
  "primitive-types 0.13.1",
  "scale-bits",
  "scale-encode-derive",
  "scale-type-resolver",
  "smallvec",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "scale-encode-derive"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102fbc6236de6c53906c0b262f12c7aa69c2bdc604862c12728f5f4d370bc137"
+checksum = "78a3993a13b4eafa89350604672c8757b7ea84c7c5947d4b3691e3169c96379b"
 dependencies = [
- "darling",
- "proc-macro-crate 3.3.0",
+ "darling 0.20.11",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -15440,10 +15761,10 @@ version = "2.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -15458,44 +15779,43 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen"
-version = "0.9.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc4c70c7fea2eef1740f0081d3fe385d8bee1eef11e9272d3bec7dc8e5438e0"
+checksum = "05c61b6b706a3eaad63b506ab50a1d2319f817ae01cf753adcc3f055f9f0fcd6"
 dependencies = [
  "proc-macro2",
  "quote",
  "scale-info",
- "syn 2.0.104",
- "thiserror 1.0.69",
+ "syn 2.0.106",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "scale-value"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e0ef2a0ee1e02a69ada37feb87ea1616ce9808aca072befe2d3131bf28576e"
+checksum = "8ca8b26b451ecb7fd7b62b259fa28add63d12ec49bbcac0e01fcb4b5ae0c09aa"
 dependencies = [
  "base58",
  "blake2 0.10.6",
- "derive_more 1.0.0",
  "either",
  "parity-scale-codec",
  "scale-bits",
- "scale-decode 0.14.0",
+ "scale-decode",
  "scale-encode",
- "scale-info",
  "scale-type-resolver",
  "serde",
+ "thiserror 2.0.17",
  "yap",
 ]
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -15545,12 +15865,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15558,9 +15872,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scratch"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f6280af86e5f559536da57a45ebc84948833b3bee313a7dd25232e09c878a52"
+checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
 
 [[package]]
 name = "scrypt"
@@ -15678,7 +15992,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -15687,11 +16001,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.2.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -15700,9 +16014,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -15737,11 +16051,12 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -15761,20 +16076,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.17"
+version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -15788,26 +16105,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -15829,6 +16156,34 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c522100790450cf78eeac1507263d0a350d4d5b30df0c8e1fe051a10c22b376e"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327ada00f7d64abaac1e55a6911e90cf665aa051b9a561c7006c157f4633135e"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -15954,9 +16309,9 @@ dependencies = [
 
 [[package]]
 name = "simba"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a386a501cd104797982c15ae17aafe8b9261315b5d07e3ec803f2ea26be0fa"
+checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
 dependencies = [
  "approx",
  "num-complex",
@@ -15971,7 +16326,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee851d0e5e7af3721faea1843e8015e820a234f81fda3dea9247e15bac9a86a"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -15994,9 +16349,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slice-group-by"
@@ -16006,8 +16361,8 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "slot-range-helper"
-version = "17.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "18.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -16055,11 +16410,11 @@ checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
 dependencies = [
  "async-channel 2.5.0",
  "async-executor",
- "async-fs 2.1.3",
- "async-io 2.5.0",
+ "async-fs 2.2.0",
+ "async-io 2.6.0",
  "async-lock 3.4.1",
  "async-net 2.0.0",
- "async-process 2.4.0",
+ "async-process 2.5.0",
  "blocking",
  "futures-lite 2.6.1",
 ]
@@ -16269,11 +16624,10 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-core"
-version = "0.13.2"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.14.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bp-relayers",
- "ethabi-decode",
  "frame-support",
  "frame-system",
  "hex-literal",
@@ -16354,8 +16708,8 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
-version = "36.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "37.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "docify",
  "hash-db",
@@ -16364,10 +16718,10 @@ dependencies = [
  "scale-info",
  "sp-api-proc-macro",
  "sp-core",
- "sp-externalities 0.30.0",
+ "sp-externalities",
  "sp-metadata-ir",
  "sp-runtime",
- "sp-runtime-interface 29.0.1",
+ "sp-runtime-interface",
  "sp-state-machine",
  "sp-trie",
  "sp-version",
@@ -16376,22 +16730,22 @@ dependencies = [
 
 [[package]]
 name = "sp-api-proc-macro"
-version = "22.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "23.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
  "expander",
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "sp-application-crypto"
-version = "40.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16402,8 +16756,8 @@ dependencies = [
 
 [[package]]
 name = "sp-arithmetic"
-version = "26.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "27.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -16420,13 +16774,13 @@ version = "0.4.2"
 source = "git+https://github.com/paritytech/substrate-curves#f08093a5f7c32778eae1295430ec064dccd062a6"
 dependencies = [
  "ark-bls12-381-ext",
- "sp-crypto-ec-utils 0.10.0",
+ "sp-crypto-ec-utils",
 ]
 
 [[package]]
 name = "sp-authority-discovery"
-version = "36.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "37.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16437,8 +16791,8 @@ dependencies = [
 
 [[package]]
 name = "sp-block-builder"
-version = "36.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "37.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -16447,8 +16801,8 @@ dependencies = [
 
 [[package]]
 name = "sp-blockchain"
-version = "39.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "40.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -16466,8 +16820,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus"
-version = "0.42.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.43.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "futures",
@@ -16480,8 +16834,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-aura"
-version = "0.42.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.43.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -16496,8 +16850,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-babe"
-version = "0.42.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.43.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -16514,8 +16868,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-beefy"
-version = "24.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "25.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16523,7 +16877,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234)",
  "sp-io",
  "sp-keystore",
  "sp-mmr-primitives",
@@ -16534,8 +16888,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-grandpa"
-version = "23.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -16551,8 +16905,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-slots"
-version = "0.42.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.43.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16562,16 +16916,16 @@ dependencies = [
 
 [[package]]
 name = "sp-core"
-version = "36.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "37.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "ark-vrf",
- "array-bytes",
+ "array-bytes 6.2.3",
  "bitflags 1.3.2",
  "blake2 0.10.6",
- "bounded-collections",
+ "bounded-collections 0.2.4",
  "bs58",
- "dyn-clonable",
+ "dyn-clone",
  "ed25519-zebra",
  "futures",
  "hash-db",
@@ -16593,24 +16947,25 @@ dependencies = [
  "secp256k1 0.28.2",
  "secrecy 0.8.0",
  "serde",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8)",
+ "sha2 0.10.9",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234)",
  "sp-debug-derive",
- "sp-externalities 0.30.0",
- "sp-runtime-interface 29.0.1",
+ "sp-externalities",
+ "sp-runtime-interface",
  "sp-std",
- "sp-storage 22.0.0",
+ "sp-storage",
  "ss58-registry",
  "substrate-bip39",
  "thiserror 1.0.69",
  "tracing",
- "w3f-bls",
+ "w3f-bls 0.1.9",
  "zeroize",
 ]
 
 [[package]]
 name = "sp-crypto-ec-utils"
-version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#59fb2e7482d471a7ec4e8d3b30499497efa7b34c"
+version = "0.16.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -16624,27 +16979,7 @@ dependencies = [
  "ark-ed-on-bls12-381-bandersnatch 0.4.0",
  "ark-ed-on-bls12-381-bandersnatch-ext",
  "ark-scale 0.0.12",
- "sp-runtime-interface 24.0.0",
-]
-
-[[package]]
-name = "sp-crypto-ec-utils"
-version = "0.15.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
-dependencies = [
- "ark-bls12-377",
- "ark-bls12-377-ext",
- "ark-bls12-381 0.4.0",
- "ark-bls12-381-ext",
- "ark-bw6-761",
- "ark-bw6-761-ext",
- "ark-ec 0.4.2",
- "ark-ed-on-bls12-377",
- "ark-ed-on-bls12-377-ext",
- "ark-ed-on-bls12-381-bandersnatch 0.4.0",
- "ark-ed-on-bls12-381-bandersnatch-ext",
- "ark-scale 0.0.12",
- "sp-runtime-interface 29.0.1",
+ "sp-runtime-interface",
 ]
 
 [[package]]
@@ -16664,7 +16999,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -16677,17 +17012,17 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8)",
- "syn 2.0.104",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234)",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.4",
@@ -16696,37 +17031,27 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "sp-externalities"
-version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#59fb2e7482d471a7ec4e8d3b30499497efa7b34c"
-dependencies = [
- "environmental",
- "parity-scale-codec",
- "sp-storage 19.0.0",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "sp-externalities"
 version = "0.30.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "environmental",
  "parity-scale-codec",
- "sp-storage 22.0.0",
+ "sp-storage",
 ]
 
 [[package]]
 name = "sp-genesis-builder"
-version = "0.17.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.18.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16737,8 +17062,8 @@ dependencies = [
 
 [[package]]
 name = "sp-inherents"
-version = "36.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "37.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -16750,8 +17075,8 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "40.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "41.0.1"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bytes",
  "docify",
@@ -16759,16 +17084,16 @@ dependencies = [
  "libsecp256k1",
  "log",
  "parity-scale-codec",
- "polkavm-derive 0.18.0",
+ "polkavm-derive 0.24.0",
  "rustversion",
  "secp256k1 0.28.2",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8)",
- "sp-externalities 0.30.0",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234)",
+ "sp-externalities",
  "sp-keystore",
- "sp-runtime-interface 29.0.1",
+ "sp-runtime-interface",
  "sp-state-machine",
- "sp-tracing 17.1.0",
+ "sp-tracing",
  "sp-trie",
  "tracing",
  "tracing-core",
@@ -16776,8 +17101,8 @@ dependencies = [
 
 [[package]]
 name = "sp-keyring"
-version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "42.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -16786,19 +17111,19 @@ dependencies = [
 
 [[package]]
 name = "sp-keystore"
-version = "0.42.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.43.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.4",
  "sp-core",
- "sp-externalities 0.30.0",
+ "sp-externalities",
 ]
 
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -16806,18 +17131,18 @@ dependencies = [
 
 [[package]]
 name = "sp-metadata-ir"
-version = "0.10.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.11.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "frame-metadata 20.0.0",
+ "frame-metadata 23.0.0",
  "parity-scale-codec",
  "scale-info",
 ]
 
 [[package]]
 name = "sp-mixnet"
-version = "0.14.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.15.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16827,8 +17152,8 @@ dependencies = [
 
 [[package]]
 name = "sp-mmr-primitives"
-version = "36.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "37.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -16844,8 +17169,8 @@ dependencies = [
 
 [[package]]
 name = "sp-npos-elections"
-version = "36.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "37.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16857,8 +17182,8 @@ dependencies = [
 
 [[package]]
 name = "sp-offchain"
-version = "36.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "37.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -16868,7 +17193,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "backtrace",
  "regex",
@@ -16876,8 +17201,8 @@ dependencies = [
 
 [[package]]
 name = "sp-rpc"
-version = "34.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "35.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -16886,8 +17211,8 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "41.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "42.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -16915,71 +17240,40 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface"
-version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#59fb2e7482d471a7ec4e8d3b30499497efa7b34c"
+version = "30.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "polkavm-derive 0.26.0",
- "sp-externalities 0.25.0",
- "sp-runtime-interface-proc-macro 17.0.0",
- "sp-std",
- "sp-storage 19.0.0",
- "sp-tracing 16.0.0",
- "sp-wasm-interface 20.0.0",
- "static_assertions",
-]
-
-[[package]]
-name = "sp-runtime-interface"
-version = "29.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
-dependencies = [
- "bytes",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "polkavm-derive 0.18.0",
+ "polkavm-derive 0.24.0",
  "primitive-types 0.13.1",
- "sp-externalities 0.30.0",
- "sp-runtime-interface-proc-macro 18.0.0",
+ "sp-externalities",
+ "sp-runtime-interface-proc-macro",
  "sp-std",
- "sp-storage 22.0.0",
- "sp-tracing 17.1.0",
- "sp-wasm-interface 21.0.1",
+ "sp-storage",
+ "sp-tracing",
+ "sp-wasm-interface",
  "static_assertions",
 ]
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
-version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#59fb2e7482d471a7ec4e8d3b30499497efa7b34c"
+version = "19.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "Inflector",
  "expander",
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "sp-runtime-interface-proc-macro"
-version = "18.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
-dependencies = [
- "Inflector",
- "expander",
- "proc-macro-crate 3.3.0",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "sp-session"
-version = "38.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "39.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16992,8 +17286,8 @@ dependencies = [
 
 [[package]]
 name = "sp-staking"
-version = "38.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "39.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -17005,8 +17299,8 @@ dependencies = [
 
 [[package]]
 name = "sp-state-machine"
-version = "0.45.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.46.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "hash-db",
  "log",
@@ -17015,7 +17309,7 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "sp-core",
- "sp-externalities 0.30.0",
+ "sp-externalities",
  "sp-panic-handler",
  "sp-trie",
  "thiserror 1.0.69",
@@ -17025,8 +17319,8 @@ dependencies = [
 
 [[package]]
 name = "sp-statement-store"
-version = "20.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "21.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -17039,10 +17333,10 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8)",
- "sp-externalities 0.30.0",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234)",
+ "sp-externalities",
  "sp-runtime",
- "sp-runtime-interface 29.0.1",
+ "sp-runtime-interface",
  "thiserror 1.0.69",
  "x25519-dalek",
 ]
@@ -17050,24 +17344,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
-
-[[package]]
-name = "sp-storage"
-version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#59fb2e7482d471a7ec4e8d3b30499497efa7b34c"
-dependencies = [
- "impl-serde 0.5.0",
- "parity-scale-codec",
- "ref-cast",
- "serde",
- "sp-debug-derive",
-]
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "impl-serde 0.5.0",
  "parity-scale-codec",
@@ -17078,8 +17360,8 @@ dependencies = [
 
 [[package]]
 name = "sp-timestamp"
-version = "36.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "37.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17090,31 +17372,19 @@ dependencies = [
 
 [[package]]
 name = "sp-tracing"
-version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#59fb2e7482d471a7ec4e8d3b30499497efa7b34c"
-dependencies = [
- "parity-scale-codec",
- "regex",
- "tracing",
- "tracing-core",
- "tracing-subscriber 0.3.19",
-]
-
-[[package]]
-name = "sp-tracing"
 version = "17.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "parity-scale-codec",
  "tracing",
  "tracing-core",
- "tracing-subscriber 0.3.19",
+ "tracing-subscriber 0.3.20",
 ]
 
 [[package]]
 name = "sp-transaction-pool"
-version = "36.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "37.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -17122,8 +17392,8 @@ dependencies = [
 
 [[package]]
 name = "sp-transaction-storage-proof"
-version = "36.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "37.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17136,11 +17406,13 @@ dependencies = [
 
 [[package]]
 name = "sp-trie"
-version = "39.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "40.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "ahash 0.8.12",
+ "foldhash 0.1.5",
  "hash-db",
+ "hashbrown 0.15.5",
  "memory-db",
  "nohash-hasher",
  "parity-scale-codec",
@@ -17149,7 +17421,8 @@ dependencies = [
  "scale-info",
  "schnellru",
  "sp-core",
- "sp-externalities 0.30.0",
+ "sp-externalities",
+ "substrate-prometheus-endpoint",
  "thiserror 1.0.69",
  "tracing",
  "trie-db",
@@ -17158,8 +17431,8 @@ dependencies = [
 
 [[package]]
 name = "sp-version"
-version = "39.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "40.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "impl-serde 0.5.0",
  "parity-scale-codec",
@@ -17176,30 +17449,19 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "sp-wasm-interface"
-version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#59fb2e7482d471a7ec4e8d3b30499497efa7b34c"
-dependencies = [
- "anyhow",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
-]
-
-[[package]]
-name = "sp-wasm-interface"
-version = "21.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "22.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -17210,10 +17472,10 @@ dependencies = [
 
 [[package]]
 name = "sp-weights"
-version = "31.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "32.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "bounded-collections",
+ "bounded-collections 0.2.4",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -17283,9 +17545,9 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "hashlink 0.10.0",
- "indexmap 2.10.0",
+ "indexmap 2.11.4",
  "log",
  "memchr",
  "native-tls",
@@ -17294,7 +17556,7 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -17311,7 +17573,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -17332,7 +17594,7 @@ dependencies = [
  "sha2 0.10.9",
  "sqlx-core",
  "sqlx-sqlite",
- "syn 2.0.104",
+ "syn 2.0.106",
  "tokio",
  "url",
 ]
@@ -17356,7 +17618,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tracing",
  "url",
 ]
@@ -17384,21 +17646,21 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "staging-chain-spec-builder"
-version = "10.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "12.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "clap",
  "docify",
  "sc-chain-spec",
  "serde",
  "serde_json",
- "sp-tracing 17.1.0",
+ "sp-tracing",
 ]
 
 [[package]]
 name = "staging-node-inspect"
-version = "0.27.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.29.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -17415,8 +17677,8 @@ dependencies = [
 
 [[package]]
 name = "staging-parachain-info"
-version = "0.20.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.21.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -17428,11 +17690,11 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm"
-version = "16.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "17.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "array-bytes",
- "bounded-collections",
+ "array-bytes 6.2.3",
+ "bounded-collections 0.2.4",
  "derive-where",
  "environmental",
  "frame-support",
@@ -17449,8 +17711,8 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-builder"
-version = "20.1.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "21.1.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "environmental",
  "frame-support",
@@ -17473,8 +17735,8 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-executor"
-version = "19.1.2"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "20.0.1"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -17580,13 +17842,13 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -17611,7 +17873,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 
 [[package]]
 name = "substrate-fixed"
@@ -17626,8 +17888,8 @@ dependencies = [
 
 [[package]]
 name = "substrate-frame-rpc-system"
-version = "43.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "45.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -17646,11 +17908,11 @@ dependencies = [
 
 [[package]]
 name = "substrate-prometheus-endpoint"
-version = "0.17.2"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.17.6"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "http-body-util",
- "hyper 1.6.0",
+ "hyper 1.7.0",
  "hyper-util",
  "log",
  "prometheus",
@@ -17660,8 +17922,8 @@ dependencies = [
 
 [[package]]
 name = "substrate-state-trie-migration-rpc"
-version = "42.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "44.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -17687,26 +17949,26 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "26.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "27.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.2.3",
  "build-helper",
  "cargo_metadata",
  "console",
  "filetime",
- "frame-metadata 20.0.0",
+ "frame-metadata 23.0.0",
  "jobserver",
  "merkleized-metadata",
  "parity-scale-codec",
  "parity-wasm",
- "polkavm-linker 0.18.0",
+ "polkavm-linker 0.24.0",
  "sc-executor",
  "shlex",
  "sp-core",
  "sp-io",
  "sp-maybe-compressed-blob",
- "sp-tracing 17.1.0",
+ "sp-tracing",
  "sp-version",
  "strum 0.26.3",
  "tempfile",
@@ -17723,7 +17985,7 @@ dependencies = [
  "quote",
  "rayon",
  "subtensor-linting",
- "syn 2.0.104",
+ "syn 2.0.106",
  "walkdir",
 ]
 
@@ -17758,7 +18020,7 @@ dependencies = [
  "proc-macro2",
  "procedural-fork",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -17768,7 +18030,7 @@ dependencies = [
  "ahash 0.8.12",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -17836,8 +18098,8 @@ dependencies = [
  "anyhow",
  "clap",
  "node-subtensor-runtime",
- "semver 1.0.26",
- "toml_edit",
+ "semver 1.0.27",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -17867,7 +18129,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "sp-tracing 17.1.0",
+ "sp-tracing",
  "sp-weights",
  "substrate-fixed",
  "subtensor-runtime-common",
@@ -17894,33 +18156,32 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "subxt"
-version = "0.38.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c17d7ec2359d33133b63c97e28c8b7cd3f0a5bc6ce567ae3aef9d9e85be3433"
+checksum = "03459d84546def5e1d0d22b162754609f18e031522b0319b53306f5829de9c09"
 dependencies = [
  "async-trait",
  "derive-where",
  "either",
- "frame-metadata 17.0.0",
+ "frame-metadata 20.0.0",
  "futures",
  "hex",
- "impl-serde 0.5.0",
- "jsonrpsee",
  "parity-scale-codec",
- "polkadot-sdk 0.7.0",
  "primitive-types 0.13.1",
  "scale-bits",
- "scale-decode 0.14.0",
+ "scale-decode",
  "scale-encode",
  "scale-info",
  "scale-value",
  "serde",
  "serde_json",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subxt-core",
  "subxt-lightclient",
  "subxt-macro",
  "subxt-metadata",
- "thiserror 1.0.69",
+ "subxt-rpcs",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-util",
  "tracing",
@@ -17930,9 +18191,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.38.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6550ef451c77db6e3bc7c56fb6fe1dca9398a2c8fc774b127f6a396a769b9c5b"
+checksum = "324c52c09919fec8c22a4b572a466878322e99fe14a9e3d50d6c3700a226ec25"
 dependencies = [
  "heck 0.5.0",
  "parity-scale-codec",
@@ -17941,51 +18202,52 @@ dependencies = [
  "scale-info",
  "scale-typegen",
  "subxt-metadata",
- "syn 2.0.104",
- "thiserror 1.0.69",
+ "syn 2.0.106",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "subxt-core"
-version = "0.38.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7a1bc6c9c1724971636a66e3225a7253cdb35bb6efb81524a6c71c04f08c59"
+checksum = "66ef00be9d64885ec94e478a58e4e39d222024b20013ae7df4fc6ece545391aa"
 dependencies = [
  "base58",
  "blake2 0.10.6",
  "derive-where",
  "frame-decode",
- "frame-metadata 17.0.0",
+ "frame-metadata 20.0.0",
  "hashbrown 0.14.5",
  "hex",
  "impl-serde 0.5.0",
  "keccak-hash",
  "parity-scale-codec",
- "polkadot-sdk 0.7.0",
  "primitive-types 0.13.1",
  "scale-bits",
- "scale-decode 0.14.0",
+ "scale-decode",
  "scale-encode",
  "scale-info",
  "scale-value",
  "serde",
  "serde_json",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subxt-metadata",
+ "thiserror 2.0.17",
  "tracing",
 ]
 
 [[package]]
 name = "subxt-lightclient"
-version = "0.38.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ebc9131da4d0ba1f7814495b8cc79698798ccd52cacd7bcefe451e415bd945"
+checksum = "ce07c2515b2e63b85ec3043fe4461b287af0615d4832c2fe6e81ba780b906bc0"
 dependencies = [
  "futures",
  "futures-util",
  "serde",
  "serde_json",
  "smoldot-light 0.16.2",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -17993,39 +18255,63 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.38.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7819c5e09aae0319981ee853869f2fcd1fac4db8babd0d004c17161297aadc05"
+checksum = "7c2c8da275a620dd676381d72395dfea91f0a6cd849665b4f1d0919371850701"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "parity-scale-codec",
  "proc-macro-error2",
  "quote",
  "scale-typegen",
  "subxt-codegen",
  "subxt-utils-fetchmetadata",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "subxt-metadata"
-version = "0.38.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aacd4e7484fef58deaa2dcb32d94753a864b208a668c0dd0c28be1d8abeeadb2"
+checksum = "fff4591673600c4388e21305788282414d26c791b4dee21b7cb0b19c10076f98"
 dependencies = [
  "frame-decode",
- "frame-metadata 17.0.0",
+ "frame-metadata 20.0.0",
  "hashbrown 0.14.5",
  "parity-scale-codec",
- "polkadot-sdk 0.7.0",
  "scale-info",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "subxt-rpcs"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba7494d250d65dc3439365ac5e8e0fbb9c3992e6e84b7aa01d69e082249b8b8"
+dependencies = [
+ "derive-where",
+ "frame-metadata 20.0.0",
+ "futures",
+ "hex",
+ "impl-serde 0.5.0",
+ "jsonrpsee",
+ "parity-scale-codec",
+ "primitive-types 0.13.1",
+ "serde",
+ "serde_json",
+ "subxt-core",
+ "subxt-lightclient",
+ "thiserror 2.0.17",
+ "tracing",
+ "url",
 ]
 
 [[package]]
 name = "subxt-signer"
-version = "0.38.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d680352d04665b1e4eb6f9d2a54b800c4d8e1b20478e69be1b7d975b08d9fc34"
+checksum = "4a2370298a210ed1df26152db7209a85e0ed8cfbce035309c3b37f7b61755377"
 dependencies = [
  "base64 0.22.1",
  "bip32",
@@ -18037,7 +18323,6 @@ dependencies = [
  "keccak-hash",
  "parity-scale-codec",
  "pbkdf2",
- "polkadot-sdk 0.7.0",
  "regex",
  "schnorrkel 0.11.5",
  "scrypt",
@@ -18046,19 +18331,21 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subxt-core",
+ "thiserror 2.0.17",
  "zeroize",
 ]
 
 [[package]]
 name = "subxt-utils-fetchmetadata"
-version = "0.38.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3c53bc3eeaacc143a2f29ace4082edd2edaccab37b69ad20befba9fb00fdb3d"
+checksum = "fc868b55fe2303788dc7703457af390111940c3da4714b510983284501780ed5"
 dependencies = [
  "hex",
  "parity-scale-codec",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -18074,9 +18361,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -18085,14 +18372,14 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.25"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4560533fbd6914b94a8fb5cc803ed6801c3455668db3b810702c57612bac9412"
+checksum = "2375c17f6067adc651d8c2c51658019cef32edfff4a982adaf1d7fd1c039f08b"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -18115,7 +18402,22 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -18124,7 +18426,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -18159,15 +18461,15 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand 2.3.0",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.8",
- "windows-sys 0.59.0",
+ "rustix 1.1.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -18181,12 +18483,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
+checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
- "rustix 1.0.8",
- "windows-sys 0.59.0",
+ "rustix 1.1.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -18206,11 +18508,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -18230,7 +18532,7 @@ checksum = "e4c60d69f36615a077cc7663b9cb8e42275722d23e58a7fa3d2c7f2915d09d04"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -18241,18 +18543,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -18302,9 +18604,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
@@ -18317,15 +18619,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
@@ -18352,9 +18654,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -18378,7 +18680,7 @@ dependencies = [
  "ark-poly 0.4.2",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
- "array-bytes",
+ "array-bytes 6.2.3",
  "chacha20poly1305",
  "generic-array 0.14.7",
  "parity-scale-codec",
@@ -18390,7 +18692,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sha3",
- "w3f-bls",
+ "w3f-bls 0.1.3",
 ]
 
 [[package]]
@@ -18421,14 +18723,14 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -18493,8 +18795,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -18507,16 +18809,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.4",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3effe7c0e86fdff4f69cdd2ccc1b96f933e24811c5441d44904e8683e27184b"
+dependencies = [
+ "indexmap 2.11.4",
+ "toml_datetime 0.7.2",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
+dependencies = [
  "winnow",
 ]
 
@@ -18547,7 +18879,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "bytes",
  "http 1.3.1",
  "http-body 1.0.1",
@@ -18589,7 +18921,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -18614,8 +18946,8 @@ dependencies = [
 
 [[package]]
 name = "tracing-gum"
-version = "19.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "20.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -18626,13 +18958,13 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "expander",
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -18657,15 +18989,15 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
  "parking_lot 0.12.4",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -18723,7 +19055,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "url",
  "utf-8",
 ]
@@ -18748,9 +19080,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "ucd-trie"
@@ -18790,9 +19122,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unicode-normalization"
@@ -18867,13 +19199,14 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -18896,9 +19229,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.17.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",
@@ -18918,6 +19251,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "verifiable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225eaa083192400abfe78838e3089c539a361e0dd9b6884f61b5c6237676ec01"
+dependencies = [
+ "ark-scale 0.0.13",
+ "ark-serialize 0.5.0",
+ "ark-vrf",
+ "bounded-collections 0.1.9",
+ "derive-where",
+ "parity-scale-codec",
+ "scale-info",
+ "schnorrkel 0.10.2",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18933,6 +19283,28 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 name = "w3f-bls"
 version = "0.1.3"
 source = "git+https://github.com/opentensor/bls?branch=fix-no-std#4ac443d11a6c9fdebe329d113702ad7387ba1688"
+dependencies = [
+ "ark-bls12-377",
+ "ark-bls12-381 0.4.0",
+ "ark-ec 0.4.2",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-serialize-derive 0.4.2",
+ "arrayref",
+ "digest 0.10.7",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+ "sha3",
+ "zeroize",
+]
+
+[[package]]
+name = "w3f-bls"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6bfb937b3d12077654a9e43e32a4e9c20177dd9fea0f3aba673e7840bb54f32"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381 0.4.0",
@@ -19038,11 +19410,20 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
- "wit-bindgen-rt",
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -19056,35 +19437,36 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -19095,9 +19477,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -19105,22 +19487,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
 ]
@@ -19476,9 +19858,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -19520,8 +19902,8 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "westend-runtime"
-version = "22.3.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "24.0.1"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -19548,12 +19930,10 @@ dependencies = [
  "pallet-delegated-staking",
  "pallet-election-provider-multi-phase",
  "pallet-election-provider-support-benchmarking",
- "pallet-elections-phragmen",
  "pallet-fast-unstake",
  "pallet-grandpa",
  "pallet-identity",
  "pallet-indices",
- "pallet-membership",
  "pallet-message-queue",
  "pallet-meta-tx",
  "pallet-migrations",
@@ -19573,10 +19953,10 @@ dependencies = [
  "pallet-scheduler",
  "pallet-session",
  "pallet-session-benchmarking",
- "pallet-society",
  "pallet-staking",
+ "pallet-staking-async-ah-client",
+ "pallet-staking-async-rc-client",
  "pallet-staking-runtime-api",
- "pallet-state-trie-migration",
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-transaction-payment",
@@ -19616,7 +19996,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-storage 22.0.0",
+ "sp-storage",
  "sp-transaction-pool",
  "sp-version",
  "staging-xcm",
@@ -19629,8 +20009,8 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime-constants"
-version = "20.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "21.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -19677,11 +20057,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -19689,6 +20069,16 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows"
@@ -19701,25 +20091,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows"
-version = "0.61.3"
+name = "windows-core"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-collections",
- "windows-core 0.61.2",
- "windows-future",
- "windows-link",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core 0.61.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -19734,65 +20111,44 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.62.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "6844ee5416b285084d3d3fffd743b925a6c9385455f64f6d4fa3031c4c2749a9"
 dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
- "windows-result 0.3.4",
+ "windows-result 0.4.0",
  "windows-strings",
 ]
 
 [[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link",
- "windows-threading",
-]
-
-[[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "edb307e42a74fb6de9bf3a02d9712678b22399c87e6fa869d6dfcd8c1b7754e0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "c0abd1ddbc6964ac14db11c7213d6532ef34bd9aa042c2e5935f59d7908b46a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link",
-]
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-result"
@@ -19805,18 +20161,18 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
 dependencies = [
  "windows-link",
 ]
@@ -19863,7 +20219,16 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets 0.53.4",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -19914,9 +20279,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
 dependencies = [
  "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
@@ -19927,15 +20292,6 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]
@@ -20120,9 +20476,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
@@ -20138,13 +20494,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags 2.9.1",
-]
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"
@@ -20203,25 +20556,25 @@ dependencies = [
  "nom",
  "oid-registry 0.8.1",
  "rusticata-macros",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "time",
 ]
 
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "xcm-runtime-apis"
-version = "0.7.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "0.8.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -20234,8 +20587,8 @@ dependencies = [
 
 [[package]]
 name = "xcm-simulator"
-version = "20.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=ff7026b2e31fc2b0aaeede8cc259417bce56b2a8#ff7026b2e31fc2b0aaeede8cc259417bce56b2a8"
+version = "21.0.0"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234#7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -20285,9 +20638,9 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.13.6"
+version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2dd50a6d6115feb3e5d7d0efd45e8ca364b6c83722c1e9c602f5764e0e9597"
+checksum = "6927cfe0edfae4b26a369df6bad49cd0ef088c0ec48f4045b2084bcaedc10246"
 dependencies = [
  "futures",
  "log",
@@ -20301,9 +20654,9 @@ dependencies = [
 
 [[package]]
 name = "yap"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4524214bc4629eba08d78ceb1d6507070cc0bcbbed23af74e19e6e924a24cf"
+checksum = "bfe269e7b803a5e8e20cbd97860e136529cd83bf2c9c6d37b142467e7e1f051f"
 
 [[package]]
 name = "yasna"
@@ -20334,28 +20687,28 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "synstructure 0.13.2",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -20375,15 +20728,15 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "synstructure 0.13.2",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]
@@ -20396,7 +20749,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -20412,9 +20765,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbb9122ea75b11bf96e7492afb723e8a7fbe12c67417aa95e7e3d18144d37cd"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -20429,7 +20782,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -20472,9 +20825,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.15+zstd.1.5.7"
+version = "2.0.16+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6390,7 +6390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.15.5",
  "serde",
  "serde_core",
 ]
@@ -7719,7 +7719,7 @@ checksum = "b3e3e3f549d27d2dc054372f320ddf68045a833fab490563ff70d4cf1b9d91ea"
 dependencies = [
  "array-bytes 9.3.0",
  "blake3",
- "frame-metadata 23.0.0",
+ "frame-metadata 21.0.0",
  "parity-scale-codec",
  "scale-decode",
  "scale-info",
@@ -8536,7 +8536,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate 1.1.3",
  "proc-macro2",
  "quote",
  "syn 2.0.106",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3636,7 +3636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -6390,7 +6390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
  "serde",
  "serde_core",
 ]
@@ -7719,7 +7719,7 @@ checksum = "b3e3e3f549d27d2dc054372f320ddf68045a833fab490563ff70d4cf1b9d91ea"
 dependencies = [
  "array-bytes 9.3.0",
  "blake3",
- "frame-metadata 21.0.0",
+ "frame-metadata 23.0.0",
  "parity-scale-codec",
  "scale-decode",
  "scale-info",
@@ -8260,7 +8260,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-executive",
- "frame-metadata 20.0.0",
+ "frame-metadata 23.0.0",
  "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
@@ -8536,7 +8536,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4415,7 +4415,7 @@ dependencies = [
 [[package]]
 name = "fc-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "async-trait",
  "fp-storage",
@@ -4427,7 +4427,7 @@ dependencies = [
 [[package]]
 name = "fc-aura"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "fc-rpc",
  "fp-storage",
@@ -4443,7 +4443,7 @@ dependencies = [
 [[package]]
 name = "fc-babe"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "fc-rpc",
  "sc-client-api",
@@ -4459,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "async-trait",
  "fp-consensus",
@@ -4475,7 +4475,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "async-trait",
  "ethereum",
@@ -4505,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "fc-db",
  "fc-storage",
@@ -4528,7 +4528,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4579,7 +4579,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4594,7 +4594,7 @@ dependencies = [
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4786,7 +4786,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "hex",
  "impl-serde",
@@ -4804,7 +4804,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -4815,7 +4815,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4827,7 +4827,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "environmental",
  "evm",
@@ -4843,7 +4843,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4859,7 +4859,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4871,7 +4871,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -9015,7 +9015,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -9592,7 +9592,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -9615,7 +9615,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "environmental",
@@ -9640,7 +9640,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9651,7 +9651,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -9661,7 +9661,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -9673,7 +9673,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "fp-evm",
  "num",
@@ -9682,7 +9682,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -9691,7 +9691,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "fp-evm",
  "ripemd",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "pallet-hotfix-sufficients"
 version = "1.0.0"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -13007,7 +13007,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils"
 version = "0.1.0"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "environmental",
  "evm",
@@ -13031,7 +13031,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/opentensor/frontier?rev=583a15cdb409900d1f0d6b8c0d12b45901e78683#583a15cdb409900d1f0d6b8c0d12b45901e78683"
+source = "git+https://github.com/opentensor/frontier?rev=a741e4695c4e864b443482a03e82529d761e5064#a741e4695c4e864b443482a03e82529d761e5064"
 dependencies = [
  "case",
  "num_enum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,35 +228,35 @@ polkadot-sdk = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "
 runtime-common = { package = "polkadot-runtime-common", git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2503-6", default-features = false }
 
 # Frontier
-fp-evm = { git = "https://github.com/opentensor/frontier", rev = "830e61f370d88f7ace1c5a5659dd58db75a19844", default-features = false }
-fp-rpc = { git = "https://github.com/opentensor/frontier", rev = "830e61f370d88f7ace1c5a5659dd58db75a19844", default-features = false }
-fp-self-contained = { git = "https://github.com/opentensor/frontier", rev = "830e61f370d88f7ace1c5a5659dd58db75a19844", default-features = false }
-fp-account = { git = "https://github.com/opentensor/frontier", rev = "830e61f370d88f7ace1c5a5659dd58db75a19844", default-features = false }
-fc-storage = { git = "https://github.com/opentensor/frontier", rev = "830e61f370d88f7ace1c5a5659dd58db75a19844", default-features = false }
-fc-db = { git = "https://github.com/opentensor/frontier", rev = "830e61f370d88f7ace1c5a5659dd58db75a19844", default-features = false }
-fc-consensus = { git = "https://github.com/opentensor/frontier", rev = "830e61f370d88f7ace1c5a5659dd58db75a19844", default-features = false }
-fp-consensus = { git = "https://github.com/opentensor/frontier", rev = "830e61f370d88f7ace1c5a5659dd58db75a19844", default-features = false }
-fp-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "830e61f370d88f7ace1c5a5659dd58db75a19844", default-features = false }
-fc-api = { git = "https://github.com/opentensor/frontier", rev = "830e61f370d88f7ace1c5a5659dd58db75a19844", default-features = false }
-fc-rpc = { git = "https://github.com/opentensor/frontier", rev = "830e61f370d88f7ace1c5a5659dd58db75a19844", default-features = false }
-fc-rpc-core = { git = "https://github.com/opentensor/frontier", rev = "830e61f370d88f7ace1c5a5659dd58db75a19844", default-features = false }
-fc-aura = { git = "https://github.com/opentensor/frontier", rev = "830e61f370d88f7ace1c5a5659dd58db75a19844", default-features = false }
-fc-babe = { git = "https://github.com/opentensor/frontier", rev = "830e61f370d88f7ace1c5a5659dd58db75a19844", default-features = false }
-fc-mapping-sync = { git = "https://github.com/opentensor/frontier", rev = "830e61f370d88f7ace1c5a5659dd58db75a19844", default-features = false }
-precompile-utils = { git = "https://github.com/opentensor/frontier", rev = "830e61f370d88f7ace1c5a5659dd58db75a19844", default-features = false }
+fp-evm = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
+fp-rpc = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
+fp-self-contained = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
+fp-account = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
+fc-storage = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
+fc-db = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
+fc-consensus = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
+fp-consensus = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
+fp-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
+fc-api = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
+fc-rpc = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
+fc-rpc-core = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
+fc-aura = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
+fc-babe = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
+fc-mapping-sync = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
+precompile-utils = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
 
 # Frontier FRAME
-pallet-base-fee = { git = "https://github.com/opentensor/frontier", rev = "830e61f370d88f7ace1c5a5659dd58db75a19844", default-features = false }
-pallet-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "830e61f370d88f7ace1c5a5659dd58db75a19844", default-features = false }
-pallet-ethereum = { git = "https://github.com/opentensor/frontier", rev = "830e61f370d88f7ace1c5a5659dd58db75a19844", default-features = false }
-pallet-evm = { git = "https://github.com/opentensor/frontier", rev = "830e61f370d88f7ace1c5a5659dd58db75a19844", default-features = false }
-pallet-evm-precompile-dispatch = { git = "https://github.com/opentensor/frontier", rev = "830e61f370d88f7ace1c5a5659dd58db75a19844", default-features = false }
-pallet-evm-chain-id = { git = "https://github.com/opentensor/frontier", rev = "830e61f370d88f7ace1c5a5659dd58db75a19844", default-features = false }
-pallet-evm-precompile-modexp = { git = "https://github.com/opentensor/frontier", rev = "830e61f370d88f7ace1c5a5659dd58db75a19844", default-features = false }
-pallet-evm-precompile-sha3fips = { git = "https://github.com/opentensor/frontier", rev = "830e61f370d88f7ace1c5a5659dd58db75a19844", default-features = false }
-pallet-evm-precompile-simple = { git = "https://github.com/opentensor/frontier", rev = "830e61f370d88f7ace1c5a5659dd58db75a19844", default-features = false }
-pallet-evm-precompile-bn128 = { git = "https://github.com/opentensor/frontier", rev = "830e61f370d88f7ace1c5a5659dd58db75a19844", default-features = false }
-pallet-hotfix-sufficients = { git = "https://github.com/opentensor/frontier", rev = "830e61f370d88f7ace1c5a5659dd58db75a19844", default-features = false }
+pallet-base-fee = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
+pallet-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
+pallet-ethereum = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
+pallet-evm = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
+pallet-evm-precompile-dispatch = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
+pallet-evm-chain-id = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
+pallet-evm-precompile-modexp = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
+pallet-evm-precompile-sha3fips = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
+pallet-evm-precompile-simple = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
+pallet-evm-precompile-bn128 = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
+pallet-hotfix-sufficients = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
 
 #DRAND
 pallet-drand = { path = "pallets/drand", default-features = false }
@@ -310,190 +310,190 @@ w3f-bls = { git = "https://github.com/opentensor/bls", branch = "fix-no-std" }
 # NOTE: The Diener will patch unnecesarry crates while this is waiting to be merged: <https://github.com/paritytech/diener/pull/46>.
 # You may install diener from `liamaharon:ignore-unused-flag` if you like in the meantime.
 [patch."https://github.com/paritytech/polkadot-sdk"]
-frame-support = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-binary-merkle-tree = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-core = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-crypto-hashing = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-crypto-hashing-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-debug-derive = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-externalities = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-storage = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-runtime-interface = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-runtime-interface-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-std = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-tracing = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-wasm-interface = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-io = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-keystore = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-state-machine = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-panic-handler = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-trie = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-runtime = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-application-crypto = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-arithmetic = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-weights = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-api-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-metadata-ir = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-version = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-version-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-block-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-block-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-inherents = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-blockchain = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-consensus = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-database = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-client-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-substrate-prometheus-endpoint = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-executor = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-executor-common = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-allocator = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-maybe-compressed-blob = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-executor-polkavm = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-executor-wasmtime = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-substrate-wasm-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-tracing = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-tracing-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-frame-executive = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-frame-system = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-frame-try-runtime = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-balances = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-frame-benchmarking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-frame-support-procedural = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-frame-support-procedural-tools = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-frame-support-procedural-tools-derive = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-client-db = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-state-db = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-polkadot-sdk-frame = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-frame-system-benchmarking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-frame-system-rpc-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-consensus-aura = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-consensus-slots = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-timestamp = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-consensus-grandpa = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-genesis-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-keyring = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-offchain = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-session = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-staking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-transaction-pool = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-polkadot-sdk = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-cumulus-primitives-core = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-polkadot-core-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-polkadot-parachain-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-polkadot-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-authority-discovery = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-staging-xcm = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-xcm-procedural = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-cumulus-primitives-proof-size-hostfunction = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-message-queue = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-polkadot-runtime-parachains = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-authority-discovery = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-session = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-timestamp = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-authorship = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-babe = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-consensus-babe = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-frame-election-provider-support = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-frame-election-provider-solution-type = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-npos-elections = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-offences = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-staking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-bags-list = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-staking-reward-curve = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-broker = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-mmr = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-mmr-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-polkadot-runtime-metrics = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-staging-xcm-executor = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-keystore = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-staging-xcm-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-asset-conversion = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-transaction-payment = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-grandpa = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-sudo = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-vesting = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-polkadot-runtime-common = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-asset-rate = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-election-provider-multi-phase = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-election-provider-support-benchmarking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-fast-unstake = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-identity = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-staking-reward-fn = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-treasury = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-utility = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-root-testing = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-slot-range-helper = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-aura = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-chain-spec = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-chain-spec-derive = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-network = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-network-common = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-network-types = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-utils = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-telemetry = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-cli = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-mixnet = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-transaction-pool-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-mixnet = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-service = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-consensus = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-informant = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-network-sync = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-fork-tree = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-network-light = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-network-transactions = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-rpc-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-statement-store = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-transaction-pool = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-rpc-server = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-rpc-spec-v2 = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-sysinfo = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-transaction-storage-proof = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-cumulus-relay-chain-interface = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-polkadot-overseer = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-tracing-gum = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-tracing-gum-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-polkadot-node-metrics = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-polkadot-node-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-polkadot-node-subsystem-types = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-polkadot-node-network-protocol = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-authority-discovery = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-polkadot-statement-table = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-frame-benchmarking-cli = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-cumulus-client-parachain-inherent = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-runtime-utilities = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-frame-metadata-hash-extension = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-nomination-pools = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-membership = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-multisig = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-nomination-pools-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-preimage = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-proxy = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-scheduler = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-staking-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-offchain = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-consensus-babe = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-consensus-epochs = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-consensus-slots = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-transaction-payment-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-consensus-babe-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-network-gossip = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-consensus-grandpa = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-consensus-grandpa-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-substrate-frame-rpc-system = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-basic-authorship = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-proposer-metrics = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-substrate-build-script-utils = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-consensus-aura = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-insecure-randomness-collective-flip = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-pallet-safe-mode = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sc-consensus-manual-seal = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-sp-crypto-ec-utils = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
-substrate-bip39 = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "ff7026b2e31fc2b0aaeede8cc259417bce56b2a8" }
+frame-support = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+binary-merkle-tree = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-core = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-crypto-hashing = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-crypto-hashing-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-debug-derive = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-externalities = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-storage = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-runtime-interface = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-runtime-interface-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-std = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-tracing = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-wasm-interface = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-io = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-keystore = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-state-machine = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-panic-handler = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-trie = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-runtime = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-application-crypto = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-arithmetic = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-weights = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-api = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-api-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-metadata-ir = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-version = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-version-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-block-builder = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-block-builder = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-inherents = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-blockchain = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-consensus = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-database = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-client-api = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+substrate-prometheus-endpoint = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-executor = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-executor-common = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-allocator = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-maybe-compressed-blob = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-executor-polkavm = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-executor-wasmtime = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+substrate-wasm-builder = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-tracing = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-tracing-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+frame-executive = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+frame-system = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+frame-try-runtime = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-balances = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+frame-benchmarking = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+frame-support-procedural = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+frame-support-procedural-tools = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+frame-support-procedural-tools-derive = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-client-db = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-state-db = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-sdk-frame = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+frame-system-benchmarking = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+frame-system-rpc-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-consensus-aura = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-consensus-slots = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-timestamp = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-consensus-grandpa = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-genesis-builder = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-keyring = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-offchain = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-session = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-staking = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-transaction-pool = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-sdk = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+cumulus-primitives-core = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-core-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-parachain-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-authority-discovery = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+staging-xcm = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+xcm-procedural = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+cumulus-primitives-proof-size-hostfunction = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-message-queue = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-runtime-parachains = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-authority-discovery = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-session = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-timestamp = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-authorship = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-babe = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-consensus-babe = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+frame-election-provider-support = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+frame-election-provider-solution-type = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-npos-elections = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-offences = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-staking = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-bags-list = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-staking-reward-curve = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-broker = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-mmr = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-mmr-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-runtime-metrics = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+staging-xcm-executor = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-keystore = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+staging-xcm-builder = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-asset-conversion = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-transaction-payment = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-grandpa = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-sudo = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-vesting = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-runtime-common = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-asset-rate = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-election-provider-multi-phase = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-election-provider-support-benchmarking = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-fast-unstake = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-identity = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-staking-reward-fn = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-treasury = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-utility = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-root-testing = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+slot-range-helper = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-aura = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-chain-spec = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-chain-spec-derive = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-network = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-network-common = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-network-types = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-utils = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-telemetry = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-cli = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-mixnet = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-transaction-pool-api = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-mixnet = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-service = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-consensus = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-informant = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-network-sync = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+fork-tree = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-network-light = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-network-transactions = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-rpc-api = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-statement-store = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-transaction-pool = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-rpc-server = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-rpc-spec-v2 = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-sysinfo = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-transaction-storage-proof = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+cumulus-relay-chain-interface = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-overseer = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+tracing-gum = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+tracing-gum-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-node-metrics = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-node-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-node-subsystem-types = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-node-network-protocol = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-authority-discovery = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-statement-table = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+frame-benchmarking-cli = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+cumulus-client-parachain-inherent = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-runtime-utilities = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+frame-metadata-hash-extension = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-nomination-pools = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-membership = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-multisig = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-nomination-pools-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-preimage = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-proxy = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-scheduler = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-staking-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-offchain = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-consensus-babe = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-consensus-epochs = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-consensus-slots = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-transaction-payment-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-consensus-babe-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-network-gossip = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-consensus-grandpa = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-consensus-grandpa-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+substrate-frame-rpc-system = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-basic-authorship = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-proposer-metrics = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+substrate-build-script-utils = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-consensus-aura = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-insecure-randomness-collective-flip = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-safe-mode = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-consensus-manual-seal = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-crypto-ec-utils = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+substrate-bip39 = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ frame-system = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "
 frame-system-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2503-6", default-features = false }
 frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2503-6", default-features = false }
 frame-try-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2503-6", default-features = false }
-frame-metadata = { version = "20.0.0", default-features = false }
+frame-metadata = { version = "23.0.0", default-features = false }
 
 pallet-subtensor-proxy = { path = "pallets/proxy", default-features = false }
 pallet-subtensor-utility = { path = "pallets/utility", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,6 @@ libsecp256k1 = { version = "0.7.2", default-features = false }
 log = { version = "0.4.21", default-features = false }
 memmap2 = "0.9.4"
 ndarray = { version = "0.15.6", default-features = false }
-parity-util-mem = "0.12.0"
 rand = "0.8.5"
 scale-info = { version = "2.11.2", default-features = false }
 serde = { version = "1.0.214", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ libsecp256k1 = { version = "0.7.2", default-features = false }
 log = { version = "0.4.21", default-features = false }
 memmap2 = "0.9.8"
 ndarray = { version = "0.16.1", default-features = false }
-rand = "0.9.2"
+rand = "0.8.5"
 scale-info = { version = "2.11.2", default-features = false }
 serde = { version = "1.0.214", default-features = false }
 serde-tuple-vec-map = { version = "1.0.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,9 +81,9 @@ hex-literal = "0.4.1"
 jsonrpsee = { version = "0.24.9", default-features = false }
 libsecp256k1 = { version = "0.7.2", default-features = false }
 log = { version = "0.4.21", default-features = false }
-memmap2 = "0.9.4"
-ndarray = { version = "0.15.6", default-features = false }
-rand = "0.8.5"
+memmap2 = "0.9.8"
+ndarray = { version = "0.16.1", default-features = false }
+rand = "0.9.2"
 scale-info = { version = "2.11.2", default-features = false }
 serde = { version = "1.0.214", default-features = false }
 serde-tuple-vec-map = { version = "1.0.1", default-features = false }
@@ -92,7 +92,7 @@ serde_json = { version = "1.0.141", default-features = false }
 serde_with = { version = "3.14.0", default-features = false }
 smallvec = "1.13.2"
 litep2p = { git = "https://github.com/paritytech/litep2p", tag = "v0.7.0", default-features = false }
-syn = { version = "2.0.87", default-features = false }
+syn = { version = "2.0.106", default-features = false }
 quote = { version = "1", default-features = false }
 proc-macro2 = { version = "1", default-features = false }
 walkdir = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,35 +228,35 @@ polkadot-sdk = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "
 runtime-common = { package = "polkadot-runtime-common", git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2503-6", default-features = false }
 
 # Frontier
-fp-evm = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
-fp-rpc = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
-fp-self-contained = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
-fp-account = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
-fc-storage = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
-fc-db = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
-fc-consensus = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
-fp-consensus = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
-fp-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
-fc-api = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
-fc-rpc = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
-fc-rpc-core = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
-fc-aura = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
-fc-babe = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
-fc-mapping-sync = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
-precompile-utils = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
+fp-evm = { git = "https://github.com/opentensor/frontier", rev = "a741e4695c4e864b443482a03e82529d761e5064", default-features = false }
+fp-rpc = { git = "https://github.com/opentensor/frontier", rev = "a741e4695c4e864b443482a03e82529d761e5064", default-features = false }
+fp-self-contained = { git = "https://github.com/opentensor/frontier", rev = "a741e4695c4e864b443482a03e82529d761e5064", default-features = false }
+fp-account = { git = "https://github.com/opentensor/frontier", rev = "a741e4695c4e864b443482a03e82529d761e5064", default-features = false }
+fc-storage = { git = "https://github.com/opentensor/frontier", rev = "a741e4695c4e864b443482a03e82529d761e5064", default-features = false }
+fc-db = { git = "https://github.com/opentensor/frontier", rev = "a741e4695c4e864b443482a03e82529d761e5064", default-features = false }
+fc-consensus = { git = "https://github.com/opentensor/frontier", rev = "a741e4695c4e864b443482a03e82529d761e5064", default-features = false }
+fp-consensus = { git = "https://github.com/opentensor/frontier", rev = "a741e4695c4e864b443482a03e82529d761e5064", default-features = false }
+fp-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "a741e4695c4e864b443482a03e82529d761e5064", default-features = false }
+fc-api = { git = "https://github.com/opentensor/frontier", rev = "a741e4695c4e864b443482a03e82529d761e5064", default-features = false }
+fc-rpc = { git = "https://github.com/opentensor/frontier", rev = "a741e4695c4e864b443482a03e82529d761e5064", default-features = false }
+fc-rpc-core = { git = "https://github.com/opentensor/frontier", rev = "a741e4695c4e864b443482a03e82529d761e5064", default-features = false }
+fc-aura = { git = "https://github.com/opentensor/frontier", rev = "a741e4695c4e864b443482a03e82529d761e5064", default-features = false }
+fc-babe = { git = "https://github.com/opentensor/frontier", rev = "a741e4695c4e864b443482a03e82529d761e5064", default-features = false }
+fc-mapping-sync = { git = "https://github.com/opentensor/frontier", rev = "a741e4695c4e864b443482a03e82529d761e5064", default-features = false }
+precompile-utils = { git = "https://github.com/opentensor/frontier", rev = "a741e4695c4e864b443482a03e82529d761e5064", default-features = false }
 
 # Frontier FRAME
-pallet-base-fee = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
-pallet-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
-pallet-ethereum = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
-pallet-evm = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
-pallet-evm-precompile-dispatch = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
-pallet-evm-chain-id = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
-pallet-evm-precompile-modexp = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
-pallet-evm-precompile-sha3fips = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
-pallet-evm-precompile-simple = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
-pallet-evm-precompile-bn128 = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
-pallet-hotfix-sufficients = { git = "https://github.com/opentensor/frontier", rev = "583a15cdb409900d1f0d6b8c0d12b45901e78683", default-features = false }
+pallet-base-fee = { git = "https://github.com/opentensor/frontier", rev = "a741e4695c4e864b443482a03e82529d761e5064", default-features = false }
+pallet-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "a741e4695c4e864b443482a03e82529d761e5064", default-features = false }
+pallet-ethereum = { git = "https://github.com/opentensor/frontier", rev = "a741e4695c4e864b443482a03e82529d761e5064", default-features = false }
+pallet-evm = { git = "https://github.com/opentensor/frontier", rev = "a741e4695c4e864b443482a03e82529d761e5064", default-features = false }
+pallet-evm-precompile-dispatch = { git = "https://github.com/opentensor/frontier", rev = "a741e4695c4e864b443482a03e82529d761e5064", default-features = false }
+pallet-evm-chain-id = { git = "https://github.com/opentensor/frontier", rev = "a741e4695c4e864b443482a03e82529d761e5064", default-features = false }
+pallet-evm-precompile-modexp = { git = "https://github.com/opentensor/frontier", rev = "a741e4695c4e864b443482a03e82529d761e5064", default-features = false }
+pallet-evm-precompile-sha3fips = { git = "https://github.com/opentensor/frontier", rev = "a741e4695c4e864b443482a03e82529d761e5064", default-features = false }
+pallet-evm-precompile-simple = { git = "https://github.com/opentensor/frontier", rev = "a741e4695c4e864b443482a03e82529d761e5064", default-features = false }
+pallet-evm-precompile-bn128 = { git = "https://github.com/opentensor/frontier", rev = "a741e4695c4e864b443482a03e82529d761e5064", default-features = false }
+pallet-hotfix-sufficients = { git = "https://github.com/opentensor/frontier", rev = "a741e4695c4e864b443482a03e82529d761e5064", default-features = false }
 
 #DRAND
 pallet-drand = { path = "pallets/drand", default-features = false }
@@ -310,190 +310,190 @@ w3f-bls = { git = "https://github.com/opentensor/bls", branch = "fix-no-std" }
 # NOTE: The Diener will patch unnecesarry crates while this is waiting to be merged: <https://github.com/paritytech/diener/pull/46>.
 # You may install diener from `liamaharon:ignore-unused-flag` if you like in the meantime.
 [patch."https://github.com/paritytech/polkadot-sdk"]
-frame-support = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-binary-merkle-tree = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-core = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-crypto-hashing = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-crypto-hashing-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-debug-derive = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-externalities = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-storage = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-runtime-interface = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-runtime-interface-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-std = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-tracing = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-wasm-interface = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-io = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-keystore = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-state-machine = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-panic-handler = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-trie = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-runtime = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-application-crypto = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-arithmetic = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-weights = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-api = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-api-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-metadata-ir = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-version = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-version-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-block-builder = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-block-builder = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-inherents = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-blockchain = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-consensus = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-database = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-client-api = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-substrate-prometheus-endpoint = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-executor = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-executor-common = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-allocator = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-maybe-compressed-blob = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-executor-polkavm = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-executor-wasmtime = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-substrate-wasm-builder = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-tracing = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-tracing-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-frame-executive = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-frame-system = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-frame-try-runtime = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-balances = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-frame-benchmarking = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-frame-support-procedural = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-frame-support-procedural-tools = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-frame-support-procedural-tools-derive = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-client-db = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-state-db = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-polkadot-sdk-frame = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-frame-system-benchmarking = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-frame-system-rpc-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-consensus-aura = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-consensus-slots = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-timestamp = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-consensus-grandpa = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-genesis-builder = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-keyring = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-offchain = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-session = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-staking = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-transaction-pool = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-polkadot-sdk = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-cumulus-primitives-core = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-polkadot-core-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-polkadot-parachain-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-polkadot-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-authority-discovery = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-staging-xcm = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-xcm-procedural = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-cumulus-primitives-proof-size-hostfunction = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-message-queue = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-polkadot-runtime-parachains = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-authority-discovery = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-session = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-timestamp = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-authorship = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-babe = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-consensus-babe = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-frame-election-provider-support = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-frame-election-provider-solution-type = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-npos-elections = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-offences = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-staking = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-bags-list = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-staking-reward-curve = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-broker = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-mmr = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-mmr-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-polkadot-runtime-metrics = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-staging-xcm-executor = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-keystore = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-staging-xcm-builder = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-asset-conversion = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-transaction-payment = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-grandpa = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-sudo = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-vesting = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-polkadot-runtime-common = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-asset-rate = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-election-provider-multi-phase = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-election-provider-support-benchmarking = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-fast-unstake = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-identity = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-staking-reward-fn = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-treasury = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-utility = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-root-testing = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-slot-range-helper = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-aura = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-chain-spec = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-chain-spec-derive = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-network = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-network-common = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-network-types = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-utils = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-telemetry = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-cli = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-mixnet = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-transaction-pool-api = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-mixnet = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-service = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-consensus = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-informant = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-network-sync = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-fork-tree = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-network-light = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-network-transactions = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-rpc-api = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-statement-store = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-transaction-pool = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-rpc-server = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-rpc-spec-v2 = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-sysinfo = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-transaction-storage-proof = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-cumulus-relay-chain-interface = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-polkadot-overseer = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-tracing-gum = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-tracing-gum-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-polkadot-node-metrics = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-polkadot-node-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-polkadot-node-subsystem-types = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-polkadot-node-network-protocol = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-authority-discovery = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-polkadot-statement-table = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-frame-benchmarking-cli = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-cumulus-client-parachain-inherent = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-runtime-utilities = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-frame-metadata-hash-extension = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-nomination-pools = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-membership = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-multisig = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-nomination-pools-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-preimage = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-proxy = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-scheduler = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-staking-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-offchain = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-consensus-babe = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-consensus-epochs = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-consensus-slots = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-transaction-payment-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-consensus-babe-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-network-gossip = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-consensus-grandpa = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-consensus-grandpa-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-substrate-frame-rpc-system = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-basic-authorship = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-proposer-metrics = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-substrate-build-script-utils = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-consensus-aura = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-insecure-randomness-collective-flip = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-pallet-safe-mode = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sc-consensus-manual-seal = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-sp-crypto-ec-utils = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
-substrate-bip39 = { git = "https://github.com/opentensor/polkadot-sdk.git" , rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+frame-support = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+binary-merkle-tree = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-core = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-crypto-hashing = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-crypto-hashing-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-debug-derive = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-externalities = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-storage = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-runtime-interface = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-runtime-interface-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-std = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-tracing = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-wasm-interface = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-io = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-keystore = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-state-machine = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-panic-handler = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-trie = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-runtime = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-application-crypto = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-arithmetic = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-weights = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-api-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-metadata-ir = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-version = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-version-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-block-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-block-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-inherents = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-blockchain = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-consensus = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-database = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-client-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+substrate-prometheus-endpoint = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-executor = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-executor-common = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-allocator = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-maybe-compressed-blob = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-executor-polkavm = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-executor-wasmtime = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+substrate-wasm-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-tracing = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-tracing-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+frame-executive = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+frame-system = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+frame-try-runtime = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-balances = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+frame-benchmarking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+frame-support-procedural = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+frame-support-procedural-tools = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+frame-support-procedural-tools-derive = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-client-db = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-state-db = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-sdk-frame = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+frame-system-benchmarking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+frame-system-rpc-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-consensus-aura = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-consensus-slots = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-timestamp = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-consensus-grandpa = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-genesis-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-keyring = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-offchain = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-session = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-staking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-transaction-pool = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-sdk = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+cumulus-primitives-core = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-core-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-parachain-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-authority-discovery = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+staging-xcm = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+xcm-procedural = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+cumulus-primitives-proof-size-hostfunction = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-message-queue = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-runtime-parachains = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-authority-discovery = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-session = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-timestamp = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-authorship = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-babe = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-consensus-babe = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+frame-election-provider-support = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+frame-election-provider-solution-type = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-npos-elections = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-offences = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-staking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-bags-list = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-staking-reward-curve = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-broker = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-mmr = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-mmr-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-runtime-metrics = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+staging-xcm-executor = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-keystore = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+staging-xcm-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-asset-conversion = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-transaction-payment = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-grandpa = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-sudo = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-vesting = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-runtime-common = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-asset-rate = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-election-provider-multi-phase = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-election-provider-support-benchmarking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-fast-unstake = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-identity = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-staking-reward-fn = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-treasury = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-utility = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-root-testing = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+slot-range-helper = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-aura = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-chain-spec = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-chain-spec-derive = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-network = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-network-common = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-network-types = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-utils = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-telemetry = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-cli = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-mixnet = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-transaction-pool-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-mixnet = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-service = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-consensus = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-informant = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-network-sync = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+fork-tree = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-network-light = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-network-transactions = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-rpc-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-statement-store = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-transaction-pool = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-rpc-server = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-rpc-spec-v2 = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-sysinfo = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-transaction-storage-proof = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+cumulus-relay-chain-interface = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-overseer = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+tracing-gum = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+tracing-gum-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-node-metrics = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-node-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-node-subsystem-types = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-node-network-protocol = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-authority-discovery = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+polkadot-statement-table = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+frame-benchmarking-cli = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+cumulus-client-parachain-inherent = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-runtime-utilities = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+frame-metadata-hash-extension = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-nomination-pools = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-membership = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-multisig = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-nomination-pools-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-preimage = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-proxy = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-scheduler = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-staking-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-offchain = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-consensus-babe = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-consensus-epochs = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-consensus-slots = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-transaction-payment-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-consensus-babe-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-network-gossip = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-consensus-grandpa = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-consensus-grandpa-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+substrate-frame-rpc-system = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-basic-authorship = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-proposer-metrics = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+substrate-build-script-utils = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-consensus-aura = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-insecure-randomness-collective-flip = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+pallet-safe-mode = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sc-consensus-manual-seal = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+sp-crypto-ec-utils = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }
+substrate-bip39 = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "7d1855ebff04c96bb273b43cfd5a5cf6fa2a7234" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ proc-macro-warning = { version = "1", default-features = false }
 expander = "2"
 ahash = { version = "0.8", default-features = false }
 regex = { version = "1.11.1", default-features = false }
+ethereum = { version = "0.18.2", default-features = false }
 
 frame = { package = "polkadot-sdk-frame", git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2503-6", default-features = false }
 frame-benchmarking = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2503-6", default-features = false }

--- a/evm-tests/test/eth.substrate-transfer.test.ts
+++ b/evm-tests/test/eth.substrate-transfer.test.ts
@@ -145,7 +145,8 @@ describe("Balance transfers between substrate and EVM", () => {
             max_priority_fee_per_gas: undefined,
             input: Binary.fromText(""),
             nonce: undefined,
-            access_list: []
+            access_list: [],
+            authorization_list: []
         })
         // txFee not accurate
         const txFee = (await tx.getPaymentInfo(ss58Address)).partial_fee
@@ -313,7 +314,8 @@ describe("Balance transfers between substrate and EVM", () => {
                 max_priority_fee_per_gas: undefined,
                 input: Binary.fromText(""),
                 nonce: undefined,
-                access_list: []
+                access_list: [],
+                authorization_list: []
             })
             await waitForTransactionCompletion(api, tx, signer)
                 .then(() => { })

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -194,8 +194,9 @@ pub fn run() -> sc_cli::Result<()> {
                     BenchmarkCmd::Storage(cmd) => {
                         let db = backend.expose_db();
                         let storage = backend.expose_storage();
+						let shared_cache = backend.expose_shared_trie_cache();
 
-                        cmd.run(config, client, db, storage)
+                        cmd.run(config, client, db, storage, shared_cache)
                     }
                     BenchmarkCmd::Overhead(cmd) => {
                         let ext_builder = RemarkBuilder::new(client.clone());
@@ -351,6 +352,7 @@ fn override_default_heap_pages(config: Configuration, pages: u64) -> Configurati
         keystore: config.keystore,
         database: config.database,
         trie_cache_maximum_size: config.trie_cache_maximum_size,
+        warm_up_trie_cache: config.warm_up_trie_cache,
         state_pruning: config.state_pruning,
         blocks_pruning: config.blocks_pruning,
         chain_spec: config.chain_spec,

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -194,7 +194,7 @@ pub fn run() -> sc_cli::Result<()> {
                     BenchmarkCmd::Storage(cmd) => {
                         let db = backend.expose_db();
                         let storage = backend.expose_storage();
-						let shared_cache = backend.expose_shared_trie_cache();
+                        let shared_cache = backend.expose_shared_trie_cache();
 
                         cmd.run(config, client, db, storage, shared_cache)
                     }

--- a/node/src/consensus/hybrid_import_queue.rs
+++ b/node/src/consensus/hybrid_import_queue.rs
@@ -200,7 +200,7 @@ where
 {
     async fn verify(&self, block: BlockImportParams<B>) -> Result<BlockImportParams<B>, String> {
         let number: NumberFor<B> = *block.post_header().number();
-        log::debug!("Verifying block: {:?}", number);
+        log::debug!("Verifying block: {number:?}");
         if is_babe_digest(block.header.digest()) {
             self.inner_babe.verify(block).await
         } else {

--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -42,9 +42,6 @@ pub mod pallet {
         + pallet_subtensor::pallet::Config
         + pallet_evm_chain_id::pallet::Config
     {
-        /// Because this pallet emits events, it depends on the runtime's definition of an event.
-        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
-
         /// Implementation of the AuraInterface
         type Aura: crate::AuraInterface<<Self as Config>::AuthorityId, Self::MaxAuthorities>;
 

--- a/pallets/admin-utils/src/tests/mock.rs
+++ b/pallets/admin-utils/src/tests/mock.rs
@@ -458,7 +458,7 @@ impl<LocalCall> frame_system::offchain::CreateInherent<LocalCall> for Test
 where
     RuntimeCall: From<LocalCall>,
 {
-    fn create_inherent(call: Self::RuntimeCall) -> Self::Extrinsic {
+    fn create_bare(call: Self::RuntimeCall) -> Self::Extrinsic {
         UncheckedExtrinsic::new_inherent(call)
     }
 }

--- a/pallets/admin-utils/src/tests/mock.rs
+++ b/pallets/admin-utils/src/tests/mock.rs
@@ -156,7 +156,6 @@ parameter_types! {
 }
 
 impl pallet_subtensor::Config for Test {
-    type RuntimeEvent = RuntimeEvent;
     type RuntimeCall = RuntimeCall;
     type Currency = Balances;
     type InitialIssuance = InitialIssuance;
@@ -263,7 +262,6 @@ impl pallet_crowdloan::Config for Test {
     type PalletId = CrowdloanPalletId;
     type Currency = Balances;
     type RuntimeCall = RuntimeCall;
-    type RuntimeEvent = RuntimeEvent;
     type WeightInfo = pallet_crowdloan::weights::SubstrateWeight<Test>;
     type Preimages = Preimage;
     type MinimumDeposit = MinimumDeposit;
@@ -340,7 +338,6 @@ parameter_types! {
 }
 
 impl pallet_subtensor_swap::Config for Test {
-    type RuntimeEvent = RuntimeEvent;
     type SubnetInfo = SubtensorModule;
     type BalanceOps = SubtensorModule;
     type ProtocolId = SwapProtocolId;
@@ -376,7 +373,6 @@ impl crate::GrandpaInterface<Test> for GrandpaInterfaceImpl {
 }
 
 impl crate::Config for Test {
-    type RuntimeEvent = RuntimeEvent;
     type AuthorityId = AuraId;
     type MaxAuthorities = ConstU32<32>;
     type Aura = ();
@@ -407,7 +403,6 @@ impl pallet_scheduler::Config for Test {
 
 impl pallet_evm_chain_id::Config for Test {}
 impl pallet_drand::Config for Test {
-    type RuntimeEvent = RuntimeEvent;
     type AuthorityId = TestAuthId;
     type Verifier = pallet_drand::verifier::QuicknetVerifier;
     type UnsignedPriority = ConstU64<{ 1 << 20 }>;

--- a/pallets/collective/src/benchmarking.rs
+++ b/pallets/collective/src/benchmarking.rs
@@ -31,7 +31,9 @@ const SEED: u32 = 0;
 
 const MAX_BYTES: u32 = 1_024;
 
-fn assert_last_event<T: frame_system::pallet::Config>(generic_event: <T as frame_system::pallet::Config>::RuntimeEvent) {
+fn assert_last_event<T: frame_system::pallet::Config>(
+    generic_event: <T as frame_system::pallet::Config>::RuntimeEvent,
+) {
     frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
 

--- a/pallets/collective/src/benchmarking.rs
+++ b/pallets/collective/src/benchmarking.rs
@@ -31,7 +31,7 @@ const SEED: u32 = 0;
 
 const MAX_BYTES: u32 = 1_024;
 
-fn assert_last_event<T: Config<I>, I: 'static>(generic_event: <T as Config<I>>::RuntimeEvent) {
+fn assert_last_event<T: frame_system::pallet::Config>(generic_event: <T as frame_system::pallet::Config>::RuntimeEvent) {
     frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
 
@@ -131,7 +131,7 @@ benchmarks_instance_pallet! {
     verify {
         let proposal_hash = T::Hashing::hash_of(&proposal);
         // Note that execution fails due to mis-matched origin
-        assert_last_event::<T, I>(
+        assert_last_event::<T>(
             Event::MemberExecuted { proposal_hash, result: Ok(()) }.into()
         );
     }
@@ -176,7 +176,7 @@ benchmarks_instance_pallet! {
         // New proposal is recorded
         assert_eq!(Collective::<T, I>::proposals().len(), p as usize);
         let proposal_hash = T::Hashing::hash_of(&proposal);
-        assert_last_event::<T, I>(Event::Proposed { account: caller, proposal_index: p - 1, proposal_hash, threshold }.into());
+        assert_last_event::<T>(Event::Proposed { account: caller, proposal_index: p - 1, proposal_hash, threshold }.into());
     }
 
     vote {
@@ -319,7 +319,7 @@ benchmarks_instance_pallet! {
     verify {
         // The last proposal is removed.
         assert_eq!(Collective::<T, I>::proposals().len(), (p - 1) as usize);
-        assert_last_event::<T, I>(Event::Disapproved { proposal_hash: last_hash }.into());
+        assert_last_event::<T>(Event::Disapproved { proposal_hash: last_hash }.into());
     }
 
     close_early_approved {
@@ -397,7 +397,7 @@ benchmarks_instance_pallet! {
     verify {
         // The last proposal is removed.
         assert_eq!(Collective::<T, I>::proposals().len(), (p - 1) as usize);
-        assert_last_event::<T, I>(Event::Executed { proposal_hash: last_hash, result: Ok(()) }.into());
+        assert_last_event::<T>(Event::Executed { proposal_hash: last_hash, result: Ok(()) }.into());
     }
 
     close_disapproved {
@@ -476,7 +476,7 @@ benchmarks_instance_pallet! {
     }: close(SystemOrigin::Root, last_hash, index, Weight::MAX, bytes_in_storage)
     verify {
         assert_eq!(Collective::<T, I>::proposals().len(), (p - 1) as usize);
-        assert_last_event::<T, I>(Event::Disapproved { proposal_hash: last_hash }.into());
+        assert_last_event::<T>(Event::Disapproved { proposal_hash: last_hash }.into());
     }
 
     close_approved {
@@ -545,7 +545,7 @@ benchmarks_instance_pallet! {
     }: close(SystemOrigin::Root, last_hash, p - 1, Weight::MAX, bytes_in_storage)
     verify {
         assert_eq!(Collective::<T, I>::proposals().len(), (p - 1) as usize);
-        assert_last_event::<T, I>(Event::Executed { proposal_hash: last_hash, result: Ok(()) }.into());
+        assert_last_event::<T>(Event::Executed { proposal_hash: last_hash, result: Ok(()) }.into());
     }
 
     disapprove_proposal {
@@ -593,7 +593,7 @@ benchmarks_instance_pallet! {
     }: _(SystemOrigin::Root, last_hash)
     verify {
         assert_eq!(Collective::<T, I>::proposals().len(), (p - 1) as usize);
-        assert_last_event::<T, I>(Event::Disapproved { proposal_hash: last_hash }.into());
+        assert_last_event::<T>(Event::Disapproved { proposal_hash: last_hash }.into());
     }
 
     impl_benchmark_test_suite!(Collective, crate::tests::new_test_ext(), crate::tests::Test);

--- a/pallets/collective/src/lib.rs
+++ b/pallets/collective/src/lib.rs
@@ -204,10 +204,6 @@ pub mod pallet {
             > + From<frame_system::Call<Self>>
             + GetDispatchInfo;
 
-        /// The runtime event type.
-        type RuntimeEvent: From<Event<Self, I>>
-            + IsType<<Self as frame_system::Config>::RuntimeEvent>;
-
         /// The time-out for council motions.
         type MotionDuration: Get<BlockNumberFor<Self>>;
 

--- a/pallets/collective/src/tests.rs
+++ b/pallets/collective/src/tests.rs
@@ -55,8 +55,6 @@ mod mock_democracy {
 
         #[pallet::config]
         pub trait Config: frame_system::Config + Sized {
-            type RuntimeEvent: From<Event<Self>>
-                + IsType<<Self as frame_system::Config>::RuntimeEvent>;
             type ExternalMajorityOrigin: EnsureOrigin<Self::RuntimeOrigin>;
         }
 
@@ -141,7 +139,6 @@ impl Get<MemberCount> for GetCollectiveCount {
 impl Config<Instance1> for Test {
     type RuntimeOrigin = RuntimeOrigin;
     type Proposal = RuntimeCall;
-    type RuntimeEvent = RuntimeEvent;
     type MotionDuration = ConstU64<3>;
     type MaxProposals = MaxProposals;
     type MaxMembers = MaxMembers;
@@ -182,7 +179,6 @@ impl Get<MemberCount> for GetCollectiveMajorityCount {
 impl Config<Instance2> for Test {
     type RuntimeOrigin = RuntimeOrigin;
     type Proposal = RuntimeCall;
-    type RuntimeEvent = RuntimeEvent;
     type MotionDuration = ConstU64<3>;
     type MaxProposals = MaxProposals;
     type MaxMembers = MaxMembers;
@@ -194,7 +190,6 @@ impl Config<Instance2> for Test {
     type GetVotingMembers = GetCollectiveMajorityCount;
 }
 impl mock_democracy::Config for Test {
-    type RuntimeEvent = RuntimeEvent;
     type ExternalMajorityOrigin = EnsureProportionAtLeast<u64, Instance1, 3, 4>;
 }
 
@@ -227,7 +222,6 @@ impl Get<MemberCount> for GetDefaultCollectiveCount {
 impl Config for Test {
     type RuntimeOrigin = RuntimeOrigin;
     type Proposal = RuntimeCall;
-    type RuntimeEvent = RuntimeEvent;
     type MotionDuration = ConstU64<3>;
     type MaxProposals = MaxProposals;
     type MaxMembers = MaxMembers;

--- a/pallets/commitments/src/benchmarking.rs
+++ b/pallets/commitments/src/benchmarking.rs
@@ -11,7 +11,7 @@ use sp_std::vec;
 
 use sp_runtime::traits::Bounded;
 
-fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
+fn assert_last_event<T: frame_system::pallet::Config>(generic_event: <T as frame_system::pallet::Config>::RuntimeEvent) {
     frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
 

--- a/pallets/commitments/src/benchmarking.rs
+++ b/pallets/commitments/src/benchmarking.rs
@@ -11,7 +11,9 @@ use sp_std::vec;
 
 use sp_runtime::traits::Bounded;
 
-fn assert_last_event<T: frame_system::pallet::Config>(generic_event: <T as frame_system::pallet::Config>::RuntimeEvent) {
+fn assert_last_event<T: frame_system::pallet::Config>(
+    generic_event: <T as frame_system::pallet::Config>::RuntimeEvent,
+) {
     frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
 

--- a/pallets/commitments/src/lib.rs
+++ b/pallets/commitments/src/lib.rs
@@ -49,9 +49,6 @@ pub mod pallet {
     // Configure the pallet by specifying the parameters and types on which it depends.
     #[pallet::config]
     pub trait Config: frame_system::Config + pallet_drand::Config {
-        /// Because this pallet emits events, it depends on the runtime's definition of an event.
-        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
-
         ///Currency type that will be used to reserve deposits for commitments
         type Currency: ReservableCurrency<Self::AccountId> + Send + Sync;
 

--- a/pallets/commitments/src/mock.rs
+++ b/pallets/commitments/src/mock.rs
@@ -170,7 +170,7 @@ impl<LocalCall> frame_system::offchain::CreateInherent<LocalCall> for Test
 where
     RuntimeCall: From<LocalCall>,
 {
-    fn create_inherent(call: Self::RuntimeCall) -> Self::Extrinsic {
+    fn create_bare(call: Self::RuntimeCall) -> Self::Extrinsic {
         UncheckedExtrinsic::new_inherent(call)
     }
 }

--- a/pallets/commitments/src/mock.rs
+++ b/pallets/commitments/src/mock.rs
@@ -94,7 +94,6 @@ impl pallet_commitments::CanCommit<u64> for TestCanCommit {
 }
 
 impl pallet_commitments::Config for Test {
-    type RuntimeEvent = RuntimeEvent;
     type Currency = Balances;
     type WeightInfo = ();
     type MaxFields = TestMaxFields;
@@ -118,7 +117,6 @@ impl pallet_commitments::GetTempoInterface for MockTempoInterface {
 }
 
 impl pallet_drand::Config for Test {
-    type RuntimeEvent = RuntimeEvent;
     type AuthorityId = test_crypto::TestAuthId;
     type Verifier = pallet_drand::verifier::QuicknetVerifier;
     type UnsignedPriority = ConstU64<{ 1 << 20 }>;

--- a/pallets/crowdloan/src/benchmarking.rs
+++ b/pallets/crowdloan/src/benchmarking.rs
@@ -16,9 +16,9 @@ const SEED: u32 = 0;
 
 use alloc::{boxed::Box, vec};
 
-fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
+fn assert_last_event<T: frame_system::pallet::Config>(generic_event: <T as frame_system::pallet::Config>::RuntimeEvent) {
     let events = frame_system::Pallet::<T>::events();
-    let system_event: <T as frame_system::Config>::RuntimeEvent = generic_event.into();
+    let system_event: <T as frame_system::pallet::Config>::RuntimeEvent = generic_event.into();
     // compare to the last event record
     let frame_system::EventRecord { event, .. } = &events[events.len() - 1];
     assert_eq!(event, &system_event);

--- a/pallets/crowdloan/src/benchmarking.rs
+++ b/pallets/crowdloan/src/benchmarking.rs
@@ -16,7 +16,9 @@ const SEED: u32 = 0;
 
 use alloc::{boxed::Box, vec};
 
-fn assert_last_event<T: frame_system::pallet::Config>(generic_event: <T as frame_system::pallet::Config>::RuntimeEvent) {
+fn assert_last_event<T: frame_system::pallet::Config>(
+    generic_event: <T as frame_system::pallet::Config>::RuntimeEvent,
+) {
     let events = frame_system::Pallet::<T>::events();
     let system_event: <T as frame_system::pallet::Config>::RuntimeEvent = generic_event.into();
     // compare to the last event record

--- a/pallets/crowdloan/src/lib.rs
+++ b/pallets/crowdloan/src/lib.rs
@@ -97,9 +97,6 @@ pub mod pallet {
     /// Configuration trait.
     #[pallet::config]
     pub trait Config: frame_system::Config {
-        /// The overarching event type.
-        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
-
         /// The overarching call type.
         type RuntimeCall: Parameter
             + Dispatchable<RuntimeOrigin = Self::RuntimeOrigin>

--- a/pallets/crowdloan/src/mock.rs
+++ b/pallets/crowdloan/src/mock.rs
@@ -119,7 +119,6 @@ impl pallet_crowdloan::Config for Test {
     type PalletId = CrowdloanPalletId;
     type Currency = Balances;
     type RuntimeCall = RuntimeCall;
-    type RuntimeEvent = RuntimeEvent;
     type WeightInfo = TestWeightInfo;
     type Preimages = Preimage;
     type MinimumDeposit = MinimumDeposit;

--- a/pallets/drand/src/lib.rs
+++ b/pallets/drand/src/lib.rs
@@ -164,8 +164,6 @@ pub mod pallet {
     {
         /// The identifier type for an offchain worker.
         type AuthorityId: AppCrypto<Self::Public, Self::Signature>;
-        /// The overarching runtime event type.
-        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
         /// something that knows how to verify beacon pulses
         type Verifier: Verifier;
         /// A configuration for base priority of unsigned transactions.

--- a/pallets/drand/src/mock.rs
+++ b/pallets/drand/src/mock.rs
@@ -71,7 +71,7 @@ impl<LocalCall> frame_system::offchain::CreateInherent<LocalCall> for Test
 where
     RuntimeCall: From<LocalCall>,
 {
-    fn create_inherent(call: RuntimeCall) -> Self::Extrinsic {
+    fn create_bare(call: RuntimeCall) -> Self::Extrinsic {
         Extrinsic::new_inherent(call)
     }
 }
@@ -98,7 +98,6 @@ parameter_types! {
 
 impl pallet_drand_bridge::Config for Test {
     type AuthorityId = crypto::TestAuthId;
-    type RuntimeEvent = RuntimeEvent;
     type Verifier = QuicknetVerifier;
     type UnsignedPriority = UnsignedPriority;
     type HttpFetchTimeout = ConstU64<1_000>;

--- a/pallets/proxy/src/benchmarking.rs
+++ b/pallets/proxy/src/benchmarking.rs
@@ -29,7 +29,7 @@ use frame::benchmarking::prelude::{
 
 const SEED: u32 = 0;
 
-fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
+fn assert_last_event<T: frame_system::pallet::Config>(generic_event: <T as frame_system::pallet::Config>::RuntimeEvent) {
     frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
 

--- a/pallets/proxy/src/benchmarking.rs
+++ b/pallets/proxy/src/benchmarking.rs
@@ -29,11 +29,13 @@ use frame::benchmarking::prelude::{
 
 const SEED: u32 = 0;
 
-fn assert_last_event<T: frame_system::pallet::Config>(generic_event: <T as frame_system::pallet::Config>::RuntimeEvent) {
+fn assert_last_event<T: frame_system::pallet::Config>(
+    generic_event: <T as frame_system::pallet::Config>::RuntimeEvent,
+) {
     frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
 
-fn assert_has_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
+fn assert_has_event<T: Config>(generic_event: <T as frame_system::pallet::Config>::RuntimeEvent) {
     frame_system::Pallet::<T>::assert_has_event(generic_event.into());
 }
 

--- a/pallets/proxy/src/lib.rs
+++ b/pallets/proxy/src/lib.rs
@@ -121,9 +121,6 @@ pub mod pallet {
     /// Configuration trait.
     #[pallet::config]
     pub trait Config: frame_system::Config {
-        /// The overarching event type.
-        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
-
         /// The overarching call type.
         type RuntimeCall: Parameter
             + Dispatchable<RuntimeOrigin = Self::RuntimeOrigin>

--- a/pallets/proxy/src/lib.rs
+++ b/pallets/proxy/src/lib.rs
@@ -774,7 +774,7 @@ pub mod pallet {
         ValueQuery,
     >;
 
-    #[pallet::view_functions_experimental]
+    #[pallet::view_functions]
     impl<T: Config> Pallet<T> {
         /// Check if a `RuntimeCall` is allowed for a given `ProxyType`.
         pub fn check_permissions(

--- a/pallets/proxy/src/lib.rs
+++ b/pallets/proxy/src/lib.rs
@@ -58,6 +58,7 @@ type AccountIdLookupOf<T> = <<T as frame_system::Config>::Lookup as StaticLookup
 #[derive(
     Encode,
     Decode,
+    DecodeWithMemTracking,
     Clone,
     Copy,
     Eq,
@@ -684,6 +685,17 @@ pub mod pallet {
             proxy_type: T::ProxyType,
             disambiguation_index: u16,
         },
+        /// A pure proxy was killed by its spawner.
+        PureKilled {
+            // The pure proxy account that was destroyed.
+            pure: T::AccountId,
+            // The account that created the pure proxy.
+            spawner: T::AccountId,
+            // The proxy type of the pure proxy that was destroyed.
+            proxy_type: T::ProxyType,
+            // The index originally passed to `create_pure` when this pure proxy was created.
+            disambiguation_index: u16,
+        },
         /// An announcement was placed to make a call in the future.
         Announced {
             real: T::AccountId,
@@ -703,17 +715,6 @@ pub mod pallet {
             delegatee: T::AccountId,
             proxy_type: T::ProxyType,
             delay: BlockNumberFor<T>,
-        },
-        /// A pure proxy was killed by its spawner.
-        PureKilled {
-            // The pure proxy account that was destroyed.
-            pure: T::AccountId,
-            // The account that created the pure proxy.
-            spawner: T::AccountId,
-            // The proxy type of the pure proxy that was destroyed.
-            proxy_type: T::ProxyType,
-            // The index originally passed to `create_pure` when this pure proxy was created.
-            disambiguation_index: u16,
         },
         /// A deposit stored for proxies or announcements was poked / updated.
         DepositPoked {

--- a/pallets/proxy/src/tests.rs
+++ b/pallets/proxy/src/tests.rs
@@ -54,7 +54,6 @@ impl pallet_balances::Config for Test {
 }
 
 impl pallet_utility::Config for Test {
-    type RuntimeEvent = RuntimeEvent;
     type RuntimeCall = RuntimeCall;
     type PalletsOrigin = OriginCaller;
     type WeightInfo = ();
@@ -121,7 +120,6 @@ parameter_types! {
 }
 
 impl Config for Test {
-    type RuntimeEvent = RuntimeEvent;
     type RuntimeCall = RuntimeCall;
     type Currency = Balances;
     type ProxyType = ProxyType;

--- a/pallets/registry/src/benchmarking.rs
+++ b/pallets/registry/src/benchmarking.rs
@@ -13,7 +13,9 @@ use sp_std::vec;
 
 use sp_runtime::traits::Bounded;
 
-fn assert_last_event<T: frame_system::pallet::Config>(generic_event: <T as frame_system::pallet::Config>::RuntimeEvent) {
+fn assert_last_event<T: frame_system::pallet::Config>(
+    generic_event: <T as frame_system::pallet::Config>::RuntimeEvent,
+) {
     frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
 

--- a/pallets/registry/src/benchmarking.rs
+++ b/pallets/registry/src/benchmarking.rs
@@ -13,7 +13,7 @@ use sp_std::vec;
 
 use sp_runtime::traits::Bounded;
 
-fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
+fn assert_last_event<T: frame_system::pallet::Config>(generic_event: <T as frame_system::pallet::Config>::RuntimeEvent) {
     frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
 

--- a/pallets/registry/src/lib.rs
+++ b/pallets/registry/src/lib.rs
@@ -35,6 +35,7 @@ pub mod pallet {
     #[pallet::config]
     pub trait Config: frame_system::Config {
         /// Currency type that will be used to place deposits on neurons
+        #[allow(deprecated)]
         type Currency: fungible::Mutate<Self::AccountId>
             + fungible::MutateHold<Self::AccountId, Reason = Self::RuntimeHoldReason>;
 

--- a/pallets/registry/src/lib.rs
+++ b/pallets/registry/src/lib.rs
@@ -34,9 +34,6 @@ pub mod pallet {
     // Configure the pallet by specifying the parameters and types on which it depends.
     #[pallet::config]
     pub trait Config: frame_system::Config {
-        /// Because this pallet emits events, it depends on the runtime's definition of an event.
-        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
-
         /// Currency type that will be used to place deposits on neurons
         type Currency: fungible::Mutate<Self::AccountId>
             + fungible::MutateHold<Self::AccountId, Reason = Self::RuntimeHoldReason>;

--- a/pallets/subtensor/Cargo.toml
+++ b/pallets/subtensor/Cargo.toml
@@ -64,7 +64,6 @@ pallet-subtensor-swap.workspace = true
 sp-version.workspace = true
 # Substrate
 sp-tracing.workspace = true
-parity-util-mem = { workspace = true, features = ["primitive-types"] }
 rand.workspace = true
 sp-core.workspace = true
 sp-std.workspace = true

--- a/pallets/subtensor/src/macros/config.rs
+++ b/pallets/subtensor/src/macros/config.rs
@@ -22,9 +22,6 @@ mod config {
             + IsType<<Self as frame_system::Config>::RuntimeCall>
             + From<frame_system::Call<Self>>;
 
-        /// Because this pallet emits events, it depends on the runtime's definition of an event.
-        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
-
         /// A sudo-able call.
         type SudoRuntimeCall: Parameter
             + UnfilteredDispatchable<RuntimeOrigin = Self::RuntimeOrigin>

--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -1070,7 +1070,9 @@ pub(crate) fn last_event() -> RuntimeEvent {
     System::events().pop().expect("RuntimeEvent expected").event
 }
 
-pub fn assert_last_event<T: frame_system::pallet::Config>(generic_event: <T as frame_system::pallet::Config>::RuntimeEvent) {
+pub fn assert_last_event<T: frame_system::pallet::Config>(
+    generic_event: <T as frame_system::pallet::Config>::RuntimeEvent,
+) {
     frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
 

--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -325,7 +325,6 @@ type TriumvirateCollective = pallet_collective::Instance1;
 impl pallet_collective::Config<TriumvirateCollective> for Test {
     type RuntimeOrigin = RuntimeOrigin;
     type Proposal = RuntimeCall;
-    type RuntimeEvent = RuntimeEvent;
     type MotionDuration = CouncilMotionDuration;
     type MaxProposals = CouncilMaxProposals;
     type MaxMembers = GetSenateMemberCount;
@@ -360,7 +359,6 @@ type SenateCollective = pallet_collective::Instance2;
 impl pallet_collective::Config<SenateCollective> for Test {
     type RuntimeOrigin = RuntimeOrigin;
     type Proposal = RuntimeCall;
-    type RuntimeEvent = RuntimeEvent;
     type MotionDuration = CouncilMotionDuration;
     type MaxProposals = CouncilMaxProposals;
     type MaxMembers = SenateMaxMembers;
@@ -389,7 +387,6 @@ impl pallet_membership::Config<SenateMembership> for Test {
 }
 
 impl crate::Config for Test {
-    type RuntimeEvent = RuntimeEvent;
     type RuntimeCall = RuntimeCall;
     type Currency = Balances;
     type InitialIssuance = InitialIssuance;
@@ -478,7 +475,6 @@ parameter_types! {
 }
 
 impl pallet_subtensor_swap::Config for Test {
-    type RuntimeEvent = RuntimeEvent;
     type SubnetInfo = SubtensorModule;
     type BalanceOps = SubtensorModule;
     type ProtocolId = SwapProtocolId;
@@ -524,7 +520,6 @@ impl pallet_scheduler::Config for Test {
 }
 
 impl pallet_utility::Config for Test {
-    type RuntimeEvent = RuntimeEvent;
     type RuntimeCall = RuntimeCall;
     type PalletsOrigin = OriginCaller;
     type WeightInfo = pallet_utility::weights::SubstrateWeight<Test>;
@@ -583,7 +578,6 @@ impl pallet_crowdloan::Config for Test {
     type PalletId = CrowdloanPalletId;
     type Currency = Balances;
     type RuntimeCall = RuntimeCall;
-    type RuntimeEvent = RuntimeEvent;
     type WeightInfo = pallet_crowdloan::weights::SubstrateWeight<Test>;
     type Preimages = Preimage;
     type MinimumDeposit = MinimumDeposit;
@@ -629,7 +623,6 @@ mod test_crypto {
 pub type TestAuthId = test_crypto::TestAuthId;
 
 impl pallet_drand::Config for Test {
-    type RuntimeEvent = RuntimeEvent;
     type AuthorityId = TestAuthId;
     type Verifier = pallet_drand::verifier::QuicknetVerifier;
     type UnsignedPriority = ConstU64<{ 1 << 20 }>;
@@ -1077,7 +1070,7 @@ pub(crate) fn last_event() -> RuntimeEvent {
     System::events().pop().expect("RuntimeEvent expected").event
 }
 
-pub fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
+pub fn assert_last_event<T: frame_system::pallet::Config>(generic_event: <T as frame_system::pallet::Config>::RuntimeEvent) {
     frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
 

--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -648,7 +648,7 @@ impl<LocalCall> frame_system::offchain::CreateInherent<LocalCall> for Test
 where
     RuntimeCall: From<LocalCall>,
 {
-    fn create_inherent(call: Self::RuntimeCall) -> Self::Extrinsic {
+    fn create_bare(call: Self::RuntimeCall) -> Self::Extrinsic {
         UncheckedExtrinsic::new_inherent(call)
     }
 }

--- a/pallets/swap/src/mock.rs
+++ b/pallets/swap/src/mock.rs
@@ -205,7 +205,6 @@ impl BalanceOps<AccountId> for MockBalanceOps {
 }
 
 impl crate::pallet::Config for Test {
-    type RuntimeEvent = RuntimeEvent;
     type SubnetInfo = MockLiquidityProvider;
     type BalanceOps = MockBalanceOps;
     type ProtocolId = SwapProtocolId;

--- a/pallets/swap/src/pallet/mod.rs
+++ b/pallets/swap/src/pallet/mod.rs
@@ -32,9 +32,6 @@ mod pallet {
     /// Configure the pallet by specifying the parameters and types on which it depends.
     #[pallet::config]
     pub trait Config: frame_system::Config {
-        /// Because this pallet emits events, it depends on the runtime's definition of an event.
-        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
-
         /// Implementor of
         /// [`SubnetInfo`](subtensor_swap_interface::SubnetInfo).
         type SubnetInfo: SubnetInfo<Self::AccountId>;

--- a/pallets/transaction-fee/src/tests/mock.rs
+++ b/pallets/transaction-fee/src/tests/mock.rs
@@ -221,7 +221,6 @@ parameter_types! {
 }
 
 impl pallet_subtensor::Config for Test {
-    type RuntimeEvent = RuntimeEvent;
     type RuntimeCall = RuntimeCall;
     type Currency = Balances;
     type InitialIssuance = InitialIssuance;
@@ -328,7 +327,6 @@ impl pallet_crowdloan::Config for Test {
     type PalletId = CrowdloanPalletId;
     type Currency = Balances;
     type RuntimeCall = RuntimeCall;
-    type RuntimeEvent = RuntimeEvent;
     type WeightInfo = pallet_crowdloan::weights::SubstrateWeight<Test>;
     type Preimages = Preimage;
     type MinimumDeposit = MinimumDeposit;
@@ -405,7 +403,6 @@ parameter_types! {
 }
 
 impl pallet_subtensor_swap::Config for Test {
-    type RuntimeEvent = RuntimeEvent;
     type SubnetInfo = SubtensorModule;
     type BalanceOps = SubtensorModule;
     type ProtocolId = SwapProtocolId;
@@ -451,8 +448,7 @@ impl pallet_scheduler::Config for Test {
 }
 
 impl pallet_evm_chain_id::Config for Test {}
-impl pallet_drand::Config for Test {
-    type RuntimeEvent = RuntimeEvent;
+impl pallet_ RuntimeEvent = RuntimeEvent;
     type AuthorityId = TestAuthId;
     type Verifier = pallet_drand::verifier::QuicknetVerifier;
     type UnsignedPriority = ConstU64<{ 1 << 20 }>;
@@ -508,7 +504,7 @@ impl<LocalCall> frame_system::offchain::CreateInherent<LocalCall> for Test
 where
     RuntimeCall: From<LocalCall>,
 {
-    fn create_inherent(call: Self::RuntimeCall) -> Self::Extrinsic {
+    fn create_bare(call: Self::RuntimeCall) -> Self::Extrinsic {
         UncheckedExtrinsic::new_inherent(call)
     }
 }

--- a/pallets/transaction-fee/src/tests/mock.rs
+++ b/pallets/transaction-fee/src/tests/mock.rs
@@ -448,7 +448,7 @@ impl pallet_scheduler::Config for Test {
 }
 
 impl pallet_evm_chain_id::Config for Test {}
-impl pallet_ RuntimeEvent = RuntimeEvent;
+impl pallet_drand::Config for Test {
     type AuthorityId = TestAuthId;
     type Verifier = pallet_drand::verifier::QuicknetVerifier;
     type UnsignedPriority = ConstU64<{ 1 << 20 }>;

--- a/pallets/utility/src/benchmarking.rs
+++ b/pallets/utility/src/benchmarking.rs
@@ -27,7 +27,9 @@ use crate::*;
 
 const SEED: u32 = 0;
 
-fn assert_last_event<T: frame_system::pallet::Config>(generic_event: <T as frame_system::pallet::Config>::RuntimeEvent) {
+fn assert_last_event<T: frame_system::pallet::Config>(
+    generic_event: <T as frame_system::pallet::Config>::RuntimeEvent,
+) {
     frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
 

--- a/pallets/utility/src/benchmarking.rs
+++ b/pallets/utility/src/benchmarking.rs
@@ -27,7 +27,7 @@ use crate::*;
 
 const SEED: u32 = 0;
 
-fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
+fn assert_last_event<T: frame_system::pallet::Config>(generic_event: <T as frame_system::pallet::Config>::RuntimeEvent) {
     frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
 

--- a/pallets/utility/src/lib.rs
+++ b/pallets/utility/src/lib.rs
@@ -88,9 +88,6 @@ pub mod pallet {
     /// Configuration trait.
     #[pallet::config]
     pub trait Config: frame_system::Config {
-        /// The overarching event type.
-        type RuntimeEvent: From<Event> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
-
         /// The overarching call type.
         type RuntimeCall: Parameter
             + Dispatchable<RuntimeOrigin = Self::RuntimeOrigin, PostInfo = PostDispatchInfo>

--- a/pallets/utility/src/tests.rs
+++ b/pallets/utility/src/tests.rs
@@ -101,8 +101,6 @@ mod mock_democracy {
 
         #[pallet::config]
         pub trait Config: frame_system::Config + Sized {
-            type RuntimeEvent: From<Event<Self>>
-                + IsType<<Self as frame_system::Config>::RuntimeEvent>;
             type ExternalMajorityOrigin: EnsureOrigin<Self::RuntimeOrigin>;
         }
 
@@ -205,7 +203,6 @@ type CouncilCollective = pallet_collective::Instance1;
 impl pallet_collective::Config<CouncilCollective> for Test {
     type RuntimeOrigin = RuntimeOrigin;
     type Proposal = RuntimeCall;
-    type RuntimeEvent = RuntimeEvent;
     type MotionDuration = MotionDuration;
     type MaxProposals = MaxProposals;
     type MaxMembers = MaxMembers;
@@ -237,11 +234,9 @@ impl Contains<RuntimeCall> for TestBaseCallFilter {
     }
 }
 impl mock_democracy::Config for Test {
-    type RuntimeEvent = RuntimeEvent;
     type ExternalMajorityOrigin = EnsureProportionAtLeast<u64, Instance1, 3, 4>;
 }
 impl Config for Test {
-    type RuntimeEvent = RuntimeEvent;
     type RuntimeCall = RuntimeCall;
     type PalletsOrigin = OriginCaller;
     type WeightInfo = ();

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -148,6 +148,8 @@ ark-serialize = { workspace = true, features = ["derive"] }
 # Crowdloan
 pallet-crowdloan.workspace = true
 
+ethereum.workspace = true
+
 [dev-dependencies]
 frame-metadata.workspace = true
 sp-io.workspace = true
@@ -267,6 +269,7 @@ std = [
 	"pallet-subtensor-swap/std",
 	"pallet-subtensor-swap-runtime-api/std",
 	"subtensor-swap-interface/std",
+	"ethereum/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -68,6 +68,7 @@ use sp_version::RuntimeVersion;
 use subtensor_precompiles::Precompiles;
 use subtensor_runtime_common::{AlphaCurrency, TaoCurrency, time::*, *};
 use subtensor_swap_interface::{OrderType, SwapHandler};
+use ethereum::AuthorizationList;
 
 // A few exports that help ease life for downstream crates.
 pub use frame_support::{
@@ -2012,6 +2013,7 @@ impl_runtime_apis! {
             nonce: Option<U256>,
             estimate: bool,
             access_list: Option<Vec<(H160, Vec<H256>)>>,
+            authorization_list: Option<AuthorizationList>,
         ) -> Result<pallet_evm::CallInfo, sp_runtime::DispatchError> {
             use pallet_evm::GasWeightMapping as _;
 
@@ -2073,6 +2075,7 @@ impl_runtime_apis! {
                 max_priority_fee_per_gas,
                 nonce,
                 access_list.unwrap_or_default(),
+                authorization_list.unwrap_or_default(),
                 false,
                 true,
                 weight_limit,
@@ -2091,6 +2094,7 @@ impl_runtime_apis! {
             nonce: Option<U256>,
             estimate: bool,
             access_list: Option<Vec<(H160, Vec<H256>)>>,
+            authorization_list: Option<AuthorizationList>,
         ) -> Result<pallet_evm::CreateInfo, sp_runtime::DispatchError> {
             use pallet_evm::GasWeightMapping as _;
 
@@ -2155,6 +2159,7 @@ impl_runtime_apis! {
                 access_list.unwrap_or_default(),
                 whitelist,
                 whitelist_disabled,
+                authorization_list.unwrap_or_default(),
                 false,
                 true,
                 weight_limit,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -126,8 +126,8 @@ where
     type RuntimeCall = RuntimeCall;
 }
 
-impl frame_system::offchain::CreateInherent<pallet_drand::Call<Runtime>> for Runtime {
-    fn create_inherent(call: Self::RuntimeCall) -> Self::Extrinsic {
+impl frame_system::offchain::CreateBare<pallet_drand::Call<Runtime>> for Runtime {
+    fn create_bare(call: Self::RuntimeCall) -> Self::Extrinsic {
         UncheckedExtrinsic::new_bare(call)
     }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -107,7 +107,6 @@ use pallet_evm::{
 
 // Drand
 impl pallet_drand::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
     type AuthorityId = pallet_drand::crypto::TestAuthId;
     type Verifier = pallet_drand::verifier::QuicknetVerifier;
     type UnsignedPriority = ConstU64<{ 1 << 20 }>;
@@ -395,7 +394,6 @@ impl pallet_timestamp::Config for Runtime {
 }
 
 impl pallet_utility::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
     type RuntimeCall = RuntimeCall;
     type PalletsOrigin = OriginCaller;
     type WeightInfo = pallet_utility::weights::SubstrateWeight<Runtime>;
@@ -590,7 +588,6 @@ type TriumvirateCollective = pallet_collective::Instance1;
 impl pallet_collective::Config<TriumvirateCollective> for Runtime {
     type RuntimeOrigin = RuntimeOrigin;
     type Proposal = RuntimeCall;
-    type RuntimeEvent = RuntimeEvent;
     type MotionDuration = CouncilMotionDuration;
     type MaxProposals = CouncilMaxProposals;
     type MaxMembers = GetSenateMemberCount;
@@ -902,7 +899,6 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 }
 
 impl pallet_proxy::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
     type RuntimeCall = RuntimeCall;
     type Currency = Balances;
     type ProxyType = ProxyType;
@@ -1050,7 +1046,6 @@ parameter_types! {
 }
 
 impl pallet_registry::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
     type RuntimeHoldReason = RuntimeHoldReason;
     type Currency = Balances;
     type CanRegister = AllowIdentityReg;
@@ -1114,7 +1109,6 @@ impl GetCommitments<AccountId> for GetCommitmentsStruct {
 }
 
 impl pallet_commitments::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
     type Currency = Balances;
     type WeightInfo = pallet_commitments::weights::SubstrateWeight<Runtime>;
 
@@ -1219,7 +1213,6 @@ parameter_types! {
 }
 
 impl pallet_subtensor::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
     type RuntimeCall = RuntimeCall;
     type SudoRuntimeCall = RuntimeCall;
     type Currency = Balances;
@@ -1308,7 +1301,6 @@ parameter_types! {
 }
 
 impl pallet_subtensor_swap::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
     type SubnetInfo = SubtensorModule;
     type BalanceOps = SubtensorModule;
     type ProtocolId = SwapProtocolId;
@@ -1342,7 +1334,6 @@ impl pallet_admin_utils::GrandpaInterface<Runtime> for GrandpaInterfaceImpl {
 }
 
 impl pallet_admin_utils::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
     type AuthorityId = AuraId;
     type MaxAuthorities = ConstU32<32>;
     type Aura = AuraPalletIntrf;
@@ -1462,7 +1453,6 @@ impl pallet_evm::Config for Runtime {
     type WithdrawOrigin = pallet_evm::EnsureAddressTruncated;
     type AddressMapping = pallet_evm::HashedAddressMapping<BlakeTwo256>;
     type Currency = Balances;
-    type RuntimeEvent = RuntimeEvent;
     type PrecompilesType = Precompiles<Self>;
     type PrecompilesValue = PrecompilesValue;
     type ChainId = ConfigurableChainId;
@@ -1493,7 +1483,6 @@ impl sp_core::Get<sp_version::RuntimeVersion> for Runtime {
 }
 
 impl pallet_ethereum::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
     type StateRoot = pallet_ethereum::IntermediateStateRoot<Self>;
     type PostLogContent = PostBlockAndTxnHashes;
     type ExtraDataLength = ConstU32<30>;
@@ -1520,7 +1509,6 @@ impl pallet_base_fee::BaseFeeThreshold for BaseFeeThreshold {
     }
 }
 impl pallet_base_fee::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
     type Threshold = BaseFeeThreshold;
     type DefaultBaseFeePerGas = DefaultBaseFeePerGas;
     type DefaultElasticity = DefaultElasticity;
@@ -1622,7 +1610,6 @@ parameter_types! {
 
 impl pallet_crowdloan::Config for Runtime {
     type PalletId = CrowdloanPalletId;
-    type RuntimeEvent = RuntimeEvent;
     type RuntimeCall = RuntimeCall;
     type Currency = Balances;
     type WeightInfo = pallet_crowdloan::weights::SubstrateWeight<Runtime>;
@@ -1863,7 +1850,7 @@ impl_runtime_apis! {
         ) -> TransactionValidity {
             use codec::DecodeLimit;
             use frame_support::pallet_prelude::{InvalidTransaction, TransactionValidityError};
-            use frame_support::traits::ExtrinsicCall;
+            use sp_runtime::traits::ExtrinsicCall;
             let encoded = tx.call().encode();
             if RuntimeCall::decode_all_with_depth_limit(8, &mut encoded.as_slice()).is_err() {
                 log::warn!("failed to decode with depth limit of 8");

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -17,6 +17,7 @@ pub mod transaction_payment_wrapper;
 extern crate alloc;
 
 use codec::{Compact, Decode, Encode};
+use ethereum::AuthorizationList;
 use frame_support::{
     PalletId,
     dispatch::{DispatchResult, DispatchResultWithPostInfo},
@@ -68,7 +69,6 @@ use sp_version::RuntimeVersion;
 use subtensor_precompiles::Precompiles;
 use subtensor_runtime_common::{AlphaCurrency, TaoCurrency, time::*, *};
 use subtensor_swap_interface::{OrderType, SwapHandler};
-use ethereum::AuthorizationList;
 
 // A few exports that help ease life for downstream crates.
 pub use frame_support::{


### PR DESCRIPTION
This PR introduces the update from the Polkadot SDK version stable2503-6 to the stable2506-2 OTF fork.

- Bump substrate dependencies versions

- Remove unused RuntimeEvent when needed (now automatically injected)

- Update cargo audit ignore file

- Fix type issues/tests
