### PR TITLE
Allow crowdloan finalize/refund before end

### DIFF
--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -731,7 +731,7 @@ pub mod pallet {
         /// It is only callable by the root account.
         /// The extrinsic will call the Subtensor pallet to set the target registrations per interval.
         #[pallet::call_index(21)]
-        #[pallet::weight(Weight::from_parts(44_320_000, 0)
+        #[pallet::weight(Weight::from_parts(25_980_000, 0)
         .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(3_u64))
         .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1_u64)))]
         pub fn sudo_set_target_registrations_per_interval(

--- a/pallets/crowdloan/src/lib.rs
+++ b/pallets/crowdloan/src/lib.rs
@@ -565,14 +565,12 @@ pub mod pallet {
             #[pallet::compact] crowdloan_id: CrowdloanId,
         ) -> DispatchResult {
             let who = ensure_signed(origin)?;
-            let now = frame_system::Pallet::<T>::block_number();
 
             let mut crowdloan = Self::ensure_crowdloan_exists(crowdloan_id)?;
 
-            // Ensure the origin is the creator of the crowdloan and the crowdloan has ended,
-            // raised the cap and is not finalized.
+            // Ensure the origin is the creator of the crowdloan and the crowdloan has raised the cap
+            // and is not finalized.
             ensure!(who == crowdloan.creator, Error::<T>::InvalidOrigin);
-            ensure!(now >= crowdloan.end, Error::<T>::ContributionPeriodNotEnded);
             ensure!(crowdloan.raised == crowdloan.cap, Error::<T>::CapNotRaised);
             ensure!(!crowdloan.finalized, Error::<T>::AlreadyFinalized);
 

--- a/pallets/crowdloan/src/lib.rs
+++ b/pallets/crowdloan/src/lib.rs
@@ -547,7 +547,7 @@ pub mod pallet {
             Ok(())
         }
 
-        /// Finalize a successful crowdloan.
+        /// Finalize crowdloan that has reached the cap.
         ///
         /// The call will transfer the raised amount to the target address if it was provided when the crowdloan was created
         /// and dispatch the call that was provided using the creator origin. The CurrentCrowdloanId will be set to the
@@ -619,7 +619,7 @@ pub mod pallet {
             Ok(())
         }
 
-        /// Refund a failed crowdloan.
+        /// Refund a crowdloan that has not reached the cap and has ended.
         ///
         /// The call will try to refund all contributors (excluding the creator) up to the limit defined by the `RefundContributorsLimit`.
         /// If the limit is reached, the call will stop and the crowdloan will be marked as partially refunded.
@@ -635,13 +635,11 @@ pub mod pallet {
             origin: OriginFor<T>,
             #[pallet::compact] crowdloan_id: CrowdloanId,
         ) -> DispatchResultWithPostInfo {
-            let now = frame_system::Pallet::<T>::block_number();
             ensure_signed(origin)?;
 
             let mut crowdloan = Self::ensure_crowdloan_exists(crowdloan_id)?;
 
-            // Ensure the crowdloan has ended and is not finalized
-            ensure!(now >= crowdloan.end, Error::<T>::ContributionPeriodNotEnded);
+            // Ensure the crowdloan is not finalized
             ensure!(!crowdloan.finalized, Error::<T>::AlreadyFinalized);
 
             let mut refunded_contributors: Vec<T::AccountId> = vec![];

--- a/pallets/crowdloan/src/lib.rs
+++ b/pallets/crowdloan/src/lib.rs
@@ -619,7 +619,7 @@ pub mod pallet {
             Ok(())
         }
 
-        /// Refund a crowdloan that has not reached the cap and has ended.
+        /// Refund contributors of a non-finalized crowdloan.
         ///
         /// The call will try to refund all contributors (excluding the creator) up to the limit defined by the `RefundContributorsLimit`.
         /// If the limit is reached, the call will stop and the crowdloan will be marked as partially refunded.

--- a/pallets/crowdloan/src/tests.rs
+++ b/pallets/crowdloan/src/tests.rs
@@ -1147,9 +1147,6 @@ fn test_finalize_succeeds() {
                 amount
             ));
 
-            // run some more blocks past the end of the contribution period
-            run_to_block(60);
-
             // finalize the crowdloan
             assert_ok!(Crowdloan::finalize(
                 RuntimeOrigin::signed(creator),
@@ -1336,54 +1333,6 @@ fn test_finalize_fails_if_not_creator_origin() {
             assert_err!(
                 Crowdloan::finalize(RuntimeOrigin::signed(contributor), crowdloan_id),
                 pallet_crowdloan::Error::<Test>::InvalidOrigin
-            );
-        });
-}
-
-#[test]
-fn test_finalize_fails_if_crowdloan_has_not_ended() {
-    TestState::default()
-        .with_balance(U256::from(1), 100)
-        .with_balance(U256::from(2), 100)
-        .build_and_execute(|| {
-            // create a crowdloan
-            let creator: AccountOf<Test> = U256::from(1);
-            let deposit: BalanceOf<Test> = 50;
-            let min_contribution: BalanceOf<Test> = 10;
-            let cap: BalanceOf<Test> = 100;
-            let end: BlockNumberFor<Test> = 50;
-
-            assert_ok!(Crowdloan::create(
-                RuntimeOrigin::signed(creator),
-                deposit,
-                min_contribution,
-                cap,
-                end,
-                Some(noop_call()),
-                None,
-            ));
-
-            // run some blocks
-            run_to_block(10);
-
-            // some contribution
-            let crowdloan_id: CrowdloanId = 0;
-            let contributor: AccountOf<Test> = U256::from(2);
-            let amount: BalanceOf<Test> = 50;
-
-            assert_ok!(Crowdloan::contribute(
-                RuntimeOrigin::signed(contributor),
-                crowdloan_id,
-                amount
-            ));
-
-            // run some more blocks before end of contribution period
-            run_to_block(10);
-
-            // try to finalize
-            assert_err!(
-                Crowdloan::finalize(RuntimeOrigin::signed(creator), crowdloan_id),
-                pallet_crowdloan::Error::<Test>::ContributionPeriodNotEnded
             );
         });
 }

--- a/pallets/crowdloan/src/tests.rs
+++ b/pallets/crowdloan/src/tests.rs
@@ -1534,8 +1534,8 @@ fn test_refund_succeeds() {
                     .is_some_and(|c| c.contributors_count == 7)
             );
 
-            // run some more blocks past the end of the contribution period
-            run_to_block(60);
+            // run some more blocks before the end of the contribution period
+            run_to_block(20);
 
             //  first round of refund
             assert_ok!(Crowdloan::refund(
@@ -1563,7 +1563,7 @@ fn test_refund_succeeds() {
                 pallet_crowdloan::Event::<Test>::PartiallyRefunded { crowdloan_id }.into()
             );
 
-            // run some more blocks
+            // run some more blocks past the end of the contribution period
             run_to_block(70);
 
             //  second round of refund
@@ -1645,39 +1645,6 @@ fn test_refund_fails_if_crowdloan_does_not_exist() {
             assert_err!(
                 Crowdloan::refund(RuntimeOrigin::signed(creator), crowdloan_id),
                 pallet_crowdloan::Error::<Test>::InvalidCrowdloanId
-            );
-        });
-}
-
-#[test]
-fn test_refund_fails_if_crowdloan_has_not_ended() {
-    TestState::default()
-        .with_balance(U256::from(1), 100)
-        .build_and_execute(|| {
-            // create a crowdloan
-            let creator: AccountOf<Test> = U256::from(1);
-            let initial_deposit: BalanceOf<Test> = 50;
-            let min_contribution: BalanceOf<Test> = 10;
-            let cap: BalanceOf<Test> = 300;
-            let end: BlockNumberFor<Test> = 50;
-            assert_ok!(Crowdloan::create(
-                RuntimeOrigin::signed(creator),
-                initial_deposit,
-                min_contribution,
-                cap,
-                end,
-                Some(noop_call()),
-                None,
-            ));
-
-            // run some blocks
-            run_to_block(10);
-
-            // try to refund
-            let crowdloan_id: CrowdloanId = 0;
-            assert_err!(
-                Crowdloan::refund(RuntimeOrigin::signed(creator), crowdloan_id),
-                pallet_crowdloan::Error::<Test>::ContributionPeriodNotEnded
             );
         });
 }

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -1058,7 +1058,7 @@ mod dispatches {
         /// The extrinsic for user to change its hotkey in subnet or all subnets.
         #[pallet::call_index(70)]
         #[pallet::weight((Weight::from_parts(275_300_000, 0)
-        .saturating_add(T::DbWeight::get().reads(47))
+        .saturating_add(T::DbWeight::get().reads(49_u64))
         .saturating_add(T::DbWeight::get().writes(37)), DispatchClass::Normal, Pays::No))]
         pub fn swap_hotkey(
             origin: OriginFor<T>,
@@ -2293,8 +2293,8 @@ mod dispatches {
         ///     - The hotkey account to designate as the autostake destination.
         #[pallet::call_index(114)]
         #[pallet::weight((Weight::from_parts(29_930_000, 0)
-		.saturating_add(T::DbWeight::get().reads(3_u64))
-		.saturating_add(T::DbWeight::get().writes(1)), DispatchClass::Normal, Pays::No))]
+		.saturating_add(T::DbWeight::get().reads(4_u64))
+		.saturating_add(T::DbWeight::get().writes(2_u64)), DispatchClass::Normal, Pays::No))]
         pub fn set_coldkey_auto_stake_hotkey(
             origin: T::RuntimeOrigin,
             netuid: NetUid,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -223,7 +223,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 326,
+    spec_version: 328,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION

- Allow to finalize a crowdloan if the cap is reached, even before end.
- Allow to refund the contributors before the crowdloan has ended
