### PR TITLE
fix utility::force_batch weight mismatch

### DIFF
--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -1060,7 +1060,7 @@ mod dispatches {
         /// The extrinsic for user to change its hotkey in subnet or all subnets.
         #[pallet::call_index(70)]
         #[pallet::weight((Weight::from_parts(275_300_000, 0)
-        .saturating_add(T::DbWeight::get().reads(49_u64))
+        .saturating_add(T::DbWeight::get().reads(53_u64))
         .saturating_add(T::DbWeight::get().writes(37)), DispatchClass::Normal, Pays::No))]
         pub fn swap_hotkey(
             origin: OriginFor<T>,
@@ -1134,7 +1134,7 @@ mod dispatches {
         ///
         #[pallet::call_index(75)]
         #[pallet::weight((
-            Weight::from_parts(45_360_000, 0)
+            Weight::from_parts(66_450_000, 0)
             .saturating_add(T::DbWeight::get().reads(5))
             .saturating_add(T::DbWeight::get().writes(2)),
             DispatchClass::Normal,

--- a/pallets/utility/src/lib.rs
+++ b/pallets/utility/src/lib.rs
@@ -448,7 +448,7 @@ pub mod pallet {
             } else {
                 Self::deposit_event(Event::BatchCompleted);
             }
-            let base_weight = T::WeightInfo::batch(calls_len as u32);
+            let base_weight = T::WeightInfo::force_batch(calls_len as u32);
             Ok(Some(base_weight.saturating_add(weight)).into())
         }
 


### PR DESCRIPTION
# Description

The returned weights from the `pallet_utility::force_batch` dispatch is using `batch` weights instead of its own `force_batch` causing a weight mismatch log:

```
2025-10-03 14:57:48 Post dispatch weight is greater than pre dispatch weight. Pre dispatch weight may underestimating the actual weight. Greater post dispatch weight components are ignored.
                                        Pre dispatch weight: Weight { ref_time: 5963137729, proof_size: 3997 },
                                        Post dispatch weight: Weight { ref_time: 5963148560, proof_size: 3997 }    
2025-10-03 14:59:00 Post dispatch weight is greater than pre dispatch weight. Pre dispatch weight may underestimating the actual weight. Greater post dispatch weight components are ignored.
                                        Pre dispatch weight: Weight { ref_time: 2837593294, proof_size: 8703 },
                                        Post dispatch weight: Weight { ref_time: 2837604125, proof_size: 8703 }   
``` 

This PR correct the returned weights.

Also created a PR upstream paritytech/polkadot-sdk#9983