### PR TITLE
Add linter rule to flag expect. Remove expects/allow exceptions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ edition = "2024"
 
 [workspace.lints.clippy]
 arithmetic-side-effects = "deny"
+expect-used = "deny"
 indexing-slicing = "deny"
 manual_inspect = "allow"
 result_large_err = "allow"

--- a/node/src/benchmarking.rs
+++ b/node/src/benchmarking.rs
@@ -105,6 +105,7 @@ impl frame_benchmarking_cli::ExtrinsicBuilder for TransferKeepAliveBuilder {
 // Create a transaction using the given `call`.
 //
 // Note: Should only be used for benchmarking.
+#[allow(clippy::expect_used)]
 pub fn create_benchmark_extrinsic(
     client: &FullClient,
     sender: sp_core::sr25519::Pair,

--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -1,5 +1,5 @@
 // Allowed since it's actually better to panic during chain setup when there is an error
-#![allow(clippy::unwrap_used)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 
 pub mod devnet;
 pub mod finney;

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -245,6 +245,7 @@ pub fn run() -> sc_cli::Result<()> {
     }
 }
 
+#[allow(clippy::expect_used)]
 fn start_babe_service(arg_matches: &ArgMatches) -> Result<(), sc_cli::Error> {
     let cli = Cli::from_arg_matches(arg_matches).expect("Bad arg_matches");
     let runner = cli.create_runner(&cli.run)?;
@@ -281,6 +282,7 @@ fn start_babe_service(arg_matches: &ArgMatches) -> Result<(), sc_cli::Error> {
     }
 }
 
+#[allow(clippy::expect_used)]
 fn start_aura_service(arg_matches: &ArgMatches) -> Result<(), sc_cli::Error> {
     let cli = Cli::from_arg_matches(arg_matches).expect("Bad arg_matches");
     let runner = cli.create_runner(&cli.run)?;
@@ -313,6 +315,7 @@ fn start_aura_service(arg_matches: &ArgMatches) -> Result<(), sc_cli::Error> {
     }
 }
 
+#[allow(clippy::expect_used)]
 fn customise_config(arg_matches: &ArgMatches, config: Configuration) -> Configuration {
     let cli = Cli::from_arg_matches(arg_matches).expect("Bad arg_matches");
 

--- a/node/src/consensus/babe_consensus.rs
+++ b/node/src/consensus/babe_consensus.rs
@@ -44,6 +44,7 @@ impl ConsensusMechanism for BabeConsensus {
         sp_timestamp::InherentDataProvider,
     );
 
+    #[allow(clippy::expect_used)]
     fn start_authoring<C, SC, I, PF, SO, L, CIDP, BS, Error>(
         self,
         task_manager: &mut TaskManager,

--- a/node/src/consensus/hybrid_import_queue.rs
+++ b/node/src/consensus/hybrid_import_queue.rs
@@ -77,6 +77,7 @@ impl HybridBlockImport {
             FrontierBlockImport::new(grandpa_block_import.clone(), client.clone()),
         );
 
+        #[allow(clippy::expect_used)]
         let (babe_import, babe_link) = sc_consensus_babe::block_import(
             babe_config,
             grandpa_block_import.clone(),

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -60,6 +60,7 @@ pub type BIQ<'a> = Box<
         + 'a,
 >;
 
+#[allow(clippy::expect_used)]
 pub fn new_partial(
     config: &Configuration,
     eth_config: &EthConfiguration,
@@ -250,6 +251,7 @@ pub fn build_manual_seal_import_queue(
 }
 
 /// Builds a new service for a full client.
+#[allow(clippy::expect_used)]
 pub async fn new_full<NB, CM>(
     mut config: Configuration,
     eth_config: EthConfiguration,

--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -18,6 +18,7 @@ mod tests;
 
 #[deny(missing_docs)]
 #[frame_support::pallet]
+#[allow(clippy::expect_used)]
 pub mod pallet {
     use super::*;
     use frame_support::pallet_prelude::*;
@@ -162,6 +163,8 @@ pub mod pallet {
     /// Dispatchable functions allows users to interact with the pallet and invoke state changes.
     #[pallet::call]
     impl<T: Config> Pallet<T> {
+        #![deny(clippy::expect_used)]
+
         /// The extrinsic sets the new authorities for Aura consensus.
         /// It is only callable by the root account.
         /// The extrinsic will call the Aura pallet to change the authorities.

--- a/pallets/collective/src/benchmarking.rs
+++ b/pallets/collective/src/benchmarking.rs
@@ -16,7 +16,11 @@
 // limitations under the License.
 
 //! Staking pallet benchmarking.
-#![allow(clippy::arithmetic_side_effects, clippy::indexing_slicing)]
+#![allow(
+    clippy::arithmetic_side_effects,
+    clippy::expect_used,
+    clippy::indexing_slicing
+)]
 
 use super::*;
 use crate::Pallet as Collective;

--- a/pallets/collective/src/lib.rs
+++ b/pallets/collective/src/lib.rs
@@ -179,6 +179,7 @@ pub struct Votes<AccountId, BlockNumber> {
 
 #[deny(missing_docs)]
 #[frame_support::pallet]
+#[allow(clippy::expect_used)]
 pub mod pallet {
     use super::*;
     use frame_system::pallet_prelude::*;
@@ -397,6 +398,8 @@ pub mod pallet {
     // Note that councillor operations are assigned to the operational class.
     #[pallet::call]
     impl<T: Config<I>, I: 'static> Pallet<T, I> {
+        #![deny(clippy::expect_used)]
+
         /// Set the collective's membership.
         ///
         /// - `new_members`: The new member list. Be nice to the chain and provide it sorted.

--- a/pallets/collective/src/lib.rs
+++ b/pallets/collective/src/lib.rs
@@ -1131,6 +1131,7 @@ impl<
     }
 
     #[cfg(feature = "runtime-benchmarks")]
+    #[allow(clippy::expect_used)]
     fn try_successful_origin() -> Result<O, ()> {
         let zero_account_id =
             AccountId::decode(&mut sp_runtime::traits::TrailingZeroInput::zeroes())

--- a/pallets/collective/src/tests.rs
+++ b/pallets/collective/src/tests.rs
@@ -15,7 +15,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(non_camel_case_types, clippy::indexing_slicing, clippy::unwrap_used)]
+#![allow(
+    non_camel_case_types,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::unwrap_used
+)]
 
 use super::{Event as CollectiveEvent, *};
 use crate as pallet_collective;

--- a/pallets/commitments/src/benchmarking.rs
+++ b/pallets/commitments/src/benchmarking.rs
@@ -1,6 +1,6 @@
 //! Benchmarking setup
 #![cfg(feature = "runtime-benchmarks")]
-#![allow(clippy::arithmetic_side_effects)]
+#![allow(clippy::arithmetic_side_effects, clippy::expect_used)]
 use super::*;
 
 #[allow(unused)]

--- a/pallets/commitments/src/lib.rs
+++ b/pallets/commitments/src/lib.rs
@@ -37,6 +37,7 @@ type BalanceOf<T> =
     <<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 #[deny(missing_docs)]
 #[frame_support::pallet]
+#[allow(clippy::expect_used)]
 pub mod pallet {
     use super::*;
     use frame_support::{pallet_prelude::*, traits::ReservableCurrency};
@@ -204,6 +205,8 @@ pub mod pallet {
 
     #[pallet::call]
     impl<T: Config> Pallet<T> {
+        #![deny(clippy::expect_used)]
+
         /// Set the commitment for a given netuid
         #[pallet::call_index(0)]
         #[pallet::weight((

--- a/pallets/commitments/src/mock.rs
+++ b/pallets/commitments/src/mock.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::expect_used)]
 use crate as pallet_commitments;
 use frame_support::{
     derive_impl,

--- a/pallets/commitments/src/tests.rs
+++ b/pallets/commitments/src/tests.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::expect_used, clippy::indexing_slicing)]
+
 use codec::Encode;
 use sp_std::prelude::*;
 use subtensor_runtime_common::NetUid;
@@ -19,7 +21,6 @@ use frame_support::{
 };
 use frame_system::{Pallet as System, RawOrigin};
 
-#[allow(clippy::indexing_slicing)]
 #[test]
 fn manual_data_type_info() {
     let mut registry = scale_info::Registry::new();

--- a/pallets/commitments/src/types.rs
+++ b/pallets/commitments/src/types.rs
@@ -100,7 +100,7 @@ impl Decode for Data {
             n @ 1..=129 => {
                 let mut r: BoundedVec<_, _> = vec![0u8; (n as usize).saturating_sub(1)]
                     .try_into()
-                    .expect("bound checked in match arm condition; qed");
+                    .map_err(|_| codec::Error::from("bound checked in match arm condition; qed"))?;
                 input.read(&mut r[..])?;
                 Data::Raw(r)
             }

--- a/pallets/crowdloan/src/lib.rs
+++ b/pallets/crowdloan/src/lib.rs
@@ -88,6 +88,7 @@ pub type CrowdloanInfoOf<T> = CrowdloanInfo<
 >;
 
 #[frame_support::pallet]
+#[allow(clippy::expect_used)]
 pub mod pallet {
     use super::*;
 
@@ -285,6 +286,8 @@ pub mod pallet {
 
     #[pallet::call]
     impl<T: Config> Pallet<T> {
+        #![deny(clippy::expect_used)]
+
         /// Create a crowdloan that will raise funds up to a maximum cap and if successful,
         /// will transfer funds to the target address if provided and dispatch the call
         /// (using creator origin).

--- a/pallets/crowdloan/src/mock.rs
+++ b/pallets/crowdloan/src/mock.rs
@@ -1,5 +1,9 @@
 #![cfg(test)]
-#![allow(clippy::arithmetic_side_effects, clippy::unwrap_used)]
+#![allow(
+    clippy::arithmetic_side_effects,
+    clippy::expect_used,
+    clippy::unwrap_used
+)]
 use frame_support::{
     PalletId, derive_impl, parameter_types,
     traits::{OnFinalize, OnInitialize, fungible, fungible::*, tokens::Preservation},

--- a/pallets/proxy/src/benchmarking.rs
+++ b/pallets/proxy/src/benchmarking.rs
@@ -18,7 +18,7 @@
 // Benchmarks for Proxy Pallet
 
 #![cfg(feature = "runtime-benchmarks")]
-#![allow(clippy::arithmetic_side_effects)]
+#![allow(clippy::arithmetic_side_effects, clippy::unwrap_used)]
 
 use super::*;
 use crate::Pallet as Proxy;
@@ -321,7 +321,8 @@ mod benchmarks {
             0,
         );
 
-        let pure_account = Pallet::<T>::pure_account(&caller, &T::ProxyType::default(), 0, None);
+        let pure_account =
+            Pallet::<T>::pure_account(&caller, &T::ProxyType::default(), 0, None).unwrap();
         assert_last_event::<T>(
             Event::PureCreated {
                 pure: pure_account,
@@ -348,7 +349,8 @@ mod benchmarks {
         )?;
         let height = T::BlockNumberProvider::current_block_number();
         let ext_index = frame_system::Pallet::<T>::extrinsic_index().unwrap_or(0);
-        let pure_account = Pallet::<T>::pure_account(&caller, &T::ProxyType::default(), 0, None);
+        let pure_account =
+            Pallet::<T>::pure_account(&caller, &T::ProxyType::default(), 0, None).unwrap();
 
         add_proxies::<T>(p, Some(pure_account.clone()))?;
         ensure!(

--- a/pallets/proxy/src/lib.rs
+++ b/pallets/proxy/src/lib.rs
@@ -455,7 +455,7 @@ pub mod pallet {
                     T::AnnouncementDepositFactor::get(),
                     pending.len(),
                 )?
-                .ok_or(Error::<T>::AnnouncementDepositInvariantViolated)?; // <- new error instead of expect
+                .ok_or(Error::<T>::AnnouncementDepositInvariantViolated)?;
 
                 *deposit = new_deposit;
                 Ok::<(), DispatchError>(())

--- a/pallets/proxy/src/lib.rs
+++ b/pallets/proxy/src/lib.rs
@@ -113,6 +113,7 @@ pub enum DepositKind {
 }
 
 #[frame::pallet]
+#[allow(clippy::expect_used)]
 pub mod pallet {
     use super::*;
 
@@ -215,6 +216,8 @@ pub mod pallet {
 
     #[pallet::call]
     impl<T: Config> Pallet<T> {
+        #![deny(clippy::expect_used)]
+
         /// Dispatch the given `call` from an account that the sender is authorised for through
         /// `add_proxy`.
         ///
@@ -333,7 +336,7 @@ pub mod pallet {
         ) -> DispatchResult {
             let who = ensure_signed(origin)?;
 
-            let pure = Self::pure_account(&who, &proxy_type, index, None);
+            let pure = Self::pure_account(&who, &proxy_type, index, None)?;
             ensure!(!Proxies::<T>::contains_key(&pure), Error::<T>::Duplicate);
 
             let proxy_def = ProxyDefinition {
@@ -389,7 +392,7 @@ pub mod pallet {
             let spawner = T::Lookup::lookup(spawner)?;
 
             let when = (height, ext_index);
-            let proxy = Self::pure_account(&spawner, &proxy_type, index, Some(when));
+            let proxy = Self::pure_account(&spawner, &proxy_type, index, Some(when))?;
             ensure!(proxy == who, Error::<T>::NoPermission);
 
             let (_, deposit) = Proxies::<T>::take(&who);
@@ -445,24 +448,24 @@ pub mod pallet {
                 pending
                     .try_push(announcement)
                     .map_err(|_| Error::<T>::TooMany)?;
-                Self::rejig_deposit(
+                let new_deposit = Self::rejig_deposit(
                     &who,
                     *deposit,
                     T::AnnouncementDepositBase::get(),
                     T::AnnouncementDepositFactor::get(),
                     pending.len(),
-                )
-                .map(|d| {
-                    d.expect("Just pushed; pending.len() > 0; rejig_deposit returns Some; qed")
-                })
-                .map(|d| *deposit = d)
+                )?
+                .ok_or(Error::<T>::AnnouncementDepositInvariantViolated)?; // <- new error instead of expect
+
+                *deposit = new_deposit;
+                Ok::<(), DispatchError>(())
             })?;
+
             Self::deposit_event(Event::Announced {
                 real,
                 proxy: who,
                 call_hash,
             });
-
             Ok(())
         }
 
@@ -743,6 +746,10 @@ pub mod pallet {
         Unannounced,
         /// Cannot add self as proxy.
         NoSelfProxy,
+        /// Invariant violated: deposit recomputation returned None after updating announcements.
+        AnnouncementDepositInvariantViolated,
+        /// Failed to derive a valid account id from the provided entropy.
+        InvalidDerivedAccountId,
     }
 
     /// The set of account proxies. Maps the account which has delegated to the accounts
@@ -829,7 +836,7 @@ impl<T: Config> Pallet<T> {
         proxy_type: &T::ProxyType,
         index: u16,
         maybe_when: Option<(BlockNumberFor<T>, u32)>,
-    ) -> T::AccountId {
+    ) -> Result<T::AccountId, DispatchError> {
         let (height, ext_index) = maybe_when.unwrap_or_else(|| {
             (
                 T::BlockNumberProvider::current_block_number(),
@@ -845,8 +852,9 @@ impl<T: Config> Pallet<T> {
             index,
         )
             .using_encoded(blake2_256);
-        Decode::decode(&mut TrailingZeroInput::new(entropy.as_ref()))
-            .expect("infinite length input; no invalid inputs for type; qed")
+
+        T::AccountId::decode(&mut TrailingZeroInput::new(entropy.as_ref()))
+            .map_err(|_| Error::<T>::InvalidDerivedAccountId.into())
     }
 
     /// Register a proxy account for the delegator that is able to make calls on its behalf.

--- a/pallets/proxy/src/tests.rs
+++ b/pallets/proxy/src/tests.rs
@@ -494,7 +494,7 @@ fn filtering_works() {
             .into(),
         );
 
-        let derivative_id = Utility::derivative_account_id(1, 0);
+        let derivative_id = Utility::derivative_account_id(1, 0).unwrap();
         Balances::make_free_balance_be(&derivative_id, 1000);
         let inner = Box::new(call_transfer(6, 1));
 
@@ -876,7 +876,7 @@ fn pure_works() {
             0,
             0
         ));
-        let anon = Proxy::pure_account(&1, &ProxyType::Any, 0, None);
+        let anon = Proxy::pure_account(&1, &ProxyType::Any, 0, None).unwrap();
         System::assert_last_event(
             ProxyEvent::PureCreated {
                 pure: anon,
@@ -900,7 +900,7 @@ fn pure_works() {
             0,
             1
         ));
-        let anon2 = Proxy::pure_account(&2, &ProxyType::Any, 0, None);
+        let anon2 = Proxy::pure_account(&2, &ProxyType::Any, 0, None).unwrap();
         assert_ok!(Proxy::create_pure(
             RuntimeOrigin::signed(2),
             ProxyType::Any,

--- a/pallets/registry/src/benchmarking.rs
+++ b/pallets/registry/src/benchmarking.rs
@@ -1,6 +1,10 @@
 //! Benchmarking setup
 #![cfg(feature = "runtime-benchmarks")]
-#![allow(clippy::arithmetic_side_effects, clippy::unwrap_used)]
+#![allow(
+    clippy::arithmetic_side_effects,
+    clippy::expect_used,
+    clippy::unwrap_used
+)]
 use super::*;
 
 #[allow(unused)]

--- a/pallets/registry/src/lib.rs
+++ b/pallets/registry/src/lib.rs
@@ -22,6 +22,7 @@ type BalanceOf<T> =
     <<T as Config>::Currency as fungible::Inspect<<T as frame_system::Config>::AccountId>>::Balance;
 #[deny(missing_docs)]
 #[frame_support::pallet]
+#[allow(clippy::expect_used)]
 pub mod pallet {
     use super::*;
     use frame_support::{pallet_prelude::*, traits::tokens::fungible};
@@ -107,6 +108,8 @@ pub mod pallet {
 
     #[pallet::call]
     impl<T: Config> Pallet<T> {
+        #![deny(clippy::expect_used)]
+
         /// Register an identity for an account. This will overwrite any existing identity.
         #[pallet::call_index(0)]
         #[pallet::weight((

--- a/pallets/registry/src/types.rs
+++ b/pallets/registry/src/types.rs
@@ -71,7 +71,7 @@ impl Decode for Data {
             n @ 1..=65 => {
                 let mut r: BoundedVec<_, _> = vec![0u8; (n as usize).saturating_sub(1)]
                     .try_into()
-                    .expect("bound checked in match arm condition; qed");
+                    .map_err(|_| codec::Error::from("bounded vec length exceeds limit"))?;
                 input.read(&mut r[..])?;
                 Data::Raw(r)
             }

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -63,6 +63,7 @@ pub const MAX_CRV3_COMMIT_SIZE_BYTES: u32 = 5000;
 #[import_section(hooks::hooks)]
 #[import_section(config::config)]
 #[frame_support::pallet]
+#[allow(clippy::expect_used)]
 pub mod pallet {
     use crate::RateLimitKey;
     use crate::migrations;
@@ -415,6 +416,7 @@ pub mod pallet {
     #[pallet::type_value]
     /// Default account, derived from zero trailing bytes.
     pub fn DefaultAccount<T: Config>() -> T::AccountId {
+        #[allow(clippy::expect_used)]
         T::AccountId::decode(&mut TrailingZeroInput::zeroes())
             .expect("trailing zeroes always produce a valid account ID; qed")
     }
@@ -588,6 +590,7 @@ pub mod pallet {
     #[pallet::type_value]
     /// Default value for subnet owner.
     pub fn DefaultSubnetOwner<T: Config>() -> T::AccountId {
+        #[allow(clippy::expect_used)]
         T::AccountId::decode(&mut sp_runtime::traits::TrailingZeroInput::zeroes())
             .expect("trailing zeroes always produce a valid account ID; qed")
     }
@@ -749,6 +752,7 @@ pub mod pallet {
     #[pallet::type_value]
     /// Default value for key with type T::AccountId derived from trailing zeroes.
     pub fn DefaultKey<T: Config>() -> T::AccountId {
+        #[allow(clippy::expect_used)]
         T::AccountId::decode(&mut sp_runtime::traits::TrailingZeroInput::zeroes())
             .expect("trailing zeroes always produce a valid account ID; qed")
     }
@@ -873,6 +877,7 @@ pub mod pallet {
     #[pallet::type_value]
     /// Default value for coldkey swap scheduled
     pub fn DefaultColdkeySwapScheduled<T: Config>() -> (BlockNumberFor<T>, T::AccountId) {
+        #[allow(clippy::expect_used)]
         let default_account = T::AccountId::decode(&mut TrailingZeroInput::zeroes())
             .expect("trailing zeroes always produce a valid account ID; qed");
         (BlockNumberFor::<T>::from(0_u32), default_account)
@@ -2145,6 +2150,7 @@ impl<T, H, P> CollectiveInterface<T, H, P> for () {
 pub struct TaoCurrencyReserve<T: Config>(PhantomData<T>);
 
 impl<T: Config> CurrencyReserve<TaoCurrency> for TaoCurrencyReserve<T> {
+    #![deny(clippy::expect_used)]
     fn reserve(netuid: NetUid) -> TaoCurrency {
         SubnetTAO::<T>::get(netuid).saturating_add(SubnetTaoProvided::<T>::get(netuid))
     }
@@ -2162,6 +2168,7 @@ impl<T: Config> CurrencyReserve<TaoCurrency> for TaoCurrencyReserve<T> {
 pub struct AlphaCurrencyReserve<T: Config>(PhantomData<T>);
 
 impl<T: Config> CurrencyReserve<AlphaCurrency> for AlphaCurrencyReserve<T> {
+    #![deny(clippy::expect_used)]
     fn reserve(netuid: NetUid) -> AlphaCurrency {
         SubnetAlphaIn::<T>::get(netuid).saturating_add(SubnetAlphaInProvided::<T>::get(netuid))
     }
@@ -2183,6 +2190,7 @@ pub type GetTaoForAlpha<T> =
 impl<T: Config + pallet_balances::Config<Balance = u64>>
     subtensor_runtime_common::SubnetInfo<T::AccountId> for Pallet<T>
 {
+    #![deny(clippy::expect_used)]
     fn exists(netuid: NetUid) -> bool {
         Self::if_subnet_exist(netuid)
     }
@@ -2215,6 +2223,7 @@ impl<T: Config + pallet_balances::Config<Balance = u64>>
 impl<T: Config + pallet_balances::Config<Balance = u64>>
     subtensor_runtime_common::BalanceOps<T::AccountId> for Pallet<T>
 {
+    #![deny(clippy::expect_used)]
     fn tao_balance(account_id: &T::AccountId) -> TaoCurrency {
         pallet_balances::Pallet::<T>::free_balance(account_id).into()
     }

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -18,6 +18,8 @@ mod dispatches {
     /// Dispatchable functions must be annotated with a weight and must return a DispatchResult.
     #[pallet::call]
     impl<T: Config> Pallet<T> {
+        #![deny(clippy::expect_used)]
+
         /// --- Sets the caller weights for the incentive mechanism. The call can be
         /// made from the hotkey account so is potentially insecure, however, the damage
         /// of changing weights is minimal if caught early. This function includes all the

--- a/pallets/subtensor/src/subnets/leasing.rs
+++ b/pallets/subtensor/src/subnets/leasing.rs
@@ -87,8 +87,8 @@ impl<T: Config> Pallet<T> {
 
         // Initialize the lease id, coldkey and hotkey and keep track of them
         let lease_id = Self::get_next_lease_id()?;
-        let lease_coldkey = Self::lease_coldkey(lease_id);
-        let lease_hotkey = Self::lease_hotkey(lease_id);
+        let lease_coldkey = Self::lease_coldkey(lease_id)?;
+        let lease_hotkey = Self::lease_hotkey(lease_id)?;
         frame_system::Pallet::<T>::inc_providers(&lease_coldkey);
         frame_system::Pallet::<T>::inc_providers(&lease_hotkey);
 
@@ -341,16 +341,16 @@ impl<T: Config> Pallet<T> {
         AccumulatedLeaseDividends::<T>::insert(lease_id, AlphaCurrency::ZERO);
     }
 
-    fn lease_coldkey(lease_id: LeaseId) -> T::AccountId {
+    fn lease_coldkey(lease_id: LeaseId) -> Result<T::AccountId, DispatchError> {
         let entropy = ("leasing/coldkey", lease_id).using_encoded(blake2_256);
-        Decode::decode(&mut TrailingZeroInput::new(entropy.as_ref()))
-            .expect("infinite length input; no invalid inputs for type; qed")
+        T::AccountId::decode(&mut TrailingZeroInput::new(entropy.as_ref()))
+            .map_err(|_| Error::<T>::InvalidValue.into())
     }
 
-    fn lease_hotkey(lease_id: LeaseId) -> T::AccountId {
+    fn lease_hotkey(lease_id: LeaseId) -> Result<T::AccountId, DispatchError> {
         let entropy = ("leasing/hotkey", lease_id).using_encoded(blake2_256);
-        Decode::decode(&mut TrailingZeroInput::new(entropy.as_ref()))
-            .expect("infinite length input; no invalid inputs for type; qed")
+        T::AccountId::decode(&mut TrailingZeroInput::new(entropy.as_ref()))
+            .map_err(|_| Error::<T>::InvalidValue.into())
     }
 
     fn get_next_lease_id() -> Result<LeaseId, Error<T>> {

--- a/pallets/subtensor/src/tests/consensus.rs
+++ b/pallets/subtensor/src/tests/consensus.rs
@@ -1,5 +1,6 @@
 #![allow(
     clippy::arithmetic_side_effects,
+    clippy::expect_used,
     clippy::indexing_slicing,
     clippy::unwrap_used
 )]

--- a/pallets/subtensor/src/tests/delegate_info.rs
+++ b/pallets/subtensor/src/tests/delegate_info.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::expect_used)]
 use super::mock::*;
 
 use codec::Compact;

--- a/pallets/subtensor/src/tests/ensure.rs
+++ b/pallets/subtensor/src/tests/ensure.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::expect_used)]
 use frame_support::{assert_noop, assert_ok};
 use frame_system::Config;
 use sp_core::U256;

--- a/pallets/subtensor/src/tests/epoch.rs
+++ b/pallets/subtensor/src/tests/epoch.rs
@@ -1,5 +1,6 @@
 #![allow(
     clippy::arithmetic_side_effects,
+    clippy::expect_used,
     clippy::indexing_slicing,
     clippy::unwrap_used
 )]

--- a/pallets/subtensor/src/tests/evm.rs
+++ b/pallets/subtensor/src/tests/evm.rs
@@ -1,5 +1,6 @@
 #![allow(
     clippy::arithmetic_side_effects,
+    clippy::expect_used,
     clippy::unwrap_used,
     clippy::indexing_slicing
 )]

--- a/pallets/subtensor/src/tests/mechanism.rs
+++ b/pallets/subtensor/src/tests/mechanism.rs
@@ -1,5 +1,6 @@
 #![allow(
     clippy::arithmetic_side_effects,
+    clippy::expect_used,
     clippy::indexing_slicing,
     clippy::unwrap_used
 )]

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -1,4 +1,10 @@
-#![allow(unused, clippy::indexing_slicing, clippy::panic, clippy::unwrap_used)]
+#![allow(
+    unused,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::unwrap_used
+)]
 
 use super::mock::*;
 use crate::*;

--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -1,4 +1,8 @@
-#![allow(clippy::arithmetic_side_effects, clippy::unwrap_used)]
+#![allow(
+    clippy::arithmetic_side_effects,
+    clippy::expect_used,
+    clippy::unwrap_used
+)]
 
 use core::num::NonZeroU64;
 

--- a/pallets/subtensor/src/tests/networks.rs
+++ b/pallets/subtensor/src/tests/networks.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::expect_used)]
+
 use super::mock::*;
 use crate::migrations::migrate_network_immunity_period;
 use crate::*;

--- a/pallets/subtensor/src/tests/serving.rs
+++ b/pallets/subtensor/src/tests/serving.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::unwrap_used)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 use super::mock::*;
 
 use crate::Error;

--- a/pallets/subtensor/src/tests/swap_coldkey.rs
+++ b/pallets/subtensor/src/tests/swap_coldkey.rs
@@ -1,4 +1,10 @@
-#![allow(unused, clippy::indexing_slicing, clippy::panic, clippy::unwrap_used)]
+#![allow(
+    unused,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::unwrap_used
+)]
 
 use approx::assert_abs_diff_eq;
 use codec::Encode;

--- a/pallets/subtensor/src/tests/uids.rs
+++ b/pallets/subtensor/src/tests/uids.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::unwrap_used)]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 
 use super::mock::*;
 use crate::*;

--- a/pallets/subtensor/src/tests/weights.rs
+++ b/pallets/subtensor/src/tests/weights.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::indexing_slicing, clippy::unwrap_used)]
+#![allow(clippy::expect_used, clippy::indexing_slicing, clippy::unwrap_used)]
 
 use ark_serialize::CanonicalDeserialize;
 use ark_serialize::CanonicalSerialize;

--- a/pallets/subtensor/src/utils/try_state.rs
+++ b/pallets/subtensor/src/utils/try_state.rs
@@ -5,6 +5,7 @@ use super::*;
 impl<T: Config> Pallet<T> {
     /// Checks [`TotalIssuance`] equals the sum of currency issuance, total stake, and total subnet
     /// locked.
+    #[allow(clippy::expect_used)]
     pub(crate) fn check_total_issuance() -> Result<(), sp_runtime::TryRuntimeError> {
         // Get the total currency issuance
         let currency_issuance = <T as Config>::Currency::total_issuance();

--- a/pallets/swap/src/pallet/mod.rs
+++ b/pallets/swap/src/pallet/mod.rs
@@ -23,6 +23,7 @@ mod tests;
 
 #[allow(clippy::module_inception)]
 #[frame_support::pallet]
+#[allow(clippy::expect_used)]
 mod pallet {
     use super::*;
     use frame_system::{ensure_root, ensure_signed};
@@ -280,6 +281,8 @@ mod pallet {
 
     #[pallet::call]
     impl<T: Config> Pallet<T> {
+        #![deny(clippy::expect_used)]
+
         /// Set the fee rate for swaps on a specific subnet (normalized value).
         /// For example, 0.3% is approximately 196.
         ///

--- a/pallets/swap/src/pallet/tests.rs
+++ b/pallets/swap/src/pallet/tests.rs
@@ -1,6 +1,9 @@
-#![allow(clippy::unwrap_used)]
-#![allow(clippy::indexing_slicing)]
-#![allow(clippy::arithmetic_side_effects)]
+#![allow(
+    clippy::arithmetic_side_effects,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::unwrap_used
+)]
 
 use approx::assert_abs_diff_eq;
 use frame_support::{assert_err, assert_noop, assert_ok};

--- a/pallets/utility/src/lib.rs
+++ b/pallets/utility/src/lib.rs
@@ -69,7 +69,10 @@ use frame_support::{
 };
 use sp_core::TypeId;
 use sp_io::hashing::blake2_256;
-use sp_runtime::traits::{BadOrigin, Dispatchable, TrailingZeroInput};
+use sp_runtime::{
+    DispatchError,
+    traits::{BadOrigin, Dispatchable, TrailingZeroInput},
+};
 pub use weights::WeightInfo;
 
 use subtensor_macros::freeze_struct;
@@ -77,6 +80,7 @@ use subtensor_macros::freeze_struct;
 pub use pallet::*;
 
 #[frame_support::pallet]
+#[allow(clippy::expect_used)]
 pub mod pallet {
     use super::*;
     use frame_support::{dispatch::DispatchClass, pallet_prelude::*};
@@ -167,10 +171,14 @@ pub mod pallet {
     pub enum Error<T> {
         /// Too many calls batched.
         TooManyCalls,
+        /// Bad input data for derived account ID
+        InvalidDerivedAccount,
     }
 
     #[pallet::call]
     impl<T: Config> Pallet<T> {
+        #![deny(clippy::expect_used)]
+
         /// Send a batch of dispatch calls.
         ///
         /// May be called from any origin except `None`.
@@ -271,7 +279,7 @@ pub mod pallet {
         ) -> DispatchResultWithPostInfo {
             let mut origin = origin;
             let who = ensure_signed(origin.clone())?;
-            let pseudonym = Self::derivative_account_id(who, index);
+            let pseudonym = Self::derivative_account_id(who, index)?;
             origin.set_caller_from(frame_system::RawOrigin::Signed(pseudonym));
             let info = call.get_dispatch_info();
             let result = call.dispatch(origin);
@@ -638,9 +646,12 @@ impl TypeId for IndexedUtilityPalletId {
 
 impl<T: Config> Pallet<T> {
     /// Derive a derivative account ID from the owner account and the sub-account index.
-    pub fn derivative_account_id(who: T::AccountId, index: u16) -> T::AccountId {
+    pub fn derivative_account_id(
+        who: T::AccountId,
+        index: u16,
+    ) -> Result<T::AccountId, DispatchError> {
         let entropy = (b"modlpy/utilisuba", who, index).using_encoded(blake2_256);
-        Decode::decode(&mut TrailingZeroInput::new(entropy.as_ref()))
-            .expect("infinite length input; no invalid inputs for type; qed")
+        T::AccountId::decode(&mut TrailingZeroInput::new(entropy.as_ref()))
+            .map_err(|_| Error::<T>::InvalidDerivedAccount.into())
     }
 }

--- a/pallets/utility/src/tests.rs
+++ b/pallets/utility/src/tests.rs
@@ -18,7 +18,11 @@
 // Tests for Utility Pallet
 
 #![cfg(test)]
-#![allow(clippy::arithmetic_side_effects, clippy::unwrap_used)]
+#![allow(
+    clippy::arithmetic_side_effects,
+    clippy::expect_used,
+    clippy::unwrap_used
+)]
 
 use super::*;
 
@@ -302,7 +306,7 @@ fn utility_events() -> Vec<Event> {
 #[test]
 fn as_derivative_works() {
     new_test_ext().execute_with(|| {
-        let sub_1_0 = Utility::derivative_account_id(1, 0);
+        let sub_1_0 = Utility::derivative_account_id(1, 0).unwrap();
         assert_ok!(Balances::transfer_allow_death(
             RuntimeOrigin::signed(1),
             sub_1_0,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2293,6 +2293,7 @@ impl_runtime_apis! {
             (weight, BlockWeights::get().max_block)
         }
 
+        #[allow(clippy::expect_used)]
         fn execute_block(
             block: Block,
             state_root_check: bool,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1297,8 +1297,7 @@ parameter_types! {
     pub const SwapMaxFeeRate: u16 = 10000; // 15.26%
     pub const SwapMaxPositions: u32 = 100;
     pub const SwapMinimumLiquidity: u64 = 1_000;
-    pub const SwapMinimumReserve: NonZeroU64 = NonZeroU64::new(1_000_000)
-        .expect("1_000_000 fits NonZeroU64");
+    pub const SwapMinimumReserve: NonZeroU64 = unsafe { NonZeroU64::new_unchecked(1_000_000) };
 }
 
 impl pallet_subtensor_swap::Config for Runtime {
@@ -1526,6 +1525,7 @@ impl<B> Default for TransactionConverter<B> {
     }
 }
 
+#[allow(clippy::expect_used)]
 impl<B: BlockT> fp_rpc::ConvertTransaction<<B as BlockT>::Extrinsic> for TransactionConverter<B> {
     fn convert_transaction(
         &self,

--- a/support/linting/src/forbid_as_primitive.rs
+++ b/support/linting/src/forbid_as_primitive.rs
@@ -49,6 +49,7 @@ mod tests {
 
     fn lint(input: proc_macro2::TokenStream) -> Result {
         let mut visitor = AsPrimitiveVisitor::default();
+        #[allow(clippy::expect_used)]
         let expr: ExprMethodCall = syn::parse2(input).expect("should be a valid method call");
         visitor.visit_expr_method_call(&expr);
         if !visitor.errors.is_empty() {

--- a/support/linting/src/forbid_keys_remove.rs
+++ b/support/linting/src/forbid_keys_remove.rs
@@ -57,6 +57,7 @@ fn is_keys_remove_call(func: &Expr, args: &Punctuated<Expr, Comma>) -> bool {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::expect_used)]
     use super::*;
     use quote::quote;
 

--- a/support/linting/src/forbid_saturating_math.rs
+++ b/support/linting/src/forbid_saturating_math.rs
@@ -56,6 +56,7 @@ fn is_saturating_math_call(func: &Expr) -> bool {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::expect_used)]
     use super::*;
     use quote::quote;
 

--- a/support/linting/src/require_freeze_struct.rs
+++ b/support/linting/src/require_freeze_struct.rs
@@ -68,6 +68,7 @@ fn is_derive_encode_or_decode(attr: &Attribute) -> bool {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::expect_used)]
     use super::*;
 
     fn lint_struct(input: &str) -> Result {


### PR DESCRIPTION
## Description

Avoid using `expect` anywhere in the on-chain code.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
