### PR TITLE
disable set kappa test

### DIFF
--- a/evm-tests/test/subnet.precompile.hyperparameter.test.ts
+++ b/evm-tests/test/subnet.precompile.hyperparameter.test.ts
@@ -263,26 +263,27 @@ describe("Test the Subnet precompile contract", () => {
         assert.equal(valueFromContract, onchainValue);
     })
 
-    it("Can set kappa parameter", async () => {
+    // disable the set kappa parameter test, because it is only callable by sudo now
+    // it("Can set kappa parameter", async () => {
 
-        const totalNetwork = await api.query.SubtensorModule.TotalNetworks.getValue()
-        const contract = new ethers.Contract(ISUBNET_ADDRESS, ISubnetABI, wallet);
-        const netuid = totalNetwork - 1;
+    //     const totalNetwork = await api.query.SubtensorModule.TotalNetworks.getValue()
+    //     const contract = new ethers.Contract(ISUBNET_ADDRESS, ISubnetABI, wallet);
+    //     const netuid = totalNetwork - 1;
 
-        const newValue = 109;
-        const tx = await contract.setKappa(netuid, newValue);
-        await tx.wait();
+    //     const newValue = 109;
+    //     const tx = await contract.setKappa(netuid, newValue);
+    //     await tx.wait();
 
-        let onchainValue = await api.query.SubtensorModule.Kappa.getValue(netuid)
+    //     let onchainValue = await api.query.SubtensorModule.Kappa.getValue(netuid)
 
 
-        let valueFromContract = Number(
-            await contract.getKappa(netuid)
-        );
+    //     let valueFromContract = Number(
+    //         await contract.getKappa(netuid)
+    //     );
 
-        assert.equal(valueFromContract, newValue)
-        assert.equal(valueFromContract, onchainValue);
-    })
+    //     assert.equal(valueFromContract, newValue)
+    //     assert.equal(valueFromContract, onchainValue);
+    // })
 
     it("Can set rho parameter", async () => {
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -220,7 +220,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 330,
+    spec_version: 331,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
Remove the test case of set kappa from evm e2e, since it is only called by sudo.


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.