### PR TITLE
Fix incorrect extrinsic class.

### DIFF
--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -1584,7 +1584,7 @@ mod dispatches {
         #[pallet::call_index(84)]
         #[pallet::weight((Weight::from_parts(358_500_000, 0)
         .saturating_add(T::DbWeight::get().reads(36_u64))
-        .saturating_add(T::DbWeight::get().writes(21_u64)), DispatchClass::Operational, Pays::Yes))]
+        .saturating_add(T::DbWeight::get().writes(21_u64)), DispatchClass::Normal, Pays::Yes))]
         pub fn unstake_all_alpha(origin: OriginFor<T>, hotkey: T::AccountId) -> DispatchResult {
             Self::do_unstake_all_alpha(origin, hotkey)
         }


### PR DESCRIPTION
This PR fixes incorrect extrinsic dispatch class `Operational -> Normal` for `unstake_all_alpha`.