### PR TITLE
use origin caller in extension

### DIFF
--- a/chain-extensions/src/lib.rs
+++ b/chain-extensions/src/lib.rs
@@ -568,7 +568,7 @@ where
             .ext()
             .caller()
             .account_id()
-            .map(|id| id.clone())
+            .cloned()
             .map_err(|_| DispatchError::Other("Failed to get caller"))
     }
 }

--- a/chain-extensions/src/lib.rs
+++ b/chain-extensions/src/lib.rs
@@ -98,7 +98,7 @@ where
                     .map_err(|_| DispatchError::Other("Failed to decode input parameters"))?;
 
                 let call_result = pallet_subtensor::Pallet::<T>::add_stake(
-                    RawOrigin::Signed(env.caller()).into(),
+                    RawOrigin::Signed(env.caller()?).into(),
                     hotkey,
                     netuid,
                     amount_staked,
@@ -124,7 +124,7 @@ where
                     .map_err(|_| DispatchError::Other("Failed to decode input parameters"))?;
 
                 let call_result = pallet_subtensor::Pallet::<T>::remove_stake(
-                    RawOrigin::Signed(env.caller()).into(),
+                    RawOrigin::Signed(env.caller()?).into(),
                     hotkey,
                     netuid,
                     amount_unstaked,
@@ -150,7 +150,7 @@ where
                     .map_err(|_| DispatchError::Other("Failed to decode input parameters"))?;
 
                 let call_result = pallet_subtensor::Pallet::<T>::unstake_all(
-                    RawOrigin::Signed(env.caller()).into(),
+                    RawOrigin::Signed(env.caller()?).into(),
                     hotkey,
                 );
 
@@ -174,7 +174,7 @@ where
                     .map_err(|_| DispatchError::Other("Failed to decode input parameters"))?;
 
                 let call_result = pallet_subtensor::Pallet::<T>::unstake_all_alpha(
-                    RawOrigin::Signed(env.caller()).into(),
+                    RawOrigin::Signed(env.caller()?).into(),
                     hotkey,
                 );
 
@@ -204,7 +204,7 @@ where
                     .map_err(|_| DispatchError::Other("Failed to decode input parameters"))?;
 
                 let call_result = pallet_subtensor::Pallet::<T>::move_stake(
-                    RawOrigin::Signed(env.caller()).into(),
+                    RawOrigin::Signed(env.caller()?).into(),
                     origin_hotkey,
                     destination_hotkey,
                     origin_netuid,
@@ -238,7 +238,7 @@ where
                     .map_err(|_| DispatchError::Other("Failed to decode input parameters"))?;
 
                 let call_result = pallet_subtensor::Pallet::<T>::transfer_stake(
-                    RawOrigin::Signed(env.caller()).into(),
+                    RawOrigin::Signed(env.caller()?).into(),
                     destination_coldkey,
                     hotkey,
                     origin_netuid,
@@ -271,7 +271,7 @@ where
                     .map_err(|_| DispatchError::Other("Failed to decode input parameters"))?;
 
                 let call_result = pallet_subtensor::Pallet::<T>::swap_stake(
-                    RawOrigin::Signed(env.caller()).into(),
+                    RawOrigin::Signed(env.caller()?).into(),
                     hotkey,
                     origin_netuid,
                     destination_netuid,
@@ -304,7 +304,7 @@ where
                     .map_err(|_| DispatchError::Other("Failed to decode input parameters"))?;
 
                 let call_result = pallet_subtensor::Pallet::<T>::add_stake_limit(
-                    RawOrigin::Signed(env.caller()).into(),
+                    RawOrigin::Signed(env.caller()?).into(),
                     hotkey,
                     netuid,
                     amount_staked,
@@ -338,7 +338,7 @@ where
                     .map_err(|_| DispatchError::Other("Failed to decode input parameters"))?;
 
                 let call_result = pallet_subtensor::Pallet::<T>::remove_stake_limit(
-                    RawOrigin::Signed(env.caller()).into(),
+                    RawOrigin::Signed(env.caller()?).into(),
                     hotkey,
                     netuid,
                     amount_unstaked,
@@ -380,7 +380,7 @@ where
                     .map_err(|_| DispatchError::Other("Failed to decode input parameters"))?;
 
                 let call_result = pallet_subtensor::Pallet::<T>::swap_stake_limit(
-                    RawOrigin::Signed(env.caller()).into(),
+                    RawOrigin::Signed(env.caller()?).into(),
                     hotkey,
                     origin_netuid,
                     destination_netuid,
@@ -409,7 +409,7 @@ where
                         .map_err(|_| DispatchError::Other("Failed to decode input parameters"))?;
 
                 let call_result = pallet_subtensor::Pallet::<T>::remove_stake_full_limit(
-                    RawOrigin::Signed(env.caller()).into(),
+                    RawOrigin::Signed(env.caller()?).into(),
                     hotkey,
                     netuid,
                     limit_price,
@@ -435,7 +435,7 @@ where
                     .map_err(|_| DispatchError::Other("Failed to decode input parameters"))?;
 
                 let call_result = pallet_subtensor::Pallet::<T>::set_coldkey_auto_stake_hotkey(
-                    RawOrigin::Signed(env.caller()).into(),
+                    RawOrigin::Signed(env.caller()?).into(),
                     netuid,
                     hotkey,
                 );
@@ -463,7 +463,7 @@ where
                     <<T as frame_system::Config>::Lookup as StaticLookup>::Source::from(delegate);
 
                 let call_result = pallet_proxy::Pallet::<T>::add_proxy(
-                    RawOrigin::Signed(env.caller()).into(),
+                    RawOrigin::Signed(env.caller()?).into(),
                     delegate_lookup,
                     ProxyType::Staking,
                     0u32.into(),
@@ -492,7 +492,7 @@ where
                     <<T as frame_system::Config>::Lookup as StaticLookup>::Source::from(delegate);
 
                 let call_result = pallet_proxy::Pallet::<T>::remove_proxy(
-                    RawOrigin::Signed(env.caller()).into(),
+                    RawOrigin::Signed(env.caller()?).into(),
                     delegate_lookup,
                     ProxyType::Staking,
                     0u32.into(),
@@ -515,7 +515,7 @@ trait SubtensorExtensionEnv<AccountId> {
     fn charge_weight(&mut self, weight: Weight) -> Result<(), DispatchError>;
     fn read_as<T: Decode + MaxEncodedLen>(&mut self) -> Result<T, DispatchError>;
     fn write_output(&mut self, data: &[u8]) -> Result<(), DispatchError>;
-    fn caller(&mut self) -> AccountId;
+    fn caller(&mut self) -> Result<AccountId, DispatchError>;
 }
 
 struct ContractsEnvAdapter<'a, 'b, T, E>
@@ -563,7 +563,12 @@ where
         self.env.write(data, false, None)
     }
 
-    fn caller(&mut self) -> T::AccountId {
-        self.env.ext().address().clone()
+    fn caller(&mut self) -> Result<T::AccountId, DispatchError> {
+        self.env
+            .ext()
+            .caller()
+            .account_id()
+            .map(|id| id.clone())
+            .map_err(|_| DispatchError::Other("Failed to get caller"))
     }
 }

--- a/chain-extensions/src/tests.rs
+++ b/chain-extensions/src/tests.rs
@@ -777,8 +777,8 @@ impl SubtensorExtensionEnv<AccountId> for MockEnv {
         Ok(())
     }
 
-    fn caller(&mut self) -> AccountId {
-        self.caller
+    fn caller(&mut self) -> Result<AccountId, DispatchError> {
+        Ok(self.caller)
     }
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -220,7 +220,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 333,
+    spec_version: 334,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
We should use the original caller as origin to call extension like add_stake.
Currently, the extrinsic take the contract address as origin.


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.