### PR TITLE
add note about ink v6 support

### DIFF
--- a/docs/wasm-contracts.md
+++ b/docs/wasm-contracts.md
@@ -14,7 +14,7 @@ For general smart contract development on Subtensor, please refer to the officia
 - [ink! Getting Started Guide](https://use.ink/docs/v5/getting-started/setup)
 - [ink! Examples](https://github.com/use-ink/ink-examples/tree/v5.x.x)
 
-> [!NOTE]
+> [!WARNING]
 > ink! `>= 6.0` drops support for `pallet-contracts`, please use `ink < 6.0`.
 > See: https://github.com/use-ink/ink/releases/tag/v6.0.0-alpha
 

--- a/docs/wasm-contracts.md
+++ b/docs/wasm-contracts.md
@@ -14,6 +14,10 @@ For general smart contract development on Subtensor, please refer to the officia
 - [ink! Getting Started Guide](https://use.ink/docs/v5/getting-started/setup)
 - [ink! Examples](https://github.com/use-ink/ink-examples/tree/v5.x.x)
 
+> [!NOTE]
+> ink! `>= 6.0` drops support for `pallet-contracts`, please use `ink < 6.0`.
+> See: https://github.com/use-ink/ink/releases/tag/v6.0.0-alpha
+
 ## Subtensor-Specific Features
 
 ### Chain Extension


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
Adds a note to wasm-contracts docs on ink! v6 support.  
Ink! v6 drops support for `pallet-contracts` in favour of `pallet-revive`

See: https://github.com/use-ink/ink/releases/tag/v6.0.0-alpha

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.