### PR TITLE
Subsidy mode based on ema prices total

### DIFF
--- a/pallets/subtensor/src/staking/claim_root.rs
+++ b/pallets/subtensor/src/staking/claim_root.rs
@@ -3,7 +3,7 @@ use frame_support::weights::Weight;
 use sp_core::Get;
 use sp_std::collections::btree_set::BTreeSet;
 use substrate_fixed::types::I96F32;
-use subtensor_swap_interface::SwapHandler;
+use subtensor_swap_interface::{Order, SwapHandler};
 
 impl<T: Config> Pallet<T> {
     pub fn block_hash_to_indices(block_hash: T::Hash, k: u64, n: u64) -> Vec<u64> {
@@ -196,6 +196,13 @@ impl<T: Config> Pallet<T> {
                     netuid,
                     owed_u64.into(),
                 );
+
+                // Sim-swap and record positive TAO flow
+                let order = GetTaoForAlpha::<T>::with_amount(AlphaCurrency::from(owed_u64));
+                let maybe_result = T::SwapInterface::sim_swap(netuid.into(), order);
+                if let Ok(result) = maybe_result {
+                    Self::record_tao_inflow(netuid, TaoCurrency::from(result.amount_paid_out));
+                }
             }
         };
 

--- a/pallets/subtensor/src/tests/claim_root.rs
+++ b/pallets/subtensor/src/tests/claim_root.rs
@@ -113,6 +113,8 @@ fn test_claim_root_with_drain_emissions() {
         ),);
         assert_eq!(RootClaimType::<Test>::get(coldkey), RootClaimTypeEnum::Keep);
 
+        let tao_flow_before = SubnetTaoFlow::<Test>::get(netuid);
+
         assert_ok!(SubtensorModule::claim_root(
             RuntimeOrigin::signed(coldkey),
             BTreeSet::from([netuid])
@@ -132,6 +134,9 @@ fn test_claim_root_with_drain_emissions() {
 
         let claimed = RootClaimed::<Test>::get((netuid, &hotkey, &coldkey));
         assert_eq!(u128::from(new_stake), claimed);
+
+        // Check positive TAO flow is recorded
+        assert!(SubnetTaoFlow::<Test>::get(netuid) > tao_flow_before);
 
         // Distribute pending root alpha (round 2)
 

--- a/pallets/subtensor/src/tests/claim_root.rs
+++ b/pallets/subtensor/src/tests/claim_root.rs
@@ -3,12 +3,7 @@
 use crate::tests::mock::{
     RuntimeOrigin, SubtensorModule, Test, add_dynamic_network, new_test_ext, run_to_block,
 };
-use crate::{
-    DefaultMinRootClaimAmount, Error, MAX_NUM_ROOT_CLAIMS, MAX_ROOT_CLAIM_THRESHOLD, NetworksAdded,
-    NumRootClaim, NumStakingColdkeys, PendingRootAlphaDivs, RootClaimable, RootClaimableThreshold,
-    StakingColdkeys, StakingColdkeysByIndex, SubnetAlphaIn, SubnetMechanism, SubnetTAO,
-    SubtokenEnabled, Tempo, pallet,
-};
+use crate::*;
 use crate::{RootClaimType, RootClaimTypeEnum, RootClaimed};
 use approx::assert_abs_diff_eq;
 use frame_support::dispatch::RawOrigin;
@@ -763,6 +758,7 @@ fn test_claim_root_with_run_coinbase() {
 
         let root_stake = 200_000_000u64;
         SubnetTAO::<Test>::insert(NetUid::ROOT, TaoCurrency::from(root_stake));
+        SubnetMovingPrice::<Test>::insert(netuid, I96F32::from(2));
 
         SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
             &hotkey,
@@ -869,6 +865,7 @@ fn test_claim_root_with_block_emissions() {
 
         let root_stake = 200_000_000u64;
         SubnetTAO::<Test>::insert(NetUid::ROOT, TaoCurrency::from(root_stake));
+        SubnetMovingPrice::<Test>::insert(netuid, I96F32::from(2));
 
         SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
             &hotkey,
@@ -973,6 +970,9 @@ fn test_claim_root_coinbase_distribution() {
         let initial_tao = 200_000_000u64;
         SubnetTAO::<Test>::insert(NetUid::ROOT, TaoCurrency::from(initial_tao));
 
+        // Avoid subsidy mode
+        SubnetMovingPrice::<Test>::insert(netuid, I96F32::from(2));
+
         SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
             &hotkey,
             &coldkey,
@@ -996,7 +996,12 @@ fn test_claim_root_coinbase_distribution() {
         run_to_block(2);
 
         let alpha_issuance = SubtensorModule::get_alpha_issuance(netuid);
-        assert_eq!(initial_alpha_issuance + alpha_emissions, alpha_issuance);
+
+        // Both alpha_in and alpha_out are increased, hence multiply emissions by 2 to get total issuance increase
+        assert_eq!(
+            initial_alpha_issuance + alpha_emissions * AlphaCurrency::from(2),
+            alpha_issuance
+        );
 
         let root_prop = initial_tao as f64 / (u64::from(alpha_issuance) + initial_tao) as f64;
         let root_validators_share = 0.5f64;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -220,7 +220,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 334,
+    spec_version: 335,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -220,7 +220,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 338,
+    spec_version: 339,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description

Global subsidy mode: If sum of ema prices is <= 1, global subsidy is on (no root sell).

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

