### PR TITLE
Fix wrong alpha price precompile

### DIFF
--- a/precompiles/src/alpha.rs
+++ b/precompiles/src/alpha.rs
@@ -205,7 +205,8 @@ where
             }
         }
 
-        let price: SubstrateBalance = sum_alpha_price.saturating_to_num::<u64>().into();
+        let price = sum_alpha_price.saturating_mul(U96F32::from_num(1_000_000_000));
+        let price: SubstrateBalance = price.saturating_to_num::<u64>().into();
         let price_eth = <R as pallet_evm::Config>::BalanceConverter::into_evm_balance(price)
             .map(|amount| amount.into_u256())
             .ok_or(ExitError::InvalidRange)?;

--- a/precompiles/src/alpha.rs
+++ b/precompiles/src/alpha.rs
@@ -39,7 +39,7 @@ where
             <pallet_subtensor_swap::Pallet<R> as SwapHandler>::current_alpha_price(netuid.into());
         let price = current_alpha_price.saturating_mul(U96F32::from_num(1_000_000_000));
         let price: SubstrateBalance = price.saturating_to_num::<u64>().into();
-        let price_eth = <R as pallet_evm::Config>::BalanceConverter::into_evm_balance(price.into())
+        let price_eth = <R as pallet_evm::Config>::BalanceConverter::into_evm_balance(price)
             .map(|amount| amount.into_u256())
             .ok_or(ExitError::InvalidRange)?;
 
@@ -53,7 +53,7 @@ where
             pallet_subtensor::Pallet::<R>::get_moving_alpha_price(netuid.into());
         let price = moving_alpha_price.saturating_mul(U96F32::from_num(1_000_000_000));
         let price: SubstrateBalance = price.saturating_to_num::<u64>().into();
-        let price_eth = <R as pallet_evm::Config>::BalanceConverter::into_evm_balance(price.into())
+        let price_eth = <R as pallet_evm::Config>::BalanceConverter::into_evm_balance(price)
             .map(|amount| amount.into_u256())
             .ok_or(ExitError::InvalidRange)?;
 

--- a/precompiles/src/alpha.rs
+++ b/precompiles/src/alpha.rs
@@ -35,10 +35,11 @@ where
     #[precompile::public("getAlphaPrice(uint16)")]
     #[precompile::view]
     fn get_alpha_price(_handle: &mut impl PrecompileHandle, netuid: u16) -> EvmResult<U256> {
-        let price =
+        let current_alpha_price =
             <pallet_subtensor_swap::Pallet<R> as SwapHandler>::current_alpha_price(netuid.into());
+        let price = current_alpha_price.saturating_mul(U96F32::from_num(1_000_000_000));
         let price: SubstrateBalance = price.saturating_to_num::<u64>().into();
-        let price_eth = <R as pallet_evm::Config>::BalanceConverter::into_evm_balance(price)
+        let price_eth = <R as pallet_evm::Config>::BalanceConverter::into_evm_balance(price.into())
             .map(|amount| amount.into_u256())
             .ok_or(ExitError::InvalidRange)?;
 
@@ -48,9 +49,11 @@ where
     #[precompile::public("getMovingAlphaPrice(uint16)")]
     #[precompile::view]
     fn get_moving_alpha_price(_handle: &mut impl PrecompileHandle, netuid: u16) -> EvmResult<U256> {
-        let price: U96F32 = pallet_subtensor::Pallet::<R>::get_moving_alpha_price(netuid.into());
+        let moving_alpha_price: U96F32 =
+            pallet_subtensor::Pallet::<R>::get_moving_alpha_price(netuid.into());
+        let price = moving_alpha_price.saturating_mul(U96F32::from_num(1_000_000_000));
         let price: SubstrateBalance = price.saturating_to_num::<u64>().into();
-        let price_eth = <R as pallet_evm::Config>::BalanceConverter::into_evm_balance(price)
+        let price_eth = <R as pallet_evm::Config>::BalanceConverter::into_evm_balance(price.into())
             .map(|amount| amount.into_u256())
             .ok_or(ExitError::InvalidRange)?;
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -220,7 +220,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 346,
+    spec_version: 347,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
The current price is a float value, in most of case less than 1. can't convert it to u64 directly.


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.