### PR TITLE
Update the sp-ark-bls12-381 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16738,7 +16738,7 @@ dependencies = [
 [[package]]
 name = "sp-ark-bls12-381"
 version = "0.4.2"
-source = "git+https://github.com/paritytech/substrate-curves#f08093a5f7c32778eae1295430ec064dccd062a6"
+source = "git+https://github.com/paritytech/arkworks-substrate#f08093a5f7c32778eae1295430ec064dccd062a6"
 dependencies = [
  "ark-bls12-381-ext",
  "sp-crypto-ec-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -274,7 +274,7 @@ sp-keystore = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "p
 w3f-bls = { git = "https://github.com/opentensor/bls", branch = "fix-no-std", default-features = false }
 ark-crypto-primitives = { version = "0.4.0", default-features = false }
 ark-scale = { version = "0.0.11", default-features = false }
-sp-ark-bls12-381 = { git = "https://github.com/paritytech/substrate-curves", default-features = false }
+sp-ark-bls12-381 = { git = "https://github.com/paritytech/arkworks-substrate", package = "sp-ark-bls12-381", default-features = false }
 ark-bls12-381 = { version = "0.4.0", default-features = false }
 ark-serialize = { version = "0.4.0", default-features = false }
 ark-ff = { version = "0.4.0", default-features = false }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -220,7 +220,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 348,
+    spec_version: 349,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
The old repository for the dependency was deleted/made private `https://github.com/paritytech/substrate-curves`. Now we point to the new one `https://github.com/paritytech/arkworks-substrate`