### PR TITLE
[hotfix] disable paying tx-fees in alpha

### DIFF
--- a/pallets/transaction-fee/src/lib.rs
+++ b/pallets/transaction-fee/src/lib.rs
@@ -308,7 +308,7 @@ where
 
     fn withdraw_fee(
         who: &AccountIdOf<T>,
-        call: &CallOf<T>,
+        _call: &CallOf<T>,
         _dispatch_info: &DispatchInfoOf<CallOf<T>>,
         fee: Self::Balance,
         _tip: Self::Balance,
@@ -340,7 +340,7 @@ where
 
     fn can_withdraw_fee(
         who: &AccountIdOf<T>,
-        call: &CallOf<T>,
+        _call: &CallOf<T>,
         _dispatch_info: &DispatchInfoOf<CallOf<T>>,
         fee: Self::Balance,
         _tip: Self::Balance,

--- a/pallets/transaction-fee/src/lib.rs
+++ b/pallets/transaction-fee/src/lib.rs
@@ -327,12 +327,12 @@ where
         ) {
             Ok(imbalance) => Ok(Some(WithdrawnFee::Tao(imbalance))),
             Err(_) => {
-                let alpha_vec = Self::fees_in_alpha::<T>(who, call);
-                if !alpha_vec.is_empty() {
-                    let fee_u64: u64 = fee.into();
-                    OU::withdraw_in_alpha(who, &alpha_vec, fee_u64);
-                    return Ok(Some(WithdrawnFee::Alpha));
-                }
+                // let alpha_vec = Self::fees_in_alpha::<T>(who, call);
+                // if !alpha_vec.is_empty() {
+                //     let fee_u64: u64 = fee.into();
+                //     OU::withdraw_in_alpha(who, &alpha_vec, fee_u64);
+                //     return Ok(Some(WithdrawnFee::Alpha));
+                // }
                 Err(InvalidTransaction::Payment.into())
             }
         }
@@ -353,14 +353,14 @@ where
         match F::can_withdraw(who, fee) {
             WithdrawConsequence::Success => Ok(()),
             _ => {
-                // Fallback to fees in Alpha if possible
-                let alpha_vec = Self::fees_in_alpha::<T>(who, call);
-                if !alpha_vec.is_empty() {
-                    let fee_u64: u64 = fee.into();
-                    if OU::can_withdraw_in_alpha(who, &alpha_vec, fee_u64) {
-                        return Ok(());
-                    }
-                }
+                // // Fallback to fees in Alpha if possible
+                // let alpha_vec = Self::fees_in_alpha::<T>(who, call);
+                // if !alpha_vec.is_empty() {
+                //     let fee_u64: u64 = fee.into();
+                //     if OU::can_withdraw_in_alpha(who, &alpha_vec, fee_u64) {
+                //         return Ok(());
+                //     }
+                // }
                 Err(InvalidTransaction::Payment.into())
             }
         }

--- a/pallets/transaction-fee/src/tests/mod.rs
+++ b/pallets/transaction-fee/src/tests/mod.rs
@@ -74,6 +74,7 @@ fn test_remove_stake_fees_tao() {
 
 // cargo test --package subtensor-transaction-fee --lib -- tests::test_remove_stake_fees_alpha --exact --show-output
 #[test]
+#[ignore]
 fn test_remove_stake_fees_alpha() {
     new_test_ext().execute_with(|| {
         let stake_amount = TAO;
@@ -142,6 +143,7 @@ fn test_remove_stake_fees_alpha() {
 //
 // cargo test --package subtensor-transaction-fee --lib -- tests::test_remove_stake_root --exact --show-output
 #[test]
+#[ignore]
 fn test_remove_stake_root() {
     new_test_ext().execute_with(|| {
         let stake_amount = TAO;
@@ -200,6 +202,7 @@ fn test_remove_stake_root() {
 //
 // cargo test --package subtensor-transaction-fee --lib -- tests::test_remove_stake_completely_root --exact --show-output
 #[test]
+#[ignore]
 fn test_remove_stake_completely_root() {
     new_test_ext().execute_with(|| {
         let stake_amount = TAO;
@@ -251,6 +254,7 @@ fn test_remove_stake_completely_root() {
 
 // cargo test --package subtensor-transaction-fee --lib -- tests::test_remove_stake_completely_fees_alpha --exact --show-output
 #[test]
+#[ignore]
 fn test_remove_stake_completely_fees_alpha() {
     new_test_ext().execute_with(|| {
         let stake_amount = TAO;
@@ -381,6 +385,7 @@ fn test_remove_stake_not_enough_balance_for_fees() {
 //
 // cargo test --package subtensor-transaction-fee --lib -- tests::test_remove_stake_edge_alpha --exact --show-output
 #[test]
+#[ignore]
 fn test_remove_stake_edge_alpha() {
     new_test_ext().execute_with(|| {
         let stake_amount = TAO;
@@ -519,6 +524,7 @@ fn test_remove_stake_failing_transaction_tao_fees() {
 //
 // cargo test --package subtensor-transaction-fee --lib -- tests::test_remove_stake_failing_transaction_alpha_fees --exact --show-output
 #[test]
+#[ignore]
 fn test_remove_stake_failing_transaction_alpha_fees() {
     new_test_ext().execute_with(|| {
         let stake_amount = TAO;
@@ -584,6 +590,7 @@ fn test_remove_stake_failing_transaction_alpha_fees() {
 
 // cargo test --package subtensor-transaction-fee --lib -- tests::test_remove_stake_limit_fees_alpha --exact --show-output
 #[test]
+#[ignore]
 fn test_remove_stake_limit_fees_alpha() {
     new_test_ext().execute_with(|| {
         let stake_amount = TAO;
@@ -651,6 +658,7 @@ fn test_remove_stake_limit_fees_alpha() {
 
 // cargo test --package subtensor-transaction-fee --lib -- tests::test_unstake_all_fees_alpha --exact --show-output
 #[test]
+#[ignore]
 fn test_unstake_all_fees_alpha() {
     new_test_ext().execute_with(|| {
         let stake_amount = TAO;
@@ -723,6 +731,7 @@ fn test_unstake_all_fees_alpha() {
 
 // cargo test --package subtensor-transaction-fee --lib -- tests::test_unstake_all_alpha_fees_alpha --exact --show-output
 #[test]
+#[ignore]
 fn test_unstake_all_alpha_fees_alpha() {
     new_test_ext().execute_with(|| {
         let stake_amount = TAO;
@@ -790,6 +799,7 @@ fn test_unstake_all_alpha_fees_alpha() {
 
 // cargo test --package subtensor-transaction-fee --lib -- tests::test_move_stake_fees_alpha --exact --show-output
 #[test]
+#[ignore]
 fn test_move_stake_fees_alpha() {
     new_test_ext().execute_with(|| {
         let stake_amount = TAO;
@@ -861,6 +871,7 @@ fn test_move_stake_fees_alpha() {
 
 // cargo test --package subtensor-transaction-fee --lib -- tests::test_transfer_stake_fees_alpha --exact --show-output
 #[test]
+#[ignore]
 fn test_transfer_stake_fees_alpha() {
     new_test_ext().execute_with(|| {
         let destination_coldkey = U256::from(100000);
@@ -933,6 +944,7 @@ fn test_transfer_stake_fees_alpha() {
 
 // cargo test --package subtensor-transaction-fee --lib -- tests::test_swap_stake_fees_alpha --exact --show-output
 #[test]
+#[ignore]
 fn test_swap_stake_fees_alpha() {
     new_test_ext().execute_with(|| {
         let stake_amount = TAO;
@@ -1003,6 +1015,7 @@ fn test_swap_stake_fees_alpha() {
 
 // cargo test --package subtensor-transaction-fee --lib -- tests::test_swap_stake_limit_fees_alpha --exact --show-output
 #[test]
+#[ignore]
 fn test_swap_stake_limit_fees_alpha() {
     new_test_ext().execute_with(|| {
         let stake_amount = TAO;
@@ -1075,6 +1088,7 @@ fn test_swap_stake_limit_fees_alpha() {
 
 // cargo test --package subtensor-transaction-fee --lib -- tests::test_burn_alpha_fees_alpha --exact --show-output
 #[test]
+#[ignore]
 fn test_burn_alpha_fees_alpha() {
     new_test_ext().execute_with(|| {
         let stake_amount = TAO;
@@ -1136,6 +1150,7 @@ fn test_burn_alpha_fees_alpha() {
 
 // cargo test --package subtensor-transaction-fee --lib -- tests::test_recycle_alpha_fees_alpha --exact --show-output
 #[test]
+#[ignore]
 fn test_recycle_alpha_fees_alpha() {
     new_test_ext().execute_with(|| {
         let stake_amount = TAO;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -220,7 +220,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 348,
+    spec_version: 349,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->
This disables the ability to pay transaction/extrinsic fees using Alpha balance.  
Transaction fees can only be paid using free-tao balances.


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.