### PR TITLE
Update max fee rate

### DIFF
--- a/pallets/swap/src/lib.rs
+++ b/pallets/swap/src/lib.rs
@@ -12,6 +12,7 @@ pub use pallet::*;
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarking;
 
+mod migrations;
 #[cfg(test)]
 pub(crate) mod mock;
 

--- a/pallets/swap/src/migrations/fee_rate_migration.rs
+++ b/pallets/swap/src/migrations/fee_rate_migration.rs
@@ -1,0 +1,49 @@
+use crate::HasMigrationRun;
+use crate::{Config, pallet};
+use frame_support::traits::Get;
+use frame_support::weights::Weight;
+use scale_info::prelude::string::String;
+use sp_std::collections::btree_map::BTreeMap;
+
+pub const MAX_FEE_RATE: u16 = 1310; // 2 %
+
+pub fn migrate_fee_rate<T: Config>() -> Weight {
+    let migration_name = b"migrate_fee_rate".to_vec();
+
+    // Initialize the weight with one read operation.
+    let mut weight = T::DbWeight::get().reads(1);
+
+    // Check if the migration has already run
+    if HasMigrationRun::<T>::get(&migration_name) {
+        log::info!(
+            "Migration '{:?}' has already run. Skipping.",
+            String::from_utf8_lossy(&migration_name)
+        );
+        return weight;
+    }
+    log::info!(
+        "Running migration '{}'",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    let keypairs = pallet::FeeRate::<T>::iter().collect::<BTreeMap<_, _>>();
+    weight = weight.saturating_add(T::DbWeight::get().reads(keypairs.len() as u64));
+
+    for (netuid, rate) in keypairs {
+        if rate > MAX_FEE_RATE {
+            pallet::FeeRate::<T>::mutate(netuid, |rate| *rate = MAX_FEE_RATE);
+            weight = weight.saturating_add(T::DbWeight::get().writes(1));
+        }
+    }
+
+    // Mark the migration as completed
+    HasMigrationRun::<T>::insert(&migration_name, true);
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+    log::info!(
+        "Migration '{:?}' completed.",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    weight
+}

--- a/pallets/swap/src/migrations/mod.rs
+++ b/pallets/swap/src/migrations/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod fee_rate_migration;

--- a/pallets/swap/src/mock.rs
+++ b/pallets/swap/src/mock.rs
@@ -4,6 +4,7 @@ use core::num::NonZeroU64;
 
 use frame_support::construct_runtime;
 use frame_support::pallet_prelude::*;
+use frame_support::weights::constants::RocksDbWeight;
 use frame_support::{
     PalletId, parameter_types,
     traits::{ConstU32, Everything},
@@ -50,7 +51,7 @@ impl system::Config for Test {
     type BaseCallFilter = Everything;
     type BlockWeights = ();
     type BlockLength = ();
-    type DbWeight = ();
+    type DbWeight = RocksDbWeight;
     type RuntimeOrigin = RuntimeOrigin;
     type RuntimeCall = RuntimeCall;
     type Hash = H256;

--- a/pallets/swap/src/pallet/hooks.rs
+++ b/pallets/swap/src/pallet/hooks.rs
@@ -1,0 +1,16 @@
+use frame_support::pallet_macros::pallet_section;
+
+/// A [`pallet_section`] that defines the events for a pallet.
+/// This can later be imported into the pallet using [`import_section`].
+#[pallet_section]
+mod hooks {
+    // ================
+    // ==== Hooks =====
+    // ================
+    #[pallet::hooks]
+    impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+        fn on_runtime_upgrade() -> frame_support::weights::Weight {
+            migrations::fee_rate_migration::migrate_fee_rate::<T>()
+        }
+    }
+}

--- a/pallets/swap/src/pallet/mod.rs
+++ b/pallets/swap/src/pallet/mod.rs
@@ -16,17 +16,22 @@ use crate::{
 
 pub use pallet::*;
 
+mod hooks;
 mod impls;
 mod swap_step;
 #[cfg(test)]
 mod tests;
 
+use crate::migrations;
+
+#[import_section(hooks::hooks)]
 #[allow(clippy::module_inception)]
 #[frame_support::pallet]
 #[allow(clippy::expect_used)]
 mod pallet {
     use super::*;
     use frame_system::{ensure_root, ensure_signed};
+    use sp_std::vec::Vec;
 
     #[pallet::pallet]
     pub struct Pallet<T>(_);
@@ -77,6 +82,11 @@ mod pallet {
     pub fn DefaultFeeRate() -> u16 {
         33 // ~0.05 %
     }
+
+    /// Storage for migration run status
+    #[pallet::storage]
+    #[pallet::unbounded]
+    pub type HasMigrationRun<T: Config> = StorageMap<_, Identity, Vec<u8>, bool, ValueQuery>;
 
     /// The fee rate applied to swaps per subnet, normalized value between 0 and u16::MAX
     #[pallet::storage]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1138,7 +1138,7 @@ impl pallet_subtensor::Config for Runtime {
 
 parameter_types! {
     pub const SwapProtocolId: PalletId = PalletId(*b"ten/swap");
-    pub const SwapMaxFeeRate: u16 = 10000; // 15.26%
+    pub const SwapMaxFeeRate: u16 = 1310; // 2%
     pub const SwapMaxPositions: u32 = 100;
     pub const SwapMinimumLiquidity: u64 = 1_000;
     pub const SwapMinimumReserve: NonZeroU64 = unsafe { NonZeroU64::new_unchecked(1_000_000) };


### PR DESCRIPTION
This PR sets the max fee rate constant from the swap pallet from 10000 (15.26%) to 1310 (2%). 

Additionally, it introduces a migration infrastructure for the swap pallet with `HasMigrationRun` storage, `on_runtime_upgrade` hook, and a related test. 