### PR TITLE
Update SwapMaxFeeRate

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1138,7 +1138,7 @@ impl pallet_subtensor::Config for Runtime {
 
 parameter_types! {
     pub const SwapProtocolId: PalletId = PalletId(*b"ten/swap");
-    pub const SwapMaxFeeRate: u16 = 10000; // 15.26%
+    pub const SwapMaxFeeRate: u16 = 1310; // 2%
     pub const SwapMaxPositions: u32 = 100;
     pub const SwapMinimumLiquidity: u64 = 1_000;
     pub const SwapMinimumReserve: NonZeroU64 = unsafe { NonZeroU64::new_unchecked(1_000_000) };

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -237,7 +237,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 354,
+    spec_version: 355,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
This PR sets the max fee rate constant (`SwapMaxFeeRate`) from the swap pallet from 10000 (15.26%) to 1310 (2%).

There is no migration for FeeRate storage from `pallet-subtensor-swap` because the production chain doesn't have any entries that require updates. 