### PR TITLE
Mevshield dispatch result with post info

### DIFF
--- a/pallets/shield/src/lib.rs
+++ b/pallets/shield/src/lib.rs
@@ -437,7 +437,7 @@ pub mod pallet {
             origin: OriginFor<T>,
             id: T::Hash,
             reason: BoundedVec<u8, ConstU32<256>>,
-        ) -> DispatchResult {
+        ) -> DispatchResultWithPostInfo {
             // Unsigned: only the author node may inject this via ValidateUnsigned.
             ensure_none(origin)?;
 
@@ -449,7 +449,7 @@ pub mod pallet {
             // Emit event to notify clients
             Self::deposit_event(Event::DecryptionFailed { id, reason });
 
-            Ok(())
+            Ok(().into())
         }
     }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -237,7 +237,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 355,
+    spec_version: 356,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
This PR modifies the `mark_decryption_failed` extrinsic to return `DispatchErrorWithPostInfo` instead of `DispatchResult`.