### PR TITLE
Move set_root_claim_type to the staking proxy type

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -653,6 +653,9 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
                     | RuntimeCall::SubtensorModule(
                         pallet_subtensor::Call::remove_stake_full_limit { .. }
                     )
+                    | RuntimeCall::SubtensorModule(
+                        pallet_subtensor::Call::set_root_claim_type { .. }
+                    )
             ),
             ProxyType::Registration => matches!(
                 c,


### PR DESCRIPTION
After https://github.com/opentensor/subtensor/pull/2252 set_root_claim type was completely removed. Reverting it and moving to the proper module.