### PR TITLE
Add extrinsic to disable user liquidity on all subnets

### DIFF
--- a/pallets/subtensor/src/tests/subnet.rs
+++ b/pallets/subtensor/src/tests/subnet.rs
@@ -717,62 +717,62 @@ fn test_subtoken_enable_ok_for_burn_register_before_enable() {
     });
 }
 
-#[test]
-fn test_user_liquidity_access_control() {
-    new_test_ext(1).execute_with(|| {
-        let owner_hotkey = U256::from(1);
-        let owner_coldkey = U256::from(2);
-        let not_owner = U256::from(999); // arbitrary non-owner
+// #[test]
+// fn test_user_liquidity_access_control() {
+//     new_test_ext(1).execute_with(|| {
+//         let owner_hotkey = U256::from(1);
+//         let owner_coldkey = U256::from(2);
+//         let not_owner = U256::from(999); // arbitrary non-owner
 
-        // add network
-        let netuid = add_dynamic_network(&owner_hotkey, &owner_coldkey);
+//         // add network
+//         let netuid = add_dynamic_network(&owner_hotkey, &owner_coldkey);
 
-        // Not owner, not root: should fail
-        assert_noop!(
-            Swap::toggle_user_liquidity(RuntimeOrigin::signed(not_owner), netuid, true),
-            DispatchError::BadOrigin
-        );
+//         // Not owner, not root: should fail
+//         assert_noop!(
+//             Swap::toggle_user_liquidity(RuntimeOrigin::signed(not_owner), netuid, true),
+//             DispatchError::BadOrigin
+//         );
 
-        // Subnet owner can enable
-        assert_ok!(Swap::toggle_user_liquidity(
-            RuntimeOrigin::signed(owner_coldkey),
-            netuid,
-            true
-        ));
-        assert!(pallet_subtensor_swap::EnabledUserLiquidity::<Test>::get(
-            NetUid::from(netuid)
-        ));
+//         // Subnet owner can enable
+//         assert_ok!(Swap::toggle_user_liquidity(
+//             RuntimeOrigin::signed(owner_coldkey),
+//             netuid,
+//             true
+//         ));
+//         assert!(pallet_subtensor_swap::EnabledUserLiquidity::<Test>::get(
+//             NetUid::from(netuid)
+//         ));
 
-        // Root can disable
-        assert_ok!(Swap::toggle_user_liquidity(
-            RuntimeOrigin::root(),
-            netuid,
-            false
-        ));
-        assert!(!pallet_subtensor_swap::EnabledUserLiquidity::<Test>::get(
-            NetUid::from(netuid)
-        ));
+//         // Root can disable
+//         assert_ok!(Swap::toggle_user_liquidity(
+//             RuntimeOrigin::root(),
+//             netuid,
+//             false
+//         ));
+//         assert!(!pallet_subtensor_swap::EnabledUserLiquidity::<Test>::get(
+//             NetUid::from(netuid)
+//         ));
 
-        // Root can enable again
-        assert_ok!(Swap::toggle_user_liquidity(
-            RuntimeOrigin::root(),
-            netuid,
-            true
-        ));
-        assert!(pallet_subtensor_swap::EnabledUserLiquidity::<Test>::get(
-            NetUid::from(netuid)
-        ));
+//         // Root can enable again
+//         assert_ok!(Swap::toggle_user_liquidity(
+//             RuntimeOrigin::root(),
+//             netuid,
+//             true
+//         ));
+//         assert!(pallet_subtensor_swap::EnabledUserLiquidity::<Test>::get(
+//             NetUid::from(netuid)
+//         ));
 
-        // Subnet owner cannot disable (only root can disable)
-        assert_noop!(
-            Swap::toggle_user_liquidity(RuntimeOrigin::signed(owner_coldkey), netuid, false),
-            DispatchError::BadOrigin
-        );
-        assert!(pallet_subtensor_swap::EnabledUserLiquidity::<Test>::get(
-            NetUid::from(netuid)
-        ));
-    });
-}
+//         // Subnet owner cannot disable (only root can disable)
+//         assert_noop!(
+//             Swap::toggle_user_liquidity(RuntimeOrigin::signed(owner_coldkey), netuid, false),
+//             DispatchError::BadOrigin
+//         );
+//         assert!(pallet_subtensor_swap::EnabledUserLiquidity::<Test>::get(
+//             NetUid::from(netuid)
+//         ));
+//     });
+// }
 
 // cargo test --package pallet-subtensor --lib -- tests::subnet::test_no_duplicates_in_symbol_static --exact --show-output
 #[test]

--- a/pallets/swap/src/benchmarking.rs
+++ b/pallets/swap/src/benchmarking.rs
@@ -12,8 +12,8 @@ use subtensor_runtime_common::NetUid;
 
 use crate::{
     pallet::{
-        AlphaSqrtPrice, Call, Config, CurrentLiquidity, CurrentTick, EnabledUserLiquidity, Pallet,
-        Positions, SwapV3Initialized,
+        AlphaSqrtPrice, Call, Config, CurrentLiquidity, CurrentTick, Pallet, Positions,
+        SwapV3Initialized,
     },
     position::{Position, PositionId},
     tick::TickIndex,
@@ -131,17 +131,17 @@ mod benchmarks {
         );
     }
 
-    #[benchmark]
-    fn toggle_user_liquidity() {
-        let netuid = NetUid::from(101);
+    // #[benchmark]
+    // fn toggle_user_liquidity() {
+    //     let netuid = NetUid::from(101);
 
-        assert!(!EnabledUserLiquidity::<T>::get(netuid));
+    //     assert!(!EnabledUserLiquidity::<T>::get(netuid));
 
-        #[extrinsic_call]
-        toggle_user_liquidity(RawOrigin::Root, netuid.into(), true);
+    //     #[extrinsic_call]
+    //     toggle_user_liquidity(RawOrigin::Root, netuid.into(), true);
 
-        assert!(EnabledUserLiquidity::<T>::get(netuid));
-    }
+    //     assert!(EnabledUserLiquidity::<T>::get(netuid));
+    // }
 
     impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);
 }

--- a/pallets/swap/src/pallet/mod.rs
+++ b/pallets/swap/src/pallet/mod.rs
@@ -609,7 +609,7 @@ mod pallet {
         pub fn disable_lp(origin: OriginFor<T>) -> DispatchResult {
             ensure_root(origin)?;
 
-            for netuid in 1..128 {
+            for netuid in 1..=128 {
                 let netuid = NetUid::from(netuid as u16);
                 if EnabledUserLiquidity::<T>::get(netuid) {
                     EnabledUserLiquidity::<T>::insert(netuid, false);
@@ -617,10 +617,11 @@ mod pallet {
                         netuid,
                         enable: false,
                     });
-
-                    // Remove provided liquidity
-                    // Self::do_dissolve_all_liquidity_providers(netuid)?;
                 }
+
+                // Remove provided liquidity unconditionally because the network may have 
+                // user liquidity previously disabled
+                Self::do_dissolve_all_liquidity_providers(netuid)?;
             }
 
             Ok(())

--- a/pallets/swap/src/pallet/mod.rs
+++ b/pallets/swap/src/pallet/mod.rs
@@ -350,9 +350,9 @@ mod pallet {
                 Error::<T>::MechanismDoesNotExist
             );
 
-            EnabledUserLiquidity::<T>::insert(netuid, enable);
+            // EnabledUserLiquidity::<T>::insert(netuid, enable);
 
-            Self::deposit_event(Event::UserLiquidityToggled { netuid, enable });
+            // Self::deposit_event(Event::UserLiquidityToggled { netuid, enable });
 
             Ok(())
         }
@@ -596,6 +596,31 @@ mod pallet {
                     netuid.into(),
                     result.fee_alpha,
                 )?;
+            }
+
+            Ok(())
+        }
+
+        /// Disable user liquidity in all subnets.
+        ///
+        /// Emits `Event::UserLiquidityToggled` on success
+        #[pallet::call_index(5)]
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::modify_position())]
+        pub fn disable_lp(origin: OriginFor<T>) -> DispatchResult {
+            ensure_root(origin)?;
+
+            for netuid in 1..128 {
+                let netuid = NetUid::from(netuid as u16);
+                if EnabledUserLiquidity::<T>::get(netuid) {
+                    EnabledUserLiquidity::<T>::insert(netuid, false);
+                    Self::deposit_event(Event::UserLiquidityToggled {
+                        netuid,
+                        enable: false,
+                    });
+
+                    // Remove provided liquidity
+                    // Self::do_dissolve_all_liquidity_providers(netuid)?;
+                }
             }
 
             Ok(())

--- a/pallets/swap/src/pallet/mod.rs
+++ b/pallets/swap/src/pallet/mod.rs
@@ -619,7 +619,7 @@ mod pallet {
                     });
                 }
 
-                // Remove provided liquidity unconditionally because the network may have 
+                // Remove provided liquidity unconditionally because the network may have
                 // user liquidity previously disabled
                 Self::do_dissolve_all_liquidity_providers(netuid)?;
             }

--- a/pallets/swap/src/pallet/tests.rs
+++ b/pallets/swap/src/pallet/tests.rs
@@ -114,42 +114,42 @@ mod dispatchables {
         });
     }
 
-    #[test]
-    fn test_toggle_user_liquidity() {
-        new_test_ext().execute_with(|| {
-            let netuid = NetUid::from(101);
+    // #[test]
+    // fn test_toggle_user_liquidity() {
+    //     new_test_ext().execute_with(|| {
+    //         let netuid = NetUid::from(101);
 
-            assert!(!EnabledUserLiquidity::<Test>::get(netuid));
+    //         assert!(!EnabledUserLiquidity::<Test>::get(netuid));
 
-            assert_ok!(Swap::toggle_user_liquidity(
-                RuntimeOrigin::root(),
-                netuid.into(),
-                true
-            ));
+    //         assert_ok!(Swap::toggle_user_liquidity(
+    //             RuntimeOrigin::root(),
+    //             netuid.into(),
+    //             true
+    //         ));
 
-            assert!(EnabledUserLiquidity::<Test>::get(netuid));
+    //         assert!(EnabledUserLiquidity::<Test>::get(netuid));
 
-            assert_noop!(
-                Swap::toggle_user_liquidity(RuntimeOrigin::signed(666), netuid.into(), true),
-                DispatchError::BadOrigin
-            );
+    //         assert_noop!(
+    //             Swap::toggle_user_liquidity(RuntimeOrigin::signed(666), netuid.into(), true),
+    //             DispatchError::BadOrigin
+    //         );
 
-            assert_ok!(Swap::toggle_user_liquidity(
-                RuntimeOrigin::signed(1),
-                netuid.into(),
-                true
-            ));
+    //         assert_ok!(Swap::toggle_user_liquidity(
+    //             RuntimeOrigin::signed(1),
+    //             netuid.into(),
+    //             true
+    //         ));
 
-            assert_noop!(
-                Swap::toggle_user_liquidity(
-                    RuntimeOrigin::root(),
-                    NON_EXISTENT_NETUID.into(),
-                    true
-                ),
-                Error::<Test>::MechanismDoesNotExist
-            );
-        });
-    }
+    //         assert_noop!(
+    //             Swap::toggle_user_liquidity(
+    //                 RuntimeOrigin::root(),
+    //                 NON_EXISTENT_NETUID.into(),
+    //                 true
+    //             ),
+    //             Error::<Test>::MechanismDoesNotExist
+    //         );
+    //     });
+    // }
 }
 
 #[test]
@@ -1398,79 +1398,79 @@ fn test_convert_deltas() {
     });
 }
 
-#[test]
-fn test_user_liquidity_disabled() {
-    new_test_ext().execute_with(|| {
-        // Use a netuid above 100 since our mock enables liquidity for 0-100
-        let netuid = NetUid::from(101);
-        let tick_low = TickIndex::new_unchecked(-1000);
-        let tick_high = TickIndex::new_unchecked(1000);
-        let position_id = PositionId::from(1);
-        let liquidity = 1_000_000_000;
-        let liquidity_delta = 500_000_000;
+// #[test]
+// fn test_user_liquidity_disabled() {
+//     new_test_ext().execute_with(|| {
+//         // Use a netuid above 100 since our mock enables liquidity for 0-100
+//         let netuid = NetUid::from(101);
+//         let tick_low = TickIndex::new_unchecked(-1000);
+//         let tick_high = TickIndex::new_unchecked(1000);
+//         let position_id = PositionId::from(1);
+//         let liquidity = 1_000_000_000;
+//         let liquidity_delta = 500_000_000;
 
-        assert!(!EnabledUserLiquidity::<Test>::get(netuid));
+//         assert!(!EnabledUserLiquidity::<Test>::get(netuid));
 
-        assert_noop!(
-            Swap::do_add_liquidity(
-                netuid,
-                &OK_COLDKEY_ACCOUNT_ID,
-                &OK_HOTKEY_ACCOUNT_ID,
-                tick_low,
-                tick_high,
-                liquidity
-            ),
-            Error::<Test>::UserLiquidityDisabled
-        );
+//         assert_noop!(
+//             Swap::do_add_liquidity(
+//                 netuid,
+//                 &OK_COLDKEY_ACCOUNT_ID,
+//                 &OK_HOTKEY_ACCOUNT_ID,
+//                 tick_low,
+//                 tick_high,
+//                 liquidity
+//             ),
+//             Error::<Test>::UserLiquidityDisabled
+//         );
 
-        assert_noop!(
-            Swap::do_remove_liquidity(netuid, &OK_COLDKEY_ACCOUNT_ID, position_id),
-            Error::<Test>::LiquidityNotFound
-        );
+//         assert_noop!(
+//             Swap::do_remove_liquidity(netuid, &OK_COLDKEY_ACCOUNT_ID, position_id),
+//             Error::<Test>::LiquidityNotFound
+//         );
 
-        assert_noop!(
-            Swap::modify_position(
-                RuntimeOrigin::signed(OK_COLDKEY_ACCOUNT_ID),
-                OK_HOTKEY_ACCOUNT_ID,
-                netuid,
-                position_id,
-                liquidity_delta
-            ),
-            Error::<Test>::UserLiquidityDisabled
-        );
+//         assert_noop!(
+//             Swap::modify_position(
+//                 RuntimeOrigin::signed(OK_COLDKEY_ACCOUNT_ID),
+//                 OK_HOTKEY_ACCOUNT_ID,
+//                 netuid,
+//                 position_id,
+//                 liquidity_delta
+//             ),
+//             Error::<Test>::UserLiquidityDisabled
+//         );
 
-        assert_ok!(Swap::toggle_user_liquidity(
-            RuntimeOrigin::root(),
-            netuid,
-            true
-        ));
+//         assert_ok!(Swap::toggle_user_liquidity(
+//             RuntimeOrigin::root(),
+//             netuid,
+//             true
+//         ));
 
-        let position_id = Swap::do_add_liquidity(
-            netuid,
-            &OK_COLDKEY_ACCOUNT_ID,
-            &OK_HOTKEY_ACCOUNT_ID,
-            tick_low,
-            tick_high,
-            liquidity,
-        )
-        .unwrap()
-        .0;
+//         let position_id = Swap::do_add_liquidity(
+//             netuid,
+//             &OK_COLDKEY_ACCOUNT_ID,
+//             &OK_HOTKEY_ACCOUNT_ID,
+//             tick_low,
+//             tick_high,
+//             liquidity,
+//         )
+//         .unwrap()
+//         .0;
 
-        assert_ok!(Swap::do_modify_position(
-            netuid.into(),
-            &OK_COLDKEY_ACCOUNT_ID,
-            &OK_HOTKEY_ACCOUNT_ID,
-            position_id,
-            liquidity_delta,
-        ));
+//         assert_ok!(Swap::do_modify_position(
+//             netuid.into(),
+//             &OK_COLDKEY_ACCOUNT_ID,
+//             &OK_HOTKEY_ACCOUNT_ID,
+//             position_id,
+//             liquidity_delta,
+//         ));
 
-        assert_ok!(Swap::do_remove_liquidity(
-            netuid,
-            &OK_COLDKEY_ACCOUNT_ID,
-            position_id,
-        ));
-    });
-}
+//         assert_ok!(Swap::do_remove_liquidity(
+//             netuid,
+//             &OK_COLDKEY_ACCOUNT_ID,
+//             position_id,
+//         ));
+//     });
+// }
 
 /// Test correctness of swap fees:
 ///   - Fees are distribued to (concentrated) liquidity providers
@@ -2045,77 +2045,77 @@ fn test_liquidate_v3_removes_positions_ticks_and_state() {
     });
 }
 
-/// V3 path with user liquidity disabled at teardown:
-/// must still remove positions and clear state (after protocol clear).
-#[test]
-fn test_liquidate_v3_with_user_liquidity_disabled() {
-    new_test_ext().execute_with(|| {
-        let netuid = NetUid::from(101);
+// V3 path with user liquidity disabled at teardown:
+// must still remove positions and clear state (after protocol clear).
+// #[test]
+// fn test_liquidate_v3_with_user_liquidity_disabled() {
+//     new_test_ext().execute_with(|| {
+//         let netuid = NetUid::from(101);
 
-        assert_ok!(Pallet::<Test>::maybe_initialize_v3(netuid));
-        assert!(SwapV3Initialized::<Test>::get(netuid));
+//         assert_ok!(Pallet::<Test>::maybe_initialize_v3(netuid));
+//         assert!(SwapV3Initialized::<Test>::get(netuid));
 
-        // Enable temporarily to add a user position
-        assert_ok!(Swap::toggle_user_liquidity(
-            RuntimeOrigin::root(),
-            netuid.into(),
-            true
-        ));
+//         // Enable temporarily to add a user position
+//         assert_ok!(Swap::toggle_user_liquidity(
+//             RuntimeOrigin::root(),
+//             netuid.into(),
+//             true
+//         ));
 
-        let min_price = tick_to_price(TickIndex::MIN);
-        let max_price = tick_to_price(TickIndex::MAX);
-        let tick_low = price_to_tick(min_price);
-        let tick_high = price_to_tick(max_price);
-        let liquidity = 1_000_000_000_u64;
+//         let min_price = tick_to_price(TickIndex::MIN);
+//         let max_price = tick_to_price(TickIndex::MAX);
+//         let tick_low = price_to_tick(min_price);
+//         let tick_high = price_to_tick(max_price);
+//         let liquidity = 1_000_000_000_u64;
 
-        let (_pos_id, _tao, _alpha) = Pallet::<Test>::do_add_liquidity(
-            netuid,
-            &OK_COLDKEY_ACCOUNT_ID,
-            &OK_HOTKEY_ACCOUNT_ID,
-            tick_low,
-            tick_high,
-            liquidity,
-        )
-        .expect("add liquidity");
+//         let (_pos_id, _tao, _alpha) = Pallet::<Test>::do_add_liquidity(
+//             netuid,
+//             &OK_COLDKEY_ACCOUNT_ID,
+//             &OK_HOTKEY_ACCOUNT_ID,
+//             tick_low,
+//             tick_high,
+//             liquidity,
+//         )
+//         .expect("add liquidity");
 
-        // Disable user LP *before* liquidation; removal must ignore this flag.
-        assert_ok!(Swap::toggle_user_liquidity(
-            RuntimeOrigin::root(),
-            netuid.into(),
-            false
-        ));
+//         // Disable user LP *before* liquidation; removal must ignore this flag.
+//         assert_ok!(Swap::toggle_user_liquidity(
+//             RuntimeOrigin::root(),
+//             netuid.into(),
+//             false
+//         ));
 
-        // Users-only dissolve, then clear protocol liquidity/state.
-        assert_ok!(Pallet::<Test>::do_dissolve_all_liquidity_providers(netuid));
-        assert_ok!(Pallet::<Test>::do_clear_protocol_liquidity(netuid));
+//         // Users-only dissolve, then clear protocol liquidity/state.
+//         assert_ok!(Pallet::<Test>::do_dissolve_all_liquidity_providers(netuid));
+//         assert_ok!(Pallet::<Test>::do_clear_protocol_liquidity(netuid));
 
-        // ASSERT: positions & ticks gone, state reset
-        assert_eq!(
-            Pallet::<Test>::count_positions(netuid, &OK_COLDKEY_ACCOUNT_ID),
-            0
-        );
-        assert!(
-            Positions::<Test>::iter_prefix_values((netuid, OK_COLDKEY_ACCOUNT_ID))
-                .next()
-                .is_none()
-        );
-        assert!(Ticks::<Test>::iter_prefix(netuid).next().is_none());
-        assert!(
-            TickIndexBitmapWords::<Test>::iter_prefix((netuid,))
-                .next()
-                .is_none()
-        );
-        assert!(!SwapV3Initialized::<Test>::contains_key(netuid));
-        assert!(!AlphaSqrtPrice::<Test>::contains_key(netuid));
-        assert!(!CurrentTick::<Test>::contains_key(netuid));
-        assert!(!CurrentLiquidity::<Test>::contains_key(netuid));
-        assert!(!FeeGlobalTao::<Test>::contains_key(netuid));
-        assert!(!FeeGlobalAlpha::<Test>::contains_key(netuid));
+//         // ASSERT: positions & ticks gone, state reset
+//         assert_eq!(
+//             Pallet::<Test>::count_positions(netuid, &OK_COLDKEY_ACCOUNT_ID),
+//             0
+//         );
+//         assert!(
+//             Positions::<Test>::iter_prefix_values((netuid, OK_COLDKEY_ACCOUNT_ID))
+//                 .next()
+//                 .is_none()
+//         );
+//         assert!(Ticks::<Test>::iter_prefix(netuid).next().is_none());
+//         assert!(
+//             TickIndexBitmapWords::<Test>::iter_prefix((netuid,))
+//                 .next()
+//                 .is_none()
+//         );
+//         assert!(!SwapV3Initialized::<Test>::contains_key(netuid));
+//         assert!(!AlphaSqrtPrice::<Test>::contains_key(netuid));
+//         assert!(!CurrentTick::<Test>::contains_key(netuid));
+//         assert!(!CurrentLiquidity::<Test>::contains_key(netuid));
+//         assert!(!FeeGlobalTao::<Test>::contains_key(netuid));
+//         assert!(!FeeGlobalAlpha::<Test>::contains_key(netuid));
 
-        // `EnabledUserLiquidity` is removed by protocol clear stage.
-        assert!(!EnabledUserLiquidity::<Test>::contains_key(netuid));
-    });
-}
+//         // `EnabledUserLiquidity` is removed by protocol clear stage.
+//         assert!(!EnabledUserLiquidity::<Test>::contains_key(netuid));
+//     });
+// }
 
 /// Non‑V3 path: V3 not initialized (no positions); function must still clear any residual storages and succeed.
 #[test]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -220,7 +220,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 349,
+    spec_version: 350,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description

1. Extrinsic to disable user LP on all subnets
2. Disable extrinsic to enable user LP

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
