### PR TITLE
MevShield - Dynamic Transaction Construction

### DIFF
--- a/node/src/mev_shield/author.rs
+++ b/node/src/mev_shield/author.rs
@@ -408,10 +408,8 @@ where
         Err(e) => {
             log::debug!(
                 target: "mev-shield",
-                "runtime_api::version failed at_hash={:?}: {:?}; \
+                "runtime_api::version failed at_hash={at_hash:?}: {e:?}; \
                  falling back to compiled runtime::VERSION",
-                at_hash,
-                e
             );
             (
                 runtime::VERSION.spec_version,
@@ -467,8 +465,7 @@ where
     log::debug!(
         target: "mev-shield",
         "announce_next_key submitted: xt=0x{xt_hash_hex}, nonce={nonce:?}, \
-         spec_version={spec_version}, tx_version={tx_version}, era={:?}",
-        era,
+         spec_version={spec_version}, tx_version={tx_version}, era={era:?}",
     );
 
     Ok(())

--- a/node/src/mev_shield/author.rs
+++ b/node/src/mev_shield/author.rs
@@ -332,7 +332,7 @@ where
     use sp_runtime::{
         BoundedVec, MultiSignature,
         generic::Era,
-        traits::{ConstU32, TransactionExtension, SaturatedConversion},
+        traits::{ConstU32, SaturatedConversion, TransactionExtension},
     };
 
     fn to_h256<H: AsRef<[u8]>>(h: H) -> H256 {
@@ -425,7 +425,7 @@ where
         spec_version, // dynamic or fallback spec_version
         tx_version,   // dynamic or fallback transaction_version
         genesis_h256, // CheckEra::Implicit (Immortal => genesis hash)
-        at_hash_h256,  // CheckEra::Implicit = hash of the block the tx is created at
+        at_hash_h256, // CheckEra::Implicit = hash of the block the tx is created at
         (),           // CheckNonce::Implicit = ()
         (),           // CheckWeight::Implicit = ()
         (),           // ChargeTransactionPaymentWrapper::Implicit = ()
@@ -461,7 +461,8 @@ where
     let opaque: sp_runtime::OpaqueExtrinsic = uxt.into();
     let xt: <B as sp_runtime::traits::Block>::Extrinsic = opaque.into();
 
-    pool.submit_one(at_hash, TransactionSource::Local, xt).await?;
+    pool.submit_one(at_hash, TransactionSource::Local, xt)
+        .await?;
 
     log::debug!(
         target: "mev-shield",

--- a/node/src/mev_shield/author.rs
+++ b/node/src/mev_shield/author.rs
@@ -424,7 +424,7 @@ where
         (),           // CheckNonZeroSender
         spec_version, // dynamic or fallback spec_version
         tx_version,   // dynamic or fallback transaction_version
-        genesis_h256, // CheckEra::Implicit (Immortal => genesis hash)
+        genesis_h256, // CheckGenesis::Implicit = Hash
         at_hash_h256, // CheckEra::Implicit = hash of the block the tx is created at
         (),           // CheckNonce::Implicit = ()
         (),           // CheckWeight::Implicit = ()

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -237,7 +237,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 360,
+    spec_version: 361,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
This PR modifies the `mevshield` pallet so that extrinsics are crafted dynamically using the current runtime state rather than the state in the current binary.