### PR TITLE
Add root claim maps.

### DIFF
--- a/pallets/subtensor/src/coinbase/root.rs
+++ b/pallets/subtensor/src/coinbase/root.rs
@@ -210,7 +210,7 @@ impl<T: Config> Pallet<T> {
             Error::<T>::SubnetNotExists
         );
 
-        Self::finalize_all_subnet_root_dividends(netuid);
+        Self::clear_root_claim_root_data(netuid);
 
         // --- Perform the cleanup before removing the network.
         T::SwapInterface::dissolve_all_liquidity_providers(netuid)?;

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -2249,6 +2249,16 @@ pub mod pallet {
     #[pallet::storage] // --- Value --> num_root_claim | Number of coldkeys to claim each auto-claim.
     pub type NumRootClaim<T: Config> = StorageValue<_, u64, ValueQuery, DefaultNumRootClaim<T>>;
 
+    /// --- MAP ( subnet ) --> claimed root alpha (kept)
+    #[pallet::storage]
+    pub type SubnetRootClaimKeep<T: Config> =
+        StorageMap<_, Blake2_128Concat, NetUid, AlphaCurrency, ValueQuery, DefaultZeroAlpha<T>>;
+
+    /// --- MAP ( subnet ) --> claimed root alpha (swapped)
+    #[pallet::storage]
+    pub type SubnetRootClaimSwap<T: Config> =
+        StorageMap<_, Blake2_128Concat, NetUid, AlphaCurrency, ValueQuery, DefaultZeroAlpha<T>>;
+
     /// =============================
     /// ==== EVM related storage ====
     /// =============================

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -324,6 +324,20 @@ pub mod pallet {
     /// ==== Staking + Accounts ====
     /// ============================
 
+    #[crate::freeze_struct("e453805be107a384")]
+    #[derive(
+        Encode, Decode, Default, TypeInfo, Clone, PartialEq, Eq, Debug, DecodeWithMemTracking,
+    )]
+    /// Accounting root claim data per subnet per block.
+    pub struct PendingRootClaimedData {
+        /// Total alpha kept this block
+        pub alpha_kept: AlphaCurrency,
+        /// Total alpha swapped this block
+        pub alpha_swapped: AlphaCurrency,
+        /// Total TAO swapped this block
+        pub tao_swapped: TaoCurrency,
+    }
+
     #[derive(
         Encode, Decode, Default, TypeInfo, Clone, PartialEq, Eq, Debug, DecodeWithMemTracking,
     )]
@@ -355,6 +369,12 @@ pub mod pallet {
     #[pallet::type_value]
     pub fn DefaultRootClaimType<T: Config>() -> RootClaimTypeEnum {
         RootClaimTypeEnum::default()
+    }
+
+    /// Default root claim accounting data.
+    #[pallet::type_value]
+    pub fn DefaultRootClaimedData<T: Config>() -> PendingRootClaimedData {
+        PendingRootClaimedData::default()
     }
 
     /// Default number of root claims per claim call.
@@ -2254,15 +2274,16 @@ pub mod pallet {
     #[pallet::storage] // --- Value --> num_root_claim | Number of coldkeys to claim each auto-claim.
     pub type NumRootClaim<T: Config> = StorageValue<_, u64, ValueQuery, DefaultNumRootClaim<T>>;
 
-    /// --- MAP ( subnet ) --> claimed root alpha (kept)
+    /// --- MAP ( subnet ) --> pending accounting root claimed data. In-block storage only - to be cleaned each block.
     #[pallet::storage]
-    pub type SubnetRootClaimKeep<T: Config> =
-        StorageMap<_, Blake2_128Concat, NetUid, AlphaCurrency, ValueQuery, DefaultZeroAlpha<T>>;
-
-    /// --- MAP ( subnet ) --> claimed root alpha (swapped)
-    #[pallet::storage]
-    pub type SubnetRootClaimSwap<T: Config> =
-        StorageMap<_, Blake2_128Concat, NetUid, AlphaCurrency, ValueQuery, DefaultZeroAlpha<T>>;
+    pub type PendingSubnetRootClaimData<T: Config> = StorageMap<
+        _,
+        Blake2_128Concat,
+        NetUid,
+        PendingRootClaimedData,
+        ValueQuery,
+        DefaultRootClaimedData<T>,
+    >;
 
     /// =============================
     /// ==== EVM related storage ====

--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -479,5 +479,11 @@ mod events {
             /// The amount of alpha distributed
             alpha: AlphaCurrency,
         },
+
+        /// Root claimed data for this block.
+        RootClaimedData {
+            /// Root claim data for this block
+            data: BTreeMap<NetUid, PendingRootClaimedData>,
+        },
     }
 }

--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -47,6 +47,8 @@ mod hooks {
             for _ in StakingOperationRateLimiter::<T>::drain() {
                 // Clear all entries each block
             }
+
+            Self::deposit_root_claim_accounting_event();
         }
 
         fn on_runtime_upgrade() -> frame_support::weights::Weight {

--- a/pallets/subtensor/src/staking/claim_root.rs
+++ b/pallets/subtensor/src/staking/claim_root.rs
@@ -191,6 +191,10 @@ impl<T: Config> Pallet<T> {
                 coldkey,
                 owed_tao.amount_paid_out.into(),
             );
+
+            SubnetRootClaimSwap::<T>::mutate(netuid, |alpha| {
+                *alpha = alpha.saturating_add(owed_u64.into());
+            });
         } else
         /* Keep */
         {
@@ -206,6 +210,10 @@ impl<T: Config> Pallet<T> {
         // Increase root claimed by owed amount.
         RootClaimed::<T>::mutate((netuid, hotkey, coldkey), |root_claimed| {
             *root_claimed = root_claimed.saturating_add(owed_u64.into());
+        });
+
+        SubnetRootClaimKeep::<T>::mutate(netuid, |alpha| {
+            *alpha = alpha.saturating_add(owed_u64.into());
         });
     }
 
@@ -388,8 +396,8 @@ impl<T: Config> Pallet<T> {
         RootClaimable::<T>::insert(new_hotkey, dst_root_claimable);
     }
 
-    /// Claim all root dividends for subnet and remove all associated data.
-    pub fn finalize_all_subnet_root_dividends(netuid: NetUid) {
+    /// Remove all root claim data for subnet.
+    pub fn clear_root_claim_root_data(netuid: NetUid) {
         let hotkeys = RootClaimable::<T>::iter_keys().collect::<Vec<_>>();
 
         for hotkey in hotkeys.iter() {
@@ -399,5 +407,8 @@ impl<T: Config> Pallet<T> {
         }
 
         let _ = RootClaimed::<T>::clear_prefix((netuid,), u32::MAX, None);
+
+        SubnetRootClaimKeep::<T>::remove(&netuid);
+        SubnetRootClaimSwap::<T>::remove(&netuid);
     }
 }


### PR DESCRIPTION
This PR introduces two "accounting maps" that are populated during the root claim:
```
    /// --- MAP ( subnet ) --> claimed root alpha (kept)
    #[pallet::storage]
    pub type SubnetRootClaimKeep<T: Config> =
        StorageMap<_, Blake2_128Concat, NetUid, AlphaCurrency, ValueQuery, DefaultZeroAlpha<T>>;

    /// --- MAP ( subnet ) --> claimed root alpha (swapped)
    #[pallet::storage]
    pub type SubnetRootClaimSwap<T: Config> =
        StorageMap<_, Blake2_128Concat, NetUid, AlphaCurrency, ValueQuery, DefaultZeroAlpha<T>>;
```

Maps will be cleared on the network deregistration.
Tests verify alpha addition during root claim for both swap and keep operations, and map clearing on network deregistration.