### PR TITLE
Reduce Subtensor compilation time and run E2E tests a few times faster

### DIFF
--- a/.github/workflows/check-bittensor-e2e-tests.yml
+++ b/.github/workflows/check-bittensor-e2e-tests.yml
@@ -126,7 +126,7 @@ jobs:
           - runner: [self-hosted, type-ccx33]
             triple: x86_64-unknown-linux-gnu
             arch: amd64
-        runtime: ["fast-runtime"]
+        runtime: ["fast-runtime", "non-fast-runtime"]
 
     runs-on: ${{ matrix.platform.runner }}
 

--- a/.github/workflows/check-bittensor-e2e-tests.yml
+++ b/.github/workflows/check-bittensor-e2e-tests.yml
@@ -194,7 +194,7 @@ jobs:
           - runner: [self-hosted, type-ccx33]
             triple: x86_64-unknown-linux-gnu
             arch: amd64
-        runtime: ["fast-runtime", "non-fast-runtime"]
+        runtime: ["fast-runtime"]
 
     runs-on: ${{ matrix.platform.runner }}
 
@@ -284,6 +284,20 @@ jobs:
           pattern: binaries-*
           path: build/
           merge-multiple: true
+
+      # make fake artifacts for non-fast-runtime bc of `install_prebuilt_binaries.sh` requires (save time)
+      - name: Copy fast-runtime artifacts to non-fast-runtime (hack for e2e tests)
+        run: |
+          TRIPLE="x86_64-unknown-linux-gnu"
+          # Copy binary
+          mkdir -p build/ci_target/non-fast-runtime/${TRIPLE}/release/
+          cp -v build/ci_target/fast-runtime/${TRIPLE}/release/node-subtensor \
+            build/ci_target/non-fast-runtime/${TRIPLE}/release/node-subtensor
+          # Copy WASM
+          mkdir -p build/ci_target/non-fast-runtime/${TRIPLE}/release/wbuild/node-subtensor-runtime/
+          cp -v build/ci_target/fast-runtime/${TRIPLE}/release/wbuild/node-subtensor-runtime/node_subtensor_runtime.compact.compressed.wasm \
+            build/ci_target/non-fast-runtime/${TRIPLE}/release/wbuild/node-subtensor-runtime/node_subtensor_runtime.compact.compressed.wasm
+          echo "✅ Copied fast-runtime artifacts to non-fast-runtime"
 
       - name: Move Docker data-root to /mnt/data
         run: |

--- a/.github/workflows/check-bittensor-e2e-tests.yml
+++ b/.github/workflows/check-bittensor-e2e-tests.yml
@@ -115,7 +115,7 @@ jobs:
           echo "test-files=$test_files" >> $GITHUB_OUTPUT
         shell: bash
 
-  # build artifacts for fast-runtime (e2e tests only need this)
+  # build artifacts for fast-runtime and non-fast-runtime
   artifacts:
     name: Node • ${{ matrix.runtime }} • ${{ matrix.platform.arch }}
     needs: check-label
@@ -126,7 +126,7 @@ jobs:
           - runner: [self-hosted, type-ccx33]
             triple: x86_64-unknown-linux-gnu
             arch: amd64
-        runtime: ["fast-runtime"]
+        runtime: ["fast-runtime", "non-fast-runtime"]
 
     runs-on: ${{ matrix.platform.runner }}
 
@@ -228,7 +228,7 @@ jobs:
           docker info | grep "Docker Root Dir"
 
       - name: Build Docker Image
-        run: docker build -f Dockerfile-localnet -t localnet .
+        run: docker build -f Dockerfile-localnet --build-arg BUILT_IN_CI="Boom shakalaka" -t localnet .
 
       - name: Save Docker Image as Tar
         run: docker save -o /mnt/data/subtensor-localnet.tar localnet

--- a/.github/workflows/check-bittensor-e2e-tests.yml
+++ b/.github/workflows/check-bittensor-e2e-tests.yml
@@ -193,7 +193,7 @@ jobs:
           - runner: [self-hosted, type-ccx33]
             triple: x86_64-unknown-linux-gnu
             arch: amd64
-        runtime: ["fast-runtime"]
+        runtime: ["fast-runtime", "non-fast-runtime"]
 
     runs-on: ${{ matrix.platform.runner }}
 
@@ -283,20 +283,6 @@ jobs:
           pattern: binaries-*
           path: build/
           merge-multiple: true
-
-      # make fake artifacts for non-fast-runtime bc of `install_prebuilt_binaries.sh` requires (save time)
-      - name: Copy fast-runtime artifacts to non-fast-runtime (hack for e2e tests)
-        run: |
-          TRIPLE="x86_64-unknown-linux-gnu"
-          # Copy binary
-          mkdir -p build/ci_target/non-fast-runtime/${TRIPLE}/release/
-          cp -v build/ci_target/fast-runtime/${TRIPLE}/release/node-subtensor \
-            build/ci_target/non-fast-runtime/${TRIPLE}/release/node-subtensor
-          # Copy WASM
-          mkdir -p build/ci_target/non-fast-runtime/${TRIPLE}/release/wbuild/node-subtensor-runtime/
-          cp -v build/ci_target/fast-runtime/${TRIPLE}/release/wbuild/node-subtensor-runtime/node_subtensor_runtime.compact.compressed.wasm \
-            build/ci_target/non-fast-runtime/${TRIPLE}/release/wbuild/node-subtensor-runtime/node_subtensor_runtime.compact.compressed.wasm
-          echo "✅ Copied fast-runtime artifacts to non-fast-runtime"
 
       - name: Move Docker data-root to /mnt/data
         run: |

--- a/.github/workflows/check-bittensor-e2e-tests.yml
+++ b/.github/workflows/check-bittensor-e2e-tests.yml
@@ -115,7 +115,7 @@ jobs:
           echo "test-files=$test_files" >> $GITHUB_OUTPUT
         shell: bash
 
-  # build artifacts for non-fast-runtime (e2e tests only need this)
+  # build artifacts for fast-runtime (e2e tests only need this)
   artifacts:
     name: Node • ${{ matrix.runtime }} • ${{ matrix.platform.arch }}
     needs: check-label
@@ -123,9 +123,13 @@ jobs:
     strategy:
       matrix:
         platform:
-          - triple: x86_64-unknown-linux-gnu
+          - runner: [self-hosted, type-ccx33]
+            triple: x86_64-unknown-linux-gnu
             arch: amd64
-        runtime: ["non-fast-runtime"]
+          - runner: [ubuntu-24.04-arm]
+            triple: aarch64-unknown-linux-gnu
+            arch: arm64
+        runtime: ["fast-runtime"]
 
     runs-on: ubuntu-latest
 
@@ -156,7 +160,11 @@ jobs:
           export PATH="$HOME/.cargo/bin:$PATH"
           export CARGO_BUILD_TARGET="${{ matrix.platform.triple }}"
 
-          ./scripts/localnet.sh False --build-only
+          if [ "${{ matrix.runtime }}" = "fast-runtime" ]; then
+            ./scripts/localnet.sh --build-only
+          else
+            ./scripts/localnet.sh False --build-only
+          fi
 
       # use `ci_target` name bc .dockerignore excludes `target`
       - name: Prepare artifacts for upload

--- a/.github/workflows/check-bittensor-e2e-tests.yml
+++ b/.github/workflows/check-bittensor-e2e-tests.yml
@@ -109,9 +109,9 @@ jobs:
         run: |
           set -euo pipefail
           test_matrix=$(
-            source .venv/bin/activate
             uv run pytest -q --collect-only tests/e2e_tests \
-            | sed -n '/^tests\//p' \
+            | sed -n '/^e2e_tests\//p' \
+            | sed 's|^|tests/|' \
             | jq -R -s -c '
                 split("\n")
                 | map(select(. != ""))
@@ -170,9 +170,9 @@ jobs:
         run: |
           set -euo pipefail
           test_matrix=$(
-            source .venv/bin/activate
             uv run pytest -q --collect-only tests/e2e_tests \
-            | sed -n '/^tests\//p' \
+            | sed -n '/^e2e_tests\//p' \
+            | sed 's|^|tests/|' \
             | jq -R -s -c '
                 split("\n")
                 | map(select(. != ""))

--- a/.github/workflows/check-bittensor-e2e-tests.yml
+++ b/.github/workflows/check-bittensor-e2e-tests.yml
@@ -131,7 +131,7 @@ jobs:
             arch: arm64
         runtime: ["fast-runtime"]
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform.runner }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/check-bittensor-e2e-tests.yml
+++ b/.github/workflows/check-bittensor-e2e-tests.yml
@@ -81,11 +81,45 @@ jobs:
         working-directory: ${{ github.workspace }}/btcli
         run: git checkout staging
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: "false"
+
+      - name: Create Python virtual environment
+        working-directory: ${{ github.workspace }}/btcli
+        run: uv venv --seed
+
+      - name: Install dependencies
+        working-directory: ${{ github.workspace }}/btcli
+        run: |
+          source .venv/bin/activate
+          uv run --active pip install --upgrade pip
+          uv run --active pip install '.[dev]'
+          uv run --active pip install pytest
+
       - name: Find e2e test files
         id: get-btcli-tests
+        working-directory: ${{ github.workspace }}/btcli
         run: |
-          test_files=$(find ${{ github.workspace }}/btcli/tests/e2e_tests -name "test*.py" | jq -R -s -c 'split("\n") | map(select(. != ""))')
-          echo "test-files=$test_files" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          test_matrix=$(
+            source .venv/bin/activate
+            uv run pytest -q --collect-only tests/e2e_tests \
+            | sed -n '/^tests\//p' \
+            | jq -R -s -c '
+                split("\n")
+                | map(select(. != ""))
+                | map({nodeid: ., label: (sub("^tests/e2e_tests/"; ""))})
+              '
+          )
+          echo "Found tests: $test_matrix"
+          echo "test-files=$test_matrix" >> "$GITHUB_OUTPUT"
         shell: bash
 
   find-sdk-e2e-tests:
@@ -108,11 +142,45 @@ jobs:
         working-directory: ${{ github.workspace }}/bittensor
         run: git checkout staging
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: "false"
+
+      - name: Create Python virtual environment
+        working-directory: ${{ github.workspace }}/bittensor
+        run: uv venv --seed
+
+      - name: Install dependencies
+        working-directory: ${{ github.workspace }}/bittensor
+        run: |
+          source .venv/bin/activate
+          uv run --active pip install --upgrade pip
+          uv run --active pip install '.[dev]'
+          uv run --active pip install pytest
+
       - name: Find e2e test files
         id: get-sdk-tests
+        working-directory: ${{ github.workspace }}/bittensor
         run: |
-          test_files=$(find ${{ github.workspace }}/bittensor/tests/e2e_tests -name "test*.py" | jq -R -s -c 'split("\n") | map(select(. != ""))')
-          echo "test-files=$test_files" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          test_matrix=$(
+            source .venv/bin/activate
+            uv run pytest -q --collect-only tests/e2e_tests \
+            | sed -n '/^tests\//p' \
+            | jq -R -s -c '
+                split("\n")
+                | map(select(. != ""))
+                | map({nodeid: ., label: (sub("^tests/e2e_tests/"; ""))})
+              '
+          )
+          echo "Found tests: $test_matrix"
+          echo "test-files=$test_matrix" >> "$GITHUB_OUTPUT"
         shell: bash
 
   # build artifacts for fast-runtime and non-fast-runtime
@@ -257,7 +325,7 @@ jobs:
           - x86_64-unknown-linux-gnu
         os:
           - ubuntu-latest
-        test-file: ${{ fromJson(needs.find-btcli-e2e-tests.outputs.test-files) }}
+        include: ${{ fromJson(needs.find-btcli-e2e-tests.outputs.test-files) }}
 
     env:
       RELEASE_NAME: development
@@ -267,7 +335,7 @@ jobs:
       TARGET: ${{ matrix.rust-target }}
 
     timeout-minutes: 60
-    name: "cli: ${{ matrix.test-file }}"
+    name: "cli: ${{ matrix.label }}"
     steps:
       - name: Check-out repository
         uses: actions/checkout@v4
@@ -317,7 +385,7 @@ jobs:
           set +e
           for i in 1 2; do
             echo "🔁 Attempt $i: Running tests"
-            uv run pytest ${{ matrix.test-file }} -s
+            uv run pytest "${{ matrix.nodeid }}" -s
             status=$?
             if [ $status -eq 0 ]; then
               echo "✅ Tests passed on attempt $i"
@@ -351,7 +419,7 @@ jobs:
           - x86_64-unknown-linux-gnu
         os:
           - ubuntu-latest
-        test-file: ${{ fromJson(needs.find-sdk-e2e-tests.outputs.test-files) }}
+        include: ${{ fromJson(needs.find-sdk-e2e-tests.outputs.test-files) }}
 
     env:
       RELEASE_NAME: development
@@ -361,7 +429,7 @@ jobs:
       TARGET: ${{ matrix.rust-target }}
 
     timeout-minutes: 60
-    name: "sdk: ${{ matrix.test-file }}"
+    name: "sdk: ${{ matrix.label }}"
     steps:
       - name: Check-out repository
         uses: actions/checkout@v4
@@ -411,7 +479,7 @@ jobs:
           set +e
           for i in 1 2; do
             echo "🔁 Attempt $i: Running tests"
-            uv run pytest ${{ matrix.test-file }} -s
+            uv run pytest "${{ matrix.nodeid }}" -s
             status=$?
             if [ $status -eq 0 ]; then
               echo "✅ Tests passed on attempt $i"

--- a/.github/workflows/check-bittensor-e2e-tests.yml
+++ b/.github/workflows/check-bittensor-e2e-tests.yml
@@ -126,7 +126,7 @@ jobs:
           - runner: [self-hosted, type-ccx33]
             triple: x86_64-unknown-linux-gnu
             arch: amd64
-        runtime: ["fast-runtime", "non-fast-runtime"]
+        runtime: ["fast-runtime"]
 
     runs-on: ${{ matrix.platform.runner }}
 

--- a/.github/workflows/check-bittensor-e2e-tests.yml
+++ b/.github/workflows/check-bittensor-e2e-tests.yml
@@ -126,9 +126,6 @@ jobs:
           - runner: [self-hosted, type-ccx33]
             triple: x86_64-unknown-linux-gnu
             arch: amd64
-          - runner: [ubuntu-24.04-arm]
-            triple: aarch64-unknown-linux-gnu
-            arch: arm64
         runtime: ["fast-runtime"]
 
     runs-on: ${{ matrix.platform.runner }}

--- a/.github/workflows/check-bittensor-e2e-tests.yml
+++ b/.github/workflows/check-bittensor-e2e-tests.yml
@@ -332,20 +332,7 @@ jobs:
       fail-fast: false
       max-parallel: 32
       matrix:
-        rust-branch:
-          - stable
-        rust-target:
-          - x86_64-unknown-linux-gnu
-        os:
-          - ubuntu-latest
         include: ${{ fromJson(needs.find-btcli-e2e-tests.outputs.test-files) }}
-
-    env:
-      RELEASE_NAME: development
-      RUSTV: ${{ matrix.rust-branch }}
-      RUST_BACKTRACE: full
-      RUST_BIN_DIR: target/${{ matrix.rust-target }}
-      TARGET: ${{ matrix.rust-target }}
 
     timeout-minutes: 60
     name: "cli: ${{ matrix.label }}"
@@ -426,20 +413,7 @@ jobs:
       fail-fast: false
       max-parallel: 64
       matrix:
-        rust-branch:
-          - stable
-        rust-target:
-          - x86_64-unknown-linux-gnu
-        os:
-          - ubuntu-latest
         include: ${{ fromJson(needs.find-sdk-e2e-tests.outputs.test-files) }}
-
-    env:
-      RELEASE_NAME: development
-      RUSTV: ${{ matrix.rust-branch }}
-      RUST_BACKTRACE: full
-      RUST_BIN_DIR: target/${{ matrix.rust-target }}
-      TARGET: ${{ matrix.rust-target }}
 
     timeout-minutes: 60
     name: "sdk: ${{ matrix.label }}"

--- a/.github/workflows/check-bittensor-e2e-tests.yml
+++ b/.github/workflows/check-bittensor-e2e-tests.yml
@@ -28,7 +28,7 @@ jobs:
   check-label:
     runs-on: ubuntu-latest
     outputs:
-      skip-bittensor-e2e-tests: ${{ steps.get-labels.outputs.skip-bittensor-e2e-tests }}
+      skip-bittensor-e2e-tests: ${{ steps.get-labels.outputs.skip-bittensor-e2e-tests || steps.set-default.outputs.skip-bittensor-e2e-tests }}
     steps:
       - name: Install dependencies
         run: |
@@ -38,11 +38,12 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
 
       - name: Get labels from PR
         id: get-labels
+        if: github.event_name == 'pull_request'
         run: |
           LABELS=$(gh pr -R ${{ github.repository }} view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
           echo "Current labels: $LABELS"
@@ -53,6 +54,12 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set default skip value for workflow_dispatch
+        id: set-default
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "skip-bittensor-e2e-tests=false" >> $GITHUB_OUTPUT
 
   find-btcli-e2e-tests:
     needs: check-label
@@ -108,27 +115,102 @@ jobs:
           echo "test-files=$test_files" >> $GITHUB_OUTPUT
         shell: bash
 
-  build-image-with-current-branch:
+  # build artifacts for non-fast-runtime (e2e tests only need this)
+  artifacts:
+    name: Node • ${{ matrix.runtime }} • ${{ matrix.platform.arch }}
     needs: check-label
+    if: needs.check-label.outputs.skip-bittensor-e2e-tests == 'false'
+    strategy:
+      matrix:
+        platform:
+          - triple: x86_64-unknown-linux-gnu
+            arch: amd64
+        runtime: ["non-fast-runtime"]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
+
+      - name: Install Rust + dependencies
+        run: |
+          chmod +x ./scripts/install_build_env.sh
+          ./scripts/install_build_env.sh
+
+      - name: Add Rust target triple
+        run: |
+          source "$HOME/.cargo/env"
+          rustup target add ${{ matrix.platform.triple }}
+
+      - name: Patch limits for local run
+        run: |
+          chmod +x ./scripts/localnet_patch.sh
+          ./scripts/localnet_patch.sh
+
+      - name: Build binaries
+        run: |
+          export PATH="$HOME/.cargo/bin:$PATH"
+          export CARGO_BUILD_TARGET="${{ matrix.platform.triple }}"
+
+          ./scripts/localnet.sh False --build-only
+
+      # use `ci_target` name bc .dockerignore excludes `target`
+      - name: Prepare artifacts for upload
+        run: |
+          RUNTIME="${{ matrix.runtime }}"
+          TRIPLE="${{ matrix.platform.triple }}"
+
+          # Verify binaries exist before copying
+          BINARY_PATH="target/${RUNTIME}/${TRIPLE}/release/node-subtensor"
+          WASM_PATH="target/${RUNTIME}/${TRIPLE}/release/wbuild/node-subtensor-runtime/node_subtensor_runtime.compact.compressed.wasm"
+
+          if [[ ! -f "$BINARY_PATH" ]]; then
+            echo "❌ Error: Binary not found at $BINARY_PATH"
+            exit 1
+          fi
+
+          if [[ ! -f "$WASM_PATH" ]]; then
+            echo "❌ Error: WASM file not found at $WASM_PATH"
+            exit 1
+          fi
+
+          mkdir -p build/ci_target/${RUNTIME}/${TRIPLE}/release/
+          cp -v "$BINARY_PATH" \
+            build/ci_target/${RUNTIME}/${TRIPLE}/release/
+
+          mkdir -p build/ci_target/${RUNTIME}/${TRIPLE}/release/wbuild/node-subtensor-runtime/
+          cp -v "$WASM_PATH" \
+            build/ci_target/${RUNTIME}/${TRIPLE}/release/wbuild/node-subtensor-runtime/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries-${{ matrix.platform.triple }}-${{ matrix.runtime }}
+          path: build/
+          if-no-files-found: error
+
+  # Collect all artifacts and build a Docker image
+  build-image-with-current-branch:
+    needs: [check-label, artifacts]
     if: needs.check-label.outputs.skip-bittensor-e2e-tests == 'false'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
 
-      - name: Patch non-fast-runtime node
-        run: |
-          chmod +x ./scripts/localnet_patch.sh
-          ./scripts/localnet_patch.sh
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Download all binary artifacts
+        uses: actions/download-artifact@v5
+        with:
+          pattern: binaries-*
+          path: build/
+          merge-multiple: true
 
       - name: Move Docker data-root to /mnt/data
         run: |
@@ -185,8 +267,8 @@ jobs:
       - name: Check-out repository
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -279,8 +361,8 @@ jobs:
       - name: Check-out repository
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/check-bittensor-e2e-tests.yml
+++ b/.github/workflows/check-bittensor-e2e-tests.yml
@@ -330,7 +330,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      max-parallel: 16
+      max-parallel: 32
       matrix:
         rust-branch:
           - stable
@@ -424,7 +424,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      max-parallel: 16
+      max-parallel: 64
       matrix:
         rust-branch:
           - stable

--- a/.github/workflows/check-bittensor-e2e-tests.yml
+++ b/.github/workflows/check-bittensor-e2e-tests.yml
@@ -110,8 +110,7 @@ jobs:
           set -euo pipefail
           test_matrix=$(
             uv run pytest -q --collect-only tests/e2e_tests \
-            | sed -n '/^e2e_tests\//p' \
-            | sed 's|^|tests/|' \
+            | sed -n '/^tests\//p' \
             | jq -R -s -c '
                 split("\n")
                 | map(select(. != ""))


### PR DESCRIPTION
### Changes
- Reduced build time from 1.5 hour to 15 minutes.
- Each test case is run as a separate matrix element. If a failure occurs, there's no need to rerun all tests in the module.

Overall speedup is several times faster.

### Result:
- [before](https://github.com/opentensor/subtensor/actions/runs/20170564727) **~1.5 hours**
- [now](https://github.com/opentensor/subtensor/actions/runs/20181850039) **~30 min**