### PR TITLE
Revert root claim default type back to Swap

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -330,9 +330,9 @@ pub mod pallet {
     /// Enum for the per-coldkey root claim setting.
     pub enum RootClaimTypeEnum {
         /// Swap any alpha emission for TAO.
+        #[default]
         Swap,
         /// Keep all alpha emission.
-        #[default]
         Keep,
         /// Keep all alpha emission for specified subnets.
         KeepSubnets {

--- a/pallets/subtensor/src/tests/claim_root.rs
+++ b/pallets/subtensor/src/tests/claim_root.rs
@@ -1822,6 +1822,6 @@ fn test_claim_root_default_mode_keep() {
     new_test_ext(1).execute_with(|| {
         let coldkey = U256::from(1003);
 
-        assert_eq!(RootClaimType::<Test>::get(coldkey), RootClaimTypeEnum::Keep);
+        assert_eq!(RootClaimType::<Test>::get(coldkey), RootClaimTypeEnum::Swap);
     });
 }


### PR DESCRIPTION
This PR reverts the default root claim type change back to `Swap` while preserving the added test. 