### PR TITLE
Stop EVM frontrunning

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -61,7 +61,9 @@ use sp_runtime::{
         AccountIdLookup, BlakeTwo256, Block as BlockT, DispatchInfoOf, Dispatchable, One,
         PostDispatchInfoOf, UniqueSaturatedInto, Verify,
     },
-    transaction_validity::{TransactionSource, TransactionValidity, TransactionValidityError},
+    transaction_validity::{
+        TransactionPriority, TransactionSource, TransactionValidity, TransactionValidityError,
+    },
 };
 use sp_std::cmp::Ordering;
 use sp_std::prelude::*;
@@ -1224,6 +1226,10 @@ impl<F: FindAuthor<u32>> FindAuthor<H160> for FindAuthorTruncated<F> {
 }
 
 const BLOCK_GAS_LIMIT: u64 = 75_000_000;
+pub const NORMAL_DISPATCH_BASE_PRIORITY: TransactionPriority = 1;
+pub const OPERATIONAL_DISPATCH_PRIORITY: TransactionPriority = 10_000_000_000;
+const EVM_TRANSACTION_BASE_PRIORITY: TransactionPriority = NORMAL_DISPATCH_BASE_PRIORITY;
+const EVM_LOG_TARGET: &str = "runtime::ethereum";
 
 /// `WeightPerGas` is an approximate ratio of the amount of Weight per Gas.
 ///
@@ -1387,6 +1393,35 @@ impl<B: BlockT> fp_rpc::ConvertTransaction<<B as BlockT>::Extrinsic> for Transac
     }
 }
 
+fn adjust_evm_priority_and_warn(
+    validity: &mut Option<TransactionValidity>,
+    priority_fee: Option<U256>,
+    info: &H160,
+) {
+    if let Some(Ok(valid_transaction)) = validity.as_mut() {
+        let original_priority = valid_transaction.priority;
+        valid_transaction.priority = EVM_TRANSACTION_BASE_PRIORITY;
+
+        let has_priority_fee = priority_fee.map_or(false, |fee| !fee.is_zero());
+        if has_priority_fee {
+            log::warn!(
+                target: EVM_LOG_TARGET,
+                "Priority fee/tip from {:?} (max_priority_fee_per_gas: {:?}) is ignored for transaction ordering",
+                info,
+                priority_fee.unwrap_or_default(),
+            );
+        } else if original_priority > EVM_TRANSACTION_BASE_PRIORITY {
+            log::warn!(
+                target: EVM_LOG_TARGET,
+                "EVM transaction priority from {:?} reduced from {} to {}; priority tips are ignored for ordering",
+                info,
+                original_priority,
+                EVM_TRANSACTION_BASE_PRIORITY,
+            );
+        }
+    }
+}
+
 impl fp_self_contained::SelfContainedCall for RuntimeCall {
     type SignedInfo = H160;
 
@@ -1411,7 +1446,21 @@ impl fp_self_contained::SelfContainedCall for RuntimeCall {
         len: usize,
     ) -> Option<TransactionValidity> {
         match self {
-            RuntimeCall::Ethereum(call) => call.validate_self_contained(info, dispatch_info, len),
+            RuntimeCall::Ethereum(call) => {
+                let priority_fee = match call {
+                    pallet_ethereum::Call::transact { transaction } => match transaction {
+                        EthereumTransaction::EIP1559(tx) => Some(tx.max_priority_fee_per_gas),
+                        EthereumTransaction::EIP7702(tx) => Some(tx.max_priority_fee_per_gas),
+                        _ => None,
+                    },
+                    _ => None,
+                };
+
+                let mut validity = call.validate_self_contained(info, dispatch_info, len);
+                adjust_evm_priority_and_warn(&mut validity, priority_fee, info);
+
+                validity
+            }
             _ => None,
         }
     }
@@ -2620,6 +2669,49 @@ fn test_into_substrate_balance_zero_value() {
 
     let result = SubtensorEvmBalanceConverter::into_substrate_balance(evm_balance);
     assert_eq!(result, Some(expected_substrate_balance));
+}
+
+#[test]
+fn evm_priority_overrides_tip_to_base() {
+    let mut validity: Option<TransactionValidity> =
+        Some(Ok(sp_runtime::transaction_validity::ValidTransaction {
+            priority: 99,
+            requires: vec![],
+            provides: vec![],
+            longevity: sp_runtime::transaction_validity::TransactionLongevity::MAX,
+            propagate: true,
+        }));
+
+    let signer = H160::repeat_byte(1);
+    adjust_evm_priority_and_warn(&mut validity, Some(U256::from(10)), &signer);
+
+    let adjusted = validity
+        .expect("validity must exist")
+        .expect("must be valid");
+    assert_eq!(adjusted.priority, EVM_TRANSACTION_BASE_PRIORITY);
+}
+
+#[test]
+fn evm_priority_cannot_overtake_unstake() {
+    // Unstake is a normal-class extrinsic (priority = NORMAL_DISPATCH_BASE_PRIORITY).
+    let unstake_priority: TransactionPriority = NORMAL_DISPATCH_BASE_PRIORITY;
+    let evm_priority: TransactionPriority = EVM_TRANSACTION_BASE_PRIORITY;
+
+    // Clamp guarantees the EVM tx is never above the unstake priority.
+    assert!(evm_priority <= unstake_priority);
+
+    // If both arrive with equal priority, arrival order keeps unstake first.
+    let mut queue: Vec<(&str, TransactionPriority, usize)> = vec![
+        ("unstake", unstake_priority, 0), // arrives first
+        ("evm", evm_priority, 1),         // arrives later
+    ];
+
+    queue.sort_by(|a, b| {
+        b.1.cmp(&a.1) // higher priority first
+            .then_with(|| a.2.cmp(&b.2)) // earlier arrival first when equal
+    });
+
+    assert_eq!(queue[0].0, "unstake");
 }
 
 #[test]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1402,7 +1402,7 @@ fn adjust_evm_priority_and_warn(
         let original_priority = valid_transaction.priority;
         valid_transaction.priority = EVM_TRANSACTION_BASE_PRIORITY;
 
-        let has_priority_fee = priority_fee.map_or(false, |fee| !fee.is_zero());
+        let has_priority_fee = priority_fee.is_some_and(|fee| !fee.is_zero());
         if has_priority_fee {
             log::warn!(
                 target: EVM_LOG_TARGET,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2709,8 +2709,8 @@ fn evm_priority_cannot_overtake_unstake() {
     ];
 
     queue.sort_by(|a, b| {
-            b.1.cmp(&a.1) // higher priority first
-                .then_with(|| a.2.cmp(&b.2)) // earlier arrival first when equal
+        b.1.cmp(&a.1) // higher priority first
+            .then_with(|| a.2.cmp(&b.2)) // earlier arrival first when equal
     });
 
     let first = queue.first().map(|entry| entry.0);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2685,10 +2685,12 @@ fn evm_priority_overrides_tip_to_base() {
     let signer = H160::repeat_byte(1);
     adjust_evm_priority_and_warn(&mut validity, Some(U256::from(10)), &signer);
 
-    let adjusted = validity
-        .expect("validity must exist")
-        .expect("must be valid");
-    assert_eq!(adjusted.priority, EVM_TRANSACTION_BASE_PRIORITY);
+    let adjusted_priority = validity
+        .as_ref()
+        .and_then(|v| v.as_ref().ok())
+        .map(|v| v.priority);
+
+    assert_eq!(adjusted_priority, Some(EVM_TRANSACTION_BASE_PRIORITY));
 }
 
 #[test]
@@ -2707,11 +2709,12 @@ fn evm_priority_cannot_overtake_unstake() {
     ];
 
     queue.sort_by(|a, b| {
-        b.1.cmp(&a.1) // higher priority first
-            .then_with(|| a.2.cmp(&b.2)) // earlier arrival first when equal
+            b.1.cmp(&a.1) // higher priority first
+                .then_with(|| a.2.cmp(&b.2)) // earlier arrival first when equal
     });
 
-    assert_eq!(queue[0].0, "unstake");
+    let first = queue.first().map(|entry| entry.0);
+    assert_eq!(first, Some("unstake"));
 }
 
 #[test]


### PR DESCRIPTION
This change clamps EVM transaction priority so that regardless of the tip/priority fee that is provided, the block builder will never take this into account when ordering EVM transactions (always clamped to regular dispatch priority). A warning is also now logged when someone provides a priority fee, since it is completely ignored by the block builder.

This is to prevent a current exploit where people were using EVM transactions to frontrun all swaps in a block.