### PR TITLE
Set default weights for system pallets.

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -353,7 +353,7 @@ impl frame_system::Config for Runtime {
     type PreInherents = ();
     type PostInherents = ();
     type PostTransactions = ();
-    type ExtensionsWeightInfo = (); // frame_system exports only default extension weights
+    type ExtensionsWeightInfo = frame_system::SubstrateExtensionsWeight<Runtime>;
 }
 
 impl pallet_insecure_randomness_collective_flip::Config for Runtime {}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -241,7 +241,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 365,
+    spec_version: 366,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -340,7 +340,7 @@ impl frame_system::Config for Runtime {
     // The data to be stored in an account.
     type AccountData = pallet_balances::AccountData<Balance>;
     // Weight information for the extrinsics of this pallet.
-    type SystemWeightInfo = ();
+    type SystemWeightInfo = frame_system::weights::SubstrateWeight<Runtime>;
     // This is used as an identifier of the chain. 42 is the generic substrate prefix.
     type SS58Prefix = SS58Prefix;
     // The set code logic, just the default since we're not a parachain.
@@ -353,7 +353,7 @@ impl frame_system::Config for Runtime {
     type PreInherents = ();
     type PostInherents = ();
     type PostTransactions = ();
-    type ExtensionsWeightInfo = ();
+    type ExtensionsWeightInfo = (); // frame_system exports only default extension weights
 }
 
 impl pallet_insecure_randomness_collective_flip::Config for Runtime {}
@@ -371,7 +371,7 @@ impl pallet_grandpa::Config for Runtime {
 
     type KeyOwnerProof = sp_core::Void;
 
-    type WeightInfo = ();
+    type WeightInfo = (); // pallet_grandpa exports only default implementation
     type MaxAuthorities = ConstU32<32>;
     type MaxSetIdSessionEntries = ConstU64<0>;
     type MaxNominators = ConstU32<20>;
@@ -409,7 +409,7 @@ impl pallet_timestamp::Config for Runtime {
     type Moment = u64;
     type OnTimestampSet = Aura;
     type MinimumPeriod = ConstU64<{ SLOT_DURATION / 2 }>;
-    type WeightInfo = ();
+    type WeightInfo = pallet_timestamp::weights::SubstrateWeight<Runtime>;
 }
 
 impl pallet_utility::Config for Runtime {


### PR DESCRIPTION
This PR sets default weights for system pallets:
- frame_system
- pallet_timestamp

The default implementation `impl WeightInfo for ()` provides the same values, so the tx fee won't change. 