### PR TITLE
adds a parameterized delay on realized flow

### DIFF
--- a/pallets/subtensor/src/coinbase/block_step.rs
+++ b/pallets/subtensor/src/coinbase/block_step.rs
@@ -33,7 +33,6 @@ impl<T: Config + pallet_drand::Config> Pallet<T> {
         Self::run_auto_claim_root_divs(last_block_hash);
         // --- 9. Populate root coldkey maps.
         Self::populate_root_coldkey_staking_maps();
-
         // Return ok.
         Ok(())
     }
@@ -229,9 +228,9 @@ impl<T: Config + pallet_drand::Config> Pallet<T> {
         if next_value >= U110F18::saturating_from_num(Self::get_max_difficulty(netuid)) {
             Self::get_max_difficulty(netuid)
         } else if next_value <= U110F18::saturating_from_num(Self::get_min_difficulty(netuid)) {
-            Self::get_min_difficulty(netuid)
+            return Self::get_min_difficulty(netuid);
         } else {
-            next_value.saturating_to_num::<u64>()
+            return next_value.saturating_to_num::<u64>();
         }
     }
 
@@ -263,9 +262,9 @@ impl<T: Config + pallet_drand::Config> Pallet<T> {
         if next_value >= U110F18::saturating_from_num(Self::get_max_burn(netuid)) {
             Self::get_max_burn(netuid)
         } else if next_value <= U110F18::saturating_from_num(Self::get_min_burn(netuid)) {
-            Self::get_min_burn(netuid)
+            return Self::get_min_burn(netuid);
         } else {
-            next_value.saturating_to_num::<u64>().into()
+            return next_value.saturating_to_num::<u64>().into();
         }
     }
 

--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -22,6 +22,7 @@ impl<T: Config> Pallet<T> {
     pub fn run_coinbase(block_emission: U96F32) {
         // --- 0. Get current block.
         let current_block: u64 = Self::get_current_block_as_u64();
+        Self::update_flows(current_block);
         log::debug!(
             "Running coinbase for block {current_block:?} with block emission: {block_emission:?}"
         );

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1457,6 +1457,46 @@ pub mod pallet {
     pub type SubnetEmaTaoFlow<T: Config> =
         StorageMap<_, Identity, NetUid, (u64, I64F64), OptionQuery>;
 
+    /// Flow tick len
+    #[pallet::type_value]
+    pub fn DefaultFlowTickLen<T: Config>() -> u64 {
+        1
+    }
+    /// --- ITEM ( flow tick len )
+    #[pallet::storage]
+    pub type FlowTickLen<T> = StorageValue<_, u64, ValueQuery, DefaultFlowTickLen<T>>;
+
+    /// Flow delay
+    #[pallet::type_value]
+    pub fn DefaultFlowDelay<T: Config>() -> u64 {
+        0
+    }
+    /// --- ITEM ( flow tick len )
+    #[pallet::storage]
+    pub type FlowDelay<T> = StorageValue<_, u64, ValueQuery, DefaultFlowDelay<T>>;
+        
+    // Per-day Tao flow for subnets
+    #[pallet::storage]
+    pub type SubnetFlowAccumulator<T: Config> = StorageDoubleMap<
+        _,
+        Identity,
+        NetUid,  // subnet id
+        Identity,
+        u64,     // day
+        i64,     // taoflow
+        ValueQuery,
+        DefaultZeroI64<T>
+    >;
+
+    /// Flow delay
+    #[pallet::type_value]
+    pub fn DefaultEmissionCap<T: Config>() -> u16 {
+        u16::MAX
+    }
+    /// --- ITEM ( max emission value )
+    #[pallet::storage]
+    pub type EmissionCap<T> = StorageValue<_, u16, ValueQuery, DefaultEmissionCap<T>>;
+
     /// Default value for flow cutoff.
     #[pallet::type_value]
     pub fn DefaultFlowCutoff<T: Config>() -> I64F64 {


### PR DESCRIPTION
## Description
Implementation for delayed flow credit which arbitrarily increases exposure of staking operations to root prop. Under sufficient conditions (high average net flow) makes self-staking costly.

Conservative estimate of delay length required for terms 

e = subnet emission
p = price
r = root prop
f = average per block flow
b = purchase amount
d = required delay

d > (e * b) / (12 * r * p * f )

Example:

e = 0.02
p = 0.04
r = 0.1
f = 0.1
b = 5000
d = ( 0.02 * 5000 ) / (12 * 0.1 * 0.04 * 0.1) =  20k block delay.