### PR TITLE
Fix: Issue #590 - Enable ProxyType::Cancel

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -160,6 +160,7 @@ pub enum ProxyType {
     SwapHotkey,
     SubnetLeaseBeneficiary, // Used to operate the leased subnet
     RootClaim,
+    Cancel,
 }
 
 impl TryFrom<u8> for ProxyType {
@@ -185,6 +186,7 @@ impl TryFrom<u8> for ProxyType {
             15 => Ok(Self::SwapHotkey),
             16 => Ok(Self::SubnetLeaseBeneficiary),
             17 => Ok(Self::RootClaim),
+            18 => Ok(Self::Cancel),
             _ => Err(()),
         }
     }
@@ -211,6 +213,7 @@ impl From<ProxyType> for u8 {
             ProxyType::SwapHotkey => 15,
             ProxyType::SubnetLeaseBeneficiary => 16,
             ProxyType::RootClaim => 17,
+            ProxyType::Cancel => 18,
         }
     }
 }


### PR DESCRIPTION
## Description
Enabled the missing `ProxyType::Cancel` variant in `common/src/lib.rs` and `macros/errors.rs`. This allows proxies to execute cancellation actions, which was previously unsupported.

## Related Issue(s)

- Closes #590

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

N/A

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

N/A

## Additional Notes

Ensures full enum parity for ProxyType.
