### PR TITLE
taoflow hotfix

### DIFF
--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -862,6 +862,9 @@ impl<T: Config> Pallet<T> {
             netuid,
             alpha,
         );
+		if netuid == NetUid::ROOT {
+			Self::remove_stake_adjust_root_claimed_for_hotkey_and_coldkey(origin_hotkey, origin_coldkey, alpha);
+		}
 
         // Increase alpha on destination keys
         let actual_alpha_moved = Self::increase_stake_for_hotkey_and_coldkey_on_subnet(
@@ -870,6 +873,9 @@ impl<T: Config> Pallet<T> {
             netuid,
             actual_alpha_decrease,
         );
+		if netuid == NetUid::ROOT {
+			Self::add_stake_adjust_root_claimed_for_hotkey_and_coldkey(destination_hotkey, destination_coldkey, actual_alpha_decrease.into());
+		}
 
         // Calculate TAO equivalent based on current price (it is accurate because
         // there's no slippage in this move)

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -862,9 +862,13 @@ impl<T: Config> Pallet<T> {
             netuid,
             alpha,
         );
-		if netuid == NetUid::ROOT {
-			Self::remove_stake_adjust_root_claimed_for_hotkey_and_coldkey(origin_hotkey, origin_coldkey, alpha);
-		}
+        if netuid == NetUid::ROOT {
+            Self::remove_stake_adjust_root_claimed_for_hotkey_and_coldkey(
+                origin_hotkey,
+                origin_coldkey,
+                alpha,
+            );
+        }
 
         // Increase alpha on destination keys
         let actual_alpha_moved = Self::increase_stake_for_hotkey_and_coldkey_on_subnet(
@@ -873,9 +877,13 @@ impl<T: Config> Pallet<T> {
             netuid,
             actual_alpha_decrease,
         );
-		if netuid == NetUid::ROOT {
-			Self::add_stake_adjust_root_claimed_for_hotkey_and_coldkey(destination_hotkey, destination_coldkey, actual_alpha_decrease.into());
-		}
+        if netuid == NetUid::ROOT {
+            Self::add_stake_adjust_root_claimed_for_hotkey_and_coldkey(
+                destination_hotkey,
+                destination_coldkey,
+                actual_alpha_decrease.into(),
+            );
+        }
 
         // Calculate TAO equivalent based on current price (it is accurate because
         // there's no slippage in this move)

--- a/pallets/subtensor/src/tests/claim_root.rs
+++ b/pallets/subtensor/src/tests/claim_root.rs
@@ -1833,7 +1833,7 @@ fn test_claim_root_with_moved_stake() {
         let hotkey = U256::from(1002);
         let alice_coldkey = U256::from(1003);
         let bob_coldkey = U256::from(1004);
-		let eve_coldkey = U256::from(1005);
+        let eve_coldkey = U256::from(1005);
         let netuid = add_dynamic_network(&hotkey, &owner_coldkey);
 
         SubtensorModule::set_tao_weight(u64::MAX); // Set TAO weight to 1.0
@@ -1873,10 +1873,10 @@ fn test_claim_root_with_moved_stake() {
             RootClaimTypeEnum::Keep
         ),);
 
-		assert_ok!(SubtensorModule::set_root_claim_type(
-			RuntimeOrigin::signed(eve_coldkey),
-			RootClaimTypeEnum::Keep
-		),);
+        assert_ok!(SubtensorModule::set_root_claim_type(
+            RuntimeOrigin::signed(eve_coldkey),
+            RootClaimTypeEnum::Keep
+        ),);
 
         // Distribute pending root alpha
 
@@ -1921,7 +1921,6 @@ fn test_claim_root_with_moved_stake() {
 
         assert_abs_diff_eq!(alice_stake, estimated_stake as u64, epsilon = 100u64,);
 
-
         // Distribute pending root alpha
 
         let pending_root_alpha = 10_000_000u64;
@@ -1938,19 +1937,19 @@ fn test_claim_root_with_moved_stake() {
 
         assert_ok!(SubtensorModule::transfer_stake(
             RuntimeOrigin::signed(bob_coldkey,),
-			eve_coldkey,
+            eve_coldkey,
             hotkey,
             NetUid::ROOT,
             NetUid::ROOT,
             stake_decrement.into(),
         ));
 
-		let eve_stake: u64 = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
-			&hotkey,
-			&eve_coldkey,
-			netuid,
-		)
-		.into();
+        let eve_stake: u64 = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey,
+            &eve_coldkey,
+            netuid,
+        )
+        .into();
 
         assert_ok!(SubtensorModule::claim_root(
             RuntimeOrigin::signed(alice_coldkey),
@@ -1961,10 +1960,10 @@ fn test_claim_root_with_moved_stake() {
             BTreeSet::from([netuid])
         ));
 
-		assert_ok!(SubtensorModule::claim_root(
-			RuntimeOrigin::signed(eve_coldkey),
-			BTreeSet::from([netuid])
-		));
+        assert_ok!(SubtensorModule::claim_root(
+            RuntimeOrigin::signed(eve_coldkey),
+            BTreeSet::from([netuid])
+        ));
 
         // Check new stakes
 
@@ -1982,16 +1981,16 @@ fn test_claim_root_with_moved_stake() {
         )
         .into();
 
-		let eve_stake2: u64 = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
-			&hotkey,
-			&eve_coldkey,
-			netuid,
-		)
-		.into();
+        let eve_stake2: u64 = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey,
+            &eve_coldkey,
+            netuid,
+        )
+        .into();
 
-		// Eve should not have gotten any root claim
-		let eve_stake_diff = eve_stake2 - eve_stake;
-		assert_abs_diff_eq!(eve_stake_diff, 0, epsilon = 100u64,);
+        // Eve should not have gotten any root claim
+        let eve_stake_diff = eve_stake2 - eve_stake;
+        assert_abs_diff_eq!(eve_stake_diff, 0, epsilon = 100u64,);
 
         let estimated_stake = (pending_root_alpha as f64) * (1f64 - validator_take_percent) / 2f64;
 
@@ -2005,7 +2004,7 @@ fn test_claim_root_with_moved_stake() {
         let stake_increment = stake_decrement;
 
         assert_ok!(SubtensorModule::transfer_stake(
-			RuntimeOrigin::signed(eve_coldkey,),
+            RuntimeOrigin::signed(eve_coldkey,),
             bob_coldkey,
             hotkey,
             NetUid::ROOT,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -241,7 +241,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 365,
+    spec_version: 366,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Root subnet stake moves now adjust root-claimed tracking: on ROOT transfers we remove root claim from the origin pair and add it to the destination pair to keep accounting aligned 