### PR TITLE
`Announce_Next_Key` Validation Check

### DIFF
--- a/pallets/shield/src/lib.rs
+++ b/pallets/shield/src/lib.rs
@@ -435,6 +435,20 @@ pub mod pallet {
             source: TransactionSource,
         ) -> ValidateResult<Self::Val, RuntimeCallFor<T>> {
             match call.is_sub_type() {
+                Some(Call::announce_next_key { .. }) => {
+                    // Only accept if produced locally (authoring node) or already in the block.
+                    match source {
+                        TransactionSource::Local | TransactionSource::InBlock => {}
+                        _ => return Err(InvalidTransaction::Call.into()),
+                    }
+
+                    let origin_clone = origin.clone();
+                    if T::AuthorityOrigin::ensure_validator(origin_clone).is_err() {
+                        return Err(InvalidTransaction::Call.into());
+                    }
+
+                    Ok((Default::default(), (), origin))
+                }
                 Some(Call::mark_decryption_failed { id, .. }) => {
                     match source {
                         TransactionSource::Local | TransactionSource::InBlock => {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -241,7 +241,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 366,
+    spec_version: 367,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
This PR adds validation checks to `announce_next_key` to ensure that only extrinsics with a validator origin and with a local transaction source are accepted before entering the pool. 