### PR TITLE
MevShield Emit Failure Event on Pre-Dispatch Failures

### DIFF
--- a/node/src/mev_shield/proposer.rs
+++ b/node/src/mev_shield/proposer.rs
@@ -18,11 +18,19 @@ fn truncate_utf8_to_bytes(s: &str, max_bytes: usize) -> String {
     if s.len() <= max_bytes {
         return s.to_string();
     }
-    let mut end = max_bytes;
-    while end > 0 && !s.is_char_boundary(end) {
+
+    let mut end = max_bytes.min(s.len());
+
+    // Decrement until we find a valid UTF-8 boundary.
+    while end > 0 {
+        if let Some(prefix) = s.get(..end) {
+            return prefix.to_string();
+        }
         end = end.saturating_sub(1);
     }
-    s[..end].to_string()
+
+    // If max_bytes was 0 or we couldn't find a boundary (extremely defensive), return empty.
+    String::new()
 }
 
 /// Helper to build a `mark_decryption_failed` runtime call with a bounded reason string.
@@ -654,7 +662,6 @@ pub fn spawn_revealer<B, C, Pool>(
                             plaintext.len()
                         );
 
-                        // Safely parse plaintext layout without panics.
                         if plaintext.is_empty() {
                             let error_message = "plaintext too short";
                             log::debug!(
@@ -741,6 +748,8 @@ pub fn spawn_revealer<B, C, Pool>(
                                         );
                                     }
                                     Err(e) => {
+                                        // Emit an on-chain failure event even when the *inner*
+                                        // transaction fails pre-dispatch validation in the pool.
                                         let err_dbg = format!("{e:?}");
                                         let reason = truncate_utf8_to_bytes(
                                             &format!(
@@ -759,7 +768,6 @@ pub fn spawn_revealer<B, C, Pool>(
                                 }
                             }
                             Err(e) => {
-                                // Defensive: if we cannot even construct an OpaqueExtrinsic, mark it failed.
                                 let err_dbg = format!("{e:?}");
                                 let reason = truncate_utf8_to_bytes(
                                     &format!(

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -241,7 +241,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 368,
+    spec_version: 369,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -241,7 +241,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 366,
+    spec_version: 368,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
Currently the `MevShield` pallet will emit an event in the case that decryption of the inner extrinsic fails or if the inner extrinsic results in a runtime error. 

This PR adds logic to emit the failure event in the case that the inner extrinsic fails on a pre-dispatch check such as the inability to pay the fee.

**Requires** node upgrades to work.