### PR TITLE
Update: Use default runtime constant for start call in localnet.sh

### DIFF
--- a/node/src/chain_spec/localnet.rs
+++ b/node/src/chain_spec/localnet.rs
@@ -124,8 +124,5 @@ fn localnet_genesis(
         "evmChainId": {
             "chainId": 42,
         },
-        "subtensorModule": {
-            "startCallDelay": 10,
-        },
     })
 }


### PR DESCRIPTION
## Description
Removes the hardcoded `startCallDelay: 10` from the localnet genesis config to use the runtime constant default (`InitialStartCallDelay = 0`). 
This fixes e2e tests where start_call fails unnecessarily due to the genesis override.


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.