### PR TITLE
Filter incorrect subnet owner calls in TransactionExtension (#2338)

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -2456,6 +2456,7 @@ pub enum CustomTransactionError {
     InputLengthsUnequal,
     UidNotFound,
     EvmKeyAssociateRateLimitExceeded,
+    InvalidSubnetOwner,
 }
 
 impl From<CustomTransactionError> for u8 {
@@ -2483,6 +2484,7 @@ impl From<CustomTransactionError> for u8 {
             CustomTransactionError::InputLengthsUnequal => 18,
             CustomTransactionError::UidNotFound => 19,
             CustomTransactionError::EvmKeyAssociateRateLimitExceeded => 20,
+            CustomTransactionError::InvalidSubnetOwner => 21,
         }
     }
 }


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->

This PR implements filtering of incorrect subnet owner transactions in `TransactionExtension` to prevent them from entering the transaction pool. The validation happens early in the transaction lifecycle, rejecting signed transactions from non-owners before they are added to the pool. Root origin transactions are allowed to pass through (since they cannot be detected in TransactionExtension) and are properly validated in the dispatch functions.

## Related Issue(s)

- Closes #2338

## Type of Change
<!--
Please check the relevant options:
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

N/A - This is a bug fix that adds validation to prevent invalid transactions from entering the pool. Existing valid transactions continue to work as before.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

N/A

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.

**Implementation Details:**
- Added `InvalidSubnetOwner` variant to `CustomTransactionError` enum with error code 21
- Added `is_subnet_owner()` helper function in `SubtensorTransactionExtension` to check ownership
- Validation is performed in `TransactionExtension::validate()` for:
  - `start_call` - requires subnet owner (uses `ensure_subnet_owner`)
  - `update_symbol` - requires subnet owner or root (uses `ensure_subnet_owner_or_root`)
  - `sudo_set_root_claim_threshold` - requires subnet owner or root (uses `ensure_subnet_owner_or_root`)

**Behavior:**
- Signed transactions from subnet owners: Pass validation ✓
- Signed transactions from non-owners: Rejected with `InvalidSubnetOwner` error at transaction pool level ✓
- Root origin (unsigned) transactions: Pass through TransactionExtension, validated in dispatch function ✓

**Potential Reviewers:**
@l0r1s