### PR TITLE
fix: Remove aggressive precision check in share pool to fix alpha tx fees

### DIFF
--- a/pallets/subtensor/src/macros/errors.rs
+++ b/pallets/subtensor/src/macros/errors.rs
@@ -266,7 +266,5 @@ mod errors {
         InvalidRootClaimThreshold,
         /// Exceeded subnet limit number or zero.
         InvalidSubnetNumber,
-        /// Unintended precision loss when unstaking alpha
-        PrecisionLoss,
     }
 }

--- a/pallets/subtensor/src/staking/recycle_alpha.rs
+++ b/pallets/subtensor/src/staking/recycle_alpha.rs
@@ -55,8 +55,6 @@ impl<T: Config> Pallet<T> {
             &hotkey, &coldkey, netuid, amount,
         );
 
-        ensure!(actual_alpha_decrease <= amount, Error::<T>::PrecisionLoss);
-
         // Recycle means we should decrease the alpha issuance tracker.
         Self::recycle_subnet_alpha(netuid, actual_alpha_decrease);
 
@@ -121,8 +119,6 @@ impl<T: Config> Pallet<T> {
         let actual_alpha_decrease = Self::decrease_stake_for_hotkey_and_coldkey_on_subnet(
             &hotkey, &coldkey, netuid, amount,
         );
-
-        ensure!(actual_alpha_decrease <= amount, Error::<T>::PrecisionLoss);
 
         Self::burn_subnet_alpha(netuid, actual_alpha_decrease);
 


### PR DESCRIPTION
## Description

Removes the overly aggressive precision check in the share pool that forced full unstake when partial unstake was requested. The previous implementation would force-remove all stake when the remaining share fraction dropped below 0.00001 or when the denominator appeared "too low" after emissions. This caused problems when paying transaction fees in alpha because there was no way to return unused portions of unstaked TAO.

The fix simplifies the precision handling to only clean up shares when the remaining value is truly negligible (less than 1 unit), allowing partial unstakes to succeed as expected.

## Related Issue(s)

- Closes #2336

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

N/A - This is a bug fix that removes an error condition. Existing code that handled `PrecisionLoss` errors will no longer receive them, but operations will succeed instead of failing.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

N/A

## Additional Notes

**Files changed:**
- `primitives/share-pool/src/lib.rs` - Simplified precision handling in `update_value_for_one()`
- `pallets/subtensor/src/macros/errors.rs` - Removed `PrecisionLoss` error variant
- `pallets/subtensor/src/staking/recycle_alpha.rs` - Removed `PrecisionLoss` checks
- `pallets/subtensor/src/tests/recycle_alpha.rs` - Updated tests to verify operations succeed

**Potential Reviewers:** @const-t @opentensor/core-devs