### PR TITLE
Update base call filter

### DIFF
--- a/runtime/src/base_call_filter.rs
+++ b/runtime/src/base_call_filter.rs
@@ -1,0 +1,96 @@
+use crate::RuntimeCall;
+use crate::Vec;
+use crate::pallet_proxy;
+use crate::pallet_utility;
+use frame_support::traits::Contains;
+use sp_std::boxed::Box;
+use sp_std::vec;
+pub struct NoNestingCallFilter;
+
+impl Contains<RuntimeCall> for NoNestingCallFilter {
+    fn contains(call: &RuntimeCall) -> bool {
+        let calls = match call {
+            RuntimeCall::Utility(inner) => {
+                let calls = match inner {
+                    pallet_utility::Call::force_batch { calls } => calls,
+                    pallet_utility::Call::batch { calls } => calls,
+                    pallet_utility::Call::batch_all { calls } => calls,
+                    _ => return true,
+                };
+
+                calls
+                    .iter()
+                    .map(|call| Box::new(call.clone()))
+                    .collect::<Vec<_>>()
+            }
+            RuntimeCall::Proxy(inner) => {
+                let call = match inner {
+                    pallet_proxy::Call::proxy { call, .. } => call,
+                    pallet_proxy::Call::proxy_announced { call, .. } => call,
+                    _ => return true,
+                };
+
+                vec![call.clone()]
+            }
+            RuntimeCall::Multisig(inner) => {
+                let call = match inner {
+                    pallet_multisig::Call::as_multi { call, .. } => call,
+                    pallet_multisig::Call::as_multi_threshold_1 { call, .. } => call,
+                    _ => return true,
+                };
+
+                vec![call.clone()]
+            }
+            RuntimeCall::Crowdloan(inner) => {
+                let call = match inner {
+                    pallet_crowdloan::Call::create {
+                        call: Some(call), ..
+                    } => call,
+                    _ => return true,
+                };
+
+                vec![call.clone()]
+            }
+            RuntimeCall::Scheduler(inner) => {
+                let call = match inner {
+                    pallet_scheduler::Call::schedule { call, .. } => call,
+                    pallet_scheduler::Call::schedule_after { call, .. } => call,
+                    pallet_scheduler::Call::schedule_named { call, .. } => call,
+                    pallet_scheduler::Call::schedule_named_after { call, .. } => call,
+                    _ => return true,
+                };
+
+                vec![call.clone()]
+            }
+            _ => return true,
+        };
+
+        !calls.iter().any(|call| {
+            matches!(&**call, RuntimeCall::Utility(inner) if matches!(inner, pallet_utility::Call::force_batch { .. } | pallet_utility::Call::batch_all { .. } | pallet_utility::Call::batch { .. })) ||
+            matches!(&**call, RuntimeCall::Proxy(inner) if matches!(inner, pallet_proxy::Call::proxy { .. } | pallet_proxy::Call::proxy_announced { .. })) ||
+            matches!(&**call, RuntimeCall::Multisig(inner) if matches!(inner, pallet_multisig::Call::as_multi { .. } | pallet_multisig::Call::as_multi_threshold_1 { .. })) ||
+            matches!(&**call, RuntimeCall::Crowdloan(inner) if matches!(inner, pallet_crowdloan::Call::create { .. } )) ||
+            matches!(&**call, RuntimeCall::Scheduler(inner) if matches!(inner, pallet_scheduler::Call::schedule {..} | pallet_scheduler::Call::schedule_after { .. } | pallet_scheduler::Call::schedule_named {.. } | pallet_scheduler::Call::schedule_named_after { .. } )) ||
+            matches!(&**call, RuntimeCall::Sudo(inner) if matches!(inner, pallet_sudo::Call::sudo {..} | pallet_sudo::Call::sudo_as { .. } | pallet_sudo::Call::sudo_unchecked_weight { .. } ))
+        })
+    }
+}
+
+pub struct SafeModeWhitelistedCalls;
+impl Contains<RuntimeCall> for SafeModeWhitelistedCalls {
+    fn contains(call: &RuntimeCall) -> bool {
+        matches!(
+            call,
+            RuntimeCall::Sudo(_)
+                | RuntimeCall::Multisig(_)
+                | RuntimeCall::System(_)
+                | RuntimeCall::SafeMode(_)
+                | RuntimeCall::Timestamp(_)
+                | RuntimeCall::SubtensorModule(
+                    pallet_subtensor::Call::set_weights { .. }
+                        | pallet_subtensor::Call::serve_axon { .. }
+                )
+                | RuntimeCall::Commitments(pallet_commitments::Call::set_commitment { .. })
+        )
+    }
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -242,7 +242,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 371,
+    spec_version: 372,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -10,6 +10,7 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 use core::num::NonZeroU64;
 
+mod base_call_filter;
 pub mod check_nonce;
 mod migrations;
 pub mod sudo_wrapper;
@@ -75,6 +76,9 @@ use subtensor_runtime_common::{AlphaCurrency, TaoCurrency, time::*, *};
 use subtensor_swap_interface::{Order, SwapHandler};
 
 // A few exports that help ease life for downstream crates.
+use crate::base_call_filter::NoNestingCallFilter;
+use crate::base_call_filter::SafeModeWhitelistedCalls;
+use core::marker::PhantomData;
 pub use frame_support::{
     StorageValue, construct_runtime, parameter_types,
     traits::{
@@ -94,14 +98,11 @@ pub use pallet_balances::Call as BalancesCall;
 use pallet_commitments::GetCommitments;
 pub use pallet_timestamp::Call as TimestampCall;
 use pallet_transaction_payment::{ConstFeeMultiplier, Multiplier};
+use scale_info::TypeInfo;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
 pub use sp_runtime::{Perbill, Permill};
 use subtensor_transaction_fee::{SubtensorTxFeeHandler, TransactionFeeHandler};
-
-use core::marker::PhantomData;
-
-use scale_info::TypeInfo;
 
 // Frontier
 use fp_rpc::TransactionStatus;
@@ -276,28 +277,6 @@ parameter_types! {
     pub const SS58Prefix: u8 = 42;
 }
 
-pub struct NoNestingCallFilter;
-
-impl Contains<RuntimeCall> for NoNestingCallFilter {
-    fn contains(call: &RuntimeCall) -> bool {
-        match call {
-            RuntimeCall::Utility(inner) => {
-                let calls = match inner {
-                    pallet_utility::Call::force_batch { calls } => calls,
-                    pallet_utility::Call::batch { calls } => calls,
-                    pallet_utility::Call::batch_all { calls } => calls,
-                    _ => &Vec::new(),
-                };
-
-                !calls.iter().any(|call| {
-					matches!(call, RuntimeCall::Utility(inner) if matches!(inner, pallet_utility::Call::force_batch { .. } | pallet_utility::Call::batch_all { .. } | pallet_utility::Call::batch { .. }))
-				})
-            }
-            _ => true,
-        }
-    }
-}
-
 // Configure FRAME pallets to include in runtime.
 
 impl frame_system::Config for Runtime {
@@ -429,25 +408,6 @@ parameter_types! {
     pub const DisallowPermissionlessEntering: Option<Balance> = None;
     pub const DisallowPermissionlessExtending: Option<Balance> = None;
     pub const DisallowPermissionlessRelease: Option<BlockNumber> = None;
-}
-
-pub struct SafeModeWhitelistedCalls;
-impl Contains<RuntimeCall> for SafeModeWhitelistedCalls {
-    fn contains(call: &RuntimeCall) -> bool {
-        matches!(
-            call,
-            RuntimeCall::Sudo(_)
-                | RuntimeCall::Multisig(_)
-                | RuntimeCall::System(_)
-                | RuntimeCall::SafeMode(_)
-                | RuntimeCall::Timestamp(_)
-                | RuntimeCall::SubtensorModule(
-                    pallet_subtensor::Call::set_weights { .. }
-                        | pallet_subtensor::Call::serve_axon { .. }
-                )
-                | RuntimeCall::Commitments(pallet_commitments::Call::set_commitment { .. })
-        )
-    }
 }
 
 impl pallet_safe_mode::Config for Runtime {


### PR DESCRIPTION
This PR changes `NoNestingCallFilter`  and introduces several more pallets and extrinsics to filter in addition to the utility pallet and its nesting extrinsics.

Previously, we have only extrinsics from the utility pallet: batch_all, batch, force_batch with inner call filters for the same extrinsic set. This PR extends this set. 

#### New pallets and extrinsics affected
- multisig
  - as_multi
  - as_multi_threshold_1
- crowdload
  - create
- proxy
  - proxy_announced
  - proxy
- scheduler
  - schedule_named_after
  - schedule
  - schedule_named
  - schedule_after
- sudo (filtering inner-calls only):
  - sudo_unchecked_weight
  - sudo
  - sudo_as


I tested multiple combinations of these extrinsics manually, including scheduler, sudo, utility, crowdloan.


