### PR TITLE
lower precompile log level

### DIFF
--- a/precompiles/src/extensions.rs
+++ b/precompiles/src/extensions.rs
@@ -131,7 +131,7 @@ pub(crate) trait PrecompileHandleExt: PrecompileHandle {
                     <R as frame_system::Config>::RuntimeCall,
                 >>::post_dispatch((), &info, &mut post_info, 0, &result)
                 .map_err(extension_error)?;
-                log::info!("Precompile dispatch failed. Error: {e:?}");
+                log::info!("Precompile dispatch failed. message as: {e:?}");
                 self.charge_and_refund_after_dispatch::<R, Call>(&info, &post_info)?;
 
                 Err(PrecompileFailure::Error {

--- a/precompiles/src/extensions.rs
+++ b/precompiles/src/extensions.rs
@@ -131,8 +131,7 @@ pub(crate) trait PrecompileHandleExt: PrecompileHandle {
                     <R as frame_system::Config>::RuntimeCall,
                 >>::post_dispatch((), &info, &mut post_info, 0, &result)
                 .map_err(extension_error)?;
-                log::error!("Dispatch failed. Error: {e:?}");
-                log::warn!("Returning error PrecompileFailure::Error");
+                log::info!("Precompile dispatch failed. Error: {e:?}");
                 self.charge_and_refund_after_dispatch::<R, Call>(&info, &post_info)?;
 
                 Err(PrecompileFailure::Error {


### PR DESCRIPTION
## Description
Lower the log level for precompile dispatch error. In most of case, the failure is from some wrong parameters for extrinsic.
Not a serious issue of precompile implementation.


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.