### PR TITLE
Restore pending_create_data_providers and fix EVM pending block issues

### DIFF
--- a/node/src/consensus/aura_consensus.rs
+++ b/node/src/consensus/aura_consensus.rs
@@ -102,6 +102,18 @@ impl ConsensusMechanism for AuraConsensus {
     fn create_inherent_data_providers(
         slot_duration: SlotDuration,
     ) -> Result<Self::InherentDataProviders, Box<dyn Error + Send + Sync>> {
+        let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
+        let slot =
+            sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_slot_duration(
+                *timestamp,
+                slot_duration,
+            );
+        Ok((slot, timestamp))
+    }
+
+    fn pending_create_inherent_data_providers(
+        slot_duration: SlotDuration,
+    ) -> Result<Self::InherentDataProviders, Box<dyn Error + Send + Sync>> {
         let current = sp_timestamp::InherentDataProvider::from_system_time();
         let next_slot = current
             .timestamp()

--- a/node/src/consensus/babe_consensus.rs
+++ b/node/src/consensus/babe_consensus.rs
@@ -121,6 +121,23 @@ impl ConsensusMechanism for BabeConsensus {
         Ok((slot, timestamp))
     }
 
+    fn pending_create_inherent_data_providers(
+        slot_duration: SlotDuration,
+    ) -> Result<Self::InherentDataProviders, Box<dyn Error + Send + Sync>> {
+        let current = sp_timestamp::InherentDataProvider::from_system_time();
+        let next_slot = current
+            .timestamp()
+            .as_millis()
+            .saturating_add(slot_duration.as_millis());
+        let timestamp = sp_timestamp::InherentDataProvider::new(next_slot.into());
+        let slot =
+            sp_consensus_babe::inherents::InherentDataProvider::from_timestamp_and_slot_duration(
+                *timestamp,
+                slot_duration,
+            );
+        Ok((slot, timestamp))
+    }
+
     fn new() -> Self {
         Self {
             babe_link: None,

--- a/node/src/consensus/consensus_mechanism.rs
+++ b/node/src/consensus/consensus_mechanism.rs
@@ -87,6 +87,11 @@ pub trait ConsensusMechanism {
         slot_duration: SlotDuration,
     ) -> Result<Self::InherentDataProviders, Box<dyn std::error::Error + Send + Sync>>;
 
+    /// Creates IDPs for the consensus mechanism for pending blocks.
+    fn pending_create_inherent_data_providers(
+        slot_duration: SlotDuration,
+    ) -> Result<Self::InherentDataProviders, Box<dyn std::error::Error + Send + Sync>>;
+
     /// Creates the frontier consensus data provider with this mechanism.
     fn frontier_consensus_data_provider(
         client: Arc<FullClient>,

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -454,7 +454,7 @@ where
 
         let slot_duration = consensus_mechanism.slot_duration(&client)?;
         let pending_create_inherent_data_providers =
-            move |_, ()| async move { CM::create_inherent_data_providers(slot_duration) };
+            move |_, ()| async move { CM::pending_create_inherent_data_providers(slot_duration) };
 
         let rpc_methods = consensus_mechanism.rpc_methods(
             client.clone(),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -241,7 +241,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 371,
+    spec_version: 372,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
This PR fixes Frontier  "pending block" feature: eth_getBalance request for pending block, estimate gas feature, etc.

After merging the "NPOS" preparation PR (#1941), we united `create_inherent_data_providers` and `pending_create_data_providers` (which produce different results - one slot difference for pending data provider), and chose `pending_create_data_providers` for both aura consensus and frontier EthDeps parameter. Which, in turn, advanced our chain for one block slot in the future. The future slot is not an issue when a shift occurs every block, however, when we need to create a pending block (one slot in the future), we use the same slot, and our Aura consensus breaks with "slot must increase" assertion. 

This PR restores the correct inherent providers for both consensus cases (aura and frontier), it also adds providers for the future BABE consensus.

Relates to #2320

I tested it manually on local machine and a baedeker clone. This PR must be tested on the testnet before deployment because it changes the consensus logic. 