### PR TITLE
Fix EVM priority + priority fee and add tx type logging in txpool 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4415,7 +4415,7 @@ dependencies = [
 [[package]]
 name = "fc-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "async-trait",
  "fp-storage",
@@ -4427,7 +4427,7 @@ dependencies = [
 [[package]]
 name = "fc-aura"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "fc-rpc",
  "fp-storage",
@@ -4443,7 +4443,7 @@ dependencies = [
 [[package]]
 name = "fc-babe"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "fc-rpc",
  "sc-client-api",
@@ -4459,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "async-trait",
  "fp-consensus",
@@ -4475,7 +4475,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "async-trait",
  "ethereum",
@@ -4505,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "fc-db",
  "fc-storage",
@@ -4528,7 +4528,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4579,7 +4579,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4594,7 +4594,7 @@ dependencies = [
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4786,7 +4786,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "hex",
  "impl-serde",
@@ -4804,7 +4804,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -4815,7 +4815,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4827,7 +4827,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "environmental",
  "evm",
@@ -4843,7 +4843,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4859,7 +4859,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4871,7 +4871,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -9067,7 +9067,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -9696,7 +9696,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -9719,7 +9719,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "environmental",
@@ -9744,7 +9744,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9755,7 +9755,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -9765,7 +9765,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -9777,7 +9777,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "fp-evm",
  "num",
@@ -9786,7 +9786,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -9795,7 +9795,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "fp-evm",
  "ripemd",
@@ -9863,7 +9863,7 @@ dependencies = [
 [[package]]
 name = "pallet-hotfix-sufficients"
 version = "1.0.0"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -13114,7 +13114,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils"
 version = "0.1.0"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "environmental",
  "evm",
@@ -13138,7 +13138,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/opentensor/frontier?rev=7c93fd974ad70faec1c1c4b87ab23874f365f27a#7c93fd974ad70faec1c1c4b87ab23874f365f27a"
+source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
 dependencies = [
  "case",
  "num_enum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4415,7 +4415,7 @@ dependencies = [
 [[package]]
 name = "fc-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "async-trait",
  "fp-storage",
@@ -4427,7 +4427,7 @@ dependencies = [
 [[package]]
 name = "fc-aura"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "fc-rpc",
  "fp-storage",
@@ -4443,7 +4443,7 @@ dependencies = [
 [[package]]
 name = "fc-babe"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "fc-rpc",
  "sc-client-api",
@@ -4459,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "async-trait",
  "fp-consensus",
@@ -4475,7 +4475,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "async-trait",
  "ethereum",
@@ -4505,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "fc-db",
  "fc-storage",
@@ -4528,7 +4528,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4579,7 +4579,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4594,7 +4594,7 @@ dependencies = [
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4786,7 +4786,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "hex",
  "impl-serde",
@@ -4804,7 +4804,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -4815,7 +4815,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4827,7 +4827,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "environmental",
  "evm",
@@ -4843,7 +4843,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4859,7 +4859,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4871,7 +4871,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -9067,7 +9067,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -9696,7 +9696,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -9719,7 +9719,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "environmental",
@@ -9744,7 +9744,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9755,7 +9755,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -9765,7 +9765,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -9777,7 +9777,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "fp-evm",
  "num",
@@ -9786,7 +9786,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -9795,7 +9795,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "fp-evm",
  "ripemd",
@@ -9863,7 +9863,7 @@ dependencies = [
 [[package]]
 name = "pallet-hotfix-sufficients"
 version = "1.0.0"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -13114,7 +13114,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils"
 version = "0.1.0"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "environmental",
  "evm",
@@ -13138,7 +13138,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
+source = "git+https://github.com/opentensor/frontier?rev=f588764a2c28455a46e8d7540d3c918d2098e846#f588764a2c28455a46e8d7540d3c918d2098e846"
 dependencies = [
  "case",
  "num_enum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "assets-common"
 version = "0.22.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "cumulus-primitives-core",
  "ethereum-standards",
@@ -1435,7 +1435,7 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 [[package]]
 name = "binary-merkle-tree"
 version = "16.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "hash-db",
  "log",
@@ -1704,7 +1704,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
@@ -1721,7 +1721,7 @@ dependencies = [
 [[package]]
 name = "bp-messages"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -1737,7 +1737,7 @@ dependencies = [
 [[package]]
 name = "bp-parachains"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -1754,7 +1754,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot-core"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1770,7 +1770,7 @@ dependencies = [
 [[package]]
 name = "bp-relayers"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1788,7 +1788,7 @@ dependencies = [
 [[package]]
 name = "bp-runtime"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1811,7 +1811,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -1831,7 +1831,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub"
 version = "0.7.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1848,7 +1848,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.18.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1860,7 +1860,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-common"
 version = "0.14.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1879,7 +1879,7 @@ dependencies = [
 [[package]]
 name = "bridge-runtime-common"
 version = "0.22.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -2711,7 +2711,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-bootnodes"
 version = "0.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -2737,7 +2737,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.24.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -2754,7 +2754,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.24.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -2777,7 +2777,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.24.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -2824,7 +2824,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.24.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -2856,7 +2856,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.20.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2871,7 +2871,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.24.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -2894,7 +2894,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.24.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -2921,7 +2921,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.18.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2931,7 +2931,7 @@ dependencies = [
  "parity-scale-codec",
  "sc-client-api",
  "sc-consensus-babe",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79)",
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
@@ -2942,7 +2942,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.24.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2970,7 +2970,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.25.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-channel 1.9.0",
  "cumulus-client-cli",
@@ -3010,7 +3010,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -3027,7 +3027,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "cumulus-primitives-core",
  "frame-benchmarking",
@@ -3044,7 +3044,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -3081,7 +3081,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -3092,7 +3092,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3105,7 +3105,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-solo-to-para"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -3120,7 +3120,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-weight-reclaim"
 version = "0.3.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "derive-where",
@@ -3139,7 +3139,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.20.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3154,7 +3154,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "approx",
  "bounded-collections 0.2.4",
@@ -3179,7 +3179,7 @@ dependencies = [
 [[package]]
 name = "cumulus-ping"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-primitives-core",
@@ -3194,7 +3194,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.18.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -3203,7 +3203,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.19.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -3220,7 +3220,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.19.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3234,7 +3234,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.13.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -3244,7 +3244,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "12.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -3261,7 +3261,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3278,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.25.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -3306,7 +3306,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.24.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3326,7 +3326,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.25.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -3362,7 +3362,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.24.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3403,7 +3403,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-streams"
 version = "0.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "cumulus-relay-chain-interface",
  "futures",
@@ -3417,7 +3417,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.20.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -4198,7 +4198,7 @@ dependencies = [
 [[package]]
 name = "ethereum-standards"
 version = "0.1.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "alloy-core",
 ]
@@ -4415,7 +4415,7 @@ dependencies = [
 [[package]]
 name = "fc-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "async-trait",
  "fp-storage",
@@ -4427,7 +4427,7 @@ dependencies = [
 [[package]]
 name = "fc-aura"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "fc-rpc",
  "fp-storage",
@@ -4443,7 +4443,7 @@ dependencies = [
 [[package]]
 name = "fc-babe"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "fc-rpc",
  "sc-client-api",
@@ -4459,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "async-trait",
  "fp-consensus",
@@ -4475,7 +4475,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "async-trait",
  "ethereum",
@@ -4505,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "fc-db",
  "fc-storage",
@@ -4528,7 +4528,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4579,7 +4579,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4588,13 +4588,13 @@ dependencies = [
  "rustc-hex",
  "serde",
  "serde_json",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79)",
 ]
 
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4759,7 +4759,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4786,7 +4786,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "hex",
  "impl-serde",
@@ -4804,7 +4804,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -4815,7 +4815,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4827,7 +4827,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "environmental",
  "evm",
@@ -4843,7 +4843,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4859,7 +4859,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4871,7 +4871,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -4886,7 +4886,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 [[package]]
 name = "frame-benchmarking"
 version = "41.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -4910,7 +4910,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "49.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.3",
@@ -4975,7 +4975,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-pallet-pov"
 version = "31.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5003,7 +5003,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "16.1.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -5014,7 +5014,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -5031,7 +5031,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "41.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -5084,7 +5084,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.9.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "array-bytes 6.2.3",
  "const-hex",
@@ -5100,7 +5100,7 @@ dependencies = [
 [[package]]
 name = "frame-storage-access-test-runtime"
 version = "0.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "parity-scale-codec",
@@ -5114,7 +5114,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "aquamarine",
  "array-bytes 6.2.3",
@@ -5155,7 +5155,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "34.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -5168,7 +5168,7 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79)",
  "syn 2.0.106",
 ]
 
@@ -5188,7 +5188,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-support-procedural-tools-derive 12.0.0",
  "proc-macro-crate 3.4.0",
@@ -5211,7 +5211,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5221,7 +5221,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "cfg-if",
  "docify",
@@ -5240,7 +5240,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5254,7 +5254,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -5264,7 +5264,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.47.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -7821,7 +7821,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "46.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "futures",
  "log",
@@ -7840,7 +7840,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -8789,7 +8789,7 @@ dependencies = [
 [[package]]
 name = "pallet-alliance"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "array-bytes 6.2.3",
  "frame-benchmarking",
@@ -8801,7 +8801,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79)",
  "sp-io",
  "sp-runtime",
 ]
@@ -8809,7 +8809,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "23.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8827,7 +8827,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-ops"
 version = "0.9.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8845,7 +8845,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-tx-payment"
 version = "23.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8860,7 +8860,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "20.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8874,7 +8874,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rewards"
 version = "0.3.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8892,7 +8892,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8908,7 +8908,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "43.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "ethereum-standards",
  "frame-benchmarking",
@@ -8926,7 +8926,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-freezer"
 version = "0.8.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "log",
  "pallet-assets",
@@ -8938,7 +8938,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-holder"
 version = "0.3.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8953,7 +8953,7 @@ dependencies = [
 [[package]]
 name = "pallet-atomic-swap"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -8963,7 +8963,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8979,7 +8979,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8994,7 +8994,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9007,7 +9007,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9030,7 +9030,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "aquamarine",
  "docify",
@@ -9051,7 +9051,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "42.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9067,7 +9067,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -9081,7 +9081,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "42.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9100,7 +9100,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "42.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "array-bytes 6.2.3",
  "binary-merkle-tree",
@@ -9125,7 +9125,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9142,7 +9142,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -9161,7 +9161,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -9180,7 +9180,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-parachains"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -9200,7 +9200,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-relayers"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -9223,7 +9223,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.20.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -9241,7 +9241,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9259,7 +9259,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9278,7 +9278,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9295,7 +9295,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective-content"
 version = "0.19.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9367,7 +9367,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -9376,8 +9376,8 @@ dependencies = [
  "impl-trait-for-tuples",
  "log",
  "pallet-balances",
- "pallet-contracts-proc-macro 23.0.3 (git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a)",
- "pallet-contracts-uapi 14.0.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a)",
+ "pallet-contracts-proc-macro 23.0.3 (git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79)",
+ "pallet-contracts-uapi 14.0.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79)",
  "parity-scale-codec",
  "paste",
  "rand 0.8.5",
@@ -9398,14 +9398,14 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-mock-network"
 version = "18.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-support",
  "frame-system",
  "pallet-assets",
  "pallet-balances",
  "pallet-contracts 41.0.0",
- "pallet-contracts-uapi 14.0.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a)",
+ "pallet-contracts-uapi 14.0.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79)",
  "pallet-message-queue",
  "pallet-timestamp",
  "pallet-xcm",
@@ -9439,7 +9439,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "23.0.3"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9460,7 +9460,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-uapi"
 version = "14.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -9471,7 +9471,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -9487,7 +9487,7 @@ dependencies = [
 [[package]]
 name = "pallet-core-fellowship"
 version = "25.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9524,7 +9524,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "8.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9539,7 +9539,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9556,7 +9556,7 @@ dependencies = [
 [[package]]
 name = "pallet-dev-mode"
 version = "23.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9605,7 +9605,7 @@ dependencies = [
 [[package]]
 name = "pallet-dummy-dim"
 version = "0.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9623,7 +9623,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-block"
 version = "0.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9644,7 +9644,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9665,7 +9665,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9678,7 +9678,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "42.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9696,7 +9696,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -9719,7 +9719,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "environmental",
@@ -9744,7 +9744,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9755,7 +9755,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -9765,7 +9765,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -9777,7 +9777,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "fp-evm",
  "num",
@@ -9786,7 +9786,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -9795,7 +9795,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "fp-evm",
  "ripemd",
@@ -9805,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9823,7 +9823,7 @@ dependencies = [
 [[package]]
 name = "pallet-glutton"
 version = "27.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "blake2 0.10.6",
  "frame-benchmarking",
@@ -9841,7 +9841,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9863,7 +9863,7 @@ dependencies = [
 [[package]]
 name = "pallet-hotfix-sufficients"
 version = "1.0.0"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9878,7 +9878,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -9894,7 +9894,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9913,7 +9913,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9928,7 +9928,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "29.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9939,7 +9939,7 @@ dependencies = [
 [[package]]
 name = "pallet-lottery"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9952,7 +9952,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9968,7 +9968,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "44.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -9987,7 +9987,7 @@ dependencies = [
 [[package]]
 name = "pallet-meta-tx"
 version = "0.3.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10005,7 +10005,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "11.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10024,7 +10024,7 @@ dependencies = [
 [[package]]
 name = "pallet-mixnet"
 version = "0.17.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10038,7 +10038,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10050,7 +10050,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10061,7 +10061,7 @@ dependencies = [
 [[package]]
 name = "pallet-nft-fractionalization"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "log",
  "pallet-assets",
@@ -10074,7 +10074,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts"
 version = "35.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -10091,7 +10091,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10101,7 +10101,7 @@ dependencies = [
 [[package]]
 name = "pallet-node-authorization"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10112,7 +10112,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "39.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10130,7 +10130,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "39.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10150,7 +10150,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -10160,7 +10160,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10175,7 +10175,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10198,7 +10198,7 @@ dependencies = [
 [[package]]
 name = "pallet-origin-restriction"
 version = "0.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10216,7 +10216,7 @@ dependencies = [
 [[package]]
 name = "pallet-paged-list"
 version = "0.19.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -10227,7 +10227,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.12.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10244,7 +10244,7 @@ dependencies = [
 [[package]]
 name = "pallet-people"
 version = "0.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10262,7 +10262,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10278,7 +10278,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10288,7 +10288,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10306,7 +10306,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10316,7 +10316,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -10351,7 +10351,7 @@ dependencies = [
 [[package]]
 name = "pallet-remark"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10366,7 +10366,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive"
 version = "0.7.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "alloy-core",
  "derive_more 0.99.20",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-fixtures"
 version = "0.4.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -10426,7 +10426,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-proc-macro"
 version = "0.3.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10436,7 +10436,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-uapi"
 version = "0.5.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bitflags 1.3.2",
  "pallet-revive-proc-macro",
@@ -10448,7 +10448,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-offences"
 version = "38.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10464,7 +10464,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "17.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10477,7 +10477,7 @@ dependencies = [
 [[package]]
 name = "pallet-safe-mode"
 version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "docify",
  "pallet-balances",
@@ -10491,7 +10491,7 @@ dependencies = [
 [[package]]
 name = "pallet-salary"
 version = "26.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "log",
  "pallet-ranked-collective",
@@ -10503,7 +10503,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "42.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10520,7 +10520,7 @@ dependencies = [
 [[package]]
 name = "pallet-scored-pool"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10533,7 +10533,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10554,7 +10554,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10590,7 +10590,7 @@ dependencies = [
 [[package]]
 name = "pallet-skip-feeless-payment"
 version = "16.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10602,7 +10602,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10619,7 +10619,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10641,7 +10641,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async"
 version = "0.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10664,7 +10664,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-ah-client"
 version = "0.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10683,7 +10683,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-rc-client"
 version = "0.2.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10700,7 +10700,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "12.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -10711,7 +10711,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "23.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -10720,7 +10720,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "27.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10730,7 +10730,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "46.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10746,7 +10746,7 @@ dependencies = [
 [[package]]
 name = "pallet-statement"
 version = "23.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10901,7 +10901,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10916,7 +10916,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10934,7 +10934,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10952,7 +10952,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10967,7 +10967,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "44.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -10983,7 +10983,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -10995,7 +10995,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-storage"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "array-bytes 6.2.3",
  "frame-benchmarking",
@@ -11014,7 +11014,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11033,7 +11033,7 @@ dependencies = [
 [[package]]
 name = "pallet-tx-pause"
 version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -11044,7 +11044,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11058,7 +11058,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11073,7 +11073,7 @@ dependencies = [
 [[package]]
 name = "pallet-verify-signature"
 version = "0.4.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11088,7 +11088,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11102,7 +11102,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -11112,7 +11112,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "20.1.3"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bounded-collections 0.2.4",
  "frame-benchmarking",
@@ -11138,7 +11138,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "21.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11155,7 +11155,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub"
 version = "0.17.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -11177,7 +11177,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub-router"
 version = "0.19.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-benchmarking",
@@ -11197,7 +11197,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -11536,7 +11536,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "futures",
  "futures-timer",
@@ -11554,7 +11554,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "futures",
  "futures-timer",
@@ -11569,7 +11569,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "fatality",
  "futures",
@@ -11592,7 +11592,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "fatality",
@@ -11625,7 +11625,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "25.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -11649,7 +11649,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bitvec",
  "fatality",
@@ -11672,7 +11672,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "18.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11683,7 +11683,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "fatality",
  "futures",
@@ -11705,7 +11705,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "20.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -11719,7 +11719,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "24.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "futures",
  "futures-timer",
@@ -11732,7 +11732,7 @@ dependencies = [
  "sc-network",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79)",
  "sp-keystore",
  "tracing-gum",
 ]
@@ -11740,7 +11740,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -11763,7 +11763,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -11781,7 +11781,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -11813,7 +11813,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting-parallel"
 version = "0.7.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "futures",
@@ -11837,7 +11837,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bitvec",
  "futures",
@@ -11856,7 +11856,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bitvec",
  "fatality",
@@ -11877,7 +11877,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -11892,7 +11892,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "futures",
@@ -11914,7 +11914,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -11928,7 +11928,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "futures",
  "futures-timer",
@@ -11944,7 +11944,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "fatality",
  "futures",
@@ -11962,7 +11962,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "futures",
@@ -11979,7 +11979,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "23.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "fatality",
  "futures",
@@ -11993,7 +11993,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12010,7 +12010,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "always-assert",
  "array-bytes 6.2.3",
@@ -12038,7 +12038,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -12051,7 +12051,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "20.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "cpu-time",
  "futures",
@@ -12066,7 +12066,7 @@ dependencies = [
  "sc-executor-wasmtime",
  "seccompiler",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79)",
  "sp-externalities",
  "sp-io",
  "sp-tracing",
@@ -12077,7 +12077,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -12092,7 +12092,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bs58",
  "futures",
@@ -12109,7 +12109,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -12134,7 +12134,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "20.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -12158,7 +12158,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
@@ -12167,7 +12167,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "derive_more 0.99.20",
@@ -12195,7 +12195,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "24.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "fatality",
  "futures",
@@ -12226,7 +12226,7 @@ dependencies = [
 [[package]]
 name = "polkadot-omni-node-lib"
 version = "0.7.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "clap",
@@ -12312,7 +12312,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "futures",
@@ -12332,7 +12332,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "17.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bounded-collections 0.2.4",
  "derive_more 0.99.20",
@@ -12348,7 +12348,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "19.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bitvec",
  "bounded-collections 0.2.4",
@@ -12377,7 +12377,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "25.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -12410,7 +12410,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "20.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -12460,7 +12460,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "21.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -12472,7 +12472,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "20.0.2"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -12520,7 +12520,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk"
 version = "2506.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "assets-common",
  "bridge-hub-common",
@@ -12678,7 +12678,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.10.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -12713,7 +12713,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "25.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -12821,7 +12821,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12841,7 +12841,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "20.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -13114,7 +13114,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils"
 version = "0.1.0"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "environmental",
  "evm",
@@ -13138,14 +13138,14 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/opentensor/frontier?rev=0d36994545faa24e689e48811bbe781de9e400e0#0d36994545faa24e689e48811bbe781de9e400e0"
+source = "git+https://github.com/opentensor/frontier?rev=5a10a256f097abadf7260594a9e904f941301fb2#5a10a256f097abadf7260594a9e904f941301fb2"
 dependencies = [
  "case",
  "num_enum",
  "prettyplease",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79)",
  "syn 2.0.106",
 ]
 
@@ -13327,7 +13327,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79)",
  "syn 2.0.106",
 ]
 
@@ -13957,7 +13957,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "24.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -14055,7 +14055,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "21.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -14451,7 +14451,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "32.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "log",
  "sp-core",
@@ -14462,7 +14462,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.51.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "futures",
@@ -14493,7 +14493,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "futures",
  "log",
@@ -14514,7 +14514,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.45.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -14529,7 +14529,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "44.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "array-bytes 6.2.3",
  "clap",
@@ -14545,7 +14545,7 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79)",
  "sp-genesis-builder",
  "sp-io",
  "sp-runtime",
@@ -14556,7 +14556,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -14567,7 +14567,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.53.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "array-bytes 6.2.3",
  "chrono",
@@ -14609,7 +14609,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "fnv",
  "futures",
@@ -14635,7 +14635,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.47.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -14663,7 +14663,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "futures",
@@ -14686,7 +14686,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.51.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "futures",
@@ -14715,7 +14715,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.51.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -14740,7 +14740,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-slots",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79)",
  "sp-inherents",
  "sp-keystore",
  "sp-runtime",
@@ -14751,7 +14751,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.51.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -14773,7 +14773,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "30.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -14807,7 +14807,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "30.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -14827,7 +14827,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -14840,7 +14840,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.36.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "ahash",
  "array-bytes 6.2.3",
@@ -14874,7 +14874,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79)",
  "sp-keystore",
  "sp-runtime",
  "substrate-prometheus-endpoint",
@@ -14884,7 +14884,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.36.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -14904,7 +14904,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.52.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -14939,7 +14939,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "futures",
@@ -14962,7 +14962,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.43.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -14985,7 +14985,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.39.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "polkavm 0.24.0",
  "sc-allocator",
@@ -14998,7 +14998,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.36.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "log",
  "polkavm 0.24.0",
@@ -15009,7 +15009,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.39.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "anyhow",
  "log",
@@ -15025,7 +15025,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "console",
  "futures",
@@ -15041,7 +15041,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "36.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "array-bytes 6.2.3",
  "parking_lot 0.12.5",
@@ -15055,7 +15055,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "array-bytes 6.2.3",
  "arrayvec 0.7.6",
@@ -15083,7 +15083,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.51.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15133,7 +15133,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.49.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -15143,7 +15143,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.51.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "ahash",
  "futures",
@@ -15162,7 +15162,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15183,7 +15183,7 @@ dependencies = [
 [[package]]
 name = "sc-network-statement"
 version = "0.33.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15203,7 +15203,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15238,7 +15238,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "array-bytes 6.2.3",
  "futures",
@@ -15257,7 +15257,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.17.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bs58",
  "bytes",
@@ -15278,7 +15278,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "46.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bytes",
  "fnv",
@@ -15312,7 +15312,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.20.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -15321,7 +15321,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "46.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -15353,7 +15353,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.50.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -15373,7 +15373,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "23.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -15397,7 +15397,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.51.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "array-bytes 6.2.3",
  "futures",
@@ -15430,13 +15430,13 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.3.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
  "sc-executor-common",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79)",
  "sp-state-machine",
  "sp-wasm-interface",
  "thiserror 1.0.69",
@@ -15445,7 +15445,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.52.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "directories",
@@ -15509,7 +15509,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.39.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -15520,7 +15520,7 @@ dependencies = [
 [[package]]
 name = "sc-statement-store"
 version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "log",
  "parity-db",
@@ -15539,7 +15539,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.25.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "clap",
  "fs4",
@@ -15552,7 +15552,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.51.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -15571,7 +15571,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "43.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "derive_more 0.99.20",
  "futures",
@@ -15584,14 +15584,14 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79)",
  "sp-io",
 ]
 
 [[package]]
 name = "sc-telemetry"
 version = "29.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "chrono",
  "futures",
@@ -15610,7 +15610,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "chrono",
  "console",
@@ -15638,7 +15638,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -15649,7 +15649,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "40.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "futures",
@@ -15666,7 +15666,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79)",
  "sp-runtime",
  "sp-tracing",
  "sp-transaction-pool",
@@ -15680,7 +15680,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "futures",
@@ -15697,7 +15697,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "19.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -16395,7 +16395,7 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 [[package]]
 name = "slot-range-helper"
 version = "18.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -16658,7 +16658,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-core"
 version = "0.14.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bp-relayers",
  "frame-support",
@@ -16742,7 +16742,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "docify",
  "hash-db",
@@ -16764,7 +16764,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "23.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -16778,7 +16778,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "41.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16790,7 +16790,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "27.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -16804,7 +16804,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16816,7 +16816,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -16826,7 +16826,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -16845,7 +16845,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.43.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "futures",
@@ -16859,7 +16859,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.43.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -16875,7 +16875,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.43.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -16893,7 +16893,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "25.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16901,7 +16901,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79)",
  "sp-io",
  "sp-keystore",
  "sp-mmr-primitives",
@@ -16913,7 +16913,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "24.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -16930,7 +16930,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.43.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16941,7 +16941,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "ark-vrf",
  "array-bytes 6.2.3",
@@ -16972,7 +16972,7 @@ dependencies = [
  "secrecy 0.8.0",
  "serde",
  "sha2 0.10.9",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79)",
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
@@ -16989,7 +16989,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.16.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -17023,7 +17023,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -17036,17 +17036,17 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79)",
  "syn 2.0.106",
 ]
 
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.5",
@@ -17055,7 +17055,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -17065,7 +17065,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.30.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -17075,7 +17075,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.18.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17087,7 +17087,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -17100,7 +17100,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "41.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bytes",
  "docify",
@@ -17112,7 +17112,7 @@ dependencies = [
  "rustversion",
  "secp256k1 0.28.2",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79)",
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
@@ -17126,7 +17126,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "42.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -17136,7 +17136,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.43.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -17147,7 +17147,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -17156,7 +17156,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.11.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-metadata 23.0.0",
  "parity-scale-codec",
@@ -17166,7 +17166,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.15.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17177,7 +17177,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -17194,7 +17194,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17207,7 +17207,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -17217,7 +17217,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "backtrace",
  "regex",
@@ -17226,7 +17226,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "35.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -17236,7 +17236,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "42.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -17265,7 +17265,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "30.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -17284,7 +17284,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "19.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "Inflector",
  "expander",
@@ -17297,7 +17297,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "39.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17311,7 +17311,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "39.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -17324,7 +17324,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.46.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "hash-db",
  "log",
@@ -17344,7 +17344,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "21.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -17357,7 +17357,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79)",
  "sp-externalities",
  "sp-runtime",
  "sp-runtime-interface",
@@ -17368,12 +17368,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -17385,7 +17385,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17397,7 +17397,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -17408,7 +17408,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -17417,7 +17417,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "37.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17431,7 +17431,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "ahash",
  "foldhash 0.1.5",
@@ -17456,7 +17456,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "40.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -17473,7 +17473,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -17485,7 +17485,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "22.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -17497,7 +17497,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "32.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "bounded-collections 0.2.4",
  "parity-scale-codec",
@@ -17671,7 +17671,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-chain-spec-builder"
 version = "12.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "clap",
  "docify",
@@ -17684,7 +17684,7 @@ dependencies = [
 [[package]]
 name = "staging-node-inspect"
 version = "0.29.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -17702,7 +17702,7 @@ dependencies = [
 [[package]]
 name = "staging-parachain-info"
 version = "0.21.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -17715,7 +17715,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "17.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections 0.2.4",
@@ -17736,7 +17736,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "21.1.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "environmental",
  "frame-support",
@@ -17760,7 +17760,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "20.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -17872,7 +17872,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -17897,7 +17897,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 
 [[package]]
 name = "substrate-fixed"
@@ -17913,7 +17913,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "45.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -17933,7 +17933,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.6"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "http-body-util",
  "hyper 1.7.0",
@@ -17947,7 +17947,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "44.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -17974,7 +17974,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "27.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "array-bytes 6.2.3",
  "build-helper",
@@ -19003,7 +19003,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "20.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -19014,7 +19014,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "expander",
  "proc-macro-crate 3.4.0",
@@ -19965,7 +19965,7 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 [[package]]
 name = "westend-runtime"
 version = "24.0.1"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -20072,7 +20072,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "21.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -20625,7 +20625,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -20636,7 +20636,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.8.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -20650,7 +20650,7 @@ dependencies = [
 [[package]]
 name = "xcm-simulator"
 version = "21.0.0"
-source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a#467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a"
+source = "git+https://github.com/opentensor/polkadot-sdk.git?rev=58add17a1232888db9cfb70f4afb6dc7fd7b3a79#58add17a1232888db9cfb70f4afb6dc7fd7b3a79"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -234,35 +234,35 @@ polkadot-sdk = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "
 runtime-common = { package = "polkadot-runtime-common", git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2503-6", default-features = false }
 
 # Frontier
-fp-evm = { git = "https://github.com/opentensor/frontier", rev = "7c93fd974ad70faec1c1c4b87ab23874f365f27a", default-features = false }
-fp-rpc = { git = "https://github.com/opentensor/frontier", rev = "7c93fd974ad70faec1c1c4b87ab23874f365f27a", default-features = false }
-fp-self-contained = { git = "https://github.com/opentensor/frontier", rev = "7c93fd974ad70faec1c1c4b87ab23874f365f27a", default-features = false }
-fp-account = { git = "https://github.com/opentensor/frontier", rev = "7c93fd974ad70faec1c1c4b87ab23874f365f27a", default-features = false }
-fc-storage = { git = "https://github.com/opentensor/frontier", rev = "7c93fd974ad70faec1c1c4b87ab23874f365f27a", default-features = false }
-fc-db = { git = "https://github.com/opentensor/frontier", rev = "7c93fd974ad70faec1c1c4b87ab23874f365f27a", default-features = false }
-fc-consensus = { git = "https://github.com/opentensor/frontier", rev = "7c93fd974ad70faec1c1c4b87ab23874f365f27a", default-features = false }
-fp-consensus = { git = "https://github.com/opentensor/frontier", rev = "7c93fd974ad70faec1c1c4b87ab23874f365f27a", default-features = false }
-fp-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "7c93fd974ad70faec1c1c4b87ab23874f365f27a", default-features = false }
-fc-api = { git = "https://github.com/opentensor/frontier", rev = "7c93fd974ad70faec1c1c4b87ab23874f365f27a", default-features = false }
-fc-rpc = { git = "https://github.com/opentensor/frontier", rev = "7c93fd974ad70faec1c1c4b87ab23874f365f27a", default-features = false }
-fc-rpc-core = { git = "https://github.com/opentensor/frontier", rev = "7c93fd974ad70faec1c1c4b87ab23874f365f27a", default-features = false }
-fc-aura = { git = "https://github.com/opentensor/frontier", rev = "7c93fd974ad70faec1c1c4b87ab23874f365f27a", default-features = false }
-fc-babe = { git = "https://github.com/opentensor/frontier", rev = "7c93fd974ad70faec1c1c4b87ab23874f365f27a", default-features = false }
-fc-mapping-sync = { git = "https://github.com/opentensor/frontier", rev = "7c93fd974ad70faec1c1c4b87ab23874f365f27a", default-features = false }
-precompile-utils = { git = "https://github.com/opentensor/frontier", rev = "7c93fd974ad70faec1c1c4b87ab23874f365f27a", default-features = false }
+fp-evm = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
+fp-rpc = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
+fp-self-contained = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
+fp-account = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
+fc-storage = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
+fc-db = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
+fc-consensus = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
+fp-consensus = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
+fp-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
+fc-api = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
+fc-rpc = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
+fc-rpc-core = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
+fc-aura = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
+fc-babe = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
+fc-mapping-sync = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
+precompile-utils = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
 
 # Frontier FRAME
-pallet-base-fee = { git = "https://github.com/opentensor/frontier", rev = "7c93fd974ad70faec1c1c4b87ab23874f365f27a", default-features = false }
-pallet-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "7c93fd974ad70faec1c1c4b87ab23874f365f27a", default-features = false }
-pallet-ethereum = { git = "https://github.com/opentensor/frontier", rev = "7c93fd974ad70faec1c1c4b87ab23874f365f27a", default-features = false }
-pallet-evm = { git = "https://github.com/opentensor/frontier", rev = "7c93fd974ad70faec1c1c4b87ab23874f365f27a", default-features = false }
-pallet-evm-precompile-dispatch = { git = "https://github.com/opentensor/frontier", rev = "7c93fd974ad70faec1c1c4b87ab23874f365f27a", default-features = false }
-pallet-evm-chain-id = { git = "https://github.com/opentensor/frontier", rev = "7c93fd974ad70faec1c1c4b87ab23874f365f27a", default-features = false }
-pallet-evm-precompile-modexp = { git = "https://github.com/opentensor/frontier", rev = "7c93fd974ad70faec1c1c4b87ab23874f365f27a", default-features = false }
-pallet-evm-precompile-sha3fips = { git = "https://github.com/opentensor/frontier", rev = "7c93fd974ad70faec1c1c4b87ab23874f365f27a", default-features = false }
-pallet-evm-precompile-simple = { git = "https://github.com/opentensor/frontier", rev = "7c93fd974ad70faec1c1c4b87ab23874f365f27a", default-features = false }
-pallet-evm-precompile-bn128 = { git = "https://github.com/opentensor/frontier", rev = "7c93fd974ad70faec1c1c4b87ab23874f365f27a", default-features = false }
-pallet-hotfix-sufficients = { git = "https://github.com/opentensor/frontier", rev = "7c93fd974ad70faec1c1c4b87ab23874f365f27a", default-features = false }
+pallet-base-fee = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
+pallet-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
+pallet-ethereum = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
+pallet-evm = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
+pallet-evm-precompile-dispatch = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
+pallet-evm-chain-id = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
+pallet-evm-precompile-modexp = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
+pallet-evm-precompile-sha3fips = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
+pallet-evm-precompile-simple = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
+pallet-evm-precompile-bn128 = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
+pallet-hotfix-sufficients = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
 
 #DRAND
 pallet-drand = { path = "pallets/drand", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -234,35 +234,35 @@ polkadot-sdk = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "
 runtime-common = { package = "polkadot-runtime-common", git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2503-6", default-features = false }
 
 # Frontier
-fp-evm = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
-fp-rpc = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
-fp-self-contained = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
-fp-account = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
-fc-storage = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
-fc-db = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
-fc-consensus = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
-fp-consensus = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
-fp-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
-fc-api = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
-fc-rpc = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
-fc-rpc-core = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
-fc-aura = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
-fc-babe = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
-fc-mapping-sync = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
-precompile-utils = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
+fp-evm = { git = "https://github.com/opentensor/frontier", rev = "f588764a2c28455a46e8d7540d3c918d2098e846", default-features = false }
+fp-rpc = { git = "https://github.com/opentensor/frontier", rev = "f588764a2c28455a46e8d7540d3c918d2098e846", default-features = false }
+fp-self-contained = { git = "https://github.com/opentensor/frontier", rev = "f588764a2c28455a46e8d7540d3c918d2098e846", default-features = false }
+fp-account = { git = "https://github.com/opentensor/frontier", rev = "f588764a2c28455a46e8d7540d3c918d2098e846", default-features = false }
+fc-storage = { git = "https://github.com/opentensor/frontier", rev = "f588764a2c28455a46e8d7540d3c918d2098e846", default-features = false }
+fc-db = { git = "https://github.com/opentensor/frontier", rev = "f588764a2c28455a46e8d7540d3c918d2098e846", default-features = false }
+fc-consensus = { git = "https://github.com/opentensor/frontier", rev = "f588764a2c28455a46e8d7540d3c918d2098e846", default-features = false }
+fp-consensus = { git = "https://github.com/opentensor/frontier", rev = "f588764a2c28455a46e8d7540d3c918d2098e846", default-features = false }
+fp-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "f588764a2c28455a46e8d7540d3c918d2098e846", default-features = false }
+fc-api = { git = "https://github.com/opentensor/frontier", rev = "f588764a2c28455a46e8d7540d3c918d2098e846", default-features = false }
+fc-rpc = { git = "https://github.com/opentensor/frontier", rev = "f588764a2c28455a46e8d7540d3c918d2098e846", default-features = false }
+fc-rpc-core = { git = "https://github.com/opentensor/frontier", rev = "f588764a2c28455a46e8d7540d3c918d2098e846", default-features = false }
+fc-aura = { git = "https://github.com/opentensor/frontier", rev = "f588764a2c28455a46e8d7540d3c918d2098e846", default-features = false }
+fc-babe = { git = "https://github.com/opentensor/frontier", rev = "f588764a2c28455a46e8d7540d3c918d2098e846", default-features = false }
+fc-mapping-sync = { git = "https://github.com/opentensor/frontier", rev = "f588764a2c28455a46e8d7540d3c918d2098e846", default-features = false }
+precompile-utils = { git = "https://github.com/opentensor/frontier", rev = "f588764a2c28455a46e8d7540d3c918d2098e846", default-features = false }
 
 # Frontier FRAME
-pallet-base-fee = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
-pallet-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
-pallet-ethereum = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
-pallet-evm = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
-pallet-evm-precompile-dispatch = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
-pallet-evm-chain-id = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
-pallet-evm-precompile-modexp = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
-pallet-evm-precompile-sha3fips = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
-pallet-evm-precompile-simple = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
-pallet-evm-precompile-bn128 = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
-pallet-hotfix-sufficients = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
+pallet-base-fee = { git = "https://github.com/opentensor/frontier", rev = "f588764a2c28455a46e8d7540d3c918d2098e846", default-features = false }
+pallet-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "f588764a2c28455a46e8d7540d3c918d2098e846", default-features = false }
+pallet-ethereum = { git = "https://github.com/opentensor/frontier", rev = "f588764a2c28455a46e8d7540d3c918d2098e846", default-features = false }
+pallet-evm = { git = "https://github.com/opentensor/frontier", rev = "f588764a2c28455a46e8d7540d3c918d2098e846", default-features = false }
+pallet-evm-precompile-dispatch = { git = "https://github.com/opentensor/frontier", rev = "f588764a2c28455a46e8d7540d3c918d2098e846", default-features = false }
+pallet-evm-chain-id = { git = "https://github.com/opentensor/frontier", rev = "f588764a2c28455a46e8d7540d3c918d2098e846", default-features = false }
+pallet-evm-precompile-modexp = { git = "https://github.com/opentensor/frontier", rev = "f588764a2c28455a46e8d7540d3c918d2098e846", default-features = false }
+pallet-evm-precompile-sha3fips = { git = "https://github.com/opentensor/frontier", rev = "f588764a2c28455a46e8d7540d3c918d2098e846", default-features = false }
+pallet-evm-precompile-simple = { git = "https://github.com/opentensor/frontier", rev = "f588764a2c28455a46e8d7540d3c918d2098e846", default-features = false }
+pallet-evm-precompile-bn128 = { git = "https://github.com/opentensor/frontier", rev = "f588764a2c28455a46e8d7540d3c918d2098e846", default-features = false }
+pallet-hotfix-sufficients = { git = "https://github.com/opentensor/frontier", rev = "f588764a2c28455a46e8d7540d3c918d2098e846", default-features = false }
 
 #DRAND
 pallet-drand = { path = "pallets/drand", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -234,35 +234,35 @@ polkadot-sdk = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "
 runtime-common = { package = "polkadot-runtime-common", git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2503-6", default-features = false }
 
 # Frontier
-fp-evm = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
-fp-rpc = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
-fp-self-contained = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
-fp-account = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
-fc-storage = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
-fc-db = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
-fc-consensus = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
-fp-consensus = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
-fp-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
-fc-api = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
-fc-rpc = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
-fc-rpc-core = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
-fc-aura = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
-fc-babe = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
-fc-mapping-sync = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
-precompile-utils = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
+fp-evm = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
+fp-rpc = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
+fp-self-contained = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
+fp-account = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
+fc-storage = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
+fc-db = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
+fc-consensus = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
+fp-consensus = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
+fp-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
+fc-api = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
+fc-rpc = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
+fc-rpc-core = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
+fc-aura = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
+fc-babe = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
+fc-mapping-sync = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
+precompile-utils = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
 
 # Frontier FRAME
-pallet-base-fee = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
-pallet-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
-pallet-ethereum = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
-pallet-evm = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
-pallet-evm-precompile-dispatch = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
-pallet-evm-chain-id = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
-pallet-evm-precompile-modexp = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
-pallet-evm-precompile-sha3fips = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
-pallet-evm-precompile-simple = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
-pallet-evm-precompile-bn128 = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
-pallet-hotfix-sufficients = { git = "https://github.com/opentensor/frontier", rev = "0d36994545faa24e689e48811bbe781de9e400e0", default-features = false }
+pallet-base-fee = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
+pallet-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
+pallet-ethereum = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
+pallet-evm = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
+pallet-evm-precompile-dispatch = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
+pallet-evm-chain-id = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
+pallet-evm-precompile-modexp = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
+pallet-evm-precompile-sha3fips = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
+pallet-evm-precompile-simple = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
+pallet-evm-precompile-bn128 = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
+pallet-hotfix-sufficients = { git = "https://github.com/opentensor/frontier", rev = "5a10a256f097abadf7260594a9e904f941301fb2", default-features = false }
 
 #DRAND
 pallet-drand = { path = "pallets/drand", default-features = false }
@@ -318,190 +318,190 @@ w3f-bls = { git = "https://github.com/opentensor/bls", branch = "fix-no-std" }
 # NOTE: The Diener will patch unnecesarry crates while this is waiting to be merged: <https://github.com/paritytech/diener/pull/46>.
 # You may install diener from `liamaharon:ignore-unused-flag` if you like in the meantime.
 [patch."https://github.com/paritytech/polkadot-sdk"]
-frame-support = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-binary-merkle-tree = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-core = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-crypto-hashing = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-crypto-hashing-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-debug-derive = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-externalities = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-storage = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-runtime-interface = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-runtime-interface-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-std = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-tracing = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-wasm-interface = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-io = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-keystore = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-state-machine = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-panic-handler = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-trie = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-runtime = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-application-crypto = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-arithmetic = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-weights = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-api-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-metadata-ir = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-version = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-version-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-block-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-block-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-inherents = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-blockchain = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-consensus = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-database = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-client-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-substrate-prometheus-endpoint = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-executor = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-executor-common = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-allocator = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-maybe-compressed-blob = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-executor-polkavm = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-executor-wasmtime = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-substrate-wasm-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-tracing = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-tracing-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-frame-executive = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-frame-system = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-frame-try-runtime = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-balances = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-frame-benchmarking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-frame-support-procedural = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-frame-support-procedural-tools = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-frame-support-procedural-tools-derive = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-client-db = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-state-db = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-polkadot-sdk-frame = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-frame-system-benchmarking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-frame-system-rpc-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-consensus-aura = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-consensus-slots = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-timestamp = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-consensus-grandpa = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-genesis-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-keyring = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-offchain = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-session = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-staking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-transaction-pool = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-polkadot-sdk = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-cumulus-primitives-core = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-polkadot-core-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-polkadot-parachain-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-polkadot-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-authority-discovery = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-staging-xcm = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-xcm-procedural = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-cumulus-primitives-proof-size-hostfunction = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-message-queue = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-polkadot-runtime-parachains = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-authority-discovery = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-session = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-timestamp = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-authorship = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-babe = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-consensus-babe = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-frame-election-provider-support = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-frame-election-provider-solution-type = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-npos-elections = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-offences = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-staking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-bags-list = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-staking-reward-curve = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-broker = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-mmr = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-mmr-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-polkadot-runtime-metrics = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-staging-xcm-executor = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-keystore = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-staging-xcm-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-asset-conversion = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-transaction-payment = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-grandpa = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-sudo = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-vesting = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-polkadot-runtime-common = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-asset-rate = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-election-provider-multi-phase = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-election-provider-support-benchmarking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-fast-unstake = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-identity = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-staking-reward-fn = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-treasury = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-utility = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-root-testing = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-slot-range-helper = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-aura = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-chain-spec = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-chain-spec-derive = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-network = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-network-common = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-network-types = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-utils = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-telemetry = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-cli = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-mixnet = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-transaction-pool-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-mixnet = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-service = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-consensus = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-informant = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-network-sync = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-fork-tree = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-network-light = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-network-transactions = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-rpc-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-statement-store = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-transaction-pool = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-rpc-server = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-rpc-spec-v2 = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-sysinfo = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-transaction-storage-proof = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-cumulus-relay-chain-interface = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-polkadot-overseer = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-tracing-gum = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-tracing-gum-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-polkadot-node-metrics = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-polkadot-node-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-polkadot-node-subsystem-types = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-polkadot-node-network-protocol = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-authority-discovery = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-polkadot-statement-table = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-frame-benchmarking-cli = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-cumulus-client-parachain-inherent = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-runtime-utilities = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-frame-metadata-hash-extension = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-nomination-pools = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-membership = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-multisig = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-nomination-pools-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-preimage = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-proxy = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-scheduler = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-staking-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-offchain = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-consensus-babe = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-consensus-epochs = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-consensus-slots = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-transaction-payment-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-consensus-babe-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-network-gossip = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-consensus-grandpa = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-consensus-grandpa-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-substrate-frame-rpc-system = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-basic-authorship = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-proposer-metrics = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-substrate-build-script-utils = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-consensus-aura = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-insecure-randomness-collective-flip = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-pallet-safe-mode = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sc-consensus-manual-seal = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-sp-crypto-ec-utils = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
-substrate-bip39 = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "467c6bf8cb1bc5ffb2f1a9f70a4bef63e12a012a" }
+frame-support = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+binary-merkle-tree = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-core = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-crypto-hashing = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-crypto-hashing-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-debug-derive = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-externalities = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-storage = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-runtime-interface = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-runtime-interface-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-std = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-tracing = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-wasm-interface = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-io = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-keystore = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-state-machine = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-panic-handler = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-trie = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-runtime = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-application-crypto = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-arithmetic = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-weights = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-api-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-metadata-ir = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-version = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-version-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-block-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-block-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-inherents = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-blockchain = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-consensus = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-database = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-client-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+substrate-prometheus-endpoint = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-executor = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-executor-common = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-allocator = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-maybe-compressed-blob = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-executor-polkavm = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-executor-wasmtime = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+substrate-wasm-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-tracing = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-tracing-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+frame-executive = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+frame-system = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+frame-try-runtime = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-balances = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+frame-benchmarking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+frame-support-procedural = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+frame-support-procedural-tools = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+frame-support-procedural-tools-derive = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-client-db = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-state-db = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+polkadot-sdk-frame = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+frame-system-benchmarking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+frame-system-rpc-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-consensus-aura = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-consensus-slots = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-timestamp = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-consensus-grandpa = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-genesis-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-keyring = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-offchain = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-session = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-staking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-transaction-pool = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+polkadot-sdk = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+cumulus-primitives-core = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+polkadot-core-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+polkadot-parachain-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+polkadot-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-authority-discovery = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+staging-xcm = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+xcm-procedural = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+cumulus-primitives-proof-size-hostfunction = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-message-queue = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+polkadot-runtime-parachains = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-authority-discovery = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-session = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-timestamp = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-authorship = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-babe = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-consensus-babe = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+frame-election-provider-support = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+frame-election-provider-solution-type = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-npos-elections = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-offences = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-staking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-bags-list = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-staking-reward-curve = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-broker = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-mmr = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-mmr-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+polkadot-runtime-metrics = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+staging-xcm-executor = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-keystore = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+staging-xcm-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-asset-conversion = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-transaction-payment = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-grandpa = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-sudo = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-vesting = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+polkadot-runtime-common = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-asset-rate = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-election-provider-multi-phase = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-election-provider-support-benchmarking = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-fast-unstake = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-identity = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-staking-reward-fn = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-treasury = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-utility = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-root-testing = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+slot-range-helper = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-aura = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-chain-spec = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-chain-spec-derive = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-network = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-network-common = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-network-types = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-utils = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-telemetry = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-cli = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-mixnet = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-transaction-pool-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-mixnet = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-service = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-consensus = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-informant = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-network-sync = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+fork-tree = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-network-light = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-network-transactions = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-rpc-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-statement-store = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-transaction-pool = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-rpc-server = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-rpc-spec-v2 = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-sysinfo = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-transaction-storage-proof = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+cumulus-relay-chain-interface = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+polkadot-overseer = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+tracing-gum = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+tracing-gum-proc-macro = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+polkadot-node-metrics = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+polkadot-node-primitives = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+polkadot-node-subsystem-types = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+polkadot-node-network-protocol = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-authority-discovery = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+polkadot-statement-table = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+frame-benchmarking-cli = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+cumulus-client-parachain-inherent = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-runtime-utilities = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+frame-metadata-hash-extension = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-nomination-pools = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-membership = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-multisig = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-nomination-pools-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-preimage = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-proxy = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-scheduler = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-staking-runtime-api = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-offchain = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-consensus-babe = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-consensus-epochs = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-consensus-slots = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-transaction-payment-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-consensus-babe-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-network-gossip = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-consensus-grandpa = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-consensus-grandpa-rpc = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+substrate-frame-rpc-system = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-basic-authorship = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-proposer-metrics = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+substrate-build-script-utils = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-consensus-aura = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-insecure-randomness-collective-flip = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+pallet-safe-mode = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sc-consensus-manual-seal = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+sp-crypto-ec-utils = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }
+substrate-bip39 = { git = "https://github.com/opentensor/polkadot-sdk.git", rev = "58add17a1232888db9cfb70f4afb6dc7fd7b3a79" }

--- a/contract-tests/test/eth.substrate-transfer.test.ts
+++ b/contract-tests/test/eth.substrate-transfer.test.ts
@@ -344,8 +344,9 @@ describe("Balance transfers between substrate and EVM", () => {
             [10, 0, 21000 * 10 * 1e9],
             [10, 10, 21000 * 10 * 1e9],
             [11, 0, 21000 * 10 * 1e9],
-            [11, 1, (21000 * 10 + 21000) * 1e9],
-            [11, 2, (21000 * 10 + 21000) * 1e9],
+            // max_priority_fee_per_gas is disabled
+            // [11, 1, (21000 * 10 + 21000) * 1e9],
+            // [11, 2, (21000 * 10 + 21000) * 1e9],
         ];
 
         for (let i in testCases) {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1416,7 +1416,7 @@ impl fp_self_contained::SelfContainedCall for RuntimeCall {
         len: usize,
     ) -> Option<TransactionValidity> {
         match self {
-            RuntimeCall::Ethereum(call) =>call.validate_self_contained(info, dispatch_info, len),
+            RuntimeCall::Ethereum(call) => call.validate_self_contained(info, dispatch_info, len),
             _ => None,
         }
     }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1228,8 +1228,7 @@ impl<F: FindAuthor<u32>> FindAuthor<H160> for FindAuthorTruncated<F> {
 const BLOCK_GAS_LIMIT: u64 = 75_000_000;
 pub const NORMAL_DISPATCH_BASE_PRIORITY: TransactionPriority = 1;
 pub const OPERATIONAL_DISPATCH_PRIORITY: TransactionPriority = 10_000_000_000;
-const EVM_TRANSACTION_BASE_PRIORITY: TransactionPriority = NORMAL_DISPATCH_BASE_PRIORITY;
-const EVM_LOG_TARGET: &str = "runtime::ethereum";
+// const EVM_TRANSACTION_BASE_PRIORITY: TransactionPriority = NORMAL_DISPATCH_BASE_PRIORITY;
 
 /// `WeightPerGas` is an approximate ratio of the amount of Weight per Gas.
 ///
@@ -1393,35 +1392,6 @@ impl<B: BlockT> fp_rpc::ConvertTransaction<<B as BlockT>::Extrinsic> for Transac
     }
 }
 
-fn adjust_evm_priority_and_warn(
-    validity: &mut Option<TransactionValidity>,
-    priority_fee: Option<U256>,
-    info: &H160,
-) {
-    if let Some(Ok(valid_transaction)) = validity.as_mut() {
-        let original_priority = valid_transaction.priority;
-        valid_transaction.priority = EVM_TRANSACTION_BASE_PRIORITY;
-
-        let has_priority_fee = priority_fee.is_some_and(|fee| !fee.is_zero());
-        if has_priority_fee {
-            log::warn!(
-                target: EVM_LOG_TARGET,
-                "Priority fee/tip from {:?} (max_priority_fee_per_gas: {:?}) is ignored for transaction ordering",
-                info,
-                priority_fee.unwrap_or_default(),
-            );
-        } else if original_priority > EVM_TRANSACTION_BASE_PRIORITY {
-            log::warn!(
-                target: EVM_LOG_TARGET,
-                "EVM transaction priority from {:?} reduced from {} to {}; priority tips are ignored for ordering",
-                info,
-                original_priority,
-                EVM_TRANSACTION_BASE_PRIORITY,
-            );
-        }
-    }
-}
-
 impl fp_self_contained::SelfContainedCall for RuntimeCall {
     type SignedInfo = H160;
 
@@ -1446,21 +1416,7 @@ impl fp_self_contained::SelfContainedCall for RuntimeCall {
         len: usize,
     ) -> Option<TransactionValidity> {
         match self {
-            RuntimeCall::Ethereum(call) => {
-                let priority_fee = match call {
-                    pallet_ethereum::Call::transact { transaction } => match transaction {
-                        EthereumTransaction::EIP1559(tx) => Some(tx.max_priority_fee_per_gas),
-                        EthereumTransaction::EIP7702(tx) => Some(tx.max_priority_fee_per_gas),
-                        _ => None,
-                    },
-                    _ => None,
-                };
-
-                let mut validity = call.validate_self_contained(info, dispatch_info, len);
-                adjust_evm_priority_and_warn(&mut validity, priority_fee, info);
-
-                validity
-            }
+            RuntimeCall::Ethereum(call) =>call.validate_self_contained(info, dispatch_info, len),
             _ => None,
         }
     }
@@ -2669,52 +2625,6 @@ fn test_into_substrate_balance_zero_value() {
 
     let result = SubtensorEvmBalanceConverter::into_substrate_balance(evm_balance);
     assert_eq!(result, Some(expected_substrate_balance));
-}
-
-#[test]
-fn evm_priority_overrides_tip_to_base() {
-    let mut validity: Option<TransactionValidity> =
-        Some(Ok(sp_runtime::transaction_validity::ValidTransaction {
-            priority: 99,
-            requires: vec![],
-            provides: vec![],
-            longevity: sp_runtime::transaction_validity::TransactionLongevity::MAX,
-            propagate: true,
-        }));
-
-    let signer = H160::repeat_byte(1);
-    adjust_evm_priority_and_warn(&mut validity, Some(U256::from(10)), &signer);
-
-    let adjusted_priority = validity
-        .as_ref()
-        .and_then(|v| v.as_ref().ok())
-        .map(|v| v.priority);
-
-    assert_eq!(adjusted_priority, Some(EVM_TRANSACTION_BASE_PRIORITY));
-}
-
-#[test]
-fn evm_priority_cannot_overtake_unstake() {
-    // Unstake is a normal-class extrinsic (priority = NORMAL_DISPATCH_BASE_PRIORITY).
-    let unstake_priority: TransactionPriority = NORMAL_DISPATCH_BASE_PRIORITY;
-    let evm_priority: TransactionPriority = EVM_TRANSACTION_BASE_PRIORITY;
-
-    // Clamp guarantees the EVM tx is never above the unstake priority.
-    assert!(evm_priority <= unstake_priority);
-
-    // If both arrive with equal priority, arrival order keeps unstake first.
-    let mut queue: Vec<(&str, TransactionPriority, usize)> = vec![
-        ("unstake", unstake_priority, 0), // arrives first
-        ("evm", evm_priority, 1),         // arrives later
-    ];
-
-    queue.sort_by(|a, b| {
-        b.1.cmp(&a.1) // higher priority first
-            .then_with(|| a.2.cmp(&b.2)) // earlier arrival first when equal
-    });
-
-    let first = queue.first().map(|entry| entry.0);
-    assert_eq!(first, Some("unstake"));
 }
 
 #[test]


### PR DESCRIPTION
Frontier changes: 
- nullify `max_priority_fee_per_gas`
- set all EVM transaction priority to 1
- tag EVM transaction with a dummy provides to detect them in tx pool and log the type 
- set code size for precompiles
https://github.com/opentensor/frontier/compare/78b5fb76bb268086aa19a61242f1e4a9b068d331...f588764a2c28455a46e8d7540d3c918d2098e846

Polkadot SDK changes:
- log tx_type (evm/substrate) in the transaction pool when importing transaction
https://github.com/opentensor/polkadot-sdk/commit/58add17a1232888db9cfb70f4afb6dc7fd7b3a79