### PR TITLE
Proxy & Batch `DispatchClass::Normal`

### DIFF
--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -1685,7 +1685,7 @@ pub mod pallet {
         #[pallet::weight((
             Weight::from_parts(3_918_000, 0) // TODO: add benchmarks
 			    .saturating_add(T::DbWeight::get().writes(1_u64)),
-            DispatchClass::Operational,
+            DispatchClass::Normal,
             Pays::Yes
         ))]
         pub fn sudo_set_subnet_owner_hotkey(

--- a/pallets/proxy/src/lib.rs
+++ b/pallets/proxy/src/lib.rs
@@ -235,7 +235,7 @@ pub mod pallet {
 				 // AccountData for inner call origin accountdata.
 				.saturating_add(T::DbWeight::get().reads_writes(1, 1))
 				.saturating_add(di.call_weight),
-			di.class, di.pays_fee)
+			DispatchClass::Normal, di.pays_fee)
 		})]
         pub fn proxy(
             origin: OriginFor<T>,
@@ -544,7 +544,7 @@ pub mod pallet {
 				 // AccountData for inner call origin accountdata.
 				.saturating_add(T::DbWeight::get().reads_writes(1, 1))
 				.saturating_add(di.call_weight),
-			di.class)
+			DispatchClass::Normal)
 		})]
         pub fn proxy_announced(
             origin: OriginFor<T>,

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2037,7 +2037,7 @@ mod dispatches {
 
         /// Sets the pending childkey cooldown (in blocks). Root only.
         #[pallet::call_index(109)]
-        #[pallet::weight((Weight::from_parts(10_000, 0), DispatchClass::Operational, Pays::Yes))]
+        #[pallet::weight((Weight::from_parts(1_970_000_000_000, 0), DispatchClass::Operational, Pays::Yes))]
         pub fn set_pending_childkey_cooldown(
             origin: OriginFor<T>,
             cooldown: u64,

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2413,7 +2413,7 @@ mod dispatches {
             Weight::from_parts(5_711_000, 0)
             .saturating_add(T::DbWeight::get().reads(0_u64))
             .saturating_add(T::DbWeight::get().writes(1_u64)),
-            DispatchClass::Operational,
+            DispatchClass::Normal,
             Pays::Yes
         ))]
         pub fn sudo_set_root_claim_threshold(

--- a/pallets/utility/src/lib.rs
+++ b/pallets/utility/src/lib.rs
@@ -406,7 +406,7 @@ pub mod pallet {
         /// - O(C) where C is the number of calls to be batched.
         #[pallet::call_index(4)]
         #[pallet::weight({
-			let (dispatch_weight, _, pays) = Pallet::<T>::weight_and_dispatch_class(calls);
+			let (dispatch_weight, pays) = Pallet::<T>::weight_and_dispatch_class(calls);
 			let dispatch_weight = dispatch_weight.saturating_add(T::WeightInfo::force_batch(calls.len() as u32));
 			(dispatch_weight, DispatchClass::Normal, pays)
 		})]

--- a/pallets/utility/src/lib.rs
+++ b/pallets/utility/src/lib.rs
@@ -195,7 +195,7 @@ pub mod pallet {
         /// event is deposited.
         #[pallet::call_index(0)]
         #[pallet::weight({
-			let (dispatch_weight, _, pays) = Pallet::<T>::weight_and_dispatch_class(calls);
+			let (dispatch_weight, pays) = Pallet::<T>::weight_and_dispatch_class(calls);
 			let dispatch_weight = dispatch_weight.saturating_add(T::WeightInfo::batch(calls.len() as u32));
 			(dispatch_weight, DispatchClass::Normal, pays)
 		})]

--- a/pallets/utility/src/lib.rs
+++ b/pallets/utility/src/lib.rs
@@ -616,7 +616,7 @@ pub mod pallet {
                 }
             }
 
-            (total_weight, DispatchClass::Normal, pays)
+            (total_weight, pays)
         }
     }
 }

--- a/pallets/utility/src/lib.rs
+++ b/pallets/utility/src/lib.rs
@@ -607,12 +607,12 @@ pub mod pallet {
             calls: &[<T as Config>::RuntimeCall],
         ) -> (Weight, DispatchClass, Pays) {
             let mut total_weight = Weight::zero();
-            let mut pays = Pays::Yes;
+            let mut pays = Pays::No;
 
             for di in calls.iter().map(|call| call.get_dispatch_info()) {
                 total_weight = total_weight.saturating_add(di.call_weight);
-                if di.pays_fee == Pays::No {
-                    pays = Pays::No;
+                if di.pays_fee == Pays::Yes {
+                    pays = Pays::Yes;
                 }
             }
 

--- a/pallets/utility/src/lib.rs
+++ b/pallets/utility/src/lib.rs
@@ -603,9 +603,7 @@ pub mod pallet {
     impl<T: Config> Pallet<T> {
         /// Get the accumulated `weight` and `pays` for the given `calls`.
         /// The outer dispatch class is intentionally always `Normal`.
-        fn weight_and_dispatch_class(
-            calls: &[<T as Config>::RuntimeCall],
-        ) -> (Weight, Pays) {
+        fn weight_and_dispatch_class(calls: &[<T as Config>::RuntimeCall]) -> (Weight, Pays) {
             let mut total_weight = Weight::zero();
             let mut pays = Pays::No;
 

--- a/pallets/utility/src/lib.rs
+++ b/pallets/utility/src/lib.rs
@@ -61,10 +61,7 @@ extern crate alloc;
 use alloc::{boxed::Box, vec::Vec};
 use codec::{Decode, Encode};
 use frame_support::{
-    dispatch::{
-        DispatchClass::{Normal, Operational},
-        GetDispatchInfo, PostDispatchInfo, extract_actual_weight,
-    },
+    dispatch::{GetDispatchInfo, PostDispatchInfo, extract_actual_weight},
     traits::{IsSubType, OriginTrait, UnfilteredDispatchable},
 };
 use sp_core::TypeId;
@@ -198,9 +195,9 @@ pub mod pallet {
         /// event is deposited.
         #[pallet::call_index(0)]
         #[pallet::weight({
-			let (dispatch_weight, dispatch_class, pays) = Pallet::<T>::weight_and_dispatch_class(calls);
+			let (dispatch_weight, _, pays) = Pallet::<T>::weight_and_dispatch_class(calls);
 			let dispatch_weight = dispatch_weight.saturating_add(T::WeightInfo::batch(calls.len() as u32));
-			(dispatch_weight, dispatch_class, pays)
+			(dispatch_weight, DispatchClass::Normal, pays)
 		})]
         pub fn batch(
             origin: OriginFor<T>,
@@ -268,7 +265,7 @@ pub mod pallet {
 					// AccountData for inner call origin accountdata.
 					.saturating_add(T::DbWeight::get().reads_writes(1, 1))
 					.saturating_add(dispatch_info.call_weight),
-				dispatch_info.class,
+				DispatchClass::Normal,
 			)
 		})]
         pub fn as_derivative(
@@ -310,9 +307,9 @@ pub mod pallet {
         /// - O(C) where C is the number of calls to be batched.
         #[pallet::call_index(2)]
         #[pallet::weight({
-			let (dispatch_weight, dispatch_class, pays) = Pallet::<T>::weight_and_dispatch_class(calls);
+			let (dispatch_weight, _, pays) = Pallet::<T>::weight_and_dispatch_class(calls);
 			let dispatch_weight = dispatch_weight.saturating_add(T::WeightInfo::batch_all(calls.len() as u32));
-			(dispatch_weight, dispatch_class, pays)
+			(dispatch_weight, DispatchClass::Normal, pays)
 		})]
         pub fn batch_all(
             origin: OriginFor<T>,
@@ -376,7 +373,7 @@ pub mod pallet {
 			(
 				T::WeightInfo::dispatch_as()
 					.saturating_add(dispatch_info.call_weight),
-				dispatch_info.class,
+				DispatchClass::Normal,
 			)
 		})]
         pub fn dispatch_as(
@@ -409,9 +406,9 @@ pub mod pallet {
         /// - O(C) where C is the number of calls to be batched.
         #[pallet::call_index(4)]
         #[pallet::weight({
-			let (dispatch_weight, dispatch_class, pays) = Pallet::<T>::weight_and_dispatch_class(calls);
+			let (dispatch_weight, _, pays) = Pallet::<T>::weight_and_dispatch_class(calls);
 			let dispatch_weight = dispatch_weight.saturating_add(T::WeightInfo::force_batch(calls.len() as u32));
-			(dispatch_weight, dispatch_class, pays)
+			(dispatch_weight, DispatchClass::Normal, pays)
 		})]
         pub fn force_batch(
             origin: OriginFor<T>,
@@ -466,7 +463,7 @@ pub mod pallet {
         ///
         /// The dispatch origin for this call must be _Root_.
         #[pallet::call_index(5)]
-        #[pallet::weight((*weight, call.get_dispatch_info().class))]
+        #[pallet::weight((*weight, DispatchClass::Normal))]
         pub fn with_weight(
             origin: OriginFor<T>,
             call: Box<<T as Config>::RuntimeCall>,
@@ -510,7 +507,7 @@ pub mod pallet {
 				T::WeightInfo::if_else()
 					.saturating_add(main.call_weight)
 					.saturating_add(fallback.call_weight),
-				if main.class == Operational && fallback.class == Operational { Operational } else { Normal },
+				DispatchClass::Normal,
 			)
 		})]
         pub fn if_else(
@@ -584,7 +581,7 @@ pub mod pallet {
 			(
 				T::WeightInfo::dispatch_as_fallible()
 					.saturating_add(dispatch_info.call_weight),
-				dispatch_info.class,
+				DispatchClass::Normal,
 			)
 		})]
         pub fn dispatch_as_fallible(
@@ -604,32 +601,22 @@ pub mod pallet {
     }
 
     impl<T: Config> Pallet<T> {
-        /// Get the accumulated `weight` and the dispatch class for the given `calls`.
+        /// Get the accumulated `weight` and `pays` for the given `calls`.
+        /// The outer dispatch class is intentionally always `Normal`.
         fn weight_and_dispatch_class(
             calls: &[<T as Config>::RuntimeCall],
         ) -> (Weight, DispatchClass, Pays) {
-            let dispatch_infos = calls.iter().map(|call| call.get_dispatch_info());
-            let pays = if dispatch_infos.clone().any(|di| di.pays_fee == Pays::No) {
-                Pays::No
-            } else {
-                Pays::Yes
-            };
-            let (dispatch_weight, dispatch_class) = dispatch_infos.fold(
-                (Weight::zero(), DispatchClass::Operational),
-                |(total_weight, dispatch_class): (Weight, DispatchClass), di| {
-                    (
-                        total_weight.saturating_add(di.call_weight),
-                        // If not all are `Operational`, we want to use `DispatchClass::Normal`.
-                        if di.class == DispatchClass::Normal {
-                            di.class
-                        } else {
-                            dispatch_class
-                        },
-                    )
-                },
-            );
+            let mut total_weight = Weight::zero();
+            let mut pays = Pays::Yes;
 
-            (dispatch_weight, dispatch_class, pays)
+            for di in calls.iter().map(|call| call.get_dispatch_info()) {
+                total_weight = total_weight.saturating_add(di.call_weight);
+                if di.pays_fee == Pays::No {
+                    pays = Pays::No;
+                }
+            }
+
+            (total_weight, DispatchClass::Normal, pays)
         }
     }
 }

--- a/pallets/utility/src/lib.rs
+++ b/pallets/utility/src/lib.rs
@@ -605,7 +605,7 @@ pub mod pallet {
         /// The outer dispatch class is intentionally always `Normal`.
         fn weight_and_dispatch_class(
             calls: &[<T as Config>::RuntimeCall],
-        ) -> (Weight, DispatchClass, Pays) {
+        ) -> (Weight, Pays) {
             let mut total_weight = Weight::zero();
             let mut pays = Pays::No;
 

--- a/pallets/utility/src/lib.rs
+++ b/pallets/utility/src/lib.rs
@@ -307,7 +307,7 @@ pub mod pallet {
         /// - O(C) where C is the number of calls to be batched.
         #[pallet::call_index(2)]
         #[pallet::weight({
-			let (dispatch_weight, _, pays) = Pallet::<T>::weight_and_dispatch_class(calls);
+			let (dispatch_weight, pays) = Pallet::<T>::weight_and_dispatch_class(calls);
 			let dispatch_weight = dispatch_weight.saturating_add(T::WeightInfo::batch_all(calls.len() as u32));
 			(dispatch_weight, DispatchClass::Normal, pays)
 		})]

--- a/pallets/utility/src/tests.rs
+++ b/pallets/utility/src/tests.rs
@@ -839,7 +839,7 @@ fn with_weight_works() {
         );
         assert_eq!(
             with_weight_call.get_dispatch_info().class,
-            frame_support::dispatch::DispatchClass::Operational
+             frame_support::dispatch::DispatchClass::Normal // We only allow normal in subtensor
         );
     })
 }

--- a/pallets/utility/src/tests.rs
+++ b/pallets/utility/src/tests.rs
@@ -839,7 +839,7 @@ fn with_weight_works() {
         );
         assert_eq!(
             with_weight_call.get_dispatch_info().class,
-             frame_support::dispatch::DispatchClass::Normal // We only allow normal in subtensor
+            frame_support::dispatch::DispatchClass::Normal // We only allow normal in subtensor
         );
     })
 }


### PR DESCRIPTION
## Description
This PR modifies the `proxy` & `utility` pallets so that their extrinsics will always be `DispatchClass::Normal`.

Also Raises fee on `set_pending_childkey_cooldown`

Test results before & after this patch 
```johnreed@pop-os:~/Desktop/work/my-subtensor-scripts$ python3 ./bpdispatch.py 
[i] Inner call: SubtensorModule.set_pending_childkey_cooldown params={'cooldown': 123}
[x] Utility.batch: dispatch_class=Operational  priority=10000000000
[x] Proxy.proxy: dispatch_class=Operational  priority=10000000000
[!] Assertions failed.

[i] Inner call: SubtensorModule.set_pending_childkey_cooldown params={'cooldown': 123}
[✓] Utility.batch: dispatch_class=Normal  priority=1
[✓] Proxy.proxy: dispatch_class=Normal  priority=1
[✓] All assertions passed.
```

```
[✓] TransactionPayment::TransactionFeePaid
    actual_fee: 5523 (0.000005523 TAO)
    total:      5523 (0.000005523 TAO)

[✓] TransactionPayment::TransactionFeePaid
    actual_fee: 98505523 (0.098505523 TAO)
    total:      98505523 (0.098505523 TAO)
```
