### PR TITLE
feat: add CancelProxy type for time-delayed proxy announcements

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -160,6 +160,7 @@ pub enum ProxyType {
     SwapHotkey,
     SubnetLeaseBeneficiary, // Used to operate the leased subnet
     RootClaim,
+    CancelProxy, // Only allows rejecting proxy announcements for time-delayed proxies
 }
 
 impl TryFrom<u8> for ProxyType {
@@ -185,6 +186,7 @@ impl TryFrom<u8> for ProxyType {
             15 => Ok(Self::SwapHotkey),
             16 => Ok(Self::SubnetLeaseBeneficiary),
             17 => Ok(Self::RootClaim),
+            18 => Ok(Self::CancelProxy),
             _ => Err(()),
         }
     }
@@ -211,6 +213,7 @@ impl From<ProxyType> for u8 {
             ProxyType::SwapHotkey => 15,
             ProxyType::SubnetLeaseBeneficiary => 16,
             ProxyType::RootClaim => 17,
+            ProxyType::CancelProxy => 18,
         }
     }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -751,6 +751,10 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
                 c,
                 RuntimeCall::SubtensorModule(pallet_subtensor::Call::claim_root { .. })
             ),
+            ProxyType::CancelProxy => matches!(
+                c,
+                RuntimeCall::Proxy(pallet_proxy::Call::reject_announcement { .. })
+            ),
         }
     }
     fn is_superset(&self, o: &Self) -> bool {


### PR DESCRIPTION
## Summary

This PR adds a new `CancelProxy` proxy type that enables users to delegate the ability to reject proxy announcements without granting other permissions.

Closes #590

## Motivation

When using time-delayed proxies, users need the ability to:
- Cancel pending announcements for security purposes
- Delegate this cancel ability without granting broader permissions
- Analyze transactions before they execute and reject suspicious ones

The `CancelProxy` type addresses this by only allowing `reject_announcement` calls from the proxy pallet.

## Changes

1. **common/src/lib.rs**
   - Added `CancelProxy` variant to `ProxyType` enum
   - Added TryFrom implementation (value: 18)
   - Added From implementation (ProxyType::CancelProxy => 18)

2. **runtime/src/lib.rs**
   - Added InstanceFilter implementation that only allows `reject_announcement` calls

## Usage

Users can now add a proxy with the `CancelProxy` type to delegate the ability to reject pending announcements:

```rust
// Add a Cancel proxy
Proxy::add_proxy(origin, delegate, ProxyType::CancelProxy, delay);

// The delegate can then reject announcements
Proxy::reject_announcement(origin, real, call_hash);
```

## Testing

The existing mock implementations use catch-all patterns and will handle the new variant correctly.