### PR TITLE
fix: correct typos in lib.rs and tests

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1553,7 +1553,7 @@ pub mod pallet {
     /// ============================
     /// ==== Rate Limiting =====
     /// ============================
-    /// --- MAP ( RateLimitKey ) --> Block number in which the last rate limited operation occured
+    /// --- MAP ( RateLimitKey ) --> Block number in which the last rate limited operation occurred
     #[pallet::storage]
     pub type LastRateLimitedBlock<T: Config> =
         StorageMap<_, Identity, RateLimitKey<T::AccountId>, u64, ValueQuery, DefaultZeroU64<T>>;
@@ -2653,7 +2653,7 @@ impl<T: Config + pallet_balances::Config<Balance = u64>>
 }
 
 /// Enum that defines types of rate limited operations for
-/// storing last block when this operation occured
+/// storing last block when this operation occurred
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo)]
 pub enum RateLimitKey<AccountId> {
     // The setting sn owner hotkey operation is rate limited per netuid

--- a/pallets/subtensor/src/tests/coinbase.rs
+++ b/pallets/subtensor/src/tests/coinbase.rs
@@ -670,7 +670,7 @@ fn test_owner_cut_base() {
         let netuid = NetUid::from(1);
         add_network(netuid, 1, 0);
         mock::setup_reserves(netuid, 1_000_000_000_000.into(), 1_000_000_000_000.into());
-        SubtensorModule::set_tempo(netuid, 10000); // Large number (dont drain)
+        SubtensorModule::set_tempo(netuid, 10000); // Large number (don't drain)
         SubtensorModule::set_subnet_owner_cut(0);
         SubtensorModule::run_coinbase(U96F32::from_num(0));
         assert_eq!(PendingOwnerCut::<Test>::get(netuid), 0.into()); // No cut
@@ -695,7 +695,7 @@ fn test_pending_emission() {
         SubtensorModule::run_coinbase(U96F32::from_num(0));
         SubnetTAO::<Test>::insert(NetUid::ROOT, TaoCurrency::from(1_000_000_000)); // Add root weight.
         SubtensorModule::run_coinbase(U96F32::from_num(0));
-        SubtensorModule::set_tempo(netuid, 10000); // Large number (dont drain)
+        SubtensorModule::set_tempo(netuid, 10000); // Large number (don't drain)
         SubtensorModule::set_tao_weight(u64::MAX); // Set TAO weight to 1.0
 
         // Set moving price > 1.0

--- a/pallets/subtensor/src/tests/epoch.rs
+++ b/pallets/subtensor/src/tests/epoch.rs
@@ -1691,7 +1691,7 @@ fn test_outdated_weights() {
             U256::from(new_key),
             U256::from(new_key)
         ));
-        let deregistered_uid: u16 = n - 1; // since uid=n-1 only recieved 1/3 of weight, it will get pruned first
+        let deregistered_uid: u16 = n - 1; // since uid=n-1 only received 1/3 of weight, it will get pruned first
         assert_eq!(
             U256::from(new_key),
             SubtensorModule::get_hotkey_for_net_and_uid(netuid, deregistered_uid)
@@ -2073,7 +2073,7 @@ fn test_deregistered_miner_bonds() {
             U256::from(new_key),
             U256::from(new_key)
         ));
-        let deregistered_uid: u16 = n - 1; // since uid=n-1 only recieved 1/3 of weight, it will get pruned first
+        let deregistered_uid: u16 = n - 1; // since uid=n-1 only received 1/3 of weight, it will get pruned first
         assert_eq!(
             U256::from(new_key),
             SubtensorModule::get_hotkey_for_net_and_uid(netuid, deregistered_uid)


### PR DESCRIPTION
Fixes several spelling errors:

- lib.rs: 'occured' → 'occurred' (2 instances)
- coinbase.rs: 'dont' → "don't" (2 instances)
- epoch.rs: 'recieved' → 'received' (2 instances)