### PR TITLE
No operational calls

### DIFF
--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -208,12 +208,8 @@ pub mod pallet {
         /// It is only callable by the root account.
         /// The extrinsic will call the Subtensor pallet to set the transaction rate limit.
         #[pallet::call_index(2)]
-        #[pallet::weight(
-            (Weight::from_parts(5_400_000, 0)
-			    .saturating_add(T::DbWeight::get().writes(1_u64)),
-            DispatchClass::Operational,
-            Pays::Yes)
-        )]
+        #[pallet::weight(Weight::from_parts(5_400_000, 0)
+        .saturating_add(T::DbWeight::get().writes(1_u64)))]
         pub fn sudo_set_tx_rate_limit(origin: OriginFor<T>, tx_rate_limit: u64) -> DispatchResult {
             ensure_root(origin)?;
             pallet_subtensor::Pallet::<T>::set_tx_rate_limit(tx_rate_limit);
@@ -404,10 +400,9 @@ pub mod pallet {
         /// It is only callable by the root account or subnet owner.
         /// The extrinsic will call the Subtensor pallet to set the adjustment alpha.
         #[pallet::call_index(9)]
-        #[pallet::weight(
-            Weight::from_parts(14_000_000, 0)
-                .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1))
-                .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(1))
+        #[pallet::weight(Weight::from_parts(14_000_000, 0)
+        .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1))
+        .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(1))
         )]
         pub fn sudo_set_adjustment_alpha(
             origin: OriginFor<T>,
@@ -643,13 +638,9 @@ pub mod pallet {
         /// It is only callable by the root account or subnet owner.
         /// The extrinsic will call the Subtensor pallet to set the network registration allowed.
         #[pallet::call_index(19)]
-        #[pallet::weight((
-			Weight::from_parts(7_343_000, 0)
-                .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(0))
-				.saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1)),
-			DispatchClass::Operational,
-			Pays::Yes
-		))]
+        #[pallet::weight(Weight::from_parts(7_343_000, 0)
+        .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(0))
+        .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1)))]
         pub fn sudo_set_network_registration_allowed(
             origin: OriginFor<T>,
             netuid: NetUid,
@@ -976,12 +967,8 @@ pub mod pallet {
         /// It is only callable by the root account.
         /// The extrinsic will call the Subtensor pallet to set the subnet owner cut.
         #[pallet::call_index(28)]
-        #[pallet::weight((
-			Weight::from_parts(14_000_000, 0)
-				.saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1)),
-			DispatchClass::Operational,
-			Pays::Yes
-		))]
+        #[pallet::weight(Weight::from_parts(14_000_000, 0)
+        .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1)))]
         pub fn sudo_set_subnet_owner_cut(
             origin: OriginFor<T>,
             subnet_owner_cut: u16,
@@ -996,12 +983,8 @@ pub mod pallet {
         /// It is only callable by the root account.
         /// The extrinsic will call the Subtensor pallet to set the network rate limit.
         #[pallet::call_index(29)]
-        #[pallet::weight((
-			Weight::from_parts(14_000_000, 0)
-				.saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1)),
-			DispatchClass::Operational,
-			Pays::Yes
-		))]
+        #[pallet::weight(Weight::from_parts(14_000_000, 0)
+        .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1)))]
         pub fn sudo_set_network_rate_limit(
             origin: OriginFor<T>,
             rate_limit: u64,
@@ -1035,13 +1018,9 @@ pub mod pallet {
         /// It is only callable by the root account.
         /// The extrinsic will call the Subtensor pallet to set the issuance for the network.
         #[pallet::call_index(33)]
-        #[pallet::weight((
-            Weight::from_parts(2_875_000, 0)
-                .saturating_add(T::DbWeight::get().reads(0_u64))
-			    .saturating_add(T::DbWeight::get().writes(1_u64)),
-            DispatchClass::Operational,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(2_875_000, 0)
+        .saturating_add(T::DbWeight::get().reads(0_u64))
+        .saturating_add(T::DbWeight::get().writes(1_u64)))]
         pub fn sudo_set_total_issuance(
             origin: OriginFor<T>,
             total_issuance: TaoCurrency,
@@ -1057,12 +1036,8 @@ pub mod pallet {
         /// It is only callable by the root account.
         /// The extrinsic will call the Subtensor pallet to set the immunity period for the network.
         #[pallet::call_index(35)]
-        #[pallet::weight((
-			Weight::from_parts(14_000_000, 0)
-				.saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1)),
-			DispatchClass::Operational,
-			Pays::Yes
-		))]
+        #[pallet::weight(Weight::from_parts(14_000_000, 0)
+        .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1)))]
         pub fn sudo_set_network_immunity_period(
             origin: OriginFor<T>,
             immunity_period: u64,
@@ -1080,12 +1055,8 @@ pub mod pallet {
         /// It is only callable by the root account.
         /// The extrinsic will call the Subtensor pallet to set the min lock cost for the network.
         #[pallet::call_index(36)]
-        #[pallet::weight((
-			Weight::from_parts(14_000_000, 0)
-				.saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1)),
-			DispatchClass::Operational,
-			Pays::Yes
-		))]
+        #[pallet::weight(Weight::from_parts(14_000_000, 0)
+        .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1)))]
         pub fn sudo_set_network_min_lock_cost(
             origin: OriginFor<T>,
             lock_cost: TaoCurrency,
@@ -1103,12 +1074,8 @@ pub mod pallet {
         /// It is only callable by the root account.
         /// The extrinsic will call the Subtensor pallet to set the subnet limit.
         #[pallet::call_index(37)]
-        #[pallet::weight((
-			Weight::from_parts(14_000_000, 0)
-				.saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1)),
-			DispatchClass::Operational,
-			Pays::Yes
-		))]
+        #[pallet::weight(Weight::from_parts(14_000_000, 0)
+        .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1)))]
         pub fn sudo_set_subnet_limit(origin: OriginFor<T>, max_subnets: u16) -> DispatchResult {
             ensure_root(origin)?;
             pallet_subtensor::Pallet::<T>::set_max_subnets(max_subnets);
@@ -1120,12 +1087,8 @@ pub mod pallet {
         /// It is only callable by the root account.
         /// The extrinsic will call the Subtensor pallet to set the lock reduction interval.
         #[pallet::call_index(38)]
-        #[pallet::weight((
-			Weight::from_parts(14_000_000, 0)
-				.saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1)),
-			DispatchClass::Operational,
-			Pays::Yes
-		))]
+        #[pallet::weight(Weight::from_parts(14_000_000, 0)
+        .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1)))]
         pub fn sudo_set_lock_reduction_interval(
             origin: OriginFor<T>,
             interval: u64,
@@ -1143,13 +1106,9 @@ pub mod pallet {
         /// It is only callable by the root account.
         /// The extrinsic will call the Subtensor pallet to set the recycled RAO.
         #[pallet::call_index(39)]
-        #[pallet::weight((
-            Weight::from_parts(15_060_000, 4045)
-                .saturating_add(T::DbWeight::get().reads(1_u64))
-                .saturating_add(T::DbWeight::get().writes(1_u64)),
-            DispatchClass::Operational,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(15_060_000, 4045)
+        .saturating_add(T::DbWeight::get().reads(1_u64))
+        .saturating_add(T::DbWeight::get().writes(1_u64)))]
         pub fn sudo_set_rao_recycled(
             origin: OriginFor<T>,
             netuid: NetUid,
@@ -1168,13 +1127,9 @@ pub mod pallet {
         /// It is only callable by the root account.
         /// The extrinsic will call the Subtensor pallet to set the weights min stake.
         #[pallet::call_index(42)]
-        #[pallet::weight((
-            Weight::from_parts(5_000_000, 0)
-            .saturating_add(T::DbWeight::get().reads(0_u64))
-            .saturating_add(T::DbWeight::get().writes(1_u64)),
-            DispatchClass::Operational,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(5_000_000, 0)
+        .saturating_add(T::DbWeight::get().reads(0_u64))
+        .saturating_add(T::DbWeight::get().writes(1_u64)))]
         pub fn sudo_set_stake_threshold(origin: OriginFor<T>, min_stake: u64) -> DispatchResult {
             ensure_root(origin)?;
             pallet_subtensor::Pallet::<T>::set_stake_threshold(min_stake);
@@ -1185,13 +1140,9 @@ pub mod pallet {
         /// It is only callable by the root account.
         /// The extrinsic will call the Subtensor pallet to set the minimum stake required for nominators.
         #[pallet::call_index(43)]
-        #[pallet::weight((
-            Weight::from_parts(28_050_000, 6792)
-                .saturating_add(T::DbWeight::get().reads(4_u64))
-                .saturating_add(T::DbWeight::get().writes(1_u64)),
-            DispatchClass::Operational,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(28_050_000, 6792)
+        .saturating_add(T::DbWeight::get().reads(4_u64))
+        .saturating_add(T::DbWeight::get().writes(1_u64)))]
         pub fn sudo_set_nominator_min_required_stake(
             origin: OriginFor<T>,
             // The minimum stake required for nominators.
@@ -1213,13 +1164,9 @@ pub mod pallet {
         /// It is only callable by the root account.
         /// The extrinsic will call the Subtensor pallet to set the rate limit for delegate take transactions.
         #[pallet::call_index(45)]
-        #[pallet::weight((
-            Weight::from_parts(5_019_000, 0)
-            .saturating_add(T::DbWeight::get().reads(0_u64))
-            .saturating_add(T::DbWeight::get().writes(1_u64)),
-            DispatchClass::Operational,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(5_019_000, 0)
+        .saturating_add(T::DbWeight::get().reads(0_u64))
+        .saturating_add(T::DbWeight::get().writes(1_u64)))]
         pub fn sudo_set_tx_delegate_take_rate_limit(
             origin: OriginFor<T>,
             tx_rate_limit: u64,
@@ -1236,13 +1183,9 @@ pub mod pallet {
         /// It is only callable by the root account.
         /// The extrinsic will call the Subtensor pallet to set the minimum delegate take.
         #[pallet::call_index(46)]
-        #[pallet::weight((
-            Weight::from_parts(7_214_000, 0)
-            .saturating_add(T::DbWeight::get().reads(0_u64))
-            .saturating_add(T::DbWeight::get().writes(1_u64)),
-            DispatchClass::Operational,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(7_214_000, 0)
+        .saturating_add(T::DbWeight::get().reads(0_u64))
+        .saturating_add(T::DbWeight::get().writes(1_u64)))]
         pub fn sudo_set_min_delegate_take(origin: OriginFor<T>, take: u16) -> DispatchResult {
             ensure_root(origin)?;
             pallet_subtensor::Pallet::<T>::set_min_delegate_take(take);
@@ -1294,13 +1237,9 @@ pub mod pallet {
         /// # Weight
         /// This function has a fixed weight of 0 and is classified as an operational transaction that does not incur any fees.
         #[pallet::call_index(50)]
-        #[pallet::weight((
-            Weight::from_parts(18_300_000, 0)
-                .saturating_add(T::DbWeight::get().reads(2_u64))
-			    .saturating_add(T::DbWeight::get().writes(1_u64)),
-            DispatchClass::Normal,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(18_300_000, 0)
+        .saturating_add(T::DbWeight::get().reads(2_u64))
+        .saturating_add(T::DbWeight::get().writes(1_u64)))]
         pub fn sudo_set_liquid_alpha_enabled(
             origin: OriginFor<T>,
             netuid: NetUid,
@@ -1324,13 +1263,9 @@ pub mod pallet {
 
         /// Sets values for liquid alpha
         #[pallet::call_index(51)]
-        #[pallet::weight((
-            Weight::from_parts(25_280_000, 4089)
-                .saturating_add(T::DbWeight::get().reads(3_u64))
-                .saturating_add(T::DbWeight::get().writes(1_u64)),
-            DispatchClass::Normal,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(25_280_000, 4089)
+        .saturating_add(T::DbWeight::get().reads(3_u64))
+        .saturating_add(T::DbWeight::get().writes(1_u64)))]
         pub fn sudo_set_alpha_values(
             origin: OriginFor<T>,
             netuid: NetUid,
@@ -1371,13 +1306,9 @@ pub mod pallet {
         /// # Weight
         /// Weight is handled by the `#[pallet::weight]` attribute.
         #[pallet::call_index(54)]
-        #[pallet::weight((
-            Weight::from_parts(5_000_000, 0)
-                .saturating_add(T::DbWeight::get().reads(0_u64))
-			    .saturating_add(T::DbWeight::get().writes(1_u64)),
-            DispatchClass::Operational,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(5_000_000, 0)
+        .saturating_add(T::DbWeight::get().reads(0_u64))
+        .saturating_add(T::DbWeight::get().writes(1_u64)))]
         pub fn sudo_set_coldkey_swap_schedule_duration(
             origin: OriginFor<T>,
             duration: BlockNumberFor<T>,
@@ -1409,13 +1340,9 @@ pub mod pallet {
         /// # Weight
         /// Weight is handled by the `#[pallet::weight]` attribute.
         #[pallet::call_index(55)]
-        #[pallet::weight((
-            Weight::from_parts(5_000_000, 0)
-                .saturating_add(T::DbWeight::get().reads(0_u64))
-			    .saturating_add(T::DbWeight::get().writes(1_u64)),
-            DispatchClass::Operational,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(5_000_000, 0)
+        .saturating_add(T::DbWeight::get().reads(0_u64))
+        .saturating_add(T::DbWeight::get().writes(1_u64)))]
         pub fn sudo_set_dissolve_network_schedule_duration(
             origin: OriginFor<T>,
             duration: BlockNumberFor<T>,
@@ -1544,13 +1471,9 @@ pub mod pallet {
         /// # Weight
         /// This function has a fixed weight of 0 and is classified as an operational transaction that does not incur any fees.
         #[pallet::call_index(61)]
-        #[pallet::weight((
-            Weight::from_parts(20_460_000, 0)
-                .saturating_add(T::DbWeight::get().reads(2_u64))
-			    .saturating_add(T::DbWeight::get().writes(1_u64)),
-            DispatchClass::Normal,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(20_460_000, 0)
+        .saturating_add(T::DbWeight::get().reads(2_u64))
+        .saturating_add(T::DbWeight::get().writes(1_u64)))]
         pub fn sudo_set_toggle_transfer(
             origin: OriginFor<T>,
             netuid: NetUid,
@@ -1583,7 +1506,9 @@ pub mod pallet {
         /// - `recycle_or_burn`: The desired behaviour of the "burn" UID(s) for the subnet.
         ///
         #[pallet::call_index(80)]
-        #[pallet::weight((1_000_000, DispatchClass::Normal, Pays::Yes))] // TODO: add proper weights
+        #[pallet::weight(Weight::from_parts(20_000_000, 0)
+        .saturating_add(T::DbWeight::get().reads(2_u64))
+        .saturating_add(T::DbWeight::get().writes(2_u64)))] // TODO: add benchmarks
         pub fn sudo_set_recycle_or_burn(
             origin: OriginFor<T>,
             netuid: NetUid,
@@ -1619,13 +1544,9 @@ pub mod pallet {
         /// # Weight
         /// Weight is handled by the `#[pallet::weight]` attribute.
         #[pallet::call_index(62)]
-        #[pallet::weight((
-            Weight::from_parts(5_744_000, 3507)
-			    .saturating_add(T::DbWeight::get().reads(1_u64))
-                .saturating_add(T::DbWeight::get().writes(0_u64)),
-            DispatchClass::Operational,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(5_744_000, 3507)
+        .saturating_add(T::DbWeight::get().reads(1_u64))
+        .saturating_add(T::DbWeight::get().writes(0_u64)))]
         pub fn sudo_toggle_evm_precompile(
             origin: OriginFor<T>,
             precompile_id: PrecompileEnum,
@@ -1654,13 +1575,9 @@ pub mod pallet {
         /// # Weight
         /// Weight is handled by the `#[pallet::weight]` attribute.
         #[pallet::call_index(63)]
-        #[pallet::weight((
-            Weight::from_parts(3_000_000, 0)
-                .saturating_add(T::DbWeight::get().reads(0_u64))
-			    .saturating_add(T::DbWeight::get().writes(1_u64)),
-            DispatchClass::Operational,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(3_000_000, 0)
+        .saturating_add(T::DbWeight::get().reads(0_u64))
+        .saturating_add(T::DbWeight::get().writes(1_u64)))]
         pub fn sudo_set_subnet_moving_alpha(origin: OriginFor<T>, alpha: I96F32) -> DispatchResult {
             ensure_root(origin)?;
             pallet_subtensor::SubnetMovingAlpha::<T>::set(alpha);
@@ -1682,12 +1599,8 @@ pub mod pallet {
         /// # Weight
         /// Weight is handled by the `#[pallet::weight]` attribute.
         #[pallet::call_index(64)]
-        #[pallet::weight((
-            Weight::from_parts(3_918_000, 0) // TODO: add benchmarks
-			    .saturating_add(T::DbWeight::get().writes(1_u64)),
-            DispatchClass::Normal,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(3_918_000, 0) // TODO: add benchmarks
+        .saturating_add(T::DbWeight::get().writes(1_u64)))]
         pub fn sudo_set_subnet_owner_hotkey(
             origin: OriginFor<T>,
             netuid: NetUid,
@@ -1708,13 +1621,9 @@ pub mod pallet {
         /// # Weight
         /// Weight is handled by the `#[pallet::weight]` attribute.
         #[pallet::call_index(65)]
-        #[pallet::weight((
-            Weight::from_parts(6_201_000, 0)
-                .saturating_add(T::DbWeight::get().reads(0_u64))
-			    .saturating_add(T::DbWeight::get().writes(1_u64)),
-            DispatchClass::Operational,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(6_201_000, 0)
+        .saturating_add(T::DbWeight::get().reads(0_u64))
+        .saturating_add(T::DbWeight::get().writes(1_u64)))]
         pub fn sudo_set_ema_price_halving_period(
             origin: OriginFor<T>,
             netuid: NetUid,
@@ -1745,13 +1654,9 @@ pub mod pallet {
         /// # Weight
         /// Weight is handled by the `#[pallet::weight]` attribute.
         #[pallet::call_index(68)]
-        #[pallet::weight((
-            Weight::from_parts(23_140_000, 4045)
-                .saturating_add(T::DbWeight::get().reads(3_u64))
-                .saturating_add(T::DbWeight::get().writes(1_u64)),
-            DispatchClass::Normal,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(23_140_000, 4045)
+        .saturating_add(T::DbWeight::get().reads(3_u64))
+        .saturating_add(T::DbWeight::get().writes(1_u64)))]
         pub fn sudo_set_alpha_sigmoid_steepness(
             origin: OriginFor<T>,
             netuid: NetUid,
@@ -1796,13 +1701,9 @@ pub mod pallet {
         /// # Weight
         /// This function has a fixed weight of 0 and is classified as an operational transaction that does not incur any fees.
         #[pallet::call_index(69)]
-        #[pallet::weight((
-            Weight::from_parts(20_460_000, 0)
-                .saturating_add(T::DbWeight::get().reads(2_u64))
-			    .saturating_add(T::DbWeight::get().writes(1_u64)),
-            DispatchClass::Normal,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(20_460_000, 0)
+        .saturating_add(T::DbWeight::get().reads(2_u64))
+        .saturating_add(T::DbWeight::get().writes(1_u64)))]
         pub fn sudo_set_yuma3_enabled(
             origin: OriginFor<T>,
             netuid: NetUid,
@@ -1836,13 +1737,9 @@ pub mod pallet {
         /// # Weight
         /// This function has a fixed weight of 0 and is classified as an operational transaction that does not incur any fees.
         #[pallet::call_index(70)]
-        #[pallet::weight((
-            Weight::from_parts(32_930_000, 0)
-                .saturating_add(T::DbWeight::get().reads(2_u64))
-			    .saturating_add(T::DbWeight::get().writes(1_u64)),
-            DispatchClass::Normal,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(32_930_000, 0)
+        .saturating_add(T::DbWeight::get().reads(2_u64))
+        .saturating_add(T::DbWeight::get().writes(1_u64)))]
         pub fn sudo_set_bonds_reset_enabled(
             origin: OriginFor<T>,
             netuid: NetUid,
@@ -1897,13 +1794,9 @@ pub mod pallet {
         /// # Rate Limiting
         /// This function is rate-limited to one call per subnet per interval (e.g., one week).
         #[pallet::call_index(67)]
-        #[pallet::weight((
-            Weight::from_parts(20_570_000, 4204)
-                .saturating_add(T::DbWeight::get().reads(2_u64))
-                .saturating_add(T::DbWeight::get().writes(2_u64)),
-            DispatchClass::Normal,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(20_570_000, 4204)
+        .saturating_add(T::DbWeight::get().reads(2_u64))
+        .saturating_add(T::DbWeight::get().writes(2_u64)))]
         pub fn sudo_set_sn_owner_hotkey(
             origin: OriginFor<T>,
             netuid: NetUid,
@@ -1925,13 +1818,9 @@ pub mod pallet {
         /// # Weight
         /// Weight is handled by the `#[pallet::weight]` attribute.
         #[pallet::call_index(66)]
-        #[pallet::weight((
-            Weight::from_parts(17_980_000, 0)
-                .saturating_add(T::DbWeight::get().reads(2_u64))
-			    .saturating_add(T::DbWeight::get().writes(1_u64)),
-            DispatchClass::Operational,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(17_980_000, 0)
+        .saturating_add(T::DbWeight::get().reads(2_u64))
+        .saturating_add(T::DbWeight::get().writes(1_u64)))]
         pub fn sudo_set_subtoken_enabled(
             origin: OriginFor<T>,
             netuid: NetUid,
@@ -1949,13 +1838,9 @@ pub mod pallet {
 
         /// Sets the commit-reveal weights version for all subnets
         #[pallet::call_index(71)]
-        #[pallet::weight((
-            Weight::from_parts(7_114_000, 0)
-                .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1))
-                .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(0_u64)),
-            DispatchClass::Operational,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(7_114_000, 0)
+        .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1))
+        .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(0_u64)))]
         pub fn sudo_set_commit_reveal_version(
             origin: OriginFor<T>,
             version: u16,
@@ -2007,12 +1892,9 @@ pub mod pallet {
         /// Sets the admin freeze window length (in blocks) at the end of a tempo.
         /// Only callable by root.
         #[pallet::call_index(74)]
-        #[pallet::weight((
-			Weight::from_parts(5_510_000, 0)
-				.saturating_add(<T as frame_system::Config>::DbWeight::get().reads(0_u64))
-				.saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1_u64)),
-			DispatchClass::Operational
-		))]
+        #[pallet::weight(Weight::from_parts(5_510_000, 0)
+        .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(0_u64))
+        .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1_u64)))]
         pub fn sudo_set_admin_freeze_window(origin: OriginFor<T>, window: u16) -> DispatchResult {
             ensure_root(origin)?;
             pallet_subtensor::Pallet::<T>::set_admin_freeze_window(window);
@@ -2023,12 +1905,9 @@ pub mod pallet {
         /// Sets the owner hyperparameter rate limit in epochs (global multiplier).
         /// Only callable by root.
         #[pallet::call_index(75)]
-        #[pallet::weight((
-			Weight::from_parts(5_701_000, 0)
-				.saturating_add(<T as frame_system::Config>::DbWeight::get().reads(0_u64))
-				.saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1_u64)),
-			DispatchClass::Operational
-		))]
+        #[pallet::weight(Weight::from_parts(5_701_000, 0)
+        .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(0_u64))
+        .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1_u64)))]
         pub fn sudo_set_owner_hparam_rate_limit(
             origin: OriginFor<T>,
             epochs: u16,
@@ -2161,13 +2040,9 @@ pub mod pallet {
 
         /// Sets TAO flow cutoff value (A)
         #[pallet::call_index(81)]
-        #[pallet::weight((
-			Weight::from_parts(7_343_000, 0)
-                .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(0))
-				.saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1)),
-			DispatchClass::Operational,
-			Pays::Yes
-		))]
+        #[pallet::weight(Weight::from_parts(7_343_000, 0)
+        .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(0))
+        .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1)))]
         pub fn sudo_set_tao_flow_cutoff(
             origin: OriginFor<T>,
             flow_cutoff: I64F64,
@@ -2180,13 +2055,9 @@ pub mod pallet {
 
         /// Sets TAO flow normalization exponent (p)
         #[pallet::call_index(82)]
-        #[pallet::weight((
-			Weight::from_parts(7_343_000, 0)
-                .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(0))
-				.saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1)),
-			DispatchClass::Operational,
-			Pays::Yes
-		))]
+        #[pallet::weight(Weight::from_parts(7_343_000, 0)
+        .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(0))
+        .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1)))]
         pub fn sudo_set_tao_flow_normalization_exponent(
             origin: OriginFor<T>,
             exponent: U64F64,
@@ -2207,13 +2078,9 @@ pub mod pallet {
 
         /// Sets TAO flow smoothing factor (alpha)
         #[pallet::call_index(83)]
-        #[pallet::weight((
-			Weight::from_parts(7_343_000, 0)
-                .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(0))
-				.saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1)),
-			DispatchClass::Operational,
-			Pays::Yes
-		))]
+        #[pallet::weight(Weight::from_parts(7_343_000, 0)
+        .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(0))
+        .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1)))]
         pub fn sudo_set_tao_flow_smoothing_factor(
             origin: OriginFor<T>,
             smoothing_factor: u64,
@@ -2226,13 +2093,9 @@ pub mod pallet {
 
         /// Sets the minimum number of non-immortal & non-immune UIDs that must remain in a subnet
         #[pallet::call_index(84)]
-        #[pallet::weight((
-            Weight::from_parts(7_114_000, 0)
-                .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1))
-                .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(0_u64)),
-            DispatchClass::Operational,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(7_114_000, 0)
+        .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1))
+        .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(0_u64)))]
         pub fn sudo_set_min_non_immune_uids(
             origin: OriginFor<T>,
             netuid: NetUid,
@@ -2245,12 +2108,8 @@ pub mod pallet {
 
         /// Sets the delay before a subnet can call start
         #[pallet::call_index(85)]
-        #[pallet::weight((
-            Weight::from_parts(14_000_000, 0)
-                .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1)),
-            DispatchClass::Operational,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(14_000_000, 0)
+        .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1)))]
         pub fn sudo_set_start_call_delay(origin: OriginFor<T>, delay: u64) -> DispatchResult {
             ensure_root(origin)?;
             pallet_subtensor::Pallet::<T>::set_start_call_delay(delay);

--- a/pallets/commitments/src/lib.rs
+++ b/pallets/commitments/src/lib.rs
@@ -332,13 +332,9 @@ pub mod pallet {
 
         /// Sudo-set MaxSpace
         #[pallet::call_index(2)]
-        #[pallet::weight((
-            Weight::from_parts(2_856_000, 0)
-			.saturating_add(T::DbWeight::get().reads(0_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64)),
-            DispatchClass::Operational,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(2_856_000, 0)
+        .saturating_add(T::DbWeight::get().reads(0_u64))
+        .saturating_add(T::DbWeight::get().writes(1_u64)))]
         pub fn set_max_space(origin: OriginFor<T>, new_limit: u32) -> DispatchResult {
             ensure_root(origin)?;
             MaxSpace::<T>::set(new_limit);

--- a/pallets/drand/src/lib.rs
+++ b/pallets/drand/src/lib.rs
@@ -406,9 +406,9 @@ pub mod pallet {
         /// * `origin`: the root user
         /// * `config`: the beacon configuration
         #[pallet::call_index(1)]
-        #[pallet::weight((Weight::from_parts(8_766_000, 0)
+        #[pallet::weight(Weight::from_parts(8_766_000, 0)
         .saturating_add(T::DbWeight::get().reads(0_u64))
-        .saturating_add(T::DbWeight::get().writes(2_u64)), DispatchClass::Operational))]
+        .saturating_add(T::DbWeight::get().writes(2_u64)))]
         pub fn set_beacon_config(
             origin: OriginFor<T>,
             config_payload: BeaconConfigurationPayload<T::Public, BlockNumberFor<T>>,
@@ -427,9 +427,9 @@ pub mod pallet {
 
         /// allows the root user to set the oldest stored round
         #[pallet::call_index(2)]
-        #[pallet::weight((Weight::from_parts(5_370_000, 0)
+        #[pallet::weight(Weight::from_parts(5_370_000, 0)
         .saturating_add(T::DbWeight::get().reads(0_u64))
-        .saturating_add(T::DbWeight::get().writes(1_u64)), DispatchClass::Operational))]
+        .saturating_add(T::DbWeight::get().writes(1_u64)))]
         pub fn set_oldest_stored_round(origin: OriginFor<T>, oldest_round: u64) -> DispatchResult {
             ensure_root(origin)?;
             OldestStoredRound::<T>::put(oldest_round);

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -1082,9 +1082,9 @@ mod dispatches {
         ///
         /// Weight is calculated based on the number of database reads and writes.
         #[pallet::call_index(71)]
-        #[pallet::weight((Weight::from_parts(161_700_000, 0)
+        #[pallet::weight(Weight::from_parts(161_700_000, 0)
         .saturating_add(T::DbWeight::get().reads(16_u64))
-        .saturating_add(T::DbWeight::get().writes(11_u64)), DispatchClass::Operational, Pays::Yes))]
+        .saturating_add(T::DbWeight::get().writes(11_u64)))]
         pub fn swap_coldkey(
             origin: OriginFor<T>,
             old_coldkey: T::AccountId,
@@ -1161,13 +1161,9 @@ mod dispatches {
         /// * `BadOrigin` - If the origin is not root.
         ///
         #[pallet::call_index(69)]
-        #[pallet::weight((
-            Weight::from_parts(5_660_000, 0)
-            .saturating_add(T::DbWeight::get().reads(0))
-            .saturating_add(T::DbWeight::get().writes(1)),
-            DispatchClass::Operational,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(5_660_000, 0)
+        .saturating_add(T::DbWeight::get().reads(0))
+        .saturating_add(T::DbWeight::get().writes(1)))]
         pub fn sudo_set_tx_childkey_take_rate_limit(
             origin: OriginFor<T>,
             tx_rate_limit: u64,
@@ -1189,13 +1185,9 @@ mod dispatches {
         /// * `BadOrigin` - If the origin is not root.
         ///
         #[pallet::call_index(76)]
-        #[pallet::weight((
-            Weight::from_parts(6_000, 0)
-            .saturating_add(T::DbWeight::get().reads(1))
-            .saturating_add(T::DbWeight::get().writes(1)),
-            DispatchClass::Operational,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(6_000, 0)
+        .saturating_add(T::DbWeight::get().reads(1))
+        .saturating_add(T::DbWeight::get().writes(1)))]
         pub fn sudo_set_min_childkey_take(origin: OriginFor<T>, take: u16) -> DispatchResult {
             ensure_root(origin)?;
             Self::set_min_childkey_take(take);
@@ -1214,13 +1206,9 @@ mod dispatches {
         /// * `BadOrigin` - If the origin is not root.
         ///
         #[pallet::call_index(77)]
-        #[pallet::weight((
-            Weight::from_parts(6_000, 0)
-            .saturating_add(T::DbWeight::get().reads(1))
-            .saturating_add(T::DbWeight::get().writes(1)),
-            DispatchClass::Operational,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(6_000, 0)
+        .saturating_add(T::DbWeight::get().reads(1))
+        .saturating_add(T::DbWeight::get().writes(1)))]
         pub fn sudo_set_max_childkey_take(origin: OriginFor<T>, take: u16) -> DispatchResult {
             ensure_root(origin)?;
             Self::set_max_childkey_take(take);
@@ -1260,9 +1248,9 @@ mod dispatches {
         /// Remove a user's subnetwork
         /// The caller must be the owner of the network
         #[pallet::call_index(61)]
-        #[pallet::weight((Weight::from_parts(119_000_000, 0)
+        #[pallet::weight(Weight::from_parts(119_000_000, 0)
 		.saturating_add(T::DbWeight::get().reads(6))
-		.saturating_add(T::DbWeight::get().writes(31)), DispatchClass::Operational, Pays::Yes))]
+		.saturating_add(T::DbWeight::get().writes(31)))]
         pub fn dissolve_network(
             origin: OriginFor<T>,
             _coldkey: T::AccountId,
@@ -2037,7 +2025,7 @@ mod dispatches {
 
         /// Sets the pending childkey cooldown (in blocks). Root only.
         #[pallet::call_index(109)]
-        #[pallet::weight((Weight::from_parts(1_970_000_000_000, 0), DispatchClass::Operational, Pays::Yes))]
+        #[pallet::weight(Weight::from_parts(1_970_000_000_000, 0))]
         pub fn set_pending_childkey_cooldown(
             origin: OriginFor<T>,
             cooldown: u64,
@@ -2307,9 +2295,9 @@ mod dispatches {
         /// Remove a subnetwork
         /// The caller must be root
         #[pallet::call_index(120)]
-        #[pallet::weight((Weight::from_parts(119_000_000, 0)
+        #[pallet::weight(Weight::from_parts(119_000_000, 0)
 		.saturating_add(T::DbWeight::get().reads(6))
-		.saturating_add(T::DbWeight::get().writes(31)), DispatchClass::Operational, Pays::Yes))]
+		.saturating_add(T::DbWeight::get().writes(31)))]
         pub fn root_dissolve_network(origin: OriginFor<T>, netuid: NetUid) -> DispatchResult {
             ensure_root(origin)?;
             Self::do_dissolve_network(netuid)
@@ -2387,13 +2375,9 @@ mod dispatches {
 
         /// --- Sets root claim number (sudo extrinsic). Zero disables auto-claim.
         #[pallet::call_index(123)]
-        #[pallet::weight((
-            Weight::from_parts(4_000_000, 0)
-            .saturating_add(T::DbWeight::get().reads(0_u64))
-            .saturating_add(T::DbWeight::get().writes(1_u64)),
-            DispatchClass::Operational,
-            Pays::Yes
-        ))]
+        #[pallet::weight(Weight::from_parts(4_000_000, 0)
+        .saturating_add(T::DbWeight::get().reads(0_u64))
+        .saturating_add(T::DbWeight::get().writes(1_u64)))]
         pub fn sudo_set_num_root_claims(origin: OriginFor<T>, new_value: u64) -> DispatchResult {
             ensure_root(origin)?;
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -241,7 +241,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 374,
+    spec_version: 376,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
This PR includes the following changes:
- Change `DispatchClass::Operational` back to [default (DispatchClass::Normal) ](https://github.com/opentensor/polkadot-sdk/blob/cac11f4a5325b217ca74b0c339459597daf03838/substrate/frame/support/src/dispatch.rs#L209)on all extrinsics except `announce_next_key`.
- Remove the unneeded `Pays::Yes`, [this is the default](https://github.com/opentensor/polkadot-sdk/blob/cac11f4a5325b217ca74b0c339459597daf03838/substrate/frame/support/src/dispatch.rs#L160).
- Update low weight for `sudo_set_recycle_or_burn`