### PR TITLE
fix: remove unused storage maps NextStakeJobId, UsedWork, LargestLocked

### DIFF
--- a/pallets/subtensor/src/coinbase/root.rs
+++ b/pallets/subtensor/src/coinbase/root.rs
@@ -312,7 +312,6 @@ impl<T: Config> Pallet<T> {
         // --- 14. Locks & toggles.
         TransferToggle::<T>::remove(netuid);
         SubnetLocked::<T>::remove(netuid);
-        LargestLocked::<T>::remove(netuid);
 
         // --- 15. Mechanism step / emissions bookkeeping.
         FirstEmissionBlockNumber::<T>::remove(netuid);

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1111,10 +1111,6 @@ pub mod pallet {
         DefaultZeroU64<T>,
     >;
 
-    /// Ensures unique IDs for StakeJobs storage map
-    #[pallet::storage]
-    pub type NextStakeJobId<T> = StorageValue<_, u64, ValueQuery, DefaultZeroU64<T>>;
-
     /// ============================
     /// ==== Staking Variables ====
     /// ============================
@@ -1496,10 +1492,6 @@ pub mod pallet {
     /// ============================
     /// ==== Global Parameters =====
     /// ============================
-    /// --- StorageItem Global Used Work.
-    #[pallet::storage]
-    pub type UsedWork<T: Config> = StorageMap<_, Identity, Vec<u8>, u64, ValueQuery>;
-
     /// --- ITEM( global_max_registrations_per_block )
     #[pallet::storage]
     pub type MaxRegistrationsPerBlock<T> =
@@ -1570,11 +1562,6 @@ pub mod pallet {
     #[pallet::storage]
     pub type SubnetLocked<T: Config> =
         StorageMap<_, Identity, NetUid, TaoCurrency, ValueQuery, DefaultZeroTao<T>>;
-
-    /// --- MAP ( netuid ) --> largest_locked
-    #[pallet::storage]
-    pub type LargestLocked<T: Config> =
-        StorageMap<_, Identity, NetUid, u64, ValueQuery, DefaultZeroU64<T>>;
 
     /// =================
     /// ==== Tempos =====

--- a/pallets/subtensor/src/macros/genesis.rs
+++ b/pallets/subtensor/src/macros/genesis.rs
@@ -90,7 +90,6 @@ mod genesis {
             NetworkRegistrationAllowed::<T>::insert(netuid, true);
             SubnetOwner::<T>::insert(netuid, hotkey.clone());
             SubnetLocked::<T>::insert(netuid, TaoCurrency::from(1));
-            LargestLocked::<T>::insert(netuid, 1);
             Alpha::<T>::insert(
                 // Lock the initial funds making this key the owner.
                 (hotkey.clone(), hotkey.clone(), netuid),

--- a/pallets/subtensor/src/subnets/registration.rs
+++ b/pallets/subtensor/src/subnets/registration.rs
@@ -288,10 +288,9 @@ impl<T: Config> Pallet<T> {
             Error::<T>::InvalidDifficulty
         ); // Check that the work meets difficulty.
 
-        // --- 9. Check Work is the product of the nonce, the block number, and hotkey. Add this as used work.
+        // --- 9. Check Work is the product of the nonce, the block number, and hotkey.
         let seal: H256 = Self::create_seal_hash(block_number, nonce, &hotkey);
         ensure!(seal == work_hash, Error::<T>::InvalidSeal);
-        UsedWork::<T>::insert(work.clone(), current_block_number);
 
         // --- 10. If the network account does not exist we will create it here.
         Self::create_account_if_non_existent(&coldkey, &hotkey);
@@ -367,10 +366,9 @@ impl<T: Config> Pallet<T> {
             Error::<T>::InvalidDifficulty
         ); // Check that the work meets difficulty.
 
-        // --- 4. Check Work is the product of the nonce, the block number, and hotkey. Add this as used work.
+        // --- 4. Check Work is the product of the nonce, the block number, and hotkey.
         let seal: H256 = Self::create_seal_hash(block_number, nonce, &coldkey);
         ensure!(seal == work_hash, Error::<T>::InvalidSeal);
-        UsedWork::<T>::insert(work.clone(), current_block_number);
 
         // --- 5. Add Balance via faucet.
         let balance_to_add: u64 = 1_000_000_000_000;

--- a/pallets/subtensor/src/tests/networks.rs
+++ b/pallets/subtensor/src/tests/networks.rs
@@ -375,7 +375,6 @@ fn dissolve_clears_all_per_subnet_storages() {
         // Subnet locks
         TransferToggle::<Test>::insert(net, true);
         SubnetLocked::<Test>::insert(net, TaoCurrency::from(1));
-        LargestLocked::<Test>::insert(net, 1u64);
 
         // Subnet parameters & pending counters
         FirstEmissionBlockNumber::<Test>::insert(net, 1u64);
@@ -535,7 +534,6 @@ fn dissolve_clears_all_per_subnet_storages() {
         // Subnet locks
         assert!(!TransferToggle::<Test>::contains_key(net));
         assert!(!SubnetLocked::<Test>::contains_key(net));
-        assert!(!LargestLocked::<Test>::contains_key(net));
 
         // Subnet parameters & pending counters
         assert!(!FirstEmissionBlockNumber::<Test>::contains_key(net));


### PR DESCRIPTION
## Summary

Removes three storage maps that are either completely unused or write-only, reducing chain state bloat:

- **`NextStakeJobId`** — declared but never read or written anywhere; its companion `StakeJobs` map does not exist
- **`UsedWork`** — written during PoW registration (`do_burned_registration`, `do_registration`) but never read, so the intended work-replay protection was never enforced
- **`LargestLocked`** — written during genesis and removed during network dissolution, but never read in production code

### Audit methodology

Full `ripgrep` search across the repository for each identifier (type name, snake_case variants) confirmed:
- No reads (`.get()`, `.try_get()`, `.contains_key()`, `::iter()`) in production code
- No references in runtime APIs, RPC implementations, or metadata
- `LargestLocked` has test-only reads in `tests/networks.rs` (removed alongside the map)

### Files changed

| File | Change |
|------|--------|
| `pallets/subtensor/src/lib.rs` | Remove 3 storage declarations |
| `pallets/subtensor/src/subnets/registration.rs` | Remove 2 dead `UsedWork::insert` calls |
| `pallets/subtensor/src/macros/genesis.rs` | Remove `LargestLocked::insert` in genesis |
| `pallets/subtensor/src/coinbase/root.rs` | Remove `LargestLocked::remove` in dissolution |
| `pallets/subtensor/src/tests/networks.rs` | Remove test setup/assertion for `LargestLocked` |

Closes #2397

## Test plan

- [ ] Existing tests pass (no production code reads these maps)
- [ ] `cargo clippy` clean
- [ ] Verify no downstream RPC consumers depend on these storage keys