### PR TITLE
Fix liquidity_abs undefined behavior

### DIFF
--- a/pallets/swap/src/pallet/impls.rs
+++ b/pallets/swap/src/pallet/impls.rs
@@ -580,7 +580,7 @@ impl<T: Config> Pallet<T> {
 
         // Small delta is not allowed
         ensure!(
-            liquidity_delta.abs() >= T::MinimumLiquidity::get() as i64,
+            liquidity_delta.unsigned_abs() >= T::MinimumLiquidity::get(),
             Error::<T>::InvalidLiquidityValue
         );
         let mut delta_liquidity_abs = liquidity_delta.unsigned_abs();


### PR DESCRIPTION
## Description

**liquidity_delta.abs() panics on i64::MIN**

- **File:** `pallets/swap/src/pallet/impls.rs`
- **Severity:** Low
- **Status:** Confirmed

`liquidity_delta.abs()` on a user-supplied `i64` panics in debug / overflow-check builds when the value is `i64::MIN`. In production WASM release builds, wrapping semantics cause the value to fail the `ensure` check harmlessly. No production impact, but the code is undefined behavior-adjacent in debug builds.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
