### PR TITLE
Restore e2e.yml

### DIFF
--- a/.github/e2e.yml
+++ b/.github/e2e.yml
@@ -1,0 +1,4 @@
+name: E2E Tests
+
+on:
+  workflow_dispatch:


### PR DESCRIPTION
Restore the e2e.yml that was removed when reverting, it is needed to run workflow on other branches.