### PR TITLE
feat: make gosu optional in docker entrypoint for hardened containers

### DIFF
--- a/scripts/docker_entrypoint.sh
+++ b/scripts/docker_entrypoint.sh
@@ -52,5 +52,11 @@ if [ -d "/tmp/blockchain" ]; then
 fi
 
 # Execute node-subtensor with the original, unmodified arguments
-echo "executing: gosu subtensor node-subtensor $original_args"
-exec gosu subtensor node-subtensor $original_args
+# Skip gosu if we're already running as the subtensor user or if SKIP_GOSU is set
+if [ "$(id -un)" = "subtensor" ] || [ "${SKIP_GOSU}" = "true" ]; then
+    echo "executing: node-subtensor $original_args (without gosu)"
+    exec node-subtensor $original_args
+else
+    echo "executing: gosu subtensor node-subtensor $original_args"
+    exec gosu subtensor node-subtensor $original_args
+fi


### PR DESCRIPTION
## Description

Fixes issue where containers running with hardened security context (non-root user) fail because gosu cannot switch users from a non-root context.

## Problem

When Kubernetes/OCP securityContext specifies:
```yaml
securityContext:
  runAsUser: 10001
  runAsGroup: 10001
  fsGroup: 10001
  runAsNonRoot: false
```

The entrypoint fails with:
```
error: failed switching to "subtensor": operation not permitted
```

## Solution

1. Auto-detect if already running as `subtensor` user and skip gosu
2. Add `SKIP_GOSU=true` environment variable for explicit control
3. Maintain backward compatibility with root-to-non-root transitions

## Changes

**scripts/docker_entrypoint.sh:**
- Check current user before calling gosu
- Skip gosu if running as subtensor user or SKIP_GOSU=true

## Testing

- Backward compatible: root containers still use gosu
- Non-root containers with subtensor user skip gosu
- Works with Kubernetes hardened security contexts
- `SKIP_GOSU=true` provides explicit override

Fixes #2475

Signed-off-by: R-Panic <bot@term.com>