### PR TITLE
fix: correct typos across pallets and node

### DIFF
--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -270,7 +270,7 @@ fn start_babe_service(arg_matches: &ArgMatches) -> Result<(), sc_cli::Error> {
             } else if matches!(e, sc_service::Error::Client(sp_blockchain::Error::Backend(ref msg))
                 if msg.starts_with("IO error: lock hold by current process"))
             {
-                log::info!("Failed to aquire DB lock, trying again in 1s...");
+                log::info!("Failed to acquire DB lock, trying again in 1s...");
                 std::thread::sleep(std::time::Duration::from_secs(1));
                 start_babe_service(arg_matches)
             // Unknown error, return it.

--- a/pallets/commitments/src/lib.rs
+++ b/pallets/commitments/src/lib.rs
@@ -80,7 +80,7 @@ pub mod pallet {
 
     /// Used to retrieve the given subnet's tempo
     pub trait GetTempoInterface {
-        /// Used to retreive the epoch index for the given subnet.
+        /// Used to retrieve the epoch index for the given subnet.
         fn get_epoch_index(netuid: NetUid, cur_block: u64) -> u64;
     }
 

--- a/pallets/crowdloan/src/lib.rs
+++ b/pallets/crowdloan/src/lib.rs
@@ -292,7 +292,7 @@ pub mod pallet {
         /// will transfer funds to the target address if provided and dispatch the call
         /// (using creator origin).
         ///
-        /// The initial deposit will be transfered to the crowdloan account and will be refunded
+        /// The initial deposit will be transferred to the crowdloan account and will be refunded
         /// in case the crowdloan fails to raise the cap. Additionally, the creator will pay for
         /// the execution of the call.
         ///
@@ -399,7 +399,7 @@ pub mod pallet {
 
         /// Contribute to an active crowdloan.
         ///
-        /// The contribution will be transfered to the crowdloan account and will be refunded
+        /// The contribution will be transferred to the crowdloan account and will be refunded
         /// if the crowdloan fails to raise the cap. If the contribution would raise the amount above the cap,
         /// the contribution will be set to the amount that is left to be raised.
         ///

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1550,7 +1550,7 @@ pub mod pallet {
     /// ============================
     /// ==== Rate Limiting =====
     /// ============================
-    /// --- MAP ( RateLimitKey ) --> Block number in which the last rate limited operation occured
+    /// --- MAP ( RateLimitKey ) --> Block number in which the last rate limited operation occurred
     #[pallet::storage]
     pub type LastRateLimitedBlock<T: Config> =
         StorageMap<_, Identity, RateLimitKey<T::AccountId>, u64, ValueQuery, DefaultZeroU64<T>>;
@@ -2702,7 +2702,7 @@ impl<T: Config + pallet_balances::Config<Balance = u64>>
 }
 
 /// Enum that defines types of rate limited operations for
-/// storing last block when this operation occured
+/// storing last block when this operation occurred
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo)]
 pub enum RateLimitKey<AccountId> {
     // The setting sn owner hotkey operation is rate limited per netuid

--- a/pallets/subtensor/src/tests/epoch.rs
+++ b/pallets/subtensor/src/tests/epoch.rs
@@ -1691,7 +1691,7 @@ fn test_outdated_weights() {
             U256::from(new_key),
             U256::from(new_key)
         ));
-        let deregistered_uid: u16 = n - 1; // since uid=n-1 only recieved 1/3 of weight, it will get pruned first
+        let deregistered_uid: u16 = n - 1; // since uid=n-1 only received 1/3 of weight, it will get pruned first
         assert_eq!(
             U256::from(new_key),
             SubtensorModule::get_hotkey_for_net_and_uid(netuid, deregistered_uid)
@@ -2073,7 +2073,7 @@ fn test_deregistered_miner_bonds() {
             U256::from(new_key),
             U256::from(new_key)
         ));
-        let deregistered_uid: u16 = n - 1; // since uid=n-1 only recieved 1/3 of weight, it will get pruned first
+        let deregistered_uid: u16 = n - 1; // since uid=n-1 only received 1/3 of weight, it will get pruned first
         assert_eq!(
             U256::from(new_key),
             SubtensorModule::get_hotkey_for_net_and_uid(netuid, deregistered_uid)


### PR DESCRIPTION
## Summary

Fix spelling errors in documentation and comments across 5 files in 4 crates.

### Changes

| File | Typo | Fix |
|------|------|-----|
| `pallets/subtensor/src/lib.rs` | occured | occurred |
| `pallets/subtensor/src/tests/epoch.rs` | recieved | received |
| `pallets/crowdloan/src/lib.rs` | transfered | transferred |
| `pallets/commitments/src/lib.rs` | retreive | retrieve |
| `node/src/command.rs` | aquire | acquire |

No functional changes — documentation and comments only.