### PR TITLE
chore: add 2 return type hints in map_consensus.py

### DIFF
--- a/scripts/map_consensus.py
+++ b/scripts/map_consensus.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 from matplotlib.pyplot import cm
 
 
-def extract_data(filepath):
+def extract_data(filepath) -> None:
     """
     Extracts the emission data from a text file.
 
@@ -58,7 +58,7 @@ def extract_data(filepath):
     return data
 
 
-def visualize_data(emission_data, output_filename="consensus_plot.svg"):
+def visualize_data(emission_data, output_filename="consensus_plot.svg") -> None:
     """
     Generates and saves a contour plot of the retention map.
 


### PR DESCRIPTION
## Summary
Added return type hints to functions in `scripts/map_consensus.py`.

## Changes
- Add return type hint `-> None` to function
- Add return type hint `-> None` to function

## Type of Change
- [x] Code quality improvement (type hints)
- [ ] Bug fix
- [ ] New feature

Adding type hints improves IDE support, catches bugs earlier, and makes the codebase more maintainable.
No functional changes — only type annotations added.
