### PR TITLE
Add Cancel proxy type for rejecting time-delayed announcements

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -162,6 +162,7 @@ pub enum ProxyType {
     SwapHotkey,
     SubnetLeaseBeneficiary, // Used to operate the leased subnet
     RootClaim,
+    Cancel, // For cancelling time-delayed proxy announcements
 }
 
 impl TryFrom<u8> for ProxyType {
@@ -187,6 +188,7 @@ impl TryFrom<u8> for ProxyType {
             15 => Ok(Self::SwapHotkey),
             16 => Ok(Self::SubnetLeaseBeneficiary),
             17 => Ok(Self::RootClaim),
+            18 => Ok(Self::Cancel),
             _ => Err(()),
         }
     }
@@ -213,6 +215,7 @@ impl From<ProxyType> for u8 {
             ProxyType::SwapHotkey => 15,
             ProxyType::SubnetLeaseBeneficiary => 16,
             ProxyType::RootClaim => 17,
+            ProxyType::Cancel => 18,
         }
     }
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -779,6 +779,10 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
                 c,
                 RuntimeCall::SubtensorModule(pallet_subtensor::Call::claim_root { .. })
             ),
+            ProxyType::Cancel => matches!(
+                c,
+                RuntimeCall::Proxy(pallet_proxy::Call::reject_announcement { .. })
+            ),
         }
     }
     fn is_superset(&self, o: &Self) -> bool {


### PR DESCRIPTION
## Summary
This PR adds a new `Cancel` proxy type that allows users to create proxies specifically for rejecting/canceling time-delayed proxy announcements.

## Motivation
From #590: Users want to analyze any transaction created by an account before accepting them. With the time-delayed proxy feature, if an account has a delay configured, calls must be announced before execution. The `Cancel` proxy type enables users to grant permission to another account to reject these announcements.

## Changes
- Add `Cancel` variant to `ProxyType` enum `common/src/lib.rs`
- Add `TryFrom<u8>` conversion (value 18) for `Cancel` type
- Add `From<ProxyType>` conversion for `Cancel` type
- Add `InstanceFilter` implementation that allows `pallet_proxy::Call::reject_announcement` calls

## Testing
The changes compile successfully:
- `cargo check -p subtensor-runtime-common` ✓
- `cargo check -p node-subtensor-runtime` ✓

## Related Issue
Closes #590