### PR TITLE
Commitment Pallet Transaction Extension

### DIFF
--- a/eco-tests/src/mock.rs
+++ b/eco-tests/src/mock.rs
@@ -45,6 +45,7 @@ frame_support::construct_runtime!(
         Swap: pallet_subtensor_swap = 9,
         Crowdloan: pallet_crowdloan = 10,
         Proxy: pallet_subtensor_proxy = 11,
+        Commitments: pallet_commitments = 12,
     }
 );
 
@@ -300,7 +301,7 @@ impl pallet_subtensor::Config for Test {
     type HotkeySwapOnSubnetInterval = HotkeySwapOnSubnetInterval;
     type ProxyInterface = FakeProxier;
     type LeaseDividendsDistributionInterval = LeaseDividendsDistributionInterval;
-    type GetCommitments = ();
+    type GetCommitments = MockGetCommitments;
     type MaxImmuneUidsPercentage = MaxImmuneUidsPercentage;
     type CommitmentsInterface = CommitmentsI;
     type EvmKeyAssociateRateLimit = EvmKeyAssociateRateLimit;
@@ -339,7 +340,51 @@ impl PrivilegeCmp<OriginCaller> for OriginPrivilegeCmp {
 
 pub struct CommitmentsI;
 impl CommitmentsInterface for CommitmentsI {
-    fn purge_netuid(_netuid: NetUid) {}
+    fn purge_netuid(netuid: NetUid) {
+        pallet_commitments::Pallet::<Test>::purge_netuid(netuid);
+    }
+}
+
+pub struct MockGetCommitments;
+impl pallet_commitments::GetCommitments<AccountId> for MockGetCommitments {
+    fn get_commitments(netuid: NetUid) -> Vec<(AccountId, Vec<u8>)> {
+        pallet_commitments::Pallet::<Test>::get_commitments(netuid)
+    }
+}
+
+parameter_types! {
+    pub const MockCommitmentInitialDeposit: Balance = TaoBalance::new(0);
+    pub const MockCommitmentFieldDeposit: Balance = TaoBalance::new(0);
+}
+
+pub struct MockCanCommit;
+impl pallet_commitments::CanCommit<AccountId> for MockCanCommit {
+    fn can_commit(netuid: NetUid, address: &AccountId) -> bool {
+        SubtensorModule::is_hotkey_registered_on_network(netuid, address)
+    }
+}
+
+pub struct MockOnMetadataCommitment;
+impl pallet_commitments::OnMetadataCommitment<AccountId> for MockOnMetadataCommitment {
+    fn on_metadata_commitment(_: NetUid, _: &AccountId) {}
+}
+
+pub struct MockTempoInterface;
+impl pallet_commitments::GetTempoInterface for MockTempoInterface {
+    fn get_epoch_index(netuid: NetUid, cur_block: u64) -> u64 {
+        SubtensorModule::get_epoch_index(netuid, cur_block)
+    }
+}
+
+impl pallet_commitments::Config for Test {
+    type Currency = Balances;
+    type WeightInfo = ();
+    type CanCommit = MockCanCommit;
+    type OnMetadataCommitment = MockOnMetadataCommitment;
+    type MaxFields = frame_support::traits::ConstU32<3>;
+    type InitialDeposit = MockCommitmentInitialDeposit;
+    type FieldDeposit = MockCommitmentFieldDeposit;
+    type TempoInterface = MockTempoInterface;
 }
 
 parameter_types! {

--- a/eco-tests/src/mock.rs
+++ b/eco-tests/src/mock.rs
@@ -18,7 +18,7 @@ use frame_system::{EnsureRoot, limits, offchain::CreateTransactionBase};
 use pallet_subtensor::*;
 use pallet_subtensor_proxy as pallet_proxy;
 use pallet_subtensor_utility as pallet_utility;
-use sp_core::{ConstU64, H256, U256, offchain::KeyTypeId};
+use sp_core::{ConstU64, H256, U256, offchain::KeyTypeId, Get};
 use sp_runtime::Perbill;
 use sp_runtime::{
     Percent,
@@ -357,6 +357,14 @@ parameter_types! {
     pub const MockCommitmentFieldDeposit: Balance = TaoBalance::new(0);
 }
 
+#[derive(scale_info::TypeInfo)]
+pub struct MockMaxCommitFields;
+impl Get<u32> for MockMaxCommitFields {
+    fn get() -> u32 {
+        3
+    }
+}
+
 pub struct MockCanCommit;
 impl pallet_commitments::CanCommit<AccountId> for MockCanCommit {
     fn can_commit(netuid: NetUid, address: &AccountId) -> bool {
@@ -381,7 +389,7 @@ impl pallet_commitments::Config for Test {
     type WeightInfo = ();
     type CanCommit = MockCanCommit;
     type OnMetadataCommitment = MockOnMetadataCommitment;
-    type MaxFields = frame_support::traits::ConstU32<3>;
+    type MaxFields = MockMaxCommitFields;
     type InitialDeposit = MockCommitmentInitialDeposit;
     type FieldDeposit = MockCommitmentFieldDeposit;
     type TempoInterface = MockTempoInterface;

--- a/node/src/benchmarking.rs
+++ b/node/src/benchmarking.rs
@@ -141,6 +141,7 @@ pub fn create_benchmark_extrinsic(
             pallet_shield::CheckShieldedTxValidity::<runtime::Runtime>::new(),
             pallet_subtensor::SubtensorTransactionExtension::<runtime::Runtime>::new(),
             pallet_drand::drand_priority::DrandPriority::<runtime::Runtime>::new(),
+            pallet_commitments::CommitmentsTransactionExtension::<runtime::Runtime>::new(),
         ),
         frame_metadata_hash_extension::CheckMetadataHash::<runtime::Runtime>::new(true),
     );
@@ -158,7 +159,7 @@ pub fn create_benchmark_extrinsic(
                 (),
                 (),
             ),
-            ((), (), (), (), ()),
+            ((), (), (), (), (), ()),
             None,
         ),
     );

--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -815,7 +815,7 @@ pub mod pallet {
         /// It is only callable by the root account or subnet owner.
         /// The extrinsic will call the Subtensor pallet to set the difficulty.
         #[pallet::call_index(24)]
-        #[pallet::weight(Weight::from_parts(38_500_000, 0)
+        #[pallet::weight(Weight::from_parts(22_220_000, 0)
         .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(3_u64))
         .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(1_u64)))]
         pub fn sudo_set_difficulty(

--- a/pallets/commitments/src/lib.rs
+++ b/pallets/commitments/src/lib.rs
@@ -14,12 +14,11 @@ use ark_serialize::CanonicalDeserialize;
 use codec::Encode;
 use frame_support::{
     BoundedVec, IterableStorageDoubleMap,
-    dispatch::{DispatchInfo, PostDispatchInfo},
+    dispatch::{DispatchErrorWithPostInfo, DispatchExtension, DispatchInfo, PostDispatchInfo},
     pallet_prelude::{
-        Decode, DecodeWithMemTracking, DispatchResultWithPostInfo, OriginTrait, PhantomData,
-        ValidTransaction, ValidateResult,
+        Decode, DecodeWithMemTracking, PhantomData, ValidTransaction, ValidateResult,
     },
-    traits::{Currency, Get, IsSubType},
+    traits::{Currency, Get, IsSubType, OriginTrait},
 };
 use frame_system::pallet_prelude::BlockNumberFor;
 pub use pallet::*;
@@ -665,18 +664,27 @@ where
     }
 }
 
-pub struct CommitmentsDispatchGuard<T: Config>(PhantomData<T>);
+pub struct CommitmentsDispatchExtension<T: Config>(PhantomData<T>);
 
-impl<T> DispatchGuard<<T as frame_system::Config>::RuntimeCall> for CommitmentsDispatchGuard<T>
+impl<T> DispatchExtension<CallOf<T>> for CommitmentsDispatchExtension<T>
 where
     T: Config,
-    <T as frame_system::Config>::RuntimeCall:
+    CallOf<T>:
         Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo> + IsSubType<pallet::Call<T>>,
     OriginOf<T>: OriginTrait<AccountId = T::AccountId>,
 {
-    fn check(origin: &OriginOf<T>, call: &CallOf<T>) -> DispatchResultWithPostInfo {
+    type Pre = ();
+
+    fn weight(_call: &CallOf<T>) -> Weight {
+        T::DbWeight::get().reads(1)
+    }
+
+    fn pre_dispatch(
+        origin: &OriginOf<T>,
+        call: &CallOf<T>,
+    ) -> Result<Self::Pre, DispatchErrorWithPostInfo> {
         let Some(who) = origin.as_signer() else {
-            return Ok(().into());
+            return Ok(());
         };
 
         if let Some(pallet::Call::set_commitment { netuid, .. }) = call.is_sub_type() {
@@ -685,7 +693,7 @@ where
             }
         }
 
-        Ok(().into())
+        Ok(())
     }
 }
 

--- a/pallets/commitments/src/lib.rs
+++ b/pallets/commitments/src/lib.rs
@@ -12,16 +12,24 @@ pub mod weights;
 
 use ark_serialize::CanonicalDeserialize;
 use codec::Encode;
-use frame_support::IterableStorageDoubleMap;
 use frame_support::{
-    BoundedVec,
-    traits::{Currency, Get},
+    BoundedVec, IterableStorageDoubleMap,
+    pallet_prelude::{
+        Decode, DecodeWithMemTracking, PhantomData, ValidTransaction, ValidateResult,
+    },
+    traits::{Currency, Get, IsSubType},
 };
 use frame_system::pallet_prelude::BlockNumberFor;
 pub use pallet::*;
 use scale_info::prelude::collections::BTreeSet;
-use sp_runtime::SaturatedConversion;
-use sp_runtime::{Saturating, Weight, traits::Zero};
+use sp_runtime::{
+    SaturatedConversion, Saturating, Weight,
+    traits::Zero,
+    traits::{
+        AsSystemOriginSigner, DispatchInfoOf, Dispatchable, Implication, TransactionExtension,
+    },
+    transaction_validity::{InvalidTransaction, TransactionSource, TransactionValidityError},
+};
 use sp_std::{boxed::Box, vec::Vec};
 use subtensor_runtime_common::NetUid;
 use tle::{
@@ -573,6 +581,83 @@ impl<T: Config> Pallet<T> {
         TimelockedIndex::<T>::mutate(|index| {
             index.retain(|(n, _)| *n != netuid);
         });
+    }
+}
+
+type CallOf<T> = <T as frame_system::Config>::RuntimeCall;
+type OriginOf<T> = <CallOf<T> as Dispatchable>::RuntimeOrigin;
+
+#[derive(Default, Encode, Decode, DecodeWithMemTracking, Clone, Eq, PartialEq, TypeInfo)]
+#[scale_info(skip_type_params(T))]
+pub struct CommitmentsTransactionExtension<T>(PhantomData<T>);
+
+impl<T> sp_std::fmt::Debug for CommitmentsTransactionExtension<T> {
+    fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
+        write!(f, "CommitmentsTransactionExtension")
+    }
+}
+
+impl<T> CommitmentsTransactionExtension<T>
+where
+    T: Config + Send + Sync + TypeInfo,
+    CallOf<T>: Dispatchable + IsSubType<pallet::Call<T>>,
+{
+    pub fn new() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<T> TransactionExtension<CallOf<T>> for CommitmentsTransactionExtension<T>
+where
+    T: Config + Send + Sync + TypeInfo,
+    CallOf<T>: Dispatchable + IsSubType<pallet::Call<T>>,
+    OriginOf<T>: AsSystemOriginSigner<T::AccountId> + Clone,
+{
+    const IDENTIFIER: &'static str = "CommitmentsTransactionExtension";
+
+    type Implicit = ();
+    type Val = ();
+    type Pre = ();
+
+    fn weight(&self, _call: &CallOf<T>) -> Weight {
+        Weight::from_parts(0, 0)
+    }
+
+    fn validate(
+        &self,
+        origin: OriginOf<T>,
+        call: &CallOf<T>,
+        _info: &DispatchInfoOf<CallOf<T>>,
+        _len: usize,
+        _self_implicit: Self::Implicit,
+        _inherited_implication: &impl Implication,
+        _source: TransactionSource,
+    ) -> ValidateResult<Self::Val, CallOf<T>> {
+        let Some(who) = origin.as_system_origin_signer() else {
+            return Ok((ValidTransaction::default(), (), origin));
+        };
+
+        match call.is_sub_type() {
+            Some(pallet::Call::set_commitment { netuid, .. }) => {
+                if !T::CanCommit::can_commit(*netuid, who) {
+                    return Err(InvalidTransaction::BadSigner.into());
+                }
+
+                Ok((ValidTransaction::default(), (), origin))
+            }
+            _ => Ok((ValidTransaction::default(), (), origin)),
+        }
+    }
+
+    fn prepare(
+        self,
+        _val: Self::Val,
+        _origin: &OriginOf<T>,
+        _call: &CallOf<T>,
+        _info: &DispatchInfoOf<CallOf<T>>,
+        _len: usize,
+    ) -> Result<Self::Pre, TransactionValidityError> {
+        Ok(())
     }
 }
 

--- a/pallets/commitments/src/lib.rs
+++ b/pallets/commitments/src/lib.rs
@@ -31,6 +31,7 @@ use sp_runtime::{
     transaction_validity::{InvalidTransaction, TransactionSource, TransactionValidityError},
 };
 use sp_std::{boxed::Box, vec::Vec};
+use subtensor_macros::freeze_struct;
 use subtensor_runtime_common::NetUid;
 use tle::{
     curves::drand::TinyBLS381,
@@ -589,6 +590,7 @@ type OriginOf<T> = <CallOf<T> as Dispatchable>::RuntimeOrigin;
 
 #[derive(Default, Encode, Decode, DecodeWithMemTracking, Clone, Eq, PartialEq, TypeInfo)]
 #[scale_info(skip_type_params(T))]
+#[freeze_struct("7f03f99666ee2c4f")]
 pub struct CommitmentsTransactionExtension<T>(PhantomData<T>);
 
 impl<T> sp_std::fmt::Debug for CommitmentsTransactionExtension<T> {

--- a/pallets/commitments/src/lib.rs
+++ b/pallets/commitments/src/lib.rs
@@ -14,8 +14,10 @@ use ark_serialize::CanonicalDeserialize;
 use codec::Encode;
 use frame_support::{
     BoundedVec, IterableStorageDoubleMap,
+    dispatch::{DispatchGuard, DispatchInfo, PostDispatchInfo},
     pallet_prelude::{
-        Decode, DecodeWithMemTracking, PhantomData, ValidTransaction, ValidateResult,
+        Decode, DecodeWithMemTracking, DispatchResultWithPostInfo, OriginTrait, PhantomData,
+        ValidTransaction, ValidateResult,
     },
     traits::{Currency, Get, IsSubType},
 };
@@ -660,6 +662,30 @@ where
         _len: usize,
     ) -> Result<Self::Pre, TransactionValidityError> {
         Ok(())
+    }
+}
+
+pub struct CommitmentsDispatchGuard<T: Config>(PhantomData<T>);
+
+impl<T> DispatchGuard<<T as frame_system::Config>::RuntimeCall> for CommitmentsDispatchGuard<T>
+where
+    T: Config,
+    <T as frame_system::Config>::RuntimeCall:
+        Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo> + IsSubType<pallet::Call<T>>,
+    OriginOf<T>: OriginTrait<AccountId = T::AccountId>,
+{
+    fn check(origin: &OriginOf<T>, call: &CallOf<T>) -> DispatchResultWithPostInfo {
+        let Some(who) = origin.as_signer() else {
+            return Ok(().into());
+        };
+
+        if let Some(pallet::Call::set_commitment { netuid, .. }) = call.is_sub_type() {
+            if !T::CanCommit::can_commit(*netuid, who) {
+                return Err(Error::<T>::AccountNotAllowedCommit.into());
+            }
+        }
+
+        Ok(().into())
     }
 }
 

--- a/pallets/commitments/src/lib.rs
+++ b/pallets/commitments/src/lib.rs
@@ -14,7 +14,7 @@ use ark_serialize::CanonicalDeserialize;
 use codec::Encode;
 use frame_support::{
     BoundedVec, IterableStorageDoubleMap,
-    dispatch::{DispatchGuard, DispatchInfo, PostDispatchInfo},
+    dispatch::{DispatchInfo, PostDispatchInfo},
     pallet_prelude::{
         Decode, DecodeWithMemTracking, DispatchResultWithPostInfo, OriginTrait, PhantomData,
         ValidTransaction, ValidateResult,

--- a/pallets/commitments/src/lib.rs
+++ b/pallets/commitments/src/lib.rs
@@ -663,7 +663,6 @@ where
         Ok(())
     }
 }
-
 pub struct CommitmentsDispatchExtension<T: Config>(PhantomData<T>);
 
 impl<T> DispatchExtension<CallOf<T>> for CommitmentsDispatchExtension<T>
@@ -687,10 +686,10 @@ where
             return Ok(());
         };
 
-        if let Some(pallet::Call::set_commitment { netuid, .. }) = call.is_sub_type() {
-            if !T::CanCommit::can_commit(*netuid, who) {
-                return Err(Error::<T>::AccountNotAllowedCommit.into());
-            }
+        if let Some(pallet::Call::set_commitment { netuid, .. }) = call.is_sub_type()
+            && !T::CanCommit::can_commit(*netuid, who)
+        {
+            return Err(Error::<T>::AccountNotAllowedCommit.into());
         }
 
         Ok(())

--- a/pallets/subtensor/src/guards/check_coldkey_swap.rs
+++ b/pallets/subtensor/src/guards/check_coldkey_swap.rs
@@ -4,6 +4,7 @@ use frame_support::{
     pallet_prelude::*,
     traits::{IsSubType, OriginTrait},
 };
+use pallet_commitments::CanCommit;
 use sp_runtime::traits::Dispatchable;
 use sp_std::marker::PhantomData;
 
@@ -28,24 +29,32 @@ pub struct CheckColdkeySwap<T: Config>(PhantomData<T>);
 
 impl<T> DispatchExtension<<T as frame_system::Config>::RuntimeCall> for CheckColdkeySwap<T>
 where
-    T: Config + pallet_shield::Config,
+    T: Config + pallet_shield::Config + pallet_commitments::Config,
     <T as frame_system::Config>::RuntimeCall: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>
         + IsSubType<Call<T>>
-        + IsSubType<pallet_shield::Call<T>>,
+        + IsSubType<pallet_shield::Call<T>>
+        + IsSubType<pallet_commitments::Call<T>>,
     DispatchableOriginOf<T>: OriginTrait<AccountId = T::AccountId>,
 {
     type Pre = ();
 
-    fn weight(_call: &CallOf<T>) -> Weight {
-        T::DbWeight::get().reads(2)
+    fn weight(call: &CallOf<T>) -> Weight {
+        let mut weight = T::DbWeight::get().reads(2);
+
+        if matches!(
+            IsSubType::<pallet_commitments::Call<T>>::is_sub_type(call),
+            Some(pallet_commitments::Call::set_commitment { .. })
+        ) {
+            weight = weight.saturating_add(T::DbWeight::get().reads(1));
+        }
+
+        weight
     }
 
     fn pre_dispatch(
         origin: &DispatchableOriginOf<T>,
         call: &CallOf<T>,
     ) -> Result<Self::Pre, DispatchErrorWithPostInfo> {
-        // Only care about signed origins.
-        // Root is already bypassed by the extension before we get here.
         let Some(who) = origin.as_signer() else {
             return Ok(());
         };
@@ -75,10 +84,17 @@ where
             }
         }
 
+        if let Some(pallet_commitments::Call::set_commitment { netuid, .. }) =
+            IsSubType::<pallet_commitments::Call<T>>::is_sub_type(call)
+        {
+            if !<T as pallet_commitments::Config>::CanCommit::can_commit(*netuid, who) {
+                return Err(pallet_commitments::Error::<T>::AccountNotAllowedCommit.into());
+            }
+        }
+
         Ok(())
     }
 }
-
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {

--- a/pallets/subtensor/src/guards/check_coldkey_swap.rs
+++ b/pallets/subtensor/src/guards/check_coldkey_swap.rs
@@ -86,10 +86,9 @@ where
 
         if let Some(pallet_commitments::Call::set_commitment { netuid, .. }) =
             IsSubType::<pallet_commitments::Call<T>>::is_sub_type(call)
+            && !<T as pallet_commitments::Config>::CanCommit::can_commit(*netuid, who)
         {
-            if !<T as pallet_commitments::Config>::CanCommit::can_commit(*netuid, who) {
-                return Err(pallet_commitments::Error::<T>::AccountNotAllowedCommit.into());
-            }
+            return Err(pallet_commitments::Error::<T>::AccountNotAllowedCommit.into());
         }
 
         Ok(())

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -1190,7 +1190,7 @@ mod dispatches {
         /// * `BadOrigin` - If the origin is not root.
         ///
         #[pallet::call_index(69)]
-        #[pallet::weight(Weight::from_parts(10_190_000, 0)
+        #[pallet::weight(Weight::from_parts(5_064_000, 0)
         .saturating_add(T::DbWeight::get().reads(0))
         .saturating_add(T::DbWeight::get().writes(1)))]
         pub fn sudo_set_tx_childkey_take_rate_limit(
@@ -1455,7 +1455,7 @@ mod dispatches {
 
         /// User register a new subnetwork
         #[pallet::call_index(79)]
-        #[pallet::weight((Weight::from_parts(396_000_000, 0)
+        #[pallet::weight((Weight::from_parts(232_300_000, 0)
             .saturating_add(T::DbWeight::get().reads(35_u64))
             .saturating_add(T::DbWeight::get().writes(52_u64)), DispatchClass::Normal, Pays::Yes))]
         pub fn register_network_with_identity(

--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -313,7 +313,7 @@ impl crate::Config for Test {
     type HotkeySwapOnSubnetInterval = HotkeySwapOnSubnetInterval;
     type ProxyInterface = FakeProxier;
     type LeaseDividendsDistributionInterval = LeaseDividendsDistributionInterval;
-    type GetCommitments = ();
+    type GetCommitments = MockGetCommitments;
     type MaxImmuneUidsPercentage = MaxImmuneUidsPercentage;
     type CommitmentsInterface = CommitmentsI;
     type EvmKeyAssociateRateLimit = EvmKeyAssociateRateLimit;
@@ -352,7 +352,59 @@ impl PrivilegeCmp<OriginCaller> for OriginPrivilegeCmp {
 
 pub struct CommitmentsI;
 impl CommitmentsInterface for CommitmentsI {
-    fn purge_netuid(_netuid: NetUid) {}
+    fn purge_netuid(netuid: NetUid) {
+        pallet_commitments::Pallet::<Test>::purge_netuid(netuid);
+    }
+}
+
+pub struct MockGetCommitments;
+impl pallet_commitments::GetCommitments<AccountId> for MockGetCommitments {
+    fn get_commitments(netuid: NetUid) -> Vec<(AccountId, Vec<u8>)> {
+        pallet_commitments::Pallet::<Test>::get_commitments(netuid)
+    }
+}
+
+parameter_types! {
+    pub const MockCommitmentInitialDeposit: Balance = TaoBalance::new(0);
+    pub const MockCommitmentFieldDeposit: Balance = TaoBalance::new(0);
+}
+
+#[derive(scale_info::TypeInfo)]
+pub struct MockMaxCommitFields;
+impl Get<u32> for MockMaxCommitFields {
+    fn get() -> u32 {
+        3
+    }
+}
+
+pub struct MockCanCommit;
+impl pallet_commitments::CanCommit<AccountId> for MockCanCommit {
+    fn can_commit(netuid: NetUid, address: &AccountId) -> bool {
+        SubtensorModule::is_hotkey_registered_on_network(netuid, address)
+    }
+}
+
+pub struct MockOnMetadataCommitment;
+impl pallet_commitments::OnMetadataCommitment<AccountId> for MockOnMetadataCommitment {
+    fn on_metadata_commitment(_: NetUid, _: &AccountId) {}
+}
+
+pub struct MockTempoInterface;
+impl pallet_commitments::GetTempoInterface for MockTempoInterface {
+    fn get_epoch_index(netuid: NetUid, cur_block: u64) -> u64 {
+        SubtensorModule::get_epoch_index(netuid, cur_block)
+    }
+}
+
+impl pallet_commitments::Config for Test {
+    type Currency = Balances;
+    type WeightInfo = ();
+    type CanCommit = MockCanCommit;
+    type OnMetadataCommitment = MockOnMetadataCommitment;
+    type MaxFields = MockMaxCommitFields;
+    type InitialDeposit = MockCommitmentInitialDeposit;
+    type FieldDeposit = MockCommitmentFieldDeposit;
+    type TempoInterface = MockTempoInterface;
 }
 
 parameter_types! {

--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -49,6 +49,7 @@ frame_support::construct_runtime!(
         Swap: pallet_subtensor_swap = 9,
         Crowdloan: pallet_crowdloan = 10,
         Proxy: pallet_subtensor_proxy = 11,
+        Commitments: pallet_commitments = 12,
     }
 );
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -204,6 +204,7 @@ impl frame_system::offchain::CreateSignedTransaction<pallet_drand::Call<Runtime>
                 pallet_shield::CheckShieldedTxValidity::<Runtime>::new(),
                 pallet_subtensor::SubtensorTransactionExtension::<Runtime>::new(),
                 pallet_drand::drand_priority::DrandPriority::<Runtime>::new(),
+                pallet_commitments::CommitmentsTransactionExtension::<Runtime>::new(),
             ),
             frame_metadata_hash_extension::CheckMetadataHash::<Runtime>::new(true),
         );
@@ -1681,6 +1682,7 @@ pub type CustomTxExtension = (
     pallet_shield::CheckShieldedTxValidity<Runtime>,
     pallet_subtensor::SubtensorTransactionExtension<Runtime>,
     pallet_drand::drand_priority::DrandPriority<Runtime>,
+    pallet_commitments::CommitmentsTransactionExtension<Runtime>,
 );
 pub type TxExtension = (
     SystemTxExtension,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -22,13 +22,10 @@ use codec::{Compact, Decode, Encode};
 use ethereum::AuthorizationList;
 use frame_support::{
     PalletId,
-    dispatch::{
-        DispatchErrorWithPostInfo, DispatchExtension, DispatchInfo, DispatchResult,
-        PostDispatchInfo,
-    },
+    dispatch::DispatchResult,
     genesis_builder_helper::{build_state, get_preset},
     pallet_prelude::Get,
-    traits::{Contains, InsideBoth, LinearStoragePrice, OriginTrait, fungible::HoldConsideration},
+    traits::{Contains, InsideBoth, LinearStoragePrice, fungible::HoldConsideration},
 };
 use frame_system::{EnsureRoot, EnsureRootWithSuccess, EnsureSigned};
 use pallet_commitments::{CanCommit, OnMetadataCommitment};

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -23,7 +23,8 @@ use ethereum::AuthorizationList;
 use frame_support::{
     PalletId,
     dispatch::{
-        DispatchGuard, DispatchInfo, DispatchResult, DispatchResultWithPostInfo, PostDispatchInfo,
+        DispatchErrorWithPostInfo, DispatchExtension, DispatchInfo, DispatchResult,
+        PostDispatchInfo,
     },
     genesis_builder_helper::{build_state, get_preset},
     pallet_prelude::Get,
@@ -384,7 +385,7 @@ impl frame_system::Config for Runtime {
     type PostInherents = ();
     type PostTransactions = ();
     type ExtensionsWeightInfo = frame_system::SubstrateExtensionsWeight<Runtime>;
-    type DispatchGuard = RuntimeDispatchGuard;
+    type DispatchExtension = RuntimeDispatchExtension;
 }
 
 impl pallet_insecure_randomness_collective_flip::Config for Runtime {}
@@ -1724,18 +1725,43 @@ pub type Executive = frame_executive::Executive<
 >;
 
 type RuntimeDispatchableOrigin = <RuntimeCall as Dispatchable>::RuntimeOrigin;
+type ColdkeySwapDispatchPre =
+    <pallet_subtensor::CheckColdkeySwap<Runtime> as DispatchExtension<RuntimeCall>>::Pre;
+type CommitmentsDispatchPre =
+    <pallet_commitments::CommitmentsDispatchExtension<Runtime> as DispatchExtension<RuntimeCall>>::Pre;
 
-pub struct RuntimeDispatchGuard;
+pub struct RuntimeDispatchExtension;
 
-impl DispatchGuard<RuntimeCall> for RuntimeDispatchGuard
+impl DispatchExtension<RuntimeCall> for RuntimeDispatchExtension
 where
     RuntimeCall: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
     RuntimeDispatchableOrigin: OriginTrait<AccountId = AccountId>,
 {
-    fn check(origin: &RuntimeDispatchableOrigin, call: &RuntimeCall) -> DispatchResultWithPostInfo {
-        pallet_subtensor::CheckColdkeySwap::<Runtime>::check(origin, call)?;
-        pallet_commitments::CommitmentsDispatchGuard::<Runtime>::check(origin, call)?;
-        Ok(().into())
+    type Pre = (ColdkeySwapDispatchPre, CommitmentsDispatchPre);
+
+    fn weight(call: &RuntimeCall) -> Weight {
+        <pallet_subtensor::CheckColdkeySwap<Runtime> as DispatchExtension<RuntimeCall>>::weight(
+            call,
+        )
+        .saturating_add(
+            <pallet_commitments::CommitmentsDispatchExtension<Runtime> as DispatchExtension<
+                RuntimeCall,
+            >>::weight(call),
+        )
+    }
+
+    fn pre_dispatch(
+        origin: &RuntimeDispatchableOrigin,
+        call: &RuntimeCall,
+    ) -> Result<Self::Pre, DispatchErrorWithPostInfo> {
+        let coldkey_swap_pre =
+            <pallet_subtensor::CheckColdkeySwap<Runtime> as DispatchExtension<RuntimeCall>>::pre_dispatch(origin, call)?;
+        let commitments_pre =
+            <pallet_commitments::CommitmentsDispatchExtension<Runtime> as DispatchExtension<
+                RuntimeCall,
+            >>::pre_dispatch(origin, call)?;
+
+        Ok((coldkey_swap_pre, commitments_pre))
     }
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -22,10 +22,12 @@ use codec::{Compact, Decode, Encode};
 use ethereum::AuthorizationList;
 use frame_support::{
     PalletId,
-    dispatch::DispatchResult,
+    dispatch::{
+        DispatchGuard, DispatchInfo, DispatchResult, DispatchResultWithPostInfo, PostDispatchInfo,
+    },
     genesis_builder_helper::{build_state, get_preset},
     pallet_prelude::Get,
-    traits::{Contains, InsideBoth, LinearStoragePrice, fungible::HoldConsideration},
+    traits::{Contains, InsideBoth, LinearStoragePrice, OriginTrait, fungible::HoldConsideration},
 };
 use frame_system::{EnsureRoot, EnsureRootWithSuccess, EnsureSigned};
 use pallet_commitments::{CanCommit, OnMetadataCommitment};
@@ -382,7 +384,7 @@ impl frame_system::Config for Runtime {
     type PostInherents = ();
     type PostTransactions = ();
     type ExtensionsWeightInfo = frame_system::SubstrateExtensionsWeight<Runtime>;
-    type DispatchGuard = pallet_subtensor::CheckColdkeySwap<Runtime>;
+    type DispatchGuard = RuntimeDispatchGuard;
 }
 
 impl pallet_insecure_randomness_collective_flip::Config for Runtime {}
@@ -1720,6 +1722,22 @@ pub type Executive = frame_executive::Executive<
     AllPalletsWithSystem,
     Migrations,
 >;
+
+type RuntimeDispatchableOrigin = <RuntimeCall as Dispatchable>::RuntimeOrigin;
+
+pub struct RuntimeDispatchGuard;
+
+impl DispatchGuard<RuntimeCall> for RuntimeDispatchGuard
+where
+    RuntimeCall: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
+    RuntimeDispatchableOrigin: OriginTrait<AccountId = AccountId>,
+{
+    fn check(origin: &RuntimeDispatchableOrigin, call: &RuntimeCall) -> DispatchResultWithPostInfo {
+        pallet_subtensor::CheckColdkeySwap::<Runtime>::check(origin, call)?;
+        pallet_commitments::CommitmentsDispatchGuard::<Runtime>::check(origin, call)?;
+        Ok(().into())
+    }
+}
 
 #[cfg(feature = "runtime-benchmarks")]
 #[macro_use]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -385,7 +385,7 @@ impl frame_system::Config for Runtime {
     type PostInherents = ();
     type PostTransactions = ();
     type ExtensionsWeightInfo = frame_system::SubstrateExtensionsWeight<Runtime>;
-    type DispatchExtension = RuntimeDispatchExtension;
+    type DispatchExtension = pallet_subtensor::CheckColdkeySwap<Runtime>;
 }
 
 impl pallet_insecure_randomness_collective_flip::Config for Runtime {}
@@ -1723,47 +1723,6 @@ pub type Executive = frame_executive::Executive<
     AllPalletsWithSystem,
     Migrations,
 >;
-
-type RuntimeDispatchableOrigin = <RuntimeCall as Dispatchable>::RuntimeOrigin;
-type ColdkeySwapDispatchPre =
-    <pallet_subtensor::CheckColdkeySwap<Runtime> as DispatchExtension<RuntimeCall>>::Pre;
-type CommitmentsDispatchPre =
-    <pallet_commitments::CommitmentsDispatchExtension<Runtime> as DispatchExtension<RuntimeCall>>::Pre;
-
-pub struct RuntimeDispatchExtension;
-
-impl DispatchExtension<RuntimeCall> for RuntimeDispatchExtension
-where
-    RuntimeCall: Dispatchable<Info = DispatchInfo, PostInfo = PostDispatchInfo>,
-    RuntimeDispatchableOrigin: OriginTrait<AccountId = AccountId>,
-{
-    type Pre = (ColdkeySwapDispatchPre, CommitmentsDispatchPre);
-
-    fn weight(call: &RuntimeCall) -> Weight {
-        <pallet_subtensor::CheckColdkeySwap<Runtime> as DispatchExtension<RuntimeCall>>::weight(
-            call,
-        )
-        .saturating_add(
-            <pallet_commitments::CommitmentsDispatchExtension<Runtime> as DispatchExtension<
-                RuntimeCall,
-            >>::weight(call),
-        )
-    }
-
-    fn pre_dispatch(
-        origin: &RuntimeDispatchableOrigin,
-        call: &RuntimeCall,
-    ) -> Result<Self::Pre, DispatchErrorWithPostInfo> {
-        let coldkey_swap_pre =
-            <pallet_subtensor::CheckColdkeySwap<Runtime> as DispatchExtension<RuntimeCall>>::pre_dispatch(origin, call)?;
-        let commitments_pre =
-            <pallet_commitments::CommitmentsDispatchExtension<Runtime> as DispatchExtension<
-                RuntimeCall,
-            >>::pre_dispatch(origin, call)?;
-
-        Ok((coldkey_swap_pre, commitments_pre))
-    }
-}
 
 #[cfg(feature = "runtime-benchmarks")]
 #[macro_use]


### PR DESCRIPTION
## Description
This PR adds a Transaction Extension to the Commitments pallets in order to add some checks like `can_commit` to the pool validation step.