### PR TITLE
Add `set_pending_childkey_cooldown` benchmark

### DIFF
--- a/pallets/subtensor/src/benchmarks.rs
+++ b/pallets/subtensor/src/benchmarks.rs
@@ -1855,4 +1855,14 @@ mod pallet_benchmarks {
             Some(limit),
         );
     }
+
+    #[benchmark]
+    fn set_pending_childkey_cooldown() {
+        let cooldown: u64 = 7200;
+
+        #[extrinsic_call]
+        _(RawOrigin::Root, cooldown);
+
+        assert_eq!(PendingChildKeyCooldown::<T>::get(), cooldown);
+    }
 }

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -1190,7 +1190,7 @@ mod dispatches {
         /// * `BadOrigin` - If the origin is not root.
         ///
         #[pallet::call_index(69)]
-        #[pallet::weight(Weight::from_parts(5_660_000, 0)
+        #[pallet::weight(Weight::from_parts(10_190_000, 0)
         .saturating_add(T::DbWeight::get().reads(0))
         .saturating_add(T::DbWeight::get().writes(1)))]
         pub fn sudo_set_tx_childkey_take_rate_limit(
@@ -2324,7 +2324,7 @@ mod dispatches {
 
         /// --- Sets root claim number (sudo extrinsic). Zero disables auto-claim.
         #[pallet::call_index(123)]
-        #[pallet::weight(Weight::from_parts(2_283_000, 0)
+        #[pallet::weight(Weight::from_parts(3_346_000, 0)
         .saturating_add(T::DbWeight::get().reads(0_u64))
         .saturating_add(T::DbWeight::get().writes(1_u64)))]
         pub fn sudo_set_num_root_claims(origin: OriginFor<T>, new_value: u64) -> DispatchResult {

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -1973,7 +1973,8 @@ mod dispatches {
 
         /// Sets the pending childkey cooldown (in blocks). Root only.
         #[pallet::call_index(109)]
-        #[pallet::weight(Weight::from_parts(1_970_000_000_000, 0))]
+        #[pallet::weight(Weight::from_parts(3_000_000, 0)
+			.saturating_add(T::DbWeight::get().writes(1_u64)))]
         pub fn set_pending_childkey_cooldown(
             origin: OriginFor<T>,
             cooldown: u64,


### PR DESCRIPTION
This PR adds a benchmark for `set_pending_childkey_cooldown` and sets weights. 