### PR TITLE
CK cooldown after start call

### DIFF
--- a/eco-tests/src/helpers.rs
+++ b/eco-tests/src/helpers.rs
@@ -275,7 +275,9 @@ pub fn mock_set_children(coldkey: &U256, parent: &U256, netuid: NetUid, child_ve
 pub fn mock_set_children_no_epochs(netuid: NetUid, parent: &U256, child_vec: &[(u64, U256)]) {
     let backup_block = SubtensorModule::get_current_block_as_u64();
     PendingChildKeys::<Test>::insert(netuid, parent, (child_vec, 0));
-    System::set_block_number(1);
+    FirstEmissionBlockNumber::<Test>::insert(netuid, 0);
+    let cooldown = PendingChildKeyCooldown::<Test>::get();
+    System::set_block_number(cooldown + 1);
     SubtensorModule::do_set_pending_children(netuid);
     System::set_block_number(backup_block);
 }

--- a/pallets/subtensor/src/staking/set_children.rs
+++ b/pallets/subtensor/src/staking/set_children.rs
@@ -599,38 +599,67 @@ impl<T: Config> Pallet<T> {
     pub fn do_set_pending_children(netuid: NetUid) {
         let current_block = Self::get_current_block_as_u64();
 
+        // If the childkey cools down before the subnet start call + PendingChildKeyCooldown:
+        //   - If Start call happened: Postpone to start_block + PendingChildKeyCooldown
+        //   - If Start call didn't happen: Postpone to now + PendingChildKeyCooldown
+        let cooldown_period = PendingChildKeyCooldown::<T>::get();
+        let cooldown_allowed_block =
+            if let Some(first_emission_block) = FirstEmissionBlockNumber::<T>::get(netuid) {
+                let start_call_block = first_emission_block.saturating_sub(1);
+                start_call_block.saturating_add(cooldown_period)
+            } else {
+                current_block.saturating_add(cooldown_period)
+            };
+
         // Iterate over all pending children of this subnet and set as needed
+        let mut to_remove: Vec<T::AccountId> = Vec::new();
+        let mut to_reschedule: Vec<(T::AccountId, Vec<(u64, T::AccountId)>)> = Vec::new();
+
         PendingChildKeys::<T>::iter_prefix(netuid).for_each(
             |(hotkey, (children, cool_down_block))| {
                 if cool_down_block < current_block {
-                    // If child-parent consistency is broken, we will fail setting new children silently
-                    let maybe_relations =
-                        Self::load_relations_from_pending(hotkey.clone(), &children, netuid);
-                    if let Ok(relations) = maybe_relations {
-                        let mut _weight: Weight = T::DbWeight::get().reads(0);
-                        if let Ok(()) =
-                            Self::persist_child_parent_relations(relations, netuid, &mut _weight)
-                        {
-                            // Log and emit event.
-                            log::trace!(
-                                "SetChildren( netuid:{:?}, hotkey:{:?}, children:{:?} )",
-                                hotkey,
+                    if current_block >= cooldown_allowed_block {
+                        // If child-parent consistency is broken, we will fail setting new children silently
+                        let maybe_relations =
+                            Self::load_relations_from_pending(hotkey.clone(), &children, netuid);
+                        if let Ok(relations) = maybe_relations {
+                            let mut _weight: Weight = T::DbWeight::get().reads(0);
+                            if let Ok(()) = Self::persist_child_parent_relations(
+                                relations,
                                 netuid,
-                                children.clone()
-                            );
-                            Self::deposit_event(Event::SetChildren(
-                                hotkey.clone(),
-                                netuid,
-                                children.clone(),
-                            ));
+                                &mut _weight,
+                            ) {
+                                // Log and emit event.
+                                log::trace!(
+                                    "SetChildren( netuid:{:?}, hotkey:{:?}, children:{:?} )",
+                                    hotkey,
+                                    netuid,
+                                    children.clone()
+                                );
+                                Self::deposit_event(Event::SetChildren(
+                                    hotkey.clone(),
+                                    netuid,
+                                    children.clone(),
+                                ));
+                            }
                         }
-                    }
 
-                    // Remove pending children
-                    PendingChildKeys::<T>::remove(netuid, hotkey);
+                        to_remove.push(hotkey);
+                    } else {
+                        to_remove.push(hotkey.clone());
+                        to_reschedule.push((hotkey, children));
+                    }
                 }
             },
         );
+
+        for hotkey in to_remove {
+            PendingChildKeys::<T>::remove(netuid, hotkey);
+        }
+
+        for (hotkey, children) in to_reschedule {
+            PendingChildKeys::<T>::insert(netuid, hotkey, (children, cooldown_allowed_block));
+        }
     }
 
     /* Retrieves the list of children for a given hotkey and network.

--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -881,7 +881,9 @@ pub fn mock_set_children(coldkey: &U256, parent: &U256, netuid: NetUid, child_ve
 pub fn mock_set_children_no_epochs(netuid: NetUid, parent: &U256, child_vec: &[(u64, U256)]) {
     let backup_block = SubtensorModule::get_current_block_as_u64();
     PendingChildKeys::<Test>::insert(netuid, parent, (child_vec, 0));
-    System::set_block_number(1);
+    FirstEmissionBlockNumber::<Test>::insert(netuid, 0);
+    let cooldown = PendingChildKeyCooldown::<Test>::get();
+    System::set_block_number(cooldown + 1);
     SubtensorModule::do_set_pending_children(netuid);
     System::set_block_number(backup_block);
 }


### PR DESCRIPTION
## Description

When adding child keys, child key cool down period will begin only after start call is executed.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

