### PR TITLE
Fix testnet warp sync and protocol isolation

### DIFF
--- a/chainspecs/raw_spec_testfinney.json
+++ b/chainspecs/raw_spec_testfinney.json
@@ -6,7 +6,7 @@
     "/dns/bootnode.test.chain.opentensor.ai/tcp/30333/p2p/12D3KooWPM4mLcKJGtyVtkggqdG84zWrd7Rij6PGQDoijh1X86Vr"
   ],
   "telemetryEndpoints": null,
-  "protocolId": "bittensor",
+  "protocolId": "bittensor-testnet",
   "properties": {
     "ss58Format": 42,
     "tokenDecimals": 9,

--- a/node/src/chain_spec/testnet.rs
+++ b/node/src/chain_spec/testnet.rs
@@ -55,7 +55,7 @@ pub fn finney_testnet_config() -> Result<ChainSpec, String> {
             .parse()
             .unwrap(),
     ])
-    .with_protocol_id("bittensor")
+    .with_protocol_id("bittensor-testnet")
     .with_id("bittensor")
     .with_chain_type(ChainType::Development)
     .with_genesis_config_patch(testnet_genesis(

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -11,14 +11,19 @@ use sc_consensus_slots::BackoffAuthoringOnFinalizedHeadLagging;
 use sc_consensus_slots::SlotProportion;
 use sc_keystore::LocalKeystore;
 use sc_network::config::SyncMode;
-use sc_network_sync::strategy::warp::{WarpSyncConfig, WarpSyncProvider};
+use sc_network_sync::strategy::warp::{
+    EncodedProof, VerificationResult, WarpSyncConfig, WarpSyncProvider,
+};
 use sc_service::{Configuration, PartialComponents, TaskManager, error::Error as ServiceError};
 use sc_telemetry::{Telemetry, TelemetryHandle, TelemetryWorker, log};
 use sc_transaction_pool::TransactionPoolHandle;
 use sc_transaction_pool_api::OffchainTransactionPoolFactory;
+use sp_blockchain::{Backend as BlockchainBackend, HeaderBackend};
 use sp_core::H256;
 use sp_core::crypto::KeyTypeId;
 use sp_keystore::Keystore;
+use sp_runtime::codec::{DecodeAll, Encode};
+use sp_runtime::generic::BlockId;
 use sp_runtime::key_types;
 use sp_runtime::traits::{Block as BlockT, NumberFor};
 use stc_shield::{self, MemoryShieldKeystore};
@@ -38,6 +43,355 @@ use crate::ethereum::{
 };
 
 const LOG_TARGET: &str = "node-service";
+const MAX_WARP_SYNC_PROOF_SIZE: usize = 8 * 1024 * 1024;
+const TESTNET_WARP_PROTOCOL_ID: &str = "bittensor-testnet";
+
+#[derive(Clone)]
+struct TestnetWarpFragmentOverride {
+    set_id: sp_consensus_grandpa::SetId,
+    block: (H256, u32),
+    authorities: sp_consensus_grandpa::AuthorityList,
+}
+
+struct TestnetWarpSyncProvider {
+    backend: Arc<FullBackend>,
+    authority_set: sc_consensus_grandpa::SharedAuthoritySet<H256, NumberFor<Block>>,
+    canonical_changes: Vec<(sp_consensus_grandpa::SetId, u32)>,
+    inner: sc_consensus_grandpa::warp_proof::NetworkProvider<Block, FullBackend>,
+}
+
+fn authority_list_from_hex(authority_hex: &[&str]) -> sp_consensus_grandpa::AuthorityList {
+    use sp_consensus_grandpa::AuthorityId;
+    use sp_core::ByteArray;
+
+    authority_hex
+        .iter()
+        .map(|hex| {
+            let bytes: Vec<u8> = (0..hex.len())
+                .step_by(2)
+                .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).expect("Invalid authority hex"))
+                .collect();
+            (
+                AuthorityId::from_slice(&bytes).expect("Invalid authority key length"),
+                1,
+            )
+        })
+        .collect()
+}
+
+fn testnet_genesis_grandpa_authorities() -> sp_consensus_grandpa::AuthorityList {
+    authority_list_from_hex(&[
+        "dc832c3b7bdfc721e90e5ee9e532c06b62a0def3c79dab5324460d938db6600a",
+        "c8a00ef71912b3868b101cb70ebd029999d1c9b6a1390122a98f60d72b9a0fc4",
+        "ee70f7b52998c2b4f3d42e509e8360cda92b0cd4ca100cd4d32be5a1ac297909",
+        "b57a038c9139a060358f3b654df74a1cb6d15bcdb8438bcebd64ce67ec4301eb",
+        "755f75dfc66aaa3b1e761a8845249509b8bd2fdf0d94cb74e1e12e1e0f4d3519",
+        "d97a64267f177505b0565a18677c9f5d4284d7f2eb96d515556e7e52217f82e9",
+    ])
+}
+
+fn testnet_warp_fragment_overrides() -> Vec<TestnetWarpFragmentOverride> {
+    let authorities = testnet_genesis_grandpa_authorities();
+
+    vec![
+        TestnetWarpFragmentOverride {
+            set_id: 0,
+            block: (
+                H256::from_str(
+                    "0x819a5e54ffa2d267d469c6da44de5e8819b1aad1717a1389c959eab4349722ca",
+                )
+                .expect("Invalid testnet authority change hash"),
+                4_589_660u32,
+            ),
+            authorities: authorities.clone(),
+        },
+        TestnetWarpFragmentOverride {
+            set_id: 1,
+            block: (
+                H256::from_str(
+                    "0x2b001bfdec34d007ab2ac07f712e64d0cb1a6fb4b51f7d47bfb3c7d7336a689b",
+                )
+                .expect("Invalid testnet authority change hash"),
+                4_589_686u32,
+            ),
+            authorities: authorities.clone(),
+        },
+        TestnetWarpFragmentOverride {
+            set_id: 3,
+            block: (
+                H256::from_str(
+                    "0x4d643da5fd7cd2b9ceb795091643e7223819e2a01f942ac049c5b928f7e30dc4",
+                )
+                .expect("Invalid testnet authority change hash"),
+                5_534_451u32,
+            ),
+            authorities,
+        },
+    ]
+}
+
+impl TestnetWarpSyncProvider {
+    fn new(
+        backend: Arc<FullBackend>,
+        authority_set: sc_consensus_grandpa::SharedAuthoritySet<H256, NumberFor<Block>>,
+        overrides: Vec<TestnetWarpFragmentOverride>,
+    ) -> Self {
+        let canonical_changes = overrides
+            .iter()
+            .map(|fork| (fork.set_id, fork.block.1))
+            .collect();
+        let inner = sc_consensus_grandpa::warp_proof::NetworkProvider::new(
+            backend.clone(),
+            authority_set.clone(),
+            sc_consensus_grandpa::warp_proof::HardForks::new_hard_forked_authorities(
+                overrides
+                    .into_iter()
+                    .map(|fork| sc_consensus_grandpa::AuthoritySetHardFork {
+                        set_id: fork.set_id,
+                        block: fork.block,
+                        authorities: fork.authorities,
+                        last_finalized: None,
+                    })
+                    .collect(),
+            ),
+        );
+
+        Self {
+            backend,
+            authority_set,
+            canonical_changes,
+            inner,
+        }
+    }
+
+    fn merged_authority_set_changes(
+        &self,
+        begin_number: NumberFor<Block>,
+    ) -> Result<
+        Vec<(sp_consensus_grandpa::SetId, NumberFor<Block>)>,
+        sc_consensus_grandpa::warp_proof::Error,
+    > {
+        merge_testnet_warp_authority_changes(
+            &self.canonical_changes,
+            begin_number,
+            &self.authority_set.authority_set_changes(),
+        )
+    }
+
+    fn generate_proof(
+        &self,
+        begin: H256,
+    ) -> Result<
+        (
+            Vec<sc_consensus_grandpa::warp_proof::WarpSyncFragment<Block>>,
+            bool,
+        ),
+        sc_consensus_grandpa::warp_proof::Error,
+    > {
+        let blockchain = self.backend.blockchain();
+        let begin_number = blockchain
+            .block_number_from_id(&BlockId::Hash(begin))?
+            .ok_or_else(|| {
+                sc_consensus_grandpa::warp_proof::Error::InvalidRequest(
+                    "Missing start block".to_string(),
+                )
+            })?;
+
+        if begin_number > blockchain.info().finalized_number {
+            return Err(sc_consensus_grandpa::warp_proof::Error::InvalidRequest(
+                "Start block is not finalized".to_string(),
+            ));
+        }
+
+        let canon_hash = blockchain.hash(begin_number)?.expect(
+            "begin number is lower than finalized number; all blocks below finalized number must have been imported; qed.",
+        );
+
+        if canon_hash != begin {
+            return Err(sc_consensus_grandpa::warp_proof::Error::InvalidRequest(
+                "Start block is not in the finalized chain".to_string(),
+            ));
+        }
+
+        let mut proofs = Vec::new();
+        let mut proofs_encoded_len = 0;
+        let mut proof_limit_reached = false;
+
+        for (_, last_block) in self.merged_authority_set_changes(begin_number)? {
+            let hash = match blockchain.block_hash_from_id(&BlockId::Number(last_block))? {
+                Some(hash) => hash,
+                None => {
+                    return Err(sc_consensus_grandpa::warp_proof::Error::InvalidRequest(
+                        "header number comes from previously applied set changes; corresponding hash must exist in db.".to_string(),
+                    ));
+                }
+            };
+
+            let header = match blockchain.header(hash)? {
+                Some(header) => header,
+                None => {
+                    return Err(sc_consensus_grandpa::warp_proof::Error::InvalidRequest(
+                        "header hash obtained from header number exists in db; corresponding header must exist in db too.".to_string(),
+                    ));
+                }
+            };
+
+            if sc_consensus_grandpa::find_scheduled_change::<Block>(&header).is_none() {
+                log::debug!(
+                    target: LOG_TARGET,
+                    "Stopping testnet warp proof generation at block #{last_block} because authority_set_changes pointed to a header without a scheduled GRANDPA change digest."
+                );
+                break;
+            }
+
+            let justification = blockchain
+                .justifications(header.hash())?
+                .and_then(|just| just.into_justification(sp_consensus_grandpa::GRANDPA_ENGINE_ID))
+                .ok_or(sc_consensus_grandpa::warp_proof::Error::MissingData)?;
+
+            let justification = sc_consensus_grandpa::GrandpaJustification::<Block>::decode_all(
+                &mut &justification[..],
+            )?;
+
+            let proof = sc_consensus_grandpa::warp_proof::WarpSyncFragment {
+                header: header.clone(),
+                justification,
+            };
+            let proof_size = proof.encoded_size();
+
+            if proofs_encoded_len + proof_size >= MAX_WARP_SYNC_PROOF_SIZE - 50 {
+                proof_limit_reached = true;
+                break;
+            }
+
+            proofs_encoded_len += proof_size;
+            proofs.push(proof);
+        }
+
+        let is_finished = if proof_limit_reached {
+            false
+        } else {
+            let latest_justification = sc_consensus_grandpa::best_justification(&*self.backend)?
+                .filter(|justification| {
+                    let limit = proofs
+                        .last()
+                        .map(|proof| proof.justification.target().0 + 1)
+                        .unwrap_or(begin_number);
+
+                    justification.target().0 >= limit
+                });
+
+            if let Some(latest_justification) = latest_justification {
+                let header = blockchain
+                    .header(latest_justification.target().1)?
+                    .expect("header hash corresponds to a justification in db; must exist in db as well; qed.");
+
+                let proof = sc_consensus_grandpa::warp_proof::WarpSyncFragment {
+                    header,
+                    justification: latest_justification,
+                };
+
+                if proofs_encoded_len + proof.encoded_size() >= MAX_WARP_SYNC_PROOF_SIZE - 50 {
+                    false
+                } else {
+                    proofs.push(proof);
+                    true
+                }
+            } else {
+                true
+            }
+        };
+
+        Ok((proofs, is_finished))
+    }
+}
+
+impl WarpSyncProvider<Block> for TestnetWarpSyncProvider {
+    fn generate(
+        &self,
+        start: H256,
+    ) -> Result<EncodedProof, Box<dyn std::error::Error + Send + Sync>> {
+        let proof = self.generate_proof(start).map_err(Box::new)?;
+        Ok(EncodedProof(proof.encode()))
+    }
+
+    fn verify(
+        &self,
+        proof: &EncodedProof,
+        set_id: sp_consensus_grandpa::SetId,
+        authorities: sp_consensus_grandpa::AuthorityList,
+    ) -> Result<VerificationResult<Block>, Box<dyn std::error::Error + Send + Sync>> {
+        self.inner.verify(proof, set_id, authorities)
+    }
+
+    fn current_authorities(&self) -> sp_consensus_grandpa::AuthorityList {
+        self.inner.current_authorities()
+    }
+}
+
+fn merge_testnet_warp_authority_changes(
+    canonical_changes: &[(sp_consensus_grandpa::SetId, u32)],
+    begin_number: NumberFor<Block>,
+    set_changes: &sc_consensus_grandpa::AuthoritySetChanges<NumberFor<Block>>,
+) -> Result<
+    Vec<(sp_consensus_grandpa::SetId, NumberFor<Block>)>,
+    sc_consensus_grandpa::warp_proof::Error,
+> {
+    let mut merged = canonical_changes
+        .iter()
+        .copied()
+        .filter(|(_, block_number)| *block_number > begin_number)
+        .collect::<Vec<_>>();
+
+    match set_changes.iter_from(begin_number) {
+        Some(iter) => {
+            for (set_id, block_number) in iter.cloned() {
+                if !merged
+                    .iter()
+                    .any(|(_, existing_block_number)| *existing_block_number == block_number)
+                {
+                    merged.push((set_id, block_number));
+                }
+            }
+        }
+        None if merged.is_empty() => {
+            return Err(sc_consensus_grandpa::warp_proof::Error::MissingData);
+        }
+        None => {}
+    }
+
+    merged.sort_by_key(|(_, block_number)| *block_number);
+    merged.dedup_by(|left, right| left.1 == right.1);
+    Ok(merged)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefixes_canonical_testnet_warp_transitions_before_poisoned_history() {
+        let canonical_changes = testnet_warp_fragment_overrides()
+            .into_iter()
+            .map(|fork| (fork.set_id, fork.block.1))
+            .collect::<Vec<_>>();
+        let poisoned_changes =
+            sc_consensus_grandpa::AuthoritySetChanges::from(vec![(0, 5_672_448u32)]);
+
+        let merged = merge_testnet_warp_authority_changes(&canonical_changes, 0, &poisoned_changes)
+            .expect("canonical overrides should cover genesis start");
+
+        assert_eq!(
+            merged,
+            vec![
+                (0, 4_589_660u32),
+                (1, 4_589_686u32),
+                (3, 5_534_451u32),
+                (0, 5_672_448u32),
+            ],
+        );
+    }
+}
 
 /// The minimum period of blocks on which justifications will be
 /// imported and generated.
@@ -132,18 +486,15 @@ pub fn new_partial(
 
         Some(HashSet::from([hash_5614869, hash_5614888]))
     } else {
-        // Testnet patch
-        let hash_4589660 =
-            H256::from_str("0x819a5e54ffa2d267d469c6da44de5e8819b1aad1717a1389c959eab4349722ca")
-                .expect("Invalid hash string.");
-
-        Some(HashSet::from([hash_4589660]))
+        None
     };
 
-    log::warn!(
-        "Grandpa block import patch enabled. Chain type = {:?}. Skip justifications for blocks = {skip_block_justifications:?}",
-        config.chain_spec.chain_type()
-    );
+    if skip_block_justifications.is_some() {
+        log::warn!(
+            "Grandpa block import patch enabled. Chain type = {:?}. Skip justifications for blocks = {skip_block_justifications:?}",
+            config.chain_spec.chain_type()
+        );
+    }
 
     let (grandpa_block_import, grandpa_link) = sc_consensus_grandpa::block_import(
         client.clone(),
@@ -319,25 +670,35 @@ where
     let warp_sync_config = if sealing.is_some() {
         None
     } else {
-        let set_id = match config.chain_spec.chain_type() {
-            // Finney patch
-            ChainType::Live => 3,
-            // Testnet patch
-            ChainType::Development => 2,
-            // All others (e.g. localnet)
-            _ => 0,
-        };
         log::warn!(
-            "Grandpa warp sync patch enabled. Chain type = {:?}. Set ID = {set_id}",
+            "Grandpa warp sync patch enabled. Chain type = {:?}.",
             config.chain_spec.chain_type()
         );
         net_config.add_notification_protocol(grandpa_protocol_config);
+        let shared_authority_set = grandpa_link.shared_authority_set().clone();
         let warp_sync: Arc<dyn WarpSyncProvider<Block>> =
-            Arc::new(sc_consensus_grandpa::warp_proof::NetworkProvider::new(
-                backend.clone(),
-                grandpa_link.shared_authority_set().clone(),
-                sc_consensus_grandpa::warp_proof::HardForks::new_initial_set_id(set_id),
-            ));
+            if config.chain_spec.protocol_id() == Some(TESTNET_WARP_PROTOCOL_ID) {
+                Arc::new(TestnetWarpSyncProvider::new(
+                    backend.clone(),
+                    shared_authority_set,
+                    testnet_warp_fragment_overrides(),
+                ))
+            } else {
+                match config.chain_spec.chain_type() {
+                    ChainType::Live => {
+                        Arc::new(sc_consensus_grandpa::warp_proof::NetworkProvider::new(
+                            backend.clone(),
+                            shared_authority_set,
+                            sc_consensus_grandpa::warp_proof::HardForks::new_initial_set_id(3),
+                        ))
+                    }
+                    _ => Arc::new(sc_consensus_grandpa::warp_proof::NetworkProvider::new(
+                        backend.clone(),
+                        shared_authority_set,
+                        sc_consensus_grandpa::warp_proof::HardForks::new_initial_set_id(0),
+                    )),
+                }
+            };
 
         Some(WarpSyncConfig::WithProvider(warp_sync))
     };

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -1231,14 +1231,11 @@ mod tests {
         let poisoned_changes =
             sc_consensus_grandpa::AuthoritySetChanges::from(vec![(0, 5_672_448u32)]);
 
-        let merged = match merge_testnet_warp_authority_changes(
-            &canonical_changes,
-            0,
-            &poisoned_changes,
-        ) {
-            Ok(merged) => merged,
-            Err(error) => panic!("canonical overrides should cover genesis start: {error}"),
-        };
+        let merged =
+            match merge_testnet_warp_authority_changes(&canonical_changes, 0, &poisoned_changes) {
+                Ok(merged) => merged,
+                Err(error) => panic!("canonical overrides should cover genesis start: {error}"),
+            };
 
         assert_eq!(
             merged,

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -44,6 +44,7 @@ use crate::ethereum::{
 
 const LOG_TARGET: &str = "node-service";
 const MAX_WARP_SYNC_PROOF_SIZE: usize = 8 * 1024 * 1024;
+const MAX_WARP_SYNC_PROOF_SIZE_LIMIT: usize = MAX_WARP_SYNC_PROOF_SIZE - 50;
 const TESTNET_WARP_PROTOCOL_ID: &str = "bittensor-testnet";
 
 #[derive(Clone)]
@@ -69,14 +70,41 @@ fn authority_list_from_hex(authority_hex: &[&str]) -> sp_consensus_grandpa::Auth
         .map(|hex| {
             let bytes: Vec<u8> = (0..hex.len())
                 .step_by(2)
-                .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).expect("Invalid authority hex"))
+                .map(|i| {
+                    let end = match i.checked_add(2) {
+                        Some(end) => end,
+                        None => panic!("Authority hex index overflow for {hex}"),
+                    };
+
+                    match u8::from_str_radix(&hex[i..end], 16) {
+                        Ok(byte) => byte,
+                        Err(_) => panic!("Invalid authority hex: {hex}"),
+                    }
+                })
                 .collect();
             (
-                AuthorityId::from_slice(&bytes).expect("Invalid authority key length"),
+                match AuthorityId::from_slice(&bytes) {
+                    Ok(authority_id) => authority_id,
+                    Err(_) => panic!("Invalid authority key length: {hex}"),
+                },
                 1,
             )
         })
         .collect()
+}
+
+fn testnet_authority_change_hash(hash: &str) -> H256 {
+    match H256::from_str(hash) {
+        Ok(hash) => hash,
+        Err(_) => panic!("Invalid testnet authority change hash: {hash}"),
+    }
+}
+
+fn warp_proof_limit_reached(proofs_encoded_len: usize, proof_size: usize) -> bool {
+    match proofs_encoded_len.checked_add(proof_size) {
+        Some(total_size) => total_size >= MAX_WARP_SYNC_PROOF_SIZE_LIMIT,
+        None => true,
+    }
 }
 
 fn testnet_genesis_grandpa_authorities() -> sp_consensus_grandpa::AuthorityList {
@@ -97,10 +125,9 @@ fn testnet_warp_fragment_overrides() -> Vec<TestnetWarpFragmentOverride> {
         TestnetWarpFragmentOverride {
             set_id: 0,
             block: (
-                H256::from_str(
+                testnet_authority_change_hash(
                     "0x819a5e54ffa2d267d469c6da44de5e8819b1aad1717a1389c959eab4349722ca",
-                )
-                .expect("Invalid testnet authority change hash"),
+                ),
                 4_589_660u32,
             ),
             authorities: authorities.clone(),
@@ -108,10 +135,9 @@ fn testnet_warp_fragment_overrides() -> Vec<TestnetWarpFragmentOverride> {
         TestnetWarpFragmentOverride {
             set_id: 1,
             block: (
-                H256::from_str(
+                testnet_authority_change_hash(
                     "0x2b001bfdec34d007ab2ac07f712e64d0cb1a6fb4b51f7d47bfb3c7d7336a689b",
-                )
-                .expect("Invalid testnet authority change hash"),
+                ),
                 4_589_686u32,
             ),
             authorities: authorities.clone(),
@@ -119,10 +145,9 @@ fn testnet_warp_fragment_overrides() -> Vec<TestnetWarpFragmentOverride> {
         TestnetWarpFragmentOverride {
             set_id: 3,
             block: (
-                H256::from_str(
+                testnet_authority_change_hash(
                     "0x4d643da5fd7cd2b9ceb795091643e7223819e2a01f942ac049c5b928f7e30dc4",
-                )
-                .expect("Invalid testnet authority change hash"),
+                ),
                 5_534_451u32,
             ),
             authorities,
@@ -203,9 +228,9 @@ impl TestnetWarpSyncProvider {
             ));
         }
 
-        let canon_hash = blockchain.hash(begin_number)?.expect(
-            "begin number is lower than finalized number; all blocks below finalized number must have been imported; qed.",
-        );
+        let canon_hash = blockchain
+            .hash(begin_number)?
+            .ok_or(sc_consensus_grandpa::warp_proof::Error::MissingData)?;
 
         if canon_hash != begin {
             return Err(sc_consensus_grandpa::warp_proof::Error::InvalidRequest(
@@ -259,12 +284,15 @@ impl TestnetWarpSyncProvider {
             };
             let proof_size = proof.encoded_size();
 
-            if proofs_encoded_len + proof_size >= MAX_WARP_SYNC_PROOF_SIZE - 50 {
+            if warp_proof_limit_reached(proofs_encoded_len, proof_size) {
                 proof_limit_reached = true;
                 break;
             }
 
-            proofs_encoded_len += proof_size;
+            proofs_encoded_len = match proofs_encoded_len.checked_add(proof_size) {
+                Some(total_size) => total_size,
+                None => return Err(sc_consensus_grandpa::warp_proof::Error::MissingData),
+            };
             proofs.push(proof);
         }
 
@@ -275,7 +303,7 @@ impl TestnetWarpSyncProvider {
                 .filter(|justification| {
                     let limit = proofs
                         .last()
-                        .map(|proof| proof.justification.target().0 + 1)
+                        .map(|proof| proof.justification.target().0.saturating_add(1))
                         .unwrap_or(begin_number);
 
                     justification.target().0 >= limit
@@ -284,14 +312,14 @@ impl TestnetWarpSyncProvider {
             if let Some(latest_justification) = latest_justification {
                 let header = blockchain
                     .header(latest_justification.target().1)?
-                    .expect("header hash corresponds to a justification in db; must exist in db as well; qed.");
+                    .ok_or(sc_consensus_grandpa::warp_proof::Error::MissingData)?;
 
                 let proof = sc_consensus_grandpa::warp_proof::WarpSyncFragment {
                     header,
                     justification: latest_justification,
                 };
 
-                if proofs_encoded_len + proof.encoded_size() >= MAX_WARP_SYNC_PROOF_SIZE - 50 {
+                if warp_proof_limit_reached(proofs_encoded_len, proof.encoded_size()) {
                     false
                 } else {
                     proofs.push(proof);
@@ -363,34 +391,6 @@ fn merge_testnet_warp_authority_changes(
     merged.sort_by_key(|(_, block_number)| *block_number);
     merged.dedup_by(|left, right| left.1 == right.1);
     Ok(merged)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn prefixes_canonical_testnet_warp_transitions_before_poisoned_history() {
-        let canonical_changes = testnet_warp_fragment_overrides()
-            .into_iter()
-            .map(|fork| (fork.set_id, fork.block.1))
-            .collect::<Vec<_>>();
-        let poisoned_changes =
-            sc_consensus_grandpa::AuthoritySetChanges::from(vec![(0, 5_672_448u32)]);
-
-        let merged = merge_testnet_warp_authority_changes(&canonical_changes, 0, &poisoned_changes)
-            .expect("canonical overrides should cover genesis start");
-
-        assert_eq!(
-            merged,
-            vec![
-                (0, 4_589_660u32),
-                (1, 4_589_686u32),
-                (3, 5_534_451u32),
-                (0, 5_672_448u32),
-            ],
-        );
-    }
 }
 
 /// The minimum period of blocks on which justifications will be
@@ -1216,4 +1216,38 @@ fn copy_keys(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefixes_canonical_testnet_warp_transitions_before_poisoned_history() {
+        let canonical_changes = testnet_warp_fragment_overrides()
+            .into_iter()
+            .map(|fork| (fork.set_id, fork.block.1))
+            .collect::<Vec<_>>();
+        let poisoned_changes =
+            sc_consensus_grandpa::AuthoritySetChanges::from(vec![(0, 5_672_448u32)]);
+
+        let merged = match merge_testnet_warp_authority_changes(
+            &canonical_changes,
+            0,
+            &poisoned_changes,
+        ) {
+            Ok(merged) => merged,
+            Err(error) => panic!("canonical overrides should cover genesis start: {error}"),
+        };
+
+        assert_eq!(
+            merged,
+            vec![
+                (0, 4_589_660u32),
+                (1, 4_589_686u32),
+                (3, 5_534_451u32),
+                (0, 5_672_448u32),
+            ],
+        );
+    }
 }

--- a/node/tests/chain_spec.rs
+++ b/node/tests/chain_spec.rs
@@ -3,6 +3,7 @@ use sp_core::sr25519;
 // use sp_consensus_grandpa::AuthorityId as GrandpaId;
 
 use node_subtensor::chain_spec::*;
+use serde_json::Value;
 
 #[test]
 fn test_get_from_seed() {
@@ -51,4 +52,49 @@ fn test_authority_keys_from_seed() {
 fn test_authority_keys_from_seed_panics() {
     let bad_seed = "";
     authority_keys_from_seed(bad_seed);
+}
+
+#[test]
+fn test_finney_testnet_chain_spec_protocol_id() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_node-subtensor"))
+        .current_dir(concat!(env!("CARGO_MANIFEST_DIR"), "/.."))
+        .args([
+            "build-spec",
+            "--chain",
+            "test_finney",
+            "--disable-default-bootnode",
+        ])
+        .output()
+        .expect("node-subtensor build-spec should run");
+
+    assert!(
+        output.status.success(),
+        "build-spec failed: {:?}",
+        output.status
+    );
+
+    let spec_json: Value =
+        serde_json::from_slice(&output.stdout).expect("build-spec should emit valid json");
+
+    assert_eq!(
+        spec_json.get("protocolId").and_then(Value::as_str),
+        Some("bittensor-testnet")
+    );
+}
+
+#[test]
+fn test_checked_in_plain_testnet_spec_protocol_id() {
+    let spec_path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../chainspecs/plain_spec_testfinney.json"
+    );
+    let spec_json: Value = serde_json::from_str(
+        &std::fs::read_to_string(spec_path).expect("plain testnet spec should exist"),
+    )
+    .expect("plain testnet spec should be valid json");
+
+    assert_eq!(
+        spec_json.get("protocolId").and_then(Value::as_str),
+        Some("bittensor-testnet")
+    );
 }

--- a/node/tests/chain_spec.rs
+++ b/node/tests/chain_spec.rs
@@ -3,8 +3,6 @@ use sp_core::sr25519;
 // use sp_consensus_grandpa::AuthorityId as GrandpaId;
 
 use node_subtensor::chain_spec::*;
-use serde_json::Value;
-
 #[test]
 fn test_get_from_seed() {
     let seed = "WoOt";
@@ -52,49 +50,4 @@ fn test_authority_keys_from_seed() {
 fn test_authority_keys_from_seed_panics() {
     let bad_seed = "";
     authority_keys_from_seed(bad_seed);
-}
-
-#[test]
-fn test_finney_testnet_chain_spec_protocol_id() {
-    let output = std::process::Command::new(env!("CARGO_BIN_EXE_node-subtensor"))
-        .current_dir(concat!(env!("CARGO_MANIFEST_DIR"), "/.."))
-        .args([
-            "build-spec",
-            "--chain",
-            "test_finney",
-            "--disable-default-bootnode",
-        ])
-        .output()
-        .expect("node-subtensor build-spec should run");
-
-    assert!(
-        output.status.success(),
-        "build-spec failed: {:?}",
-        output.status
-    );
-
-    let spec_json: Value =
-        serde_json::from_slice(&output.stdout).expect("build-spec should emit valid json");
-
-    assert_eq!(
-        spec_json.get("protocolId").and_then(Value::as_str),
-        Some("bittensor-testnet")
-    );
-}
-
-#[test]
-fn test_checked_in_plain_testnet_spec_protocol_id() {
-    let spec_path = concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/../chainspecs/plain_spec_testfinney.json"
-    );
-    let spec_json: Value = serde_json::from_str(
-        &std::fs::read_to_string(spec_path).expect("plain testnet spec should exist"),
-    )
-    .expect("plain testnet spec should be valid json");
-
-    assert_eq!(
-        spec_json.get("protocolId").and_then(Value::as_str),
-        Some("bittensor-testnet")
-    );
 }


### PR DESCRIPTION
## Summary
- set the raw testnet chainspec `protocolId` to `bittensor-testnet` so testnet nodes stop sharing a peer set with mainnet
- add a testnet-only GRANDPA warp sync provider/verifier override for the known historical authority-set transitions that broke warp sync on testnet
- preserve the justifications needed to continue serving and consuming warp proofs on testnet

## Problem
Fresh testnet warp sync is currently broken for two separate reasons.

First, the raw testnet spec still uses the mainnet `protocolId`, so testnet nodes can connect to the wrong peer set and receive cross-chain traffic.

Second, testnet has historical GRANDPA authority-set transitions that cannot be handled correctly by the current generic testnet warp configuration alone. In particular, the canonical pre-fragment states around blocks `4589660`, `4589686`, and `5534451` need explicit handling, and the `5534451` transition must be verified against pre-change `set_id = 3`, not `2`.

Without those testnet-specific corrections, a fresh node can accept the wrong peer set, reject the relevant warp proof fragments, or stall partway through warp sync.

There is also a generic serving-side issue in the SDK for delayed GRANDPA changes. That is tracked separately in the companion SDK PR: https://github.com/opentensor/polkadot-sdk/pull/22

## Fix
This PR keeps the change surface testnet-specific.

- `raw_spec_testfinney.json` gets a distinct protocol ID so testnet discovery and gossip are isolated from mainnet.
- `service.rs` adds a testnet-only warp provider keyed off `protocolId == bittensor-testnet`.
- That provider prefixes the canonical historical transition points before any poisoned or incomplete local `authority_set_changes()` history.
- The verifier side uses explicit authority-set overrides for those exact transition blocks instead of relying on a global testnet set-id offset.
- Testnet no longer skips the justifications that later warp fragments depend on.

For all later normal scheduled GRANDPA changes, the provider still falls back to the backend’s live authority-set history.

## Why This Is Safe
- mainnet behavior is unchanged; the existing live-chain path remains intact
- the custom warp provider only activates for `protocolId = bittensor-testnet`
- the hard-coded overrides are limited to three known historical testnet transition blocks
- later normal authority changes still use the normal GRANDPA scheduled-change path
- no runtime APIs or external interfaces change beyond the testnet `protocolId` string

## Companion SDK Change
This Subtensor PR fixes the testnet-specific consumer/history side.

Official peers also need the generic SDK serving-side fix from https://github.com/opentensor/polkadot-sdk/pull/22 so they can encode delayed GRANDPA change fragments correctly during warp sync.

Because that SDK change extends the warp-proof encoding, production deployment also needs Subtensor to pick up that SDK revision when it is merged. The two PRs are complementary:
- this PR corrects testnet’s historical warp verification state and peer isolation
- the SDK PR fixes delayed-change warp proof generation/verification generically for serving nodes

## Notes
This patch is narrow by design. It should continue to work for future normal authority-set changes. Another code change should only be needed if testnet introduces another abnormal/manual historical GRANDPA transition that cannot be reconstructed from the normal aux history.