### PR TITLE
remove an out of date e2e

### DIFF
--- a/contract-tests/test/subnet.precompile.hyperparameter.test.ts
+++ b/contract-tests/test/subnet.precompile.hyperparameter.test.ts
@@ -348,26 +348,26 @@ describe("Test the Subnet precompile contract", () => {
     //     assert.equal(valueFromContract, onchainValue);
     // })
 
-    it("Can set networkPowRegistrationAllowed parameter", async () => {
+    // it("Can set networkPowRegistrationAllowed parameter", async () => {
 
-        const totalNetwork = await api.query.SubtensorModule.TotalNetworks.getValue()
-        const contract = new ethers.Contract(ISUBNET_ADDRESS, ISubnetABI, wallet);
-        const netuid = totalNetwork - 1;
+    //     const totalNetwork = await api.query.SubtensorModule.TotalNetworks.getValue()
+    //     const contract = new ethers.Contract(ISUBNET_ADDRESS, ISubnetABI, wallet);
+    //     const netuid = totalNetwork - 1;
 
-        const newValue = true;
-        const tx = await contract.setNetworkPowRegistrationAllowed(netuid, newValue);
-        await tx.wait();
+    //     const newValue = true;
+    //     const tx = await contract.setNetworkPowRegistrationAllowed(netuid, newValue);
+    //     await tx.wait();
 
-        let onchainValue = await api.query.SubtensorModule.NetworkPowRegistrationAllowed.getValue(netuid)
+    //     let onchainValue = await api.query.SubtensorModule.NetworkPowRegistrationAllowed.getValue(netuid)
 
 
-        let valueFromContract = Boolean(
-            await contract.getNetworkPowRegistrationAllowed(netuid)
-        );
+    //     let valueFromContract = Boolean(
+    //         await contract.getNetworkPowRegistrationAllowed(netuid)
+    //     );
 
-        assert.equal(valueFromContract, newValue)
-        assert.equal(valueFromContract, onchainValue);
-    })
+    //     assert.equal(valueFromContract, newValue)
+    //     assert.equal(valueFromContract, onchainValue);
+    // })
 
     // minBurn hyperparameter. only sudo can set it now
     // newValue = 112;


### PR DESCRIPTION
## Description
The extrinsic sudo_set_network_pow_registration_allowed is disabled, remove the e2e test case.

## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.