### PR TITLE
feat: add consensus mode selection for liquid alpha calculations

### DIFF
--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -1298,6 +1298,44 @@ pub mod pallet {
             res
         }
 
+        /// Sets the liquid alpha consensus mode for a subnet.
+        ///
+        /// This extrinsic allows the subnet owner or root to configure which consensus values
+        /// are used when computing liquid alpha bonding matrices.
+        ///
+        /// # Arguments
+        /// * `origin` - The origin of the call, which must be the subnet owner or root.
+        /// * `netuid` - The unique identifier of the subnet.
+        /// * `mode` - The consensus mode to set.
+        ///
+        /// # Errors
+        /// * `BadOrigin` - If the caller is not the subnet owner or root.
+        #[pallet::call_index(91)]
+        #[pallet::weight((0, DispatchClass::Normal, Pays::No))]
+        pub fn sudo_set_liquid_alpha_consensus_mode(
+            origin: OriginFor<T>,
+            netuid: NetUid,
+            mode: pallet_subtensor::ConsensusMode,
+        ) -> DispatchResult {
+            let maybe_owner = pallet_subtensor::Pallet::<T>::ensure_sn_owner_or_root_with_limits(
+                origin.clone(),
+                netuid,
+                &[Hyperparameter::LiquidAlphaConsensusMode.into()],
+            )?;
+            pallet_subtensor::Pallet::<T>::ensure_admin_window_open(netuid)?;
+            let res = pallet_subtensor::Pallet::<T>::do_set_liquid_alpha_consensus_mode(
+                origin, netuid, mode,
+            );
+            if res.is_ok() {
+                pallet_subtensor::Pallet::<T>::record_owner_rl(
+                    maybe_owner,
+                    netuid,
+                    &[Hyperparameter::LiquidAlphaConsensusMode.into()],
+                );
+            }
+            res
+        }
+
         /// Sets the duration of the dissolve network schedule.
         ///
         /// This extrinsic allows the root account to set the duration for the dissolve network schedule.

--- a/pallets/subtensor/src/epoch/run_epoch.rs
+++ b/pallets/subtensor/src/epoch/run_epoch.rs
@@ -1286,9 +1286,21 @@ impl<T: Config> Pallet<T> {
                 .iter()
                 .any(|&c| c != I32F32::saturating_from_num(0))
         {
-            // Liquid Alpha is enabled, compute the liquid alphas matrix.
-            let alphas: Vec<Vec<I32F32>> =
-                Self::compute_liquid_alpha_values(netuid, weights, bonds, consensus);
+            // Liquid Alpha is enabled, compute the appropriate consensus for liquid alpha based on mode
+            let consensus_for_liquid_alpha =
+                Self::compute_consensus_for_liquid_alpha(netuid, consensus);
+            log::trace!(
+                "consensus_for_liquid_alpha: {:?}",
+                &consensus_for_liquid_alpha
+            );
+
+            // Compute the liquid alphas matrix.
+            let alphas: Vec<Vec<I32F32>> = Self::compute_liquid_alpha_values(
+                netuid,
+                weights,
+                bonds,
+                &consensus_for_liquid_alpha,
+            );
             log::trace!("alphas: {:?}", &alphas);
 
             // Compute the Exponential Moving Average (EMA) of bonds using the provided clamped alpha values.
@@ -1328,9 +1340,21 @@ impl<T: Config> Pallet<T> {
                 .iter()
                 .any(|&c| c != I32F32::saturating_from_num(0))
         {
-            // Liquid Alpha is enabled, compute the liquid alphas matrix.
-            let alphas: Vec<Vec<I32F32>> =
-                Self::compute_liquid_alpha_values_sparse(netuid, weights, bonds, consensus);
+            // Liquid Alpha is enabled, compute the appropriate consensus for liquid alpha based on mode
+            let consensus_for_liquid_alpha =
+                Self::compute_consensus_for_liquid_alpha(netuid, consensus);
+            log::trace!(
+                "consensus_for_liquid_alpha: {:?}",
+                &consensus_for_liquid_alpha
+            );
+
+            // Compute the liquid alphas matrix.
+            let alphas: Vec<Vec<I32F32>> = Self::compute_liquid_alpha_values_sparse(
+                netuid,
+                weights,
+                bonds,
+                &consensus_for_liquid_alpha,
+            );
             log::trace!("alphas: {:?}", &alphas);
 
             // Compute the Exponential Moving Average (EMA) of bonds using the provided clamped alpha values.
@@ -1341,6 +1365,55 @@ impl<T: Config> Pallet<T> {
 
             // Compute the Exponential Moving Average (EMA) of bonds using the calculated alpha value.
             mat_ema_sparse(weights, bonds, alpha)
+        }
+    }
+
+    /// Compute the consensus to use for liquid alpha calculation based on the configured mode
+    ///
+    /// # Args:
+    /// * `netuid` - The network ID.
+    /// * `current_consensus` - The current in-memory consensus values.
+    ///
+    /// # Returns:
+    /// A vector of consensus values to use for liquid alpha calculation
+    pub fn compute_consensus_for_liquid_alpha(
+        netuid: NetUid,
+        current_consensus: &[I32F32],
+    ) -> Vec<I32F32> {
+        let mode = Self::get_liquid_alpha_consensus_mode(netuid);
+
+        match mode {
+            ConsensusMode::Current => {
+                // Use the in-memory consensus (current behavior)
+                current_consensus.to_vec()
+            }
+            ConsensusMode::Previous => {
+                // Use consensus from storage
+                let previous_consensus_u16 = Consensus::<T>::get(netuid);
+                previous_consensus_u16
+                    .iter()
+                    .map(|&c| {
+                        I32F32::saturating_from_num(c)
+                            .safe_div(I32F32::saturating_from_num(u16::MAX))
+                    })
+                    .collect()
+            }
+            ConsensusMode::Auto => {
+                // Auto mode: Previous if bond_penalty == 1, otherwise Current
+                let bonds_penalty = Self::get_float_bonds_penalty(netuid);
+                if bonds_penalty == I32F32::from_num(1) {
+                    let previous_consensus_u16 = Consensus::<T>::get(netuid);
+                    previous_consensus_u16
+                        .iter()
+                        .map(|&c| {
+                            I32F32::saturating_from_num(c)
+                                .safe_div(I32F32::saturating_from_num(u16::MAX))
+                        })
+                        .collect()
+                } else {
+                    current_consensus.to_vec()
+                }
+            }
         }
     }
 
@@ -1548,6 +1621,19 @@ impl<T: Config> Pallet<T> {
         log::debug!(
             "AlphaValuesSet( netuid: {netuid:?}, AlphaLow: {alpha_low:?}, AlphaHigh: {alpha_high:?} ) ",
         );
+        Ok(())
+    }
+
+    pub fn do_set_liquid_alpha_consensus_mode(
+        origin: OriginFor<T>,
+        netuid: NetUid,
+        mode: ConsensusMode,
+    ) -> Result<(), DispatchError> {
+        Self::ensure_subnet_owner_or_root(origin, netuid)?;
+
+        Self::set_liquid_alpha_consensus_mode(netuid, mode.clone());
+
+        log::debug!("LiquidAlphaConsensusModeSet( netuid: {netuid:?}, mode: {mode:?} )",);
         Ok(())
     }
 

--- a/pallets/subtensor/src/epoch/run_epoch.rs
+++ b/pallets/subtensor/src/epoch/run_epoch.rs
@@ -1376,7 +1376,7 @@ impl<T: Config> Pallet<T> {
     ///
     /// # Returns:
     /// A vector of consensus values to use for liquid alpha calculation
-    pub fn compute_consensus_for_liquid_alpha(
+    pub(crate) fn compute_consensus_for_liquid_alpha(
         netuid: NetUid,
         current_consensus: &[I32F32],
     ) -> Vec<I32F32> {
@@ -1399,9 +1399,8 @@ impl<T: Config> Pallet<T> {
                     .collect()
             }
             ConsensusMode::Auto => {
-                // Auto mode: Previous if bond_penalty == 1, otherwise Current
-                let bonds_penalty = Self::get_float_bonds_penalty(netuid);
-                if bonds_penalty == I32F32::from_num(1) {
+                // Auto mode: Previous if bond_penalty == u16::MAX (i.e. 1.0), otherwise Current
+                if Self::get_bonds_penalty(netuid) == u16::MAX {
                     let previous_consensus_u16 = Consensus::<T>::get(netuid);
                     previous_consensus_u16
                         .iter()
@@ -1631,9 +1630,10 @@ impl<T: Config> Pallet<T> {
     ) -> Result<(), DispatchError> {
         Self::ensure_subnet_owner_or_root(origin, netuid)?;
 
-        Self::set_liquid_alpha_consensus_mode(netuid, mode.clone());
+        Self::set_liquid_alpha_consensus_mode(netuid, mode);
+        Self::deposit_event(Event::LiquidAlphaConsensusModeSet { netuid, mode });
 
-        log::debug!("LiquidAlphaConsensusModeSet( netuid: {netuid:?}, mode: {mode:?} )",);
+        log::debug!("LiquidAlphaConsensusModeSet( netuid: {netuid:?}, mode: {mode:?} )");
         Ok(())
     }
 

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -117,7 +117,7 @@ pub mod pallet {
 
     /// Tracks version for migrations. Should be monotonic with respect to the
     /// order of migrations. (i.e. always increasing)
-    const STORAGE_VERSION: StorageVersion = StorageVersion::new(7);
+    const STORAGE_VERSION: StorageVersion = StorageVersion::new(8);
 
     /// Minimum balance required to perform a coldkey swap
     pub const MIN_BALANCE_TO_PERFORM_COLDKEY_SWAP: TaoBalance = TaoBalance::new(100_000_000); // 0.1 TAO in RAO
@@ -349,7 +349,19 @@ pub mod pallet {
     }
 
     /// Enum for consensus mode used in liquid alpha calculation
-    #[derive(Encode, Decode, Default, TypeInfo, Clone, PartialEq, Eq, Debug)]
+    #[derive(
+        Encode,
+        Decode,
+        DecodeWithMemTracking,
+        Default,
+        TypeInfo,
+        Clone,
+        Copy,
+        PartialEq,
+        Eq,
+        Debug,
+        MaxEncodedLen,
+    )]
     pub enum ConsensusMode {
         /// Use current in-memory consensus (current behavior)
         Current,

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -348,6 +348,18 @@ pub mod pallet {
         },
     }
 
+    /// Enum for consensus mode used in liquid alpha calculation
+    #[derive(Encode, Decode, Default, TypeInfo, Clone, PartialEq, Eq, Debug)]
+    pub enum ConsensusMode {
+        /// Use current in-memory consensus (current behavior)
+        Current,
+        /// Use previous consensus from storage
+        Previous,
+        /// Auto mode: Previous if bond_penalty == 1, otherwise Current
+        #[default]
+        Auto,
+    }
+
     /// The Max Burn HalfLife Settable
     #[pallet::type_value]
     pub fn MaxBurnHalfLife<T: Config>() -> u16 {
@@ -973,6 +985,12 @@ pub mod pallet {
     #[pallet::type_value]
     pub fn DefaultAlphaValues<T: Config>() -> (u16, u16) {
         (45875, 58982)
+    }
+
+    /// Default consensus mode for liquid alpha calculation
+    #[pallet::type_value]
+    pub fn DefaultConsensusMode<T: Config>() -> ConsensusMode {
+        ConsensusMode::default()
     }
 
     /// Default value for coldkey swap announcement delay.
@@ -1941,6 +1959,11 @@ pub mod pallet {
     #[pallet::storage]
     pub type AlphaValues<T> =
         StorageMap<_, Identity, NetUid, (u16, u16), ValueQuery, DefaultAlphaValues<T>>;
+
+    /// MAP ( netuid ) --> consensus mode for liquid alpha calculation
+    #[pallet::storage]
+    pub type LiquidAlphaConsensusMode<T> =
+        StorageMap<_, Identity, NetUid, ConsensusMode, ValueQuery, DefaultConsensusMode<T>>;
 
     /// --- MAP ( netuid ) --> If subtoken trading enabled
     #[pallet::storage]

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -117,7 +117,7 @@ pub mod pallet {
 
     /// Tracks version for migrations. Should be monotonic with respect to the
     /// order of migrations. (i.e. always increasing)
-    const STORAGE_VERSION: StorageVersion = StorageVersion::new(8);
+    const STORAGE_VERSION: StorageVersion = StorageVersion::new(7);
 
     /// Minimum balance required to perform a coldkey swap
     pub const MIN_BALANCE_TO_PERFORM_COLDKEY_SWAP: TaoBalance = TaoBalance::new(100_000_000); // 0.1 TAO in RAO

--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -562,5 +562,13 @@ mod events {
             /// The burn increase multiplier value for neuron registration.
             burn_increase_mult: u64,
         },
+
+        /// Liquid alpha consensus mode set for a subnet.
+        LiquidAlphaConsensusModeSet {
+            /// The subnet identifier.
+            netuid: NetUid,
+            /// The new consensus mode.
+            mode: ConsensusMode,
+        },
     }
 }

--- a/pallets/subtensor/src/tests/consensus_mode.rs
+++ b/pallets/subtensor/src/tests/consensus_mode.rs
@@ -1,0 +1,271 @@
+use frame_support::{assert_err, assert_ok};
+use sp_core::U256;
+use substrate_fixed::types::I32F32;
+use subtensor_runtime_common::NetUid;
+
+use super::consensus::{fixed, fixed_proportion_to_u16};
+use super::mock::*;
+use crate::*;
+
+// ============================================================================
+// Test Helper Functions
+// ============================================================================
+
+/// Sets up a network with full owner permissions (root registration + network creation)
+/// Returns (netuid, hotkey, coldkey, signer)
+fn setup_network_with_owner() -> (NetUid, U256, U256, RuntimeOrigin) {
+    let hotkey = U256::from(1);
+    let coldkey = U256::from(457);
+    let netuid = add_dynamic_network(&hotkey, &coldkey);
+    let signer = RuntimeOrigin::signed(coldkey);
+
+    migrations::migrate_create_root_network::migrate_create_root_network::<Test>();
+    SubtensorModule::add_balance_to_coldkey_account(&coldkey, 1_000_000_000_000_000);
+    assert_ok!(SubtensorModule::root_register(signer.clone(), hotkey));
+    assert_ok!(SubtensorModule::register_network(signer.clone(), hotkey));
+
+    (netuid, hotkey, coldkey, signer)
+}
+
+/// Sets up a basic network environment for consensus testing
+/// Creates network and enables liquid alpha
+fn setup_consensus_test_environment(netuid: NetUid) {
+    add_network(netuid, 0, 0);
+    SubtensorModule::set_liquid_alpha_enabled(netuid, true);
+}
+
+/// Creates test consensus data and stores it in the system
+/// Returns (current_consensus, previous_values)
+fn create_test_consensus_data(netuid: NetUid) -> (Vec<I32F32>, Vec<f32>) {
+    let current_consensus: Vec<I32F32> = vec![
+        I32F32::from_num(0.2),
+        I32F32::from_num(0.3),
+        I32F32::from_num(0.4),
+        I32F32::from_num(0.1),
+    ];
+
+    let previous_values: Vec<f32> = vec![0.1, 0.2, 0.3, 0.4];
+    let previous_consensus_u16: Vec<u16> = previous_values
+        .iter()
+        .map(|&v| fixed_proportion_to_u16(fixed(v)))
+        .collect();
+    Consensus::<Test>::insert(netuid, previous_consensus_u16);
+
+    (current_consensus, previous_values)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+/// Test setting consensus mode when liquid alpha is disabled
+#[test]
+fn test_set_consensus_mode_liquid_alpha_disabled() {
+    new_test_ext(1).execute_with(|| {
+        let (netuid, _hotkey, _coldkey, signer) = setup_network_with_owner();
+
+        // Liquid Alpha is disabled by default
+        assert!(!SubtensorModule::get_liquid_alpha_enabled(netuid));
+
+        // Should succeed to set consensus mode even when liquid alpha is disabled
+        assert_ok!(SubtensorModule::do_set_liquid_alpha_consensus_mode(
+            signer.clone(),
+            netuid,
+            ConsensusMode::Previous
+        ));
+
+        // Verify the mode was set
+        assert_eq!(
+            SubtensorModule::get_liquid_alpha_consensus_mode(netuid),
+            ConsensusMode::Previous
+        );
+
+        // Also verify with liquid alpha enabled
+        SubtensorModule::set_liquid_alpha_enabled(netuid, true);
+
+        // Should still succeed
+        assert_ok!(SubtensorModule::do_set_liquid_alpha_consensus_mode(
+            signer.clone(),
+            netuid,
+            ConsensusMode::Current
+        ));
+
+        // Verify the mode was updated
+        assert_eq!(
+            SubtensorModule::get_liquid_alpha_consensus_mode(netuid),
+            ConsensusMode::Current
+        );
+    });
+}
+
+/// Test that only subnet owner or root can set consensus mode
+#[test]
+fn test_set_consensus_mode_permissions() {
+    new_test_ext(1).execute_with(|| {
+        let (netuid, _hotkey, _coldkey, owner_signer) = setup_network_with_owner();
+        let non_owner = U256::from(999);
+        let non_owner_signer = RuntimeOrigin::signed(non_owner);
+
+        // Non-owner should fail
+        assert_err!(
+            SubtensorModule::do_set_liquid_alpha_consensus_mode(
+                non_owner_signer,
+                netuid,
+                ConsensusMode::Previous
+            ),
+            DispatchError::BadOrigin
+        );
+
+        // Owner should succeed
+        assert_ok!(SubtensorModule::do_set_liquid_alpha_consensus_mode(
+            owner_signer,
+            netuid,
+            ConsensusMode::Previous
+        ));
+    });
+}
+
+/// Test setting and getting all consensus modes
+#[test]
+fn test_set_and_get_consensus_modes() {
+    new_test_ext(1).execute_with(|| {
+        let (netuid, _hotkey, _coldkey, signer) = setup_network_with_owner();
+
+        // Test Current mode
+        assert_ok!(SubtensorModule::do_set_liquid_alpha_consensus_mode(
+            signer.clone(),
+            netuid,
+            ConsensusMode::Current
+        ));
+        assert_eq!(
+            SubtensorModule::get_liquid_alpha_consensus_mode(netuid),
+            ConsensusMode::Current
+        );
+
+        // Test Previous mode
+        assert_ok!(SubtensorModule::do_set_liquid_alpha_consensus_mode(
+            signer.clone(),
+            netuid,
+            ConsensusMode::Previous
+        ));
+        assert_eq!(
+            SubtensorModule::get_liquid_alpha_consensus_mode(netuid),
+            ConsensusMode::Previous
+        );
+
+        // Test Auto mode
+        assert_ok!(SubtensorModule::do_set_liquid_alpha_consensus_mode(
+            signer.clone(),
+            netuid,
+            ConsensusMode::Auto
+        ));
+        assert_eq!(
+            SubtensorModule::get_liquid_alpha_consensus_mode(netuid),
+            ConsensusMode::Auto
+        );
+    });
+}
+
+/// Test compute_consensus_for_liquid_alpha with Current mode
+#[test]
+fn test_compute_consensus_current_mode() {
+    new_test_ext(1).execute_with(|| {
+        let netuid: NetUid = 1.into();
+        let n: usize = 4;
+
+        // Setup network and test data
+        setup_consensus_test_environment(netuid);
+        SubtensorModule::set_liquid_alpha_consensus_mode(netuid, ConsensusMode::Current);
+        let (current_consensus, _previous_values) = create_test_consensus_data(netuid);
+
+        // Compute consensus for liquid alpha
+        let result =
+            SubtensorModule::compute_consensus_for_liquid_alpha(netuid, &current_consensus);
+
+        // Should return current consensus (not previous)
+        assert_eq!(result.len(), n);
+        for (res, curr) in result.iter().zip(current_consensus.iter()) {
+            assert_eq!(res, curr);
+        }
+    });
+}
+
+/// Test compute_consensus_for_liquid_alpha with Previous mode
+#[test]
+fn test_compute_consensus_previous_mode() {
+    new_test_ext(1).execute_with(|| {
+        let netuid: NetUid = 1.into();
+        let n: usize = 4;
+
+        // Setup network and test data
+        setup_consensus_test_environment(netuid);
+        SubtensorModule::set_liquid_alpha_consensus_mode(netuid, ConsensusMode::Previous);
+        let (current_consensus, previous_values) = create_test_consensus_data(netuid);
+
+        // Compute consensus for liquid alpha
+        let result =
+            SubtensorModule::compute_consensus_for_liquid_alpha(netuid, &current_consensus);
+
+        // Should return previous consensus from storage (not current)
+        assert_eq!(result.len(), n);
+        for (res, &prev) in result.iter().zip(previous_values.iter()) {
+            let expected = I32F32::from_num(prev);
+            // Allow small floating point difference
+            let diff = if *res > expected {
+                res.saturating_sub(expected)
+            } else {
+                expected.saturating_sub(*res)
+            };
+            assert!(
+                diff < I32F32::from_num(0.001),
+                "Values should be approximately equal"
+            );
+        }
+    });
+}
+
+/// Test compute_consensus_for_liquid_alpha with Auto mode
+#[test]
+fn test_compute_consensus_auto_mode() {
+    new_test_ext(1).execute_with(|| {
+        let netuid: NetUid = 1.into();
+        let n: usize = 4;
+
+        // Setup network and test data
+        setup_consensus_test_environment(netuid);
+        SubtensorModule::set_liquid_alpha_consensus_mode(netuid, ConsensusMode::Auto);
+        let (current_consensus, previous_values) = create_test_consensus_data(netuid);
+
+        // Test 1: bond_penalty != 1, should use Current
+        SubtensorModule::set_bonds_penalty(netuid, u16::MAX.saturating_div(2)); // 0.5
+        let result =
+            SubtensorModule::compute_consensus_for_liquid_alpha(netuid, &current_consensus);
+
+        assert_eq!(result.len(), n);
+        for (res, curr) in result.iter().zip(current_consensus.iter()) {
+            assert_eq!(
+                res, curr,
+                "Should use current consensus when bond_penalty != 1"
+            );
+        }
+
+        // Test 2: bond_penalty == 1, should use Previous
+        SubtensorModule::set_bonds_penalty(netuid, u16::MAX); // 1.0
+        let result =
+            SubtensorModule::compute_consensus_for_liquid_alpha(netuid, &current_consensus);
+
+        assert_eq!(result.len(), n);
+        for (res, &prev) in result.iter().zip(previous_values.iter()) {
+            let expected = I32F32::from_num(prev);
+            let diff = if *res > expected {
+                res.saturating_sub(expected)
+            } else {
+                expected.saturating_sub(*res)
+            };
+            assert!(
+                diff < I32F32::from_num(0.001),
+                "Should use previous consensus when bond_penalty == 1"
+            );
+        }
+    });
+}

--- a/pallets/subtensor/src/tests/consensus_mode.rs
+++ b/pallets/subtensor/src/tests/consensus_mode.rs
@@ -237,7 +237,7 @@ fn test_compute_consensus_auto_mode() {
         let (current_consensus, previous_values) = create_test_consensus_data(netuid);
 
         // Test 1: bond_penalty != 1, should use Current
-        SubtensorModule::set_bonds_penalty(netuid, u16::MAX.saturating_div(2)); // 0.5
+        SubtensorModule::set_bonds_penalty(netuid, u16::MAX.saturating_div(2)); // ~0.4999847 (any value != 1.0 triggers Current)
         let result =
             SubtensorModule::compute_consensus_for_liquid_alpha(netuid, &current_consensus);
 

--- a/pallets/subtensor/src/tests/consensus_mode.rs
+++ b/pallets/subtensor/src/tests/consensus_mode.rs
@@ -20,7 +20,7 @@ fn setup_network_with_owner() -> (NetUid, U256, U256, RuntimeOrigin) {
     let signer = RuntimeOrigin::signed(coldkey);
 
     migrations::migrate_create_root_network::migrate_create_root_network::<Test>();
-    SubtensorModule::add_balance_to_coldkey_account(&coldkey, 1_000_000_000_000_000);
+    SubtensorModule::add_balance_to_coldkey_account(&coldkey, 1_000_000_000_000_000_u64.into());
     assert_ok!(SubtensorModule::root_register(signer.clone(), hotkey));
     assert_ok!(SubtensorModule::register_network(signer.clone(), hotkey));
 

--- a/pallets/subtensor/src/tests/epoch.rs
+++ b/pallets/subtensor/src/tests/epoch.rs
@@ -3617,6 +3617,70 @@ fn test_liquid_alpha_equal_values_against_itself() {
     });
 }
 
+/// Integration test: compute_bonds routes through compute_consensus_for_liquid_alpha
+/// and picks up the stored previous consensus when mode is Previous or Auto (bond_penalty==MAX).
+#[test]
+fn test_compute_bonds_uses_previous_consensus_mode() {
+    new_test_ext(1).execute_with(|| {
+        let netuid: NetUid = NetUid::from(2);
+        let weights: Vec<Vec<I32F32>> = vec_to_mat_fixed(
+            &[0., 0.1, 0., 0., 0.2, 0.4, 0., 0.3, 0.1, 0., 0.4, 0.5],
+            4,
+            false,
+        );
+        let bonds: Vec<Vec<I32F32>> = vec_to_mat_fixed(
+            &[0.1, 0.1, 0.5, 0., 0., 0.4, 0.5, 0.1, 0.1, 0., 0.4, 0.2],
+            4,
+            false,
+        );
+        let current_consensus: Vec<I32F32> = vec_to_fixed(&[0.3, 0.2, 0.1, 0.4]);
+        let previous_consensus_u16: Vec<u16> = vec![6553, 13107, 19660, 26214]; // ~0.1, 0.2, 0.3, 0.4
+
+        AlphaValues::<Test>::insert(netuid, (u16::MAX / 10, u16::MAX / 2));
+        SubtensorModule::set_liquid_alpha_enabled(netuid.into(), true);
+
+        // Seed storage-based previous consensus
+        Consensus::<Test>::insert(netuid, previous_consensus_u16);
+
+        // Current mode: should use current_consensus
+        SubtensorModule::set_liquid_alpha_consensus_mode(netuid.into(), ConsensusMode::Current);
+        let bonds_current_mode =
+            SubtensorModule::compute_bonds(netuid.into(), &weights, &bonds, &current_consensus);
+
+        // Previous mode: should use stored previous_consensus (different from current)
+        SubtensorModule::set_liquid_alpha_consensus_mode(netuid.into(), ConsensusMode::Previous);
+        let bonds_previous_mode =
+            SubtensorModule::compute_bonds(netuid.into(), &weights, &bonds, &current_consensus);
+
+        // The two results must differ since current != previous consensus
+        assert_ne!(
+            bonds_current_mode, bonds_previous_mode,
+            "Previous mode should produce different bonds than Current mode"
+        );
+
+        // Auto mode with bond_penalty == u16::MAX should behave like Previous
+        SubtensorModule::set_liquid_alpha_consensus_mode(netuid.into(), ConsensusMode::Auto);
+        SubtensorModule::set_bonds_penalty(netuid.into(), u16::MAX);
+        let bonds_auto_max_penalty =
+            SubtensorModule::compute_bonds(netuid.into(), &weights, &bonds, &current_consensus);
+
+        assert_eq!(
+            bonds_previous_mode, bonds_auto_max_penalty,
+            "Auto mode with bond_penalty==u16::MAX should equal Previous mode"
+        );
+
+        // Auto mode with bond_penalty < u16::MAX should behave like Current
+        SubtensorModule::set_bonds_penalty(netuid.into(), u16::MAX.saturating_div(2));
+        let bonds_auto_half_penalty =
+            SubtensorModule::compute_bonds(netuid.into(), &weights, &bonds, &current_consensus);
+
+        assert_eq!(
+            bonds_current_mode, bonds_auto_half_penalty,
+            "Auto mode with bond_penalty<u16::MAX should equal Current mode"
+        );
+    });
+}
+
 #[test]
 fn test_epoch_masks_incoming_to_sniped_uid_prevents_inheritance() {
     new_test_ext(1).execute_with(|| {

--- a/pallets/subtensor/src/tests/epoch.rs
+++ b/pallets/subtensor/src/tests/epoch.rs
@@ -3599,6 +3599,8 @@ fn test_liquid_alpha_equal_values_against_itself() {
 
         // compute bonds with liquid alpha enabled
         SubtensorModule::set_liquid_alpha_enabled(netuid.into(), true);
+        // Set consensus mode to Current to match the original behavior (using in-memory consensus)
+        SubtensorModule::set_liquid_alpha_consensus_mode(netuid.into(), ConsensusMode::Current);
         let new_bonds_liquid_alpha_on =
             SubtensorModule::compute_bonds(netuid.into(), &weights, &bonds, &consensus);
 

--- a/pallets/subtensor/src/tests/mod.rs
+++ b/pallets/subtensor/src/tests/mod.rs
@@ -4,6 +4,7 @@ mod children;
 mod claim_root;
 mod coinbase;
 mod consensus;
+mod consensus_mode;
 mod delegate_info;
 mod emission;
 mod ensure;

--- a/pallets/subtensor/src/utils/misc.rs
+++ b/pallets/subtensor/src/utils/misc.rs
@@ -776,6 +776,14 @@ impl<T: Config> Pallet<T> {
         (converted_low, converted_high)
     }
 
+    pub fn get_liquid_alpha_consensus_mode(netuid: NetUid) -> ConsensusMode {
+        LiquidAlphaConsensusMode::<T>::get(netuid)
+    }
+
+    pub fn set_liquid_alpha_consensus_mode(netuid: NetUid, mode: ConsensusMode) {
+        LiquidAlphaConsensusMode::<T>::insert(netuid, mode);
+    }
+
     pub fn set_alpha_sigmoid_steepness(netuid: NetUid, steepness: i16) {
         AlphaSigmoidSteepness::<T>::insert(netuid, steepness);
     }

--- a/pallets/subtensor/src/utils/rate_limiting.rs
+++ b/pallets/subtensor/src/utils/rate_limiting.rs
@@ -204,6 +204,7 @@ pub enum Hyperparameter {
     MaxAllowedUids = 25,
     BurnHalfLife = 26,
     BurnIncreaseMult = 27,
+    LiquidAlphaConsensusMode = 28,
 }
 
 impl<T: Config> Pallet<T> {


### PR DESCRIPTION
## Summary

Introduces a `ConsensusMode` enum and per-subnet storage to allow subnet owners to control which consensus values are used when computing liquid alpha bonding matrices.

### Motivation

The liquid alpha mechanism uses consensus values to compute per-validator-miner bonding alphas. Previously, only the current in-memory (just-computed) consensus was used. This change adds flexibility to use the previous epoch's consensus from storage, which provides more stable bonding behavior particularly when `bond_penalty == 1`.

### Changes

- **New `ConsensusMode` enum** (`Current`, `Previous`, `Auto`) with `Auto` as the default:
  - `Current`: use the freshly-computed in-memory consensus (existing behavior)
  - `Previous`: use the previous epoch's consensus stored in `Consensus<T>` storage, normalized from u16 to I32F32
  - `Auto`: use `Previous` when `bonds_penalty == 1`, otherwise `Current`
- **New storage map** `LiquidAlphaConsensusMode<T>` (per-netuid, default: `Auto`)
- **New extrinsic helper** `do_set_liquid_alpha_consensus_mode` (callable by subnet owner or root)
- **New utility functions** `get/set_liquid_alpha_consensus_mode` and `compute_consensus_for_liquid_alpha`
- **Updated epoch logic**: both dense and sparse bond computation paths now call `compute_consensus_for_liquid_alpha` to select the appropriate consensus vector before passing it to `compute_liquid_alpha_values[_sparse]`
- **New test module** `consensus_mode` with full coverage of all three modes, permission checks, and edge cases

## Test plan

- [ ] `test_set_consensus_mode_liquid_alpha_disabled` — can set mode regardless of liquid alpha enable state
- [ ] `test_set_consensus_mode_permissions` — non-owner is rejected, owner succeeds
- [ ] `test_set_and_get_consensus_modes` — round-trip for all three variants
- [ ] `test_compute_consensus_current_mode` — returns current in-memory consensus
- [ ] `test_compute_consensus_previous_mode` — returns normalized previous-epoch consensus from storage
- [ ] `test_compute_consensus_auto_mode` — returns current when bond_penalty ≠ 1, previous when bond_penalty == 1
- [ ] Existing epoch test `test_liquid_alpha_equal_values_against_itself` updated to set `ConsensusMode::Current` to preserve original behavior