### PR TITLE
Add AutoParentDelegationEnabled flag to toggle auto parent delegation

### DIFF
--- a/.github/workflows/typescript-e2e.yml
+++ b/.github/workflows/typescript-e2e.yml
@@ -105,6 +105,8 @@ jobs:
             binary: fast
           - test: zombienet_coldkey_swap
             binary: fast
+          - test: zombienet_subnets
+            binary: fast
 
     name: "typescript-e2e-${{ matrix.test }}"
 

--- a/pallets/subtensor/src/benchmarks.rs
+++ b/pallets/subtensor/src/benchmarks.rs
@@ -1866,6 +1866,26 @@ mod pallet_benchmarks {
     }
 
     #[benchmark]
+    fn set_auto_parent_delegation_enabled() {
+        let seed: u32 = 1;
+        let coldkey: T::AccountId = account("Test", 0, seed);
+        let hotkey: T::AccountId = account("Alice", 0, seed);
+
+        Subtensor::<T>::init_new_network(NetUid::ROOT, 1);
+        Subtensor::<T>::set_network_registration_allowed(NetUid::ROOT, true);
+        FirstEmissionBlockNumber::<T>::insert(NetUid::ROOT, 1);
+        SubtokenEnabled::<T>::insert(NetUid::ROOT, true);
+
+        let _ = Subtensor::<T>::do_root_register(
+            RawOrigin::Signed(coldkey.clone()).into(),
+            hotkey.clone(),
+        );
+
+        #[extrinsic_call]
+        _(RawOrigin::Signed(coldkey.clone()), hotkey, true);
+    }
+
+    #[benchmark]
     fn add_stake_burn() {
         let netuid = NetUid::from(1);
         let tempo: u16 = 1;

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1092,6 +1092,12 @@ pub mod pallet {
         10u16
     }
 
+    /// Default value for AutoParentDelegationEnabled.
+    #[pallet::type_value]
+    pub fn DefaultAutoParentDelegationEnabled<T: Config>() -> bool {
+        true
+    }
+
     #[pallet::storage]
     pub type MinActivityCutoff<T: Config> =
         StorageValue<_, u16, ValueQuery, DefaultMinActivityCutoff<T>>;
@@ -2453,6 +2459,21 @@ pub mod pallet {
     #[pallet::storage]
     pub type BurnIncreaseMult<T> =
         StorageMap<_, Identity, NetUid, U64F64, ValueQuery, DefaultBurnIncreaseMult<T>>;
+
+    /// --- MAP ( hotkey ) --> parent_delegation_enabled
+    ///
+    /// When `true`, this root validator allows auto parent delegation.
+    /// Defaults to `true`; validators can opt out at any time
+    /// by calling `set_auto_parent_delegation_enabled(false)`.
+    #[pallet::storage]
+    pub type AutoParentDelegationEnabled<T: Config> = StorageMap<
+        _,
+        Blake2_128Concat,
+        T::AccountId,
+        bool,
+        ValueQuery,
+        DefaultAutoParentDelegationEnabled<T>, // default = true
+    >;
 
     /// ==================
     /// ==== Genesis =====

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2510,13 +2510,7 @@ mod dispatches {
         /// --- Allows a root validator to toggle auto parent delegation
         /// for new subnets owner hotkey
         #[pallet::call_index(135)]
-        #[pallet::weight((
-            Weight::from_parts(21_000_000, 0)
-                .saturating_add(T::DbWeight::get().reads(1_u64))
-                .saturating_add(T::DbWeight::get().writes(1_u64)),
-            DispatchClass::Normal,
-            Pays::Yes
-        ))]
+        #[pallet::weight((<T as crate::pallet::Config>::WeightInfo::set_auto_parent_delegation_enabled(), DispatchClass::Normal, Pays::Yes))]
         pub fn set_auto_parent_delegation_enabled(
             origin: OriginFor<T>,
             hotkey: T::AccountId,

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2512,16 +2512,22 @@ mod dispatches {
         #[pallet::call_index(135)]
         #[pallet::weight((
             Weight::from_parts(21_000_000, 0)
-                .saturating_add(T::DbWeight::get().reads(3_u64))
+                .saturating_add(T::DbWeight::get().reads(1_u64))
                 .saturating_add(T::DbWeight::get().writes(1_u64)),
             DispatchClass::Normal,
             Pays::Yes
         ))]
         pub fn set_auto_parent_delegation_enabled(
             origin: OriginFor<T>,
+            hotkey: T::AccountId,
             enabled: bool,
         ) -> DispatchResult {
-            let hotkey = ensure_signed(origin)?;
+            let coldkey = ensure_signed(origin)?;
+
+            ensure!(
+                Self::coldkey_owns_hotkey(&coldkey, &hotkey),
+                Error::<T>::NonAssociatedColdKey
+            );
 
             ensure!(
                 Self::is_hotkey_registered_on_network(NetUid::ROOT, &hotkey),

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2506,5 +2506,32 @@ mod dispatches {
         ) -> DispatchResult {
             Self::do_register_limit(origin, netuid, hotkey, limit_price)
         }
+
+        /// --- Allows a root validator to toggle auto parent delegation
+        /// for new subnets owner hotkey
+        #[pallet::call_index(135)]
+        #[pallet::weight((
+            Weight::from_parts(21_000_000, 0)
+                .saturating_add(T::DbWeight::get().reads(3_u64))
+                .saturating_add(T::DbWeight::get().writes(1_u64)),
+            DispatchClass::Normal,
+            Pays::Yes
+        ))]
+        pub fn set_auto_parent_delegation_enabled(
+            origin: OriginFor<T>,
+            enabled: bool,
+        ) -> DispatchResult {
+            let hotkey = ensure_signed(origin)?;
+
+            ensure!(
+                Self::is_hotkey_registered_on_network(NetUid::ROOT, &hotkey),
+                Error::<T>::HotKeyNotRegisteredInSubNet
+            );
+
+            AutoParentDelegationEnabled::<T>::insert(&hotkey, enabled);
+
+            Self::deposit_event(Event::AutoParentDelegationEnabledSet { hotkey, enabled });
+            Ok(())
+        }
     }
 }

--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -562,5 +562,13 @@ mod events {
             /// The burn increase multiplier value for neuron registration.
             burn_increase_mult: u64,
         },
+
+        /// A root validator toggled the "auto parent delegation" flag.
+        AutoParentDelegationEnabledSet {
+            /// The validator hotkey.
+            hotkey: T::AccountId,
+            /// Whether delegation is now enabled.
+            enabled: bool,
+        },
     }
 }

--- a/pallets/subtensor/src/staking/set_children.rs
+++ b/pallets/subtensor/src/staking/set_children.rs
@@ -792,6 +792,10 @@ impl<T: Config> Pallet<T> {
         ChildkeyTake::<T>::get(hotkey, netuid)
     }
 
+    pub fn get_auto_parent_delegation_enabled(root_validator_hotkey: &T::AccountId) -> bool {
+        AutoParentDelegationEnabled::<T>::get(root_validator_hotkey)
+    }
+
     ////////////////////////////////////////////////////////////
     // State cleaners (for use in migration)
     // TODO: Deprecate when the state is clean for a while
@@ -829,6 +833,11 @@ impl<T: Config> Pallet<T> {
             // Skip if the root validator is the subnet owner hotkey itself
             // (cannot be both parent and child).
             if root_validator_hotkey == subnet_owner_hotkey {
+                continue;
+            }
+
+            // Skip if root validator disabled auto parent delegation via AutoParentDelegationEnabled flag
+            if !Self::get_auto_parent_delegation_enabled(&root_validator_hotkey) {
                 continue;
             }
 

--- a/pallets/subtensor/src/tests/children.rs
+++ b/pallets/subtensor/src/tests/children.rs
@@ -4580,7 +4580,8 @@ fn test_register_network_schedules_root_validators_auto_parent_delegation_flag()
         });
 
         assert_ok!(SubtensorModule::set_auto_parent_delegation_enabled(
-            RuntimeOrigin::signed(root_val_hotkey_1),
+            RuntimeOrigin::signed(root_val_coldkey_1),
+            root_val_hotkey_1,
             false,
         ));
 

--- a/pallets/subtensor/src/tests/children.rs
+++ b/pallets/subtensor/src/tests/children.rs
@@ -4514,3 +4514,132 @@ fn test_register_network_schedules_root_validators() {
         ));
     });
 }
+
+// Test that register_network automatically sets root validators as parents of the
+// subnet owner, only if AutoParentDelegationEnabled is enabled (default).
+// SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --package pallet-subtensor --lib -- tests::children::test_register_network_schedules_root_validators_auto_parent_delegation_flag --exact --show-output --nocapture
+#[test]
+fn test_register_network_schedules_root_validators_auto_parent_delegation_flag() {
+    new_test_ext(1).execute_with(|| {
+        // --- Setup root network and root validators ---
+        let root_val_coldkey_1 = U256::from(100);
+        let root_val_hotkey_1 = U256::from(101);
+        let root_val_coldkey_2 = U256::from(200);
+        let root_val_hotkey_2 = U256::from(201);
+
+        add_network(NetUid::ROOT, 1, 0);
+
+        // Root validators need to be registered on some subnet before root_register.
+        // Create a bootstrap subnet for that purpose.
+        let bootstrap_netuid = NetUid::from(1);
+        add_network(bootstrap_netuid, 1, 0);
+        register_ok_neuron(bootstrap_netuid, root_val_hotkey_1, root_val_coldkey_1, 0);
+        register_ok_neuron(bootstrap_netuid, root_val_hotkey_2, root_val_coldkey_2, 0);
+
+        assert_ok!(SubtensorModule::root_register(
+            RuntimeOrigin::signed(root_val_coldkey_1),
+            root_val_hotkey_1,
+        ));
+        assert_ok!(SubtensorModule::root_register(
+            RuntimeOrigin::signed(root_val_coldkey_2),
+            root_val_hotkey_2,
+        ));
+
+        // Give root validators significant stake on root and bootstrap subnet
+        let root_stake = AlphaBalance::from(1_000_000_000);
+        SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &root_val_hotkey_1,
+            &root_val_coldkey_1,
+            NetUid::ROOT,
+            root_stake,
+        );
+        SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &root_val_hotkey_2,
+            &root_val_coldkey_2,
+            NetUid::ROOT,
+            root_stake,
+        );
+
+        // --- Minimize cooldown so pending children activate quickly ---
+        assert_ok!(SubtensorModule::set_pending_childkey_cooldown(
+            RuntimeOrigin::root(),
+            0,
+        ));
+
+        // --- Set a high stake threshold ---
+        let high_threshold = 500_000_000u64;
+        SubtensorModule::set_stake_threshold(high_threshold);
+
+        // --- Register a new subnet (this should automatically call do_set_root_validators_for_subnet) ---
+        let subnet_owner_coldkey = U256::from(1001);
+        let subnet_owner_hotkey = U256::from(1002);
+        let lock_cost = SubtensorModule::get_network_lock_cost();
+        SubtensorModule::add_balance_to_coldkey_account(&subnet_owner_coldkey, lock_cost.into());
+        TotalIssuance::<Test>::mutate(|total| {
+            *total = total.saturating_add(lock_cost);
+        });
+
+        assert_ok!(SubtensorModule::set_auto_parent_delegation_enabled(
+            RuntimeOrigin::signed(root_val_hotkey_1),
+            false,
+        ));
+
+        assert_ok!(SubtensorModule::register_network(
+            RuntimeOrigin::signed(subnet_owner_coldkey),
+            subnet_owner_hotkey,
+        ));
+
+        // Determine the netuid that was just created
+        let netuid: NetUid = (TotalNetworks::<Test>::get().saturating_sub(1)).into();
+        assert_eq!(
+            SubnetOwnerHotkey::<Test>::get(netuid),
+            subnet_owner_hotkey,
+            "Subnet owner hotkey should be set"
+        );
+
+        // Root validators need stake on the new subnet for child stake inheritance to work
+        SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &root_val_hotkey_1,
+            &root_val_coldkey_1,
+            netuid,
+            root_stake,
+        );
+        SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &root_val_hotkey_2,
+            &root_val_coldkey_2,
+            netuid,
+            root_stake,
+        );
+
+        // --- Verify child keys were applied immediately (SubtokenEnabled is false for new subnets) ---
+        let children_1 = SubtensorModule::get_children(&root_val_hotkey_1, netuid);
+        assert_eq!(
+            children_1,
+            vec![],
+            "Root validator 1 not have subnet owner as a child because AutoParentDelegationEnabled is false"
+        );
+        let children_2 = SubtensorModule::get_children(&root_val_hotkey_2, netuid);
+        assert_eq!(
+            children_2,
+            vec![(u64::MAX, subnet_owner_hotkey)],
+            "Root validator 2 should have subnet owner as child"
+        );
+
+        // --- Verify subnet owner can now set weights ---
+        SubtensorModule::set_weights_set_rate_limit(netuid, 0);
+        SubtensorModule::set_commit_reveal_weights_enabled(netuid, false);
+        let version_key = SubtensorModule::get_weights_version_key(netuid);
+
+        assert!(
+            SubtensorModule::check_weights_min_stake(&subnet_owner_hotkey, netuid),
+            "Subnet owner should have enough inherited stake to set weights"
+        );
+        assert_ok!(SubtensorModule::set_weights(
+            RuntimeOrigin::signed(subnet_owner_hotkey),
+            netuid,
+            vec![0],
+            vec![u16::MAX],
+            version_key
+        ));
+    });
+}

--- a/pallets/subtensor/src/weights.rs
+++ b/pallets/subtensor/src/weights.rs
@@ -88,6 +88,7 @@ pub trait WeightInfo {
 	fn sudo_set_root_claim_threshold() -> Weight;
 	fn add_stake_burn() -> Weight;
 	fn set_pending_childkey_cooldown() -> Weight;
+    fn set_auto_parent_delegation_enabled() -> Weight;
 }
 
 /// Weights for `pallet_subtensor` using the Substrate node and recommended hardware.
@@ -2191,6 +2192,22 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		Weight::from_parts(2_986_000, 0)
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
+
+    /// Storage: `SubtensorModule::Owner` (r:1 w:0)
+    /// Proof: `SubtensorModule::Owner` (`max_values`: None, `max_size`: None, mode: `Measured`)
+    /// Storage: `SubtensorModule::Uids` (r:1 w:0)
+    /// Proof: `SubtensorModule::Uids` (`max_values`: None, `max_size`: None, mode: `Measured`)
+    /// Storage: `SubtensorModule::AutoParentDelegationEnabled` (r:0 w:1)
+    /// Proof: `SubtensorModule::AutoParentDelegationEnabled` (`max_values`: None, `max_size`: None, mode: `Measured`)
+    fn set_auto_parent_delegation_enabled() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `852`
+        //  Estimated: `4317`
+        // Minimum execution time: 19_000_000 picoseconds.
+        Weight::from_parts(20_000_000, 4317)
+            .saturating_add(T::DbWeight::get().reads(2_u64))
+            .saturating_add(T::DbWeight::get().writes(1_u64))
+    }
 }
 
 // For backwards compatibility and tests.
@@ -4293,4 +4310,20 @@ impl WeightInfo for () {
 		Weight::from_parts(2_986_000, 0)
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
+
+    /// Storage: `SubtensorModule::Owner` (r:1 w:0)
+    /// Proof: `SubtensorModule::Owner` (`max_values`: None, `max_size`: None, mode: `Measured`)
+    /// Storage: `SubtensorModule::Uids` (r:1 w:0)
+    /// Proof: `SubtensorModule::Uids` (`max_values`: None, `max_size`: None, mode: `Measured`)
+    /// Storage: `SubtensorModule::AutoParentDelegationEnabled` (r:0 w:1)
+    /// Proof: `SubtensorModule::AutoParentDelegationEnabled` (`max_values`: None, `max_size`: None, mode: `Measured`)
+    fn set_auto_parent_delegation_enabled() -> Weight {
+        // Proof Size summary in bytes:
+        //  Measured:  `852`
+        //  Estimated: `4317`
+        // Minimum execution time: 19_000_000 picoseconds.
+        Weight::from_parts(20_000_000, 4317)
+            .saturating_add(RocksDbWeight::get().reads(2_u64))
+            .saturating_add(RocksDbWeight::get().writes(1_u64))
+    }
 }

--- a/precompiles/src/staking.rs
+++ b/precompiles/src/staking.rs
@@ -43,7 +43,7 @@ use pallet_evm::{
 };
 use pallet_subtensor_proxy as pallet_proxy;
 use precompile_utils::EvmResult;
-use precompile_utils::prelude::{RuntimeHelper, revert, Address};
+use precompile_utils::prelude::{Address, RuntimeHelper, revert};
 use sp_core::{H160, H256, U256};
 use sp_runtime::traits::{AsSystemOriginSigner, Dispatchable, StaticLookup, UniqueSaturatedInto};
 use sp_std::vec;
@@ -63,15 +63,12 @@ impl StorageInstance for AllowancesPrefix {
 
 pub type AllowancesStorage = StorageDoubleMap<
     AllowancesPrefix,
-
     // For each approver (EVM address as only EVM-natives need the precompile)
     Blake2_128Concat,
     H160,
-
     // For each pair of (spender, netuid) (EVM address as only EVM-natives need the precompile)
     Blake2_128Concat,
     (H160, u16),
-
     // Allowed amount
     U256,
     ValueQuery,
@@ -627,20 +624,14 @@ where
         amount_alpha: U256,
     ) -> EvmResult<()> {
         let spender = handle.context().caller;
-		let source_address = source_address.0;
+        let source_address = source_address.0;
         let destination_coldkey = R::AccountId::from(destination_coldkey.0);
         let hotkey = R::AccountId::from(hotkey.0);
         let origin_netuid = try_u16_from_u256(origin_netuid)?;
         let destination_netuid = try_u16_from_u256(destination_netuid)?;
         let alpha_amount: u64 = amount_alpha.unique_saturated_into();
 
-        Self::try_consume_allowance(
-            handle,
-            source_address,
-            spender,
-            origin_netuid,
-            amount_alpha,
-        )?;
+        Self::try_consume_allowance(handle, source_address, spender, origin_netuid, amount_alpha)?;
 
         let call = pallet_subtensor::Call::<R>::transfer_stake {
             destination_coldkey,
@@ -649,7 +640,7 @@ where
             destination_netuid: destination_netuid.into(),
             alpha_amount: alpha_amount.into(),
         };
-		let source_id = <R as pallet_evm::Config>::AddressMapping::into_account_id(source_address);
+        let source_id = <R as pallet_evm::Config>::AddressMapping::into_account_id(source_address);
 
         handle.try_dispatch_runtime_call::<R, _>(call, RawOrigin::Signed(source_id))
     }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -270,7 +270,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 396,
+    spec_version: 397,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/ts-tests/moonwall.config.json
+++ b/ts-tests/moonwall.config.json
@@ -121,6 +121,31 @@
                 }
             ]
         }, {
+            "name": "zombienet_subnets",
+            "timeout": 600000,
+            "testFileDir": ["suites/zombienet_subnets"],
+            "runScripts": [
+                "generate-types.sh",
+                "build-spec.sh"
+            ],
+            "foundation": {
+                "type": "zombie",
+                "zombieSpec": {
+                    "configPath": "./configs/zombie_node.json",
+                    "skipBlockCheck": []
+                }
+            },
+            "vitestArgs": {
+                "bail": 1
+            },
+            "connections": [
+                {
+                    "name": "Node",
+                    "type": "papi",
+                    "endpoints": ["ws://127.0.0.1:9947"]
+                }
+            ]
+        } ,{
             "name": "smoke_mainnet",
             "testFileDir": ["suites/smoke"],
             "foundation": {

--- a/ts-tests/moonwall.config.json
+++ b/ts-tests/moonwall.config.json
@@ -145,7 +145,7 @@
                     "endpoints": ["ws://127.0.0.1:9947"]
                 }
             ]
-        } ,{
+        }, {
             "name": "smoke_mainnet",
             "testFileDir": ["suites/smoke"],
             "foundation": {

--- a/ts-tests/suites/zombienet_subnets/00-register-network.test.ts
+++ b/ts-tests/suites/zombienet_subnets/00-register-network.test.ts
@@ -81,7 +81,7 @@ describeSuite({
                 await addStake(api, rootVal1Coldkey, rootVal1Hotkey.address, 0, stake);
                 await addStake(api, rootVal2Coldkey, rootVal2Hotkey.address, 0, stake);
 
-                await setAutoParentDelegationEnabled(api, rootVal1Hotkey, false);
+                await setAutoParentDelegationEnabled(api, rootVal1Coldkey, rootVal1Hotkey.address, false);
                 log("val1 opted out of auto parent delegation");
 
                 const newNetuid = await addNewSubnetwork(api, subnetOwnerHotkey, subnetOwnerColdkey);

--- a/ts-tests/suites/zombienet_subnets/00-register-network.test.ts
+++ b/ts-tests/suites/zombienet_subnets/00-register-network.test.ts
@@ -1,0 +1,106 @@
+import { beforeAll, expect } from "vitest";
+import { describeSuite } from "@moonwall/cli";
+import { subtensor } from "@polkadot-api/descriptors";
+import type { TypedApi } from "polkadot-api";
+import {
+    addNewSubnetwork,
+    addStake,
+    burnedRegister,
+    forceSetBalance,
+    generateKeyringPair,
+    rootRegister,
+    startCall,
+    sudoSetLockReductionInterval,
+    waitForBlocks,
+} from "../../utils";
+import { sudoSetStakeThreshold } from "../../utils/admin_utils.ts";
+import { getChildren, setAutoParentDelegationEnabled, sudoSetPendingChildKeyCooldown } from "../../utils/children.ts";
+import { Keyring } from "@polkadot/keyring";
+
+describeSuite({
+    id: "00_register_network",
+    title: "▶ register_network extrinsic",
+    foundationMethods: "zombie",
+    testCases: ({ it, context, log }) => {
+        let api: TypedApi<typeof subtensor>;
+
+        beforeAll(async () => {
+            api = context.papi("Node").getTypedApi(subtensor);
+        });
+
+        it({
+            id: "T01",
+            title: "auto-delegation: validator with flag=true gets child, validator with flag=false does not",
+            test: async () => {
+                const keyring = new Keyring({ type: "sr25519" });
+                const rootSubnetOwner = keyring.addFromUri("//Alice");
+
+                const rootVal1Coldkey = generateKeyringPair("sr25519"); // will opt-OUT
+                const rootVal1Hotkey = generateKeyringPair("sr25519");
+                const rootVal2Coldkey = generateKeyringPair("sr25519"); // default opt-IN
+                const rootVal2Hotkey = generateKeyringPair("sr25519");
+                const subnetOwnerColdkey = generateKeyringPair("sr25519");
+                const subnetOwnerHotkey = generateKeyringPair("sr25519");
+
+                log(`rootVal1Coldkey: ${rootVal1Coldkey.address}`);
+                log(`rootVal1Hotkey: ${rootVal1Hotkey.address}`);
+                log(`rootVal2Coldkey: ${rootVal2Coldkey.address}`);
+                log(`rootVal2Hotkey: ${rootVal2Hotkey.address}`);
+                log(`subnetOwnerColdkey: ${subnetOwnerColdkey.address}`);
+                log(`subnetOwnerHotkey: ${subnetOwnerHotkey.address}`);
+
+                await sudoSetLockReductionInterval(api, 1);
+
+                for (const addr of [
+                    rootVal1Coldkey.address,
+                    rootVal1Hotkey.address,
+                    rootVal2Coldkey.address,
+                    rootVal2Hotkey.address,
+                    subnetOwnerColdkey.address,
+                    subnetOwnerHotkey.address,
+                ]) {
+                    await forceSetBalance(api, addr);
+                }
+
+                await sudoSetPendingChildKeyCooldown(api, 0n);
+
+                await sudoSetStakeThreshold(api, 0n);
+
+                const bootstrapNetuid = await addNewSubnetwork(api, rootVal1Hotkey, rootVal1Coldkey);
+                log(`Bootstrap netuid: ${bootstrapNetuid}`);
+
+                await rootRegister(api, rootVal1Coldkey, rootVal1Hotkey.address);
+
+                await startCall(api, 0, rootSubnetOwner);
+
+                await burnedRegister(api, bootstrapNetuid, rootVal2Hotkey.address, rootVal2Coldkey);
+
+                await rootRegister(api, rootVal2Coldkey, rootVal2Hotkey.address);
+
+                const stake = 1_000_000_000n;
+                await addStake(api, rootVal1Coldkey, rootVal1Hotkey.address, 0, stake);
+                await addStake(api, rootVal2Coldkey, rootVal2Hotkey.address, 0, stake);
+
+                await setAutoParentDelegationEnabled(api, rootVal1Hotkey, false);
+                log("val1 opted out of auto parent delegation");
+
+                const newNetuid = await addNewSubnetwork(api, subnetOwnerHotkey, subnetOwnerColdkey);
+                log(`New subnet netuid: ${newNetuid}`);
+
+                await waitForBlocks(api, 2);
+
+                const children1 = await getChildren(api, rootVal1Hotkey.address, newNetuid);
+                expect(children1.length, "val1 opted out — should have no children on the new subnet").toBe(0);
+
+                const children2 = await getChildren(api, rootVal2Hotkey.address, newNetuid);
+                expect(children2.length, "val2 did not opt out — should have exactly one child").toBe(1);
+                expect(children2[0].child, "val2's child should be the subnet owner hotkey").toBe(
+                    subnetOwnerHotkey.address
+                );
+                expect(children2[0].proportion, "proportion should be u64::MAX").toBe(18446744073709551615n); // u64::MAX
+
+                log("✅ Auto parent delegation flag correctly controls child assignment on subnet registration.");
+            },
+        });
+    },
+});

--- a/ts-tests/utils/admin_utils.ts
+++ b/ts-tests/utils/admin_utils.ts
@@ -1,0 +1,12 @@
+import { Keyring } from "@polkadot/keyring";
+import { waitForTransactionWithRetry } from "./transactions.js";
+import type { TypedApi } from "polkadot-api";
+import type { subtensor } from "@polkadot-api/descriptors";
+
+export async function sudoSetStakeThreshold(api: TypedApi<typeof subtensor>, threshold: bigint): Promise<void> {
+    const keyring = new Keyring({ type: "sr25519" });
+    const alice = keyring.addFromUri("//Alice");
+    const inner = api.tx.AdminUtils.sudo_set_stake_threshold({ min_stake: threshold });
+    const tx = api.tx.Sudo.sudo({ call: inner.decodedCall });
+    await waitForTransactionWithRetry(api, tx, alice, "sudo_set_stake_threshold");
+}

--- a/ts-tests/utils/children.ts
+++ b/ts-tests/utils/children.ts
@@ -6,11 +6,12 @@ import { Keyring } from "@polkadot/keyring";
 
 export async function setAutoParentDelegationEnabled(
     api: TypedApi<typeof subtensor>,
-    hotkey: KeyringPair,
+    coldkey: KeyringPair,
+    hotkey: string,
     enabled: boolean
 ): Promise<void> {
-    const tx = api.tx.SubtensorModule.set_auto_parent_delegation_enabled({ enabled });
-    await waitForTransactionWithRetry(api, tx, hotkey, "set_auto_parent_delegation_enabled");
+    const tx = api.tx.SubtensorModule.set_auto_parent_delegation_enabled({ hotkey, enabled });
+    await waitForTransactionWithRetry(api, tx, coldkey, "set_auto_parent_delegation_enabled");
 }
 
 export async function getChildren(

--- a/ts-tests/utils/children.ts
+++ b/ts-tests/utils/children.ts
@@ -1,0 +1,31 @@
+import { waitForTransactionWithRetry } from "./transactions.js";
+import type { TypedApi } from "polkadot-api";
+import type { subtensor } from "@polkadot-api/descriptors";
+import type { KeyringPair } from "@moonwall/util";
+import { Keyring } from "@polkadot/keyring";
+
+export async function setAutoParentDelegationEnabled(
+    api: TypedApi<typeof subtensor>,
+    hotkey: KeyringPair,
+    enabled: boolean
+): Promise<void> {
+    const tx = api.tx.SubtensorModule.set_auto_parent_delegation_enabled({ enabled });
+    await waitForTransactionWithRetry(api, tx, hotkey, "set_auto_parent_delegation_enabled");
+}
+
+export async function getChildren(
+    api: TypedApi<typeof subtensor>,
+    hotkeyAddress: string,
+    netuid: number
+): Promise<Array<{ proportion: bigint; child: string }>> {
+    const raw = await api.query.SubtensorModule.ChildKeys.getValue(hotkeyAddress, netuid);
+    return (raw ?? []).map(([proportion, child]: [bigint, string]) => ({ proportion, child }));
+}
+
+export async function sudoSetPendingChildKeyCooldown(api: TypedApi<typeof subtensor>, cooldown: bigint): Promise<void> {
+    const keyring = new Keyring({ type: "sr25519" });
+    const alice = keyring.addFromUri("//Alice");
+    const inner = api.tx.SubtensorModule.set_pending_childkey_cooldown({ cooldown });
+    const tx = api.tx.Sudo.sudo({ call: inner.decodedCall });
+    await waitForTransactionWithRetry(api, tx, alice, "sudo_set_pending_childkey_cooldown");
+}

--- a/ts-tests/utils/subnet.ts
+++ b/ts-tests/utils/subnet.ts
@@ -64,3 +64,12 @@ export async function startCall(api: TypedApi<typeof subtensor>, netuid: number,
 
     await new Promise((resolve) => setTimeout(resolve, 1000));
 }
+
+export async function rootRegister(
+    api: TypedApi<typeof subtensor>,
+    coldkey: KeyringPair,
+    hotkeyAddress: string
+): Promise<void> {
+    const tx = api.tx.SubtensorModule.root_register({ hotkey: hotkeyAddress });
+    await waitForTransactionWithRetry(api, tx, coldkey, "root_register");
+}


### PR DESCRIPTION

## Description
This PR adds an `AutoParentDelegationEnabled` flag to toggle auto parent delegation during network registration


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.