### PR TITLE
Fix orphaned storage cleanup on subnet deregistration

### DIFF
--- a/chain-extensions/src/mock.rs
+++ b/chain-extensions/src/mock.rs
@@ -421,6 +421,7 @@ impl pallet_subtensor::Config for Test {
     type GetCommitments = ();
     type MaxImmuneUidsPercentage = MaxImmuneUidsPercentage;
     type CommitmentsInterface = CommitmentsI;
+    type PrecompileCleanupInterface = PrecompileCleanupI;
     type EvmKeyAssociateRateLimit = EvmKeyAssociateRateLimit;
     type AuthorshipProvider = MockAuthorshipProvider;
     type WeightInfo = ();
@@ -460,6 +461,11 @@ impl PrivilegeCmp<OriginCaller> for OriginPrivilegeCmp {
 
 pub struct CommitmentsI;
 impl CommitmentsInterface for CommitmentsI {
+    fn purge_netuid(_netuid: NetUid) {}
+}
+
+pub struct PrecompileCleanupI;
+impl pallet_subtensor::PrecompileCleanupInterface for PrecompileCleanupI {
     fn purge_netuid(_netuid: NetUid) {}
 }
 

--- a/eco-tests/src/mock.rs
+++ b/eco-tests/src/mock.rs
@@ -306,6 +306,7 @@ impl pallet_subtensor::Config for Test {
     type GetCommitments = ();
     type MaxImmuneUidsPercentage = MaxImmuneUidsPercentage;
     type CommitmentsInterface = CommitmentsI;
+    type PrecompileCleanupInterface = PrecompileCleanupI;
     type EvmKeyAssociateRateLimit = EvmKeyAssociateRateLimit;
     type AuthorshipProvider = MockAuthorshipProvider;
     type WeightInfo = ();
@@ -343,6 +344,11 @@ impl PrivilegeCmp<OriginCaller> for OriginPrivilegeCmp {
 
 pub struct CommitmentsI;
 impl CommitmentsInterface for CommitmentsI {
+    fn purge_netuid(_netuid: NetUid) {}
+}
+
+pub struct PrecompileCleanupI;
+impl pallet_subtensor::PrecompileCleanupInterface for PrecompileCleanupI {
     fn purge_netuid(_netuid: NetUid) {}
 }
 

--- a/pallets/admin-utils/src/tests/mock.rs
+++ b/pallets/admin-utils/src/tests/mock.rs
@@ -230,6 +230,7 @@ impl pallet_subtensor::Config for Test {
     type GetCommitments = ();
     type MaxImmuneUidsPercentage = MaxImmuneUidsPercentage;
     type CommitmentsInterface = CommitmentsI;
+    type PrecompileCleanupInterface = PrecompileCleanupI;
     type EvmKeyAssociateRateLimit = EvmKeyAssociateRateLimit;
     type AuthorshipProvider = MockAuthorshipProvider;
     type WeightInfo = ();
@@ -363,6 +364,11 @@ impl PrivilegeCmp<OriginCaller> for OriginPrivilegeCmp {
 
 pub struct CommitmentsI;
 impl pallet_subtensor::CommitmentsInterface for CommitmentsI {
+    fn purge_netuid(_netuid: NetUid) {}
+}
+
+pub struct PrecompileCleanupI;
+impl pallet_subtensor::PrecompileCleanupInterface for PrecompileCleanupI {
     fn purge_netuid(_netuid: NetUid) {}
 }
 

--- a/pallets/subtensor/src/coinbase/root.rs
+++ b/pallets/subtensor/src/coinbase/root.rs
@@ -16,7 +16,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 use super::*;
-use crate::CommitmentsInterface;
+use crate::{CommitmentsInterface, PrecompileCleanupInterface};
 use safe_math::*;
 use substrate_fixed::types::{I64F64, U96F32};
 use subtensor_runtime_common::{AlphaBalance, NetUid, NetUidStorageIndex, TaoBalance, Token};
@@ -218,6 +218,7 @@ impl<T: Config> Pallet<T> {
         Self::destroy_alpha_in_out_stakes(netuid)?;
         T::SwapInterface::clear_protocol_liquidity(netuid)?;
         T::CommitmentsInterface::purge_netuid(netuid);
+        T::PrecompileCleanupInterface::purge_netuid(netuid);
 
         // --- Remove the network
         Self::remove_network(netuid);
@@ -282,9 +283,14 @@ impl<T: Config> Pallet<T> {
         Kappa::<T>::remove(netuid);
         Difficulty::<T>::remove(netuid);
         MaxAllowedUids::<T>::remove(netuid);
+        MinAllowedUids::<T>::remove(netuid);
         ImmunityPeriod::<T>::remove(netuid);
         ActivityCutoff::<T>::remove(netuid);
         MinAllowedWeights::<T>::remove(netuid);
+        MaxWeightsLimit::<T>::remove(netuid);
+        AdjustmentAlpha::<T>::remove(netuid);
+        AdjustmentInterval::<T>::remove(netuid);
+        MinNonImmuneUids::<T>::remove(netuid);
         RegistrationsThisInterval::<T>::remove(netuid);
         POWRegistrationsThisInterval::<T>::remove(netuid);
         BurnRegistrationsThisInterval::<T>::remove(netuid);
@@ -299,6 +305,11 @@ impl<T: Config> Pallet<T> {
         SubnetTaoFlow::<T>::remove(netuid);
         SubnetEmaTaoFlow::<T>::remove(netuid);
         SubnetTaoProvided::<T>::remove(netuid);
+
+        // --- 12. Root / emission split parameters.
+        RootProp::<T>::remove(netuid);
+        RecycleOrBurn::<T>::remove(netuid);
+        RootClaimableThreshold::<T>::remove(netuid);
 
         // --- 13. Token / mechanism / registration toggles.
         TokenSymbol::<T>::remove(netuid);
@@ -362,12 +373,19 @@ impl<T: Config> Pallet<T> {
         StakeWeight::<T>::remove(netuid);
         LoadedEmission::<T>::remove(netuid);
 
+        // --- 18b. Voting power.
+        let _ = VotingPower::<T>::clear_prefix(netuid, u32::MAX, None);
+        VotingPowerTrackingEnabled::<T>::remove(netuid);
+        VotingPowerDisableAtBlock::<T>::remove(netuid);
+        VotingPowerEmaAlpha::<T>::remove(netuid);
+
         // --- 19. DMAPs where netuid is the FIRST key: clear by prefix.
         let _ = BlockAtRegistration::<T>::clear_prefix(netuid, u32::MAX, None);
         let _ = Axons::<T>::clear_prefix(netuid, u32::MAX, None);
         let _ = NeuronCertificates::<T>::clear_prefix(netuid, u32::MAX, None);
         let _ = Prometheus::<T>::clear_prefix(netuid, u32::MAX, None);
         let _ = AlphaDividendsPerSubnet::<T>::clear_prefix(netuid, u32::MAX, None);
+        let _ = RootAlphaDividendsPerSubnet::<T>::clear_prefix(netuid, u32::MAX, None);
         let _ = PendingChildKeys::<T>::clear_prefix(netuid, u32::MAX, None);
         let _ = AssociatedEvmAddress::<T>::clear_prefix(netuid, u32::MAX, None);
 

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -2747,3 +2747,8 @@ impl<T> ProxyInterface<T> for () {
 pub trait CommitmentsInterface {
     fn purge_netuid(netuid: NetUid);
 }
+
+/// EVM precompiles that hold per-subnet state implement this to clean up on subnet deregistration.
+pub trait PrecompileCleanupInterface {
+    fn purge_netuid(netuid: NetUid);
+}

--- a/pallets/subtensor/src/macros/config.rs
+++ b/pallets/subtensor/src/macros/config.rs
@@ -6,7 +6,7 @@ use frame_support::pallet_macros::pallet_section;
 #[pallet_section]
 mod config {
 
-    use crate::{CommitmentsInterface, GetAlphaForTao, GetTaoForAlpha};
+    use crate::{CommitmentsInterface, GetAlphaForTao, GetTaoForAlpha, PrecompileCleanupInterface};
     use pallet_commitments::GetCommitments;
     use subtensor_runtime_common::AuthorshipInfo;
     use subtensor_swap_interface::{SwapEngine, SwapHandler};
@@ -59,6 +59,9 @@ mod config {
 
         ///  Interface to clean commitments on network dissolution.
         type CommitmentsInterface: CommitmentsInterface;
+
+        /// Interface to clean EVM precompile state (e.g. allowances) on network dissolution.
+        type PrecompileCleanupInterface: PrecompileCleanupInterface;
 
         /// Rate limit for associating an EVM key.
         type EvmKeyAssociateRateLimit: Get<u64>;

--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -319,6 +319,7 @@ impl crate::Config for Test {
     type GetCommitments = ();
     type MaxImmuneUidsPercentage = MaxImmuneUidsPercentage;
     type CommitmentsInterface = CommitmentsI;
+    type PrecompileCleanupInterface = PrecompileCleanupI;
     type EvmKeyAssociateRateLimit = EvmKeyAssociateRateLimit;
     type AuthorshipProvider = MockAuthorshipProvider;
     type WeightInfo = ();
@@ -358,6 +359,11 @@ impl PrivilegeCmp<OriginCaller> for OriginPrivilegeCmp {
 
 pub struct CommitmentsI;
 impl CommitmentsInterface for CommitmentsI {
+    fn purge_netuid(_netuid: NetUid) {}
+}
+
+pub struct PrecompileCleanupI;
+impl crate::PrecompileCleanupInterface for PrecompileCleanupI {
     fn purge_netuid(_netuid: NetUid) {}
 }
 

--- a/pallets/subtensor/src/tests/networks.rs
+++ b/pallets/subtensor/src/tests/networks.rs
@@ -2242,6 +2242,74 @@ fn dissolve_clears_all_mechanism_scoped_maps_for_all_mechanisms() {
     });
 }
 
+#[test]
+fn test_dissolve_network_clears_orphaned_storage() {
+    new_test_ext(0).execute_with(|| {
+        let cold = U256::from(1);
+        let hot = U256::from(2);
+        let net = add_dynamic_network(&hot, &cold);
+
+        let hotkey1 = U256::from(100);
+        let hotkey2 = U256::from(200);
+
+        // Seed RootAlphaDividendsPerSubnet (DMAP, netuid is first key).
+        RootAlphaDividendsPerSubnet::<Test>::insert(net, hotkey1, AlphaBalance::from(5_000u64));
+        RootAlphaDividendsPerSubnet::<Test>::insert(net, hotkey2, AlphaBalance::from(10_000u64));
+
+        // Seed VotingPower (DMAP, netuid is first key).
+        VotingPower::<Test>::insert(net, hotkey1, 42u64);
+
+        // Seed simple StorageMaps that were previously missed.
+        MinAllowedUids::<Test>::insert(net, 4u16);
+        MaxWeightsLimit::<Test>::insert(net, 100u16);
+        AdjustmentAlpha::<Test>::insert(net, 999u64);
+        AdjustmentInterval::<Test>::insert(net, 50u16);
+        MinNonImmuneUids::<Test>::insert(net, 2u16);
+        RecycleOrBurn::<Test>::insert(net, RecycleOrBurnEnum::Recycle);
+        VotingPowerTrackingEnabled::<Test>::insert(net, true);
+        VotingPowerDisableAtBlock::<Test>::insert(net, 1000u64);
+        VotingPowerEmaAlpha::<Test>::insert(net, 500u64);
+
+        // Seed a different netuid to ensure it's untouched.
+        let other_net = add_dynamic_network(&U256::from(3), &U256::from(4));
+        RootAlphaDividendsPerSubnet::<Test>::insert(
+            other_net,
+            hotkey1,
+            AlphaBalance::from(7_000u64),
+        );
+        VotingPower::<Test>::insert(other_net, hotkey1, 99u64);
+
+        // Dissolve the network.
+        assert_ok!(SubtensorModule::do_dissolve_network(net));
+
+        // Double-map entries for the dissolved netuid should be gone.
+        assert!(!RootAlphaDividendsPerSubnet::<Test>::contains_key(
+            net, hotkey1
+        ));
+        assert!(!RootAlphaDividendsPerSubnet::<Test>::contains_key(
+            net, hotkey2
+        ));
+        assert!(!VotingPower::<Test>::contains_key(net, hotkey1));
+
+        // Simple maps for the dissolved netuid should be gone.
+        assert!(!MinAllowedUids::<Test>::contains_key(net));
+        assert!(!MaxWeightsLimit::<Test>::contains_key(net));
+        assert!(!AdjustmentAlpha::<Test>::contains_key(net));
+        assert!(!AdjustmentInterval::<Test>::contains_key(net));
+        assert!(!MinNonImmuneUids::<Test>::contains_key(net));
+        assert!(!RecycleOrBurn::<Test>::contains_key(net));
+        assert!(!VotingPowerTrackingEnabled::<Test>::contains_key(net));
+        assert!(!VotingPowerDisableAtBlock::<Test>::contains_key(net));
+        assert!(!VotingPowerEmaAlpha::<Test>::contains_key(net));
+
+        // Entries for the other netuid should remain.
+        assert!(RootAlphaDividendsPerSubnet::<Test>::contains_key(
+            other_net, hotkey1
+        ));
+        assert!(VotingPower::<Test>::contains_key(other_net, hotkey1));
+    });
+}
+
 fn owner_alpha_from_lock_and_price(lock_cost_u64: u64, price: U96F32) -> u64 {
     let alpha = (U96F32::from_num(lock_cost_u64)
         .checked_div(price)

--- a/pallets/transaction-fee/src/tests/mock.rs
+++ b/pallets/transaction-fee/src/tests/mock.rs
@@ -302,6 +302,7 @@ impl pallet_subtensor::Config for Test {
     type GetCommitments = ();
     type MaxImmuneUidsPercentage = MaxImmuneUidsPercentage;
     type CommitmentsInterface = CommitmentsI;
+    type PrecompileCleanupInterface = PrecompileCleanupI;
     type EvmKeyAssociateRateLimit = EvmKeyAssociateRateLimit;
     type AuthorshipProvider = MockAuthorshipProvider;
     type WeightInfo = ();
@@ -435,6 +436,11 @@ impl PrivilegeCmp<OriginCaller> for OriginPrivilegeCmp {
 
 pub struct CommitmentsI;
 impl pallet_subtensor::CommitmentsInterface for CommitmentsI {
+    fn purge_netuid(_netuid: NetUid) {}
+}
+
+pub struct PrecompileCleanupI;
+impl pallet_subtensor::PrecompileCleanupInterface for PrecompileCleanupI {
     fn purge_netuid(_netuid: NetUid) {}
 }
 

--- a/precompiles/src/lib.rs
+++ b/precompiles/src/lib.rs
@@ -38,7 +38,7 @@ pub use metagraph::MetagraphPrecompile;
 pub use neuron::NeuronPrecompile;
 pub use proxy::ProxyPrecompile;
 pub use sr25519::Sr25519Verify;
-pub use staking::{StakingPrecompile, StakingPrecompileV2};
+pub use staking::{StakingPrecompile, StakingPrecompileV2, purge_allowances_for_netuid};
 pub use storage_query::StorageQueryPrecompile;
 pub use subnet::SubnetPrecompile;
 pub use uid_lookup::UidLookupPrecompile;
@@ -282,6 +282,16 @@ where
             is_precompile: Self::used_addresses().contains(&address),
             extra_cost: 0,
         }
+    }
+}
+
+/// Implementation of [`pallet_subtensor::PrecompileCleanupInterface`] that cleans up
+/// EVM precompile storage (e.g. staking allowances) when a subnet is deregistered.
+pub struct PrecompileCleanup;
+
+impl pallet_subtensor::PrecompileCleanupInterface for PrecompileCleanup {
+    fn purge_netuid(netuid: subtensor_runtime_common::NetUid) {
+        purge_allowances_for_netuid(netuid.into());
     }
 }
 

--- a/precompiles/src/staking.rs
+++ b/precompiles/src/staking.rs
@@ -74,6 +74,25 @@ pub type AllowancesStorage = StorageDoubleMap<
     ValueQuery,
 >;
 
+/// Remove all allowance entries for the given `netuid`.
+///
+/// Because `netuid` is embedded in the second key `(spender, netuid)`, we must iterate
+/// all entries and filter. Called during subnet deregistration.
+pub fn purge_allowances_for_netuid(netuid: u16) {
+    let to_rm: Vec<(H160, H160)> = AllowancesStorage::iter()
+        .filter_map(|(approver, (spender, n), _)| {
+            if n == netuid {
+                Some((approver, spender))
+            } else {
+                None
+            }
+        })
+        .collect();
+    for (approver, spender) in to_rm {
+        AllowancesStorage::remove(approver, (spender, netuid));
+    }
+}
+
 // Old StakingPrecompile had ETH-precision in values, which was not alligned with Substrate API. So
 // it's kinda deprecated, but exists for backward compatibility. Eventually, we should remove it
 // to stop supporting both precompiles.

--- a/precompiles/src/staking.rs
+++ b/precompiles/src/staking.rs
@@ -914,3 +914,43 @@ fn try_u64_from_u256(value: U256) -> Result<u64, PrecompileFailure> {
         exit_status: ExitError::Other("the value is outside of u64 bounds".into()),
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sp_core::H160;
+
+    fn addr(n: u64) -> H160 {
+        H160::from_low_u64_be(n)
+    }
+
+    #[test]
+    fn purge_allowances_for_netuid_removes_matching_entries() {
+        sp_io::TestExternalities::default().execute_with(|| {
+            let approver1 = addr(1);
+            let approver2 = addr(2);
+            let spender1 = addr(10);
+            let spender2 = addr(20);
+
+            // Insert entries for netuid 1 and netuid 2.
+            AllowancesStorage::insert(approver1, (spender1, 1u16), U256::from(100u64));
+            AllowancesStorage::insert(approver1, (spender2, 1u16), U256::from(200u64));
+            AllowancesStorage::insert(approver2, (spender1, 1u16), U256::from(300u64));
+            // This one belongs to a different netuid and must not be touched.
+            AllowancesStorage::insert(approver1, (spender1, 2u16), U256::from(999u64));
+
+            purge_allowances_for_netuid(1u16);
+
+            // All netuid-1 entries should be gone.
+            assert!(AllowancesStorage::get(approver1, (spender1, 1u16)).is_zero());
+            assert!(AllowancesStorage::get(approver1, (spender2, 1u16)).is_zero());
+            assert!(AllowancesStorage::get(approver2, (spender1, 1u16)).is_zero());
+
+            // Netuid-2 entry should be untouched.
+            assert_eq!(
+                AllowancesStorage::get(approver1, (spender1, 2u16)),
+                U256::from(999u64)
+            );
+        });
+    }
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1199,6 +1199,7 @@ impl pallet_subtensor::Config for Runtime {
     type GetCommitments = GetCommitmentsStruct;
     type MaxImmuneUidsPercentage = MaxImmuneUidsPercentage;
     type CommitmentsInterface = CommitmentsI;
+    type PrecompileCleanupInterface = subtensor_precompiles::PrecompileCleanup;
     type EvmKeyAssociateRateLimit = EvmKeyAssociateRateLimit;
     type AuthorshipProvider = BlockAuthorFromAura<Aura>;
     type WeightInfo = pallet_subtensor::weights::SubstrateWeight<Runtime>;


### PR DESCRIPTION
## Description

Clean up `AllowancesStorage`, `RootAlphaDividendsPerSubnet`, and 12 additional storage items that were not being removed during subnet deregistration in `remove_network`.

**AllowancesStorage** (EVM staking precompile) uses netuid embedded in the second key `(spender, netuid)`, so it cannot use `clear_prefix`. A new `PrecompileCleanupInterface` trait (following the existing `CommitmentsInterface` pattern) is added to handle this cross-crate cleanup.

**RootAlphaDividendsPerSubnet** and **VotingPower** have netuid as the first key and are cleaned via `clear_prefix`.

**11 additional simple StorageMaps** were also missing removal: `MinAllowedUids`, `MaxWeightsLimit`, `AdjustmentAlpha`, `AdjustmentInterval`, `MinNonImmuneUids`, `RootProp`, `RecycleOrBurn`, `RootClaimableThreshold`, `VotingPowerTrackingEnabled`, `VotingPowerDisableAtBlock`, `VotingPowerEmaAlpha`.

## Related Issue(s)

- Closes #2573

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

N/A — this only adds cleanup of storage that was previously leaked on subnet deregistration.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional Notes

The `PrecompileCleanupInterface` trait follows the same pattern as the existing `CommitmentsInterface` — a trait defined in `pallet-subtensor`, implemented in the precompiles crate, and wired through the runtime `Config`. This avoids a circular dependency since precompiles depends on `pallet-subtensor`, not the reverse.