### PR TITLE
Bottom half median owner alpha stake

### DIFF
--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -70,73 +70,68 @@ impl<T: Config> Pallet<T> {
     }
 
     /// Gets the Median Subnet Alpha Price
-    pub fn get_median_subnet_alpha_price() -> U96F32 {
+    pub fn get_bottom_half_median_subnet_alpha_price() -> U96F32 {
         let default_price = U96F32::saturating_from_num(1_u64);
         let zero_price = U96F32::saturating_from_num(0_u64);
         let two = U96F32::saturating_from_num(2_u64);
 
-        let mut price_counts: BTreeMap<U96F32, usize> = BTreeMap::new();
-        let mut total_prices: usize = 0;
+        let mut prices: Vec<U96F32> = NetworksAdded::<T>::iter()
+            .filter_map(|(netuid, added)| {
+                if added && netuid != NetUid::ROOT {
+                    let price = T::SwapInterface::current_alpha_price(netuid);
+                    if price > zero_price {
+                        Some(price)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+            .collect();
 
-        for (netuid, added) in NetworksAdded::<T>::iter() {
-            if !added || netuid == NetUid::ROOT {
-                continue;
-            }
-
-            let price = T::SwapInterface::current_alpha_price(netuid);
-            if price <= zero_price {
-                continue;
-            }
-
-            total_prices = total_prices.saturating_add(1);
-
-            if let Some(count) = price_counts.get_mut(&price) {
-                *count = count.saturating_add(1);
-            } else {
-                price_counts.insert(price, 1usize);
-            }
-        }
-
-        if total_prices == 0 {
+        if prices.is_empty() {
             return default_price;
         }
 
-        let Some(last_index) = total_prices.checked_sub(1) else {
+        prices.sort_unstable();
+
+        let len = prices.len();
+        let Some(bottom_half_len) = len.checked_add(1).and_then(|value| value.checked_div(2))
+        else {
             return default_price;
         };
-        let Some(lower_target) = last_index.checked_div(2) else {
+
+        let bottom_half_prices: Vec<U96F32> = prices.into_iter().take(bottom_half_len).collect();
+        let bottom_len = bottom_half_prices.len();
+
+        let Some(mid_index) = bottom_len.checked_div(2) else {
             return default_price;
         };
-        let Some(upper_target) = total_prices.checked_div(2) else {
+
+        let Some(remainder) = bottom_len.checked_rem(2) else {
             return default_price;
         };
 
-        let mut cumulative: usize = 0;
-        let mut lower_price: Option<U96F32> = None;
-        let mut upper_price: Option<U96F32> = None;
+        if remainder == 0 {
+            let Some(left_index) = mid_index.checked_sub(1) else {
+                return default_price;
+            };
 
-        for (price, count) in price_counts.into_iter() {
-            let next_cumulative = cumulative.saturating_add(count);
-
-            if lower_price.is_none() && lower_target < next_cumulative {
-                lower_price = Some(price);
+            match (
+                bottom_half_prices.get(left_index).copied(),
+                bottom_half_prices.get(mid_index).copied(),
+            ) {
+                (Some(left_price), Some(right_price)) => {
+                    left_price.saturating_add(right_price).safe_div(two)
+                }
+                _ => default_price,
             }
-
-            if upper_price.is_none() && upper_target < next_cumulative {
-                upper_price = Some(price);
+        } else {
+            match bottom_half_prices.get(mid_index).copied() {
+                Some(price) => price,
+                None => default_price,
             }
-
-            if lower_price.is_some() && upper_price.is_some() {
-                break;
-            }
-
-            cumulative = next_cumulative;
-        }
-
-        match (lower_price, upper_price) {
-            (Some(_), Some(upper)) if lower_target == upper_target => upper,
-            (Some(lower), Some(upper)) => lower.saturating_add(upper).safe_div(two),
-            _ => default_price,
         }
     }
 

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -1,7 +1,7 @@
 use super::*;
 use safe_math::*;
 use share_pool::{SafeFloat, SharePool, SharePoolDataOperations};
-use sp_std::{collections::btree_map::BTreeMap, ops::Neg};
+use sp_std::ops::Neg;
 use substrate_fixed::types::{I64F64, I96F32, U96F32};
 use subtensor_runtime_common::{AlphaBalance, AuthorshipInfo, NetUid, TaoBalance, Token};
 use subtensor_swap_interface::{Order, SwapHandler, SwapResult};

--- a/pallets/subtensor/src/subnets/subnet.rs
+++ b/pallets/subtensor/src/subnets/subnet.rs
@@ -185,8 +185,8 @@ impl<T: Config> Pallet<T> {
             None => Self::get_next_netuid(),
         };
 
-        // --- 11. Snapshot the current median price of the bottom 50% of subnet alpha prices
-        //         before creating the new subnet.
+        // --- 11. Snapshot the current bottom-half median subnet alpha price before
+        //         creating the new subnet.
         let bottom_half_median_subnet_alpha_price =
             Self::get_bottom_half_median_subnet_alpha_price();
 
@@ -211,31 +211,29 @@ impl<T: Config> Pallet<T> {
         let symbol = Self::get_next_available_symbol(netuid_to_register);
         TokenSymbol::<T>::insert(netuid_to_register, symbol);
 
-        // Convert the full registration lock into alpha using the median price of the bottom 50%
-        // of eligible subnet prices.
+        // Seed the new subnet with:
+        //   * 25% of the actual lock as TAO in the pool
+        //   * alpha priced off that TAO amount at the bottom-half median snapshot price
+        //   * the same alpha amount again to the owner as staked alpha
+        //
+        // This keeps the opening pool price aligned with the snapshot price and avoids
+        // ratcheting the bottom-half median downward on sequential registrations.
         let actual_tao_lock_amount_u64 = actual_tao_lock_amount.to_u64();
-        let registration_lock_alpha_equivalent_u64: u64 =
-            U96F32::saturating_from_num(actual_tao_lock_amount_u64)
-                .safe_div(bottom_half_median_subnet_alpha_price)
-                .saturating_floor()
-                .saturating_to_num::<u64>();
 
-        // Seed the new subnet as follows:
-        //   * 25% of the current lock cost as TAO into the pool.
-        //   * A / 2 as free alpha into the pool, where A is the converted lock cost in alpha.
-        //   * The remaining half of A to the subnet owner as staked alpha.
         let pool_initial_tao_u64 = actual_tao_lock_amount_u64
             .checked_div(4)
             .unwrap_or_default();
         let pool_initial_tao: TaoBalance = pool_initial_tao_u64.into();
 
-        let pool_initial_alpha_u64 = registration_lock_alpha_equivalent_u64
-            .checked_div(2)
-            .unwrap_or_default();
+        let pool_initial_alpha_u64 = U96F32::saturating_from_num(pool_initial_tao_u64)
+            .safe_div(bottom_half_median_subnet_alpha_price)
+            .saturating_floor()
+            .saturating_to_num::<u64>();
         let pool_initial_alpha: AlphaBalance = pool_initial_alpha_u64.into();
 
-        let owner_alpha_stake_u64 =
-            registration_lock_alpha_equivalent_u64.saturating_sub(pool_initial_alpha_u64);
+        // Give the owner the same alpha amount as the pool-side alpha so the launch
+        // price remains equal to the snapshot price.
+        let owner_alpha_stake_u64 = pool_initial_alpha_u64;
         let owner_alpha_stake: AlphaBalance = owner_alpha_stake_u64.into();
 
         let actual_tao_lock_amount_less_pool_tao =

--- a/pallets/subtensor/src/subnets/subnet.rs
+++ b/pallets/subtensor/src/subnets/subnet.rs
@@ -185,8 +185,10 @@ impl<T: Config> Pallet<T> {
             None => Self::get_next_netuid(),
         };
 
-        // --- 11. Snapshot the current median subnet alpha price before creating the new subnet.
-        let median_subnet_alpha_price = Self::get_median_subnet_alpha_price();
+        // --- 11. Snapshot the current median price of the bottom 50% of subnet alpha prices
+        //         before creating the new subnet.
+        let bottom_half_median_subnet_alpha_price =
+            Self::get_bottom_half_median_subnet_alpha_price();
 
         // --- 12. Set initial and custom parameters for the network.
         let default_tempo = DefaultTempo::<T>::get();
@@ -209,17 +211,33 @@ impl<T: Config> Pallet<T> {
         let symbol = Self::get_next_available_symbol(netuid_to_register);
         TokenSymbol::<T>::insert(netuid_to_register, symbol);
 
-        // Seed the new subnet pool at a 1:1 reserve ratio.
-        // Separately, grant the subnet owner outstanding alpha based on the TAO they actually spent
-        // on registration converted by the current median subnet alpha price.
-        let pool_initial_tao: TaoBalance = Self::get_network_min_lock();
-        let pool_initial_alpha: AlphaBalance = pool_initial_tao.to_u64().into();
-        let owner_alpha_stake: AlphaBalance =
-            U96F32::saturating_from_num(actual_tao_lock_amount.to_u64())
-                .safe_div(median_subnet_alpha_price)
+        // Convert the full registration lock into alpha using the median price of the bottom 50%
+        // of eligible subnet prices.
+        let actual_tao_lock_amount_u64 = actual_tao_lock_amount.to_u64();
+        let registration_lock_alpha_equivalent_u64: u64 =
+            U96F32::saturating_from_num(actual_tao_lock_amount_u64)
+                .safe_div(bottom_half_median_subnet_alpha_price)
                 .saturating_floor()
-                .saturating_to_num::<u64>()
-                .into();
+                .saturating_to_num::<u64>();
+
+        // Seed the new subnet as follows:
+        //   * 25% of the current lock cost as TAO into the pool.
+        //   * A / 2 as free alpha into the pool, where A is the converted lock cost in alpha.
+        //   * The remaining half of A to the subnet owner as staked alpha.
+        let pool_initial_tao_u64 = actual_tao_lock_amount_u64
+            .checked_div(4)
+            .unwrap_or_default();
+        let pool_initial_tao: TaoBalance = pool_initial_tao_u64.into();
+
+        let pool_initial_alpha_u64 = registration_lock_alpha_equivalent_u64
+            .checked_div(2)
+            .unwrap_or_default();
+        let pool_initial_alpha: AlphaBalance = pool_initial_alpha_u64.into();
+
+        let owner_alpha_stake_u64 =
+            registration_lock_alpha_equivalent_u64.saturating_sub(pool_initial_alpha_u64);
+        let owner_alpha_stake: AlphaBalance = owner_alpha_stake_u64.into();
+
         let actual_tao_lock_amount_less_pool_tao =
             actual_tao_lock_amount.saturating_sub(pool_initial_tao);
 
@@ -280,7 +298,7 @@ impl<T: Config> Pallet<T> {
         log::info!("NetworkAdded( netuid:{netuid_to_register:?}, mechanism:{mechid:?} )");
         Self::deposit_event(Event::NetworkAdded(netuid_to_register, mechid));
 
-        // --- 19. Return success.
+        // --- 20. Return success.
         Ok(())
     }
 

--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -842,6 +842,7 @@ pub fn add_network_disable_subtoken(netuid: NetUid, tempo: u16, _modality: u16) 
 pub fn add_dynamic_network(hotkey: &U256, coldkey: &U256) -> NetUid {
     let netuid = SubtensorModule::get_next_netuid();
     let lock_cost = SubtensorModule::get_network_lock_cost();
+
     SubtensorModule::add_balance_to_coldkey_account(coldkey, lock_cost.into());
     TotalIssuance::<Test>::mutate(|total_issuance| {
         *total_issuance = total_issuance.saturating_add(lock_cost);
@@ -851,6 +852,10 @@ pub fn add_dynamic_network(hotkey: &U256, coldkey: &U256) -> NetUid {
         RawOrigin::Signed(*coldkey).into(),
         *hotkey
     ));
+
+    // Normalize the freshly registered subnet back to the legacy 1:1 mock shape.
+    remove_owner_registration_stake(netuid);
+
     NetworkRegistrationAllowed::<Test>::insert(netuid, true);
     FirstEmissionBlockNumber::<Test>::insert(netuid, 0);
     SubtokenEnabled::<Test>::insert(netuid, true);
@@ -1111,26 +1116,38 @@ pub fn remove_owner_registration_stake(netuid: NetUid) {
     let owner_hotkey = SubnetOwnerHotkey::<Test>::get(netuid);
     let owner_coldkey = SubnetOwner::<Test>::get(netuid);
 
-    let owner_stake = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
-        &owner_hotkey,
-        &owner_coldkey,
+    let legacy_pool_tao = SubtensorModule::get_network_min_lock()
+        .min(SubtensorModule::get_subnet_locked_balance(netuid));
+    let legacy_pool_alpha: AlphaBalance = legacy_pool_tao.to_u64().into();
+
+    let current_pool_tao = SubnetTAO::<Test>::get(netuid);
+
+    // Hard-reset the owner stake/sharepool state so the subnet matches the legacy
+    // post-registration shape used by the original base-branch test suite.
+    Alpha::<Test>::remove((owner_hotkey, owner_coldkey, netuid));
+    AlphaV2::<Test>::remove((owner_hotkey, owner_coldkey, netuid));
+    TotalHotkeyShares::<Test>::remove(owner_hotkey, netuid);
+    TotalHotkeySharesV2::<Test>::remove(owner_hotkey, netuid);
+    TotalHotkeyAlpha::<Test>::remove(owner_hotkey, netuid);
+    TotalHotkeyAlphaLastEpoch::<Test>::remove(owner_hotkey, netuid);
+    AlphaDividendsPerSubnet::<Test>::remove(netuid, owner_hotkey);
+
+    // Restore the original 1:1 seeded pool used by the legacy tests.
+    SubnetTAO::<Test>::insert(netuid, legacy_pool_tao);
+    SubnetAlphaIn::<Test>::insert(netuid, legacy_pool_alpha);
+    SubnetAlphaOut::<Test>::insert(netuid, AlphaBalance::ZERO);
+    SubnetTaoProvided::<Test>::insert(netuid, TaoBalance::ZERO);
+    SubnetAlphaInProvided::<Test>::insert(netuid, AlphaBalance::ZERO);
+    RAORecycledForRegistration::<Test>::insert(
         netuid,
+        SubtensorModule::get_subnet_locked_balance(netuid).saturating_sub(legacy_pool_tao),
     );
 
-    if owner_stake.is_zero() {
-        return;
-    }
-
-    let alpha_out_before = SubnetAlphaOut::<Test>::get(netuid);
-
-    SubtensorModule::decrease_stake_for_hotkey_and_coldkey_on_subnet(
-        &owner_hotkey,
-        &owner_coldkey,
-        netuid,
-        owner_stake,
-    );
-
-    SubnetAlphaOut::<Test>::insert(netuid, alpha_out_before.saturating_sub(owner_stake));
+    TotalStake::<Test>::mutate(|total| {
+        *total = total
+            .saturating_sub(current_pool_tao)
+            .saturating_add(legacy_pool_tao);
+    });
 
     assert_eq!(
         SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
@@ -1144,4 +1161,7 @@ pub fn remove_owner_registration_stake(netuid: NetUid) {
         TotalHotkeyAlpha::<Test>::get(owner_hotkey, netuid),
         AlphaBalance::ZERO
     );
+    assert_eq!(SubnetAlphaOut::<Test>::get(netuid), AlphaBalance::ZERO);
+    assert_eq!(SubnetTAO::<Test>::get(netuid), legacy_pool_tao);
+    assert_eq!(SubnetAlphaIn::<Test>::get(netuid), legacy_pool_alpha);
 }

--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -1181,7 +1181,7 @@ pub fn total_registration_alpha_from_lock_and_price(lock_cost_u64: u64, price: U
 
 pub fn owner_alpha_from_lock_and_price(lock_cost_u64: u64, price: U96F32) -> u64 {
     let total_alpha_u64 = total_registration_alpha_from_lock_and_price(lock_cost_u64, price);
-    total_alpha_u64.saturating_sub(total_alpha_u64.checked_div(2).unwrap_or_default())
+    total_alpha_u64 - total_alpha_u64.checked_div(2).unwrap_or_default()
 }
 
 pub fn pool_alpha_from_lock_and_price(lock_cost_u64: u64, price: U96F32) -> u64 {
@@ -1195,5 +1195,5 @@ pub fn pool_tao_from_lock(lock_cost_u64: u64) -> u64 {
 }
 
 pub fn recycled_tao_from_lock(lock_cost_u64: u64) -> u64 {
-    lock_cost_u64.saturating_sub(pool_tao_from_lock(lock_cost_u64))
+    lock_cost_u64 - pool_tao_from_lock(lock_cost_u64)
 }

--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -1167,7 +1167,9 @@ pub fn remove_owner_registration_stake(netuid: NetUid) {
 }
 
 pub fn total_registration_alpha_from_lock_and_price(lock_cost_u64: u64, price: U96F32) -> u64 {
-    let alpha = (U96F32::from_num(lock_cost_u64)
+    let pool_tao_u64 = lock_cost_u64.checked_div(4).unwrap_or_default();
+
+    let alpha = (U96F32::from_num(pool_tao_u64)
         .checked_div(price)
         .unwrap_or_default())
     .floor();
@@ -1180,14 +1182,11 @@ pub fn total_registration_alpha_from_lock_and_price(lock_cost_u64: u64, price: U
 }
 
 pub fn owner_alpha_from_lock_and_price(lock_cost_u64: u64, price: U96F32) -> u64 {
-    let total_alpha_u64 = total_registration_alpha_from_lock_and_price(lock_cost_u64, price);
-    total_alpha_u64 - total_alpha_u64.checked_div(2).unwrap_or_default()
+    total_registration_alpha_from_lock_and_price(lock_cost_u64, price)
 }
 
 pub fn pool_alpha_from_lock_and_price(lock_cost_u64: u64, price: U96F32) -> u64 {
     total_registration_alpha_from_lock_and_price(lock_cost_u64, price)
-        .checked_div(2)
-        .unwrap_or_default()
 }
 
 pub fn pool_tao_from_lock(lock_cost_u64: u64) -> u64 {
@@ -1195,5 +1194,5 @@ pub fn pool_tao_from_lock(lock_cost_u64: u64) -> u64 {
 }
 
 pub fn recycled_tao_from_lock(lock_cost_u64: u64) -> u64 {
-    lock_cost_u64 - pool_tao_from_lock(lock_cost_u64)
+    lock_cost_u64.saturating_sub(pool_tao_from_lock(lock_cost_u64))
 }

--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -29,7 +29,7 @@ use sp_runtime::{
 };
 use sp_std::{cell::RefCell, cmp::Ordering, sync::OnceLock};
 use sp_tracing::tracing_subscriber;
-use substrate_fixed::types::U64F64;
+use substrate_fixed::types::{U64F64, U96F32};
 use subtensor_runtime_common::{AuthorshipInfo, NetUid, TaoBalance};
 use subtensor_swap_interface::{Order, SwapHandler};
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
@@ -1164,4 +1164,36 @@ pub fn remove_owner_registration_stake(netuid: NetUid) {
     assert_eq!(SubnetAlphaOut::<Test>::get(netuid), AlphaBalance::ZERO);
     assert_eq!(SubnetTAO::<Test>::get(netuid), legacy_pool_tao);
     assert_eq!(SubnetAlphaIn::<Test>::get(netuid), legacy_pool_alpha);
+}
+
+pub fn total_registration_alpha_from_lock_and_price(lock_cost_u64: u64, price: U96F32) -> u64 {
+    let alpha = (U96F32::from_num(lock_cost_u64)
+        .checked_div(price)
+        .unwrap_or_default())
+    .floor();
+
+    if alpha > U96F32::from_num(u64::MAX) {
+        u64::MAX
+    } else {
+        alpha.to_num::<u64>()
+    }
+}
+
+pub fn owner_alpha_from_lock_and_price(lock_cost_u64: u64, price: U96F32) -> u64 {
+    let total_alpha_u64 = total_registration_alpha_from_lock_and_price(lock_cost_u64, price);
+    total_alpha_u64.saturating_sub(total_alpha_u64.checked_div(2).unwrap_or_default())
+}
+
+pub fn pool_alpha_from_lock_and_price(lock_cost_u64: u64, price: U96F32) -> u64 {
+    total_registration_alpha_from_lock_and_price(lock_cost_u64, price)
+        .checked_div(2)
+        .unwrap_or_default()
+}
+
+pub fn pool_tao_from_lock(lock_cost_u64: u64) -> u64 {
+    lock_cost_u64.checked_div(4).unwrap_or_default()
+}
+
+pub fn recycled_tao_from_lock(lock_cost_u64: u64) -> u64 {
+    lock_cost_u64.saturating_sub(pool_tao_from_lock(lock_cost_u64))
 }

--- a/pallets/subtensor/src/tests/networks.rs
+++ b/pallets/subtensor/src/tests/networks.rs
@@ -2667,33 +2667,3 @@ fn register_network_non_associated_hotkey_does_not_withdraw_or_write_owner_alpha
         );
     });
 }
-
-fn total_registration_alpha_from_lock_and_price(lock_cost_u64: u64, price: U96F32) -> u64 {
-    let alpha = (U96F32::from_num(lock_cost_u64)
-        .checked_div(price)
-        .unwrap_or_default())
-    .floor();
-
-    if alpha > U96F32::from_num(u64::MAX) {
-        u64::MAX
-    } else {
-        alpha.to_num::<u64>()
-    }
-}
-
-fn owner_alpha_from_lock_and_price(lock_cost_u64: u64, price: U96F32) -> u64 {
-    let total_alpha_u64 = total_registration_alpha_from_lock_and_price(lock_cost_u64, price);
-    total_alpha_u64.saturating_sub(total_alpha_u64 / 2)
-}
-
-fn pool_alpha_from_lock_and_price(lock_cost_u64: u64, price: U96F32) -> u64 {
-    total_registration_alpha_from_lock_and_price(lock_cost_u64, price) / 2
-}
-
-fn pool_tao_from_lock(lock_cost_u64: u64) -> u64 {
-    lock_cost_u64 / 4
-}
-
-fn recycled_tao_from_lock(lock_cost_u64: u64) -> u64 {
-    lock_cost_u64.saturating_sub(pool_tao_from_lock(lock_cost_u64))
-}

--- a/pallets/subtensor/src/tests/networks.rs
+++ b/pallets/subtensor/src/tests/networks.rs
@@ -2444,7 +2444,11 @@ fn register_network_credits_owner_alpha_using_fallback_price_one_on_first_subnet
         let expected_owner_alpha: AlphaBalance =
             owner_alpha_from_lock_and_price(actual_locked_u64, pre_registration_price).into();
         let expected_alpha_issuance: AlphaBalance =
-            total_registration_alpha_from_lock_and_price(actual_locked_u64, pre_registration_price)
+            pool_alpha_from_lock_and_price(actual_locked_u64, pre_registration_price)
+                .saturating_add(owner_alpha_from_lock_and_price(
+                    actual_locked_u64,
+                    pre_registration_price,
+                ))
                 .into();
         let expected_recycled: TaoBalance = recycled_tao_from_lock(actual_locked_u64).into();
 
@@ -2491,11 +2495,14 @@ fn register_network_credits_owner_alpha_from_even_median_and_excludes_new_subnet
     new_test_ext(1).execute_with(|| {
         let n1 = add_dynamic_network(&U256::from(1201), &U256::from(1200));
         let n2 = add_dynamic_network(&U256::from(1203), &U256::from(1202));
+        let n3 = add_dynamic_network(&U256::from(1205), &U256::from(1204));
 
-        setup_reserves(n1, TaoBalance::from(500u64), AlphaBalance::from(100u64));
-        setup_reserves(n2, TaoBalance::from(200u64), AlphaBalance::from(100u64));
+        // Existing prices are {10, 3, 1}.
+        // Sorted prices are {1, 3, 10}; the bottom 50% is {1, 3}; its median is 2.
+        setup_reserves(n1, TaoBalance::from(1_000u64), AlphaBalance::from(100u64));
+        setup_reserves(n2, TaoBalance::from(300u64), AlphaBalance::from(100u64));
+        setup_reserves(n3, TaoBalance::from(100u64), AlphaBalance::from(100u64));
 
-        // Existing prices are {5, 2}. Sorted prices are {2, 5}; the bottom 50% is {2}.
         let pre_registration_price = SubtensorModule::get_bottom_half_median_subnet_alpha_price();
         assert_eq!(pre_registration_price, U96F32::from_num(2u64));
 
@@ -2526,8 +2533,11 @@ fn register_network_credits_owner_alpha_from_even_median_and_excludes_new_subnet
         let wrong_post_registration_owner_alpha: AlphaBalance =
             owner_alpha_from_lock_and_price(actual_locked_u64, post_registration_price).into();
 
-        // Eligible prices are now {1, 2, 5}; the bottom 50% is {1, 2}; its median is 1.5.
-        assert_eq!(new_subnet_price, U96F32::from_num(1u64));
+        // With the corrected launch math, the new subnet launches exactly at the snapshot price.
+        assert_eq!(new_subnet_price, U96F32::from_num(2u64));
+
+        // Eligible prices are now {10, 3, 1, 2}.
+        // Sorted prices are {1, 2, 3, 10}; the bottom 50% is {1, 2}; its median is 1.5.
         assert_eq!(post_registration_price, U96F32::from_num(1.5));
         assert_ne!(pre_registration_price, post_registration_price);
 

--- a/pallets/subtensor/src/tests/networks.rs
+++ b/pallets/subtensor/src/tests/networks.rs
@@ -1738,20 +1738,44 @@ fn test_register_subnet_low_lock_cost() {
         NetworkMinLockCost::<Test>::set(TaoBalance::from(1_000));
         NetworkLastLockCost::<Test>::set(TaoBalance::from(1_000));
 
-        // Make sure lock cost is lower than 100 TAO
         let lock_cost = SubtensorModule::get_network_lock_cost();
         assert!(lock_cost < 100_000_000_000_u64.into());
 
         let subnet_owner_coldkey = U256::from(1);
         let subnet_owner_hotkey = U256::from(2);
-        let netuid = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
+        SubtensorModule::add_balance_to_coldkey_account(&subnet_owner_coldkey, lock_cost.into());
+
+        assert_ok!(SubtensorModule::register_network(
+            RuntimeOrigin::signed(subnet_owner_coldkey),
+            subnet_owner_hotkey,
+        ));
+
+        let netuid = match last_event() {
+            RuntimeEvent::SubtensorModule(Event::<Test>::NetworkAdded(netuid, _)) => netuid,
+            _ => panic!("Expected NetworkAdded event"),
+        };
         assert!(SubtensorModule::if_subnet_exist(netuid));
 
-        // Ensure that both Subnet TAO and Subnet Alpha In equal to (actual) lock_cost
-        assert_eq!(SubnetTAO::<Test>::get(netuid), lock_cost);
+        let actual_locked_u64 = SubtensorModule::get_subnet_locked_balance(netuid).to_u64();
+        let fallback_price = U96F32::from_num(1u64);
+
+        assert_eq!(
+            SubnetTAO::<Test>::get(netuid),
+            TaoBalance::from(pool_tao_from_lock(actual_locked_u64))
+        );
         assert_eq!(
             SubnetAlphaIn::<Test>::get(netuid),
-            lock_cost.to_u64().into()
+            AlphaBalance::from(pool_alpha_from_lock_and_price(
+                actual_locked_u64,
+                fallback_price,
+            ))
+        );
+        assert_eq!(
+            SubnetAlphaOut::<Test>::get(netuid),
+            AlphaBalance::from(owner_alpha_from_lock_and_price(
+                actual_locked_u64,
+                fallback_price,
+            ))
         );
     })
 }
@@ -1764,20 +1788,44 @@ fn test_register_subnet_high_lock_cost() {
         NetworkMinLockCost::<Test>::set(lock_cost);
         NetworkLastLockCost::<Test>::set(lock_cost);
 
-        // Make sure lock cost is higher than 100 TAO
         let lock_cost = SubtensorModule::get_network_lock_cost();
         assert!(lock_cost >= 1_000_000_000_000_u64.into());
 
         let subnet_owner_coldkey = U256::from(1);
         let subnet_owner_hotkey = U256::from(2);
-        let netuid = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
+        SubtensorModule::add_balance_to_coldkey_account(&subnet_owner_coldkey, lock_cost.into());
+
+        assert_ok!(SubtensorModule::register_network(
+            RuntimeOrigin::signed(subnet_owner_coldkey),
+            subnet_owner_hotkey,
+        ));
+
+        let netuid = match last_event() {
+            RuntimeEvent::SubtensorModule(Event::<Test>::NetworkAdded(netuid, _)) => netuid,
+            _ => panic!("Expected NetworkAdded event"),
+        };
         assert!(SubtensorModule::if_subnet_exist(netuid));
 
-        // Ensure that both Subnet TAO and Subnet Alpha In equal to 100 TAO
-        assert_eq!(SubnetTAO::<Test>::get(netuid), lock_cost);
+        let actual_locked_u64 = SubtensorModule::get_subnet_locked_balance(netuid).to_u64();
+        let fallback_price = U96F32::from_num(1u64);
+
+        assert_eq!(
+            SubnetTAO::<Test>::get(netuid),
+            TaoBalance::from(pool_tao_from_lock(actual_locked_u64))
+        );
         assert_eq!(
             SubnetAlphaIn::<Test>::get(netuid),
-            lock_cost.to_u64().into()
+            AlphaBalance::from(pool_alpha_from_lock_and_price(
+                actual_locked_u64,
+                fallback_price,
+            ))
+        );
+        assert_eq!(
+            SubnetAlphaOut::<Test>::get(netuid),
+            AlphaBalance::from(owner_alpha_from_lock_and_price(
+                actual_locked_u64,
+                fallback_price,
+            ))
         );
     })
 }
@@ -2242,32 +2290,22 @@ fn dissolve_clears_all_mechanism_scoped_maps_for_all_mechanisms() {
     });
 }
 
-fn owner_alpha_from_lock_and_price(lock_cost_u64: u64, price: U96F32) -> u64 {
-    let alpha = (U96F32::from_num(lock_cost_u64)
-        .checked_div(price)
-        .unwrap_or_default())
-    .floor();
-
-    if alpha > U96F32::from_num(u64::MAX) {
-        u64::MAX
-    } else {
-        alpha.to_num::<u64>()
-    }
-}
-
 #[test]
 fn median_subnet_alpha_price_returns_one_when_no_eligible_subnet_prices() {
     new_test_ext(0).execute_with(|| {
         let one = U96F32::from_num(1u64);
 
-        // Empty state.
-        assert_eq!(SubtensorModule::get_median_subnet_alpha_price(), one);
+        assert_eq!(
+            SubtensorModule::get_bottom_half_median_subnet_alpha_price(),
+            one
+        );
 
-        // ROOT must be ignored.
         NetworksAdded::<Test>::insert(NetUid::ROOT, true);
-        assert_eq!(SubtensorModule::get_median_subnet_alpha_price(), one);
+        assert_eq!(
+            SubtensorModule::get_bottom_half_median_subnet_alpha_price(),
+            one
+        );
 
-        // Zero-priced subnet must be ignored.
         let zero_cold = U256::from(101);
         let zero_hot = U256::from(102);
         let zero_netuid = add_dynamic_network(&zero_hot, &zero_cold);
@@ -2276,9 +2314,11 @@ fn median_subnet_alpha_price_returns_one_when_no_eligible_subnet_prices() {
             <Test as pallet::Config>::SwapInterface::current_alpha_price(zero_netuid.into()),
             U96F32::from_num(0u64)
         );
-        assert_eq!(SubtensorModule::get_median_subnet_alpha_price(), one);
+        assert_eq!(
+            SubtensorModule::get_bottom_half_median_subnet_alpha_price(),
+            one
+        );
 
-        // added=false subnet must be ignored as well.
         let hidden_cold = U256::from(103);
         let hidden_hot = U256::from(104);
         let hidden_netuid = add_dynamic_network(&hidden_hot, &hidden_cold);
@@ -2289,7 +2329,10 @@ fn median_subnet_alpha_price_returns_one_when_no_eligible_subnet_prices() {
         );
         NetworksAdded::<Test>::insert(hidden_netuid, false);
 
-        assert_eq!(SubtensorModule::get_median_subnet_alpha_price(), one);
+        assert_eq!(
+            SubtensorModule::get_bottom_half_median_subnet_alpha_price(),
+            one
+        );
     });
 }
 
@@ -2300,7 +2343,6 @@ fn median_subnet_alpha_price_returns_middle_value_for_odd_unsorted_prices() {
         let n2 = add_dynamic_network(&U256::from(203), &U256::from(202));
         let n3 = add_dynamic_network(&U256::from(205), &U256::from(204));
 
-        // Unsorted prices: 7, 2, 5 -> median should be 5.
         setup_reserves(n1, TaoBalance::from(700u64), AlphaBalance::from(100u64));
         setup_reserves(n2, TaoBalance::from(200u64), AlphaBalance::from(100u64));
         setup_reserves(n3, TaoBalance::from(500u64), AlphaBalance::from(100u64));
@@ -2318,9 +2360,10 @@ fn median_subnet_alpha_price_returns_middle_value_for_odd_unsorted_prices() {
             U96F32::from_num(5u64)
         );
 
+        // Sorted prices are {2, 5, 7}; the bottom 50% is {2, 5}; its median is 3.5.
         assert_eq!(
-            SubtensorModule::get_median_subnet_alpha_price(),
-            U96F32::from_num(5u64)
+            SubtensorModule::get_bottom_half_median_subnet_alpha_price(),
+            U96F32::from_num(3.5)
         );
     });
 }
@@ -2328,7 +2371,7 @@ fn median_subnet_alpha_price_returns_middle_value_for_odd_unsorted_prices() {
 #[test]
 fn median_subnet_alpha_price_averages_even_prices_and_ignores_root_zero_and_unadded() {
     new_test_ext(0).execute_with(|| {
-        // If ROOT were included, its price would be 1 and change the median.
+        // If ROOT were included, its price would be 1 and change the result.
         NetworksAdded::<Test>::insert(NetUid::ROOT, true);
 
         let n1 = add_dynamic_network(&U256::from(301), &U256::from(300)); // eligible, price 2
@@ -2360,10 +2403,10 @@ fn median_subnet_alpha_price_averages_even_prices_and_ignores_root_zero_and_unad
             U96F32::from_num(0u64)
         );
 
-        // Eligible prices are only {2, 8}, so the median is (2 + 8) / 2 = 5.
+        // Eligible prices are only {2, 8}. The bottom 50% is just {2}, so the result is 2.
         assert_eq!(
-            SubtensorModule::get_median_subnet_alpha_price(),
-            U96F32::from_num(5u64)
+            SubtensorModule::get_bottom_half_median_subnet_alpha_price(),
+            U96F32::from_num(2u64)
         );
     });
 }
@@ -2376,22 +2419,9 @@ fn register_network_credits_owner_alpha_using_fallback_price_one_on_first_subnet
         let new_netuid = SubtensorModule::get_next_netuid();
 
         let lock_cost_u64: u64 = SubtensorModule::get_network_lock_cost().into();
-        let pre_registration_median = SubtensorModule::get_median_subnet_alpha_price();
-        let expected_owner_alpha_u64 =
-            owner_alpha_from_lock_and_price(lock_cost_u64, pre_registration_median);
-        let expected_owner_alpha: AlphaBalance = expected_owner_alpha_u64.into();
+        let pre_registration_price = SubtensorModule::get_bottom_half_median_subnet_alpha_price();
 
-        let pool_initial_tao = SubtensorModule::get_network_min_lock();
-        let pool_initial_tao_u64 = pool_initial_tao.to_u64();
-        let expected_pool_alpha: AlphaBalance = pool_initial_tao_u64.into();
-        let expected_alpha_issuance: AlphaBalance = pool_initial_tao_u64
-            .saturating_add(expected_owner_alpha_u64)
-            .into();
-        let expected_recycled: TaoBalance =
-            lock_cost_u64.saturating_sub(pool_initial_tao_u64).into();
-
-        assert_eq!(pre_registration_median, U96F32::from_num(1u64));
-        assert_eq!(expected_owner_alpha_u64, lock_cost_u64);
+        assert_eq!(pre_registration_price, U96F32::from_num(1u64));
 
         SubtensorModule::add_balance_to_coldkey_account(
             &new_cold,
@@ -2405,15 +2435,25 @@ fn register_network_credits_owner_alpha_using_fallback_price_one_on_first_subnet
             None,
         ));
 
+        let actual_locked = SubtensorModule::get_subnet_locked_balance(new_netuid);
+        let actual_locked_u64 = actual_locked.to_u64();
+
+        let expected_pool_tao: TaoBalance = pool_tao_from_lock(actual_locked_u64).into();
+        let expected_pool_alpha: AlphaBalance =
+            pool_alpha_from_lock_and_price(actual_locked_u64, pre_registration_price).into();
+        let expected_owner_alpha: AlphaBalance =
+            owner_alpha_from_lock_and_price(actual_locked_u64, pre_registration_price).into();
+        let expected_alpha_issuance: AlphaBalance =
+            total_registration_alpha_from_lock_and_price(actual_locked_u64, pre_registration_price)
+                .into();
+        let expected_recycled: TaoBalance = recycled_tao_from_lock(actual_locked_u64).into();
+
         assert!(SubtensorModule::if_subnet_exist(new_netuid));
         assert_eq!(TotalNetworks::<Test>::get(), 1);
         assert_eq!(SubnetOwner::<Test>::get(new_netuid), new_cold);
         assert_eq!(SubnetOwnerHotkey::<Test>::get(new_netuid), new_hot);
-        assert_eq!(
-            SubtensorModule::get_subnet_locked_balance(new_netuid),
-            TaoBalance::from(lock_cost_u64)
-        );
-        assert_eq!(SubnetTAO::<Test>::get(new_netuid), pool_initial_tao);
+        assert_eq!(actual_locked, TaoBalance::from(actual_locked_u64));
+        assert_eq!(SubnetTAO::<Test>::get(new_netuid), expected_pool_tao);
         assert_eq!(SubnetAlphaIn::<Test>::get(new_netuid), expected_pool_alpha);
         assert_eq!(
             SubnetAlphaOut::<Test>::get(new_netuid),
@@ -2448,25 +2488,21 @@ fn register_network_credits_owner_alpha_using_fallback_price_one_on_first_subnet
 
 #[test]
 fn register_network_credits_owner_alpha_from_even_median_and_excludes_new_subnet_price() {
-    new_test_ext(0).execute_with(|| {
+    new_test_ext(1).execute_with(|| {
         let n1 = add_dynamic_network(&U256::from(1201), &U256::from(1200));
         let n2 = add_dynamic_network(&U256::from(1203), &U256::from(1202));
 
-        // Existing prices are {5, 2} -> pre-registration median is 3.5.
         setup_reserves(n1, TaoBalance::from(500u64), AlphaBalance::from(100u64));
         setup_reserves(n2, TaoBalance::from(200u64), AlphaBalance::from(100u64));
 
-        let pre_registration_median = SubtensorModule::get_median_subnet_alpha_price();
-        assert_eq!(pre_registration_median, U96F32::from_num(3.5));
+        // Existing prices are {5, 2}. Sorted prices are {2, 5}; the bottom 50% is {2}.
+        let pre_registration_price = SubtensorModule::get_bottom_half_median_subnet_alpha_price();
+        assert_eq!(pre_registration_price, U96F32::from_num(2u64));
 
         let new_cold = U256::from(1300);
         let new_hot = U256::from(1301);
         let new_netuid = SubtensorModule::get_next_netuid();
         let lock_cost_u64: u64 = SubtensorModule::get_network_lock_cost().into();
-
-        let expected_owner_alpha_u64 =
-            owner_alpha_from_lock_and_price(lock_cost_u64, pre_registration_median);
-        let expected_owner_alpha: AlphaBalance = expected_owner_alpha_u64.into();
 
         SubtensorModule::add_balance_to_coldkey_account(
             &new_cold,
@@ -2480,22 +2516,21 @@ fn register_network_credits_owner_alpha_from_even_median_and_excludes_new_subnet
             None,
         ));
 
-        // After registration, the new subnet exists and is seeded at price 1,
-        // so the live median becomes median({1, 2, 5}) = 2.
+        let actual_locked_u64 = SubtensorModule::get_subnet_locked_balance(new_netuid).to_u64();
+        let expected_owner_alpha: AlphaBalance =
+            owner_alpha_from_lock_and_price(actual_locked_u64, pre_registration_price).into();
+
         let new_subnet_price =
             <Test as pallet::Config>::SwapInterface::current_alpha_price(new_netuid.into());
-        let post_registration_median = SubtensorModule::get_median_subnet_alpha_price();
-        let wrong_post_registration_owner_alpha_u64 =
-            owner_alpha_from_lock_and_price(lock_cost_u64, post_registration_median);
+        let post_registration_price = SubtensorModule::get_bottom_half_median_subnet_alpha_price();
         let wrong_post_registration_owner_alpha: AlphaBalance =
-            wrong_post_registration_owner_alpha_u64.into();
+            owner_alpha_from_lock_and_price(actual_locked_u64, post_registration_price).into();
 
+        // Eligible prices are now {1, 2, 5}; the bottom 50% is {1, 2}; its median is 1.5.
         assert_eq!(new_subnet_price, U96F32::from_num(1u64));
-        assert_eq!(post_registration_median, U96F32::from_num(2u64));
-        assert_ne!(pre_registration_median, post_registration_median);
+        assert_eq!(post_registration_price, U96F32::from_num(1.5));
+        assert_ne!(pre_registration_price, post_registration_price);
 
-        // The registration flow must use the pre-registration median snapshot (3.5),
-        // not the post-init median (2).
         assert_eq!(
             SubnetAlphaOut::<Test>::get(new_netuid),
             expected_owner_alpha
@@ -2631,4 +2666,34 @@ fn register_network_non_associated_hotkey_does_not_withdraw_or_write_owner_alpha
             AlphaBalance::ZERO
         );
     });
+}
+
+fn total_registration_alpha_from_lock_and_price(lock_cost_u64: u64, price: U96F32) -> u64 {
+    let alpha = (U96F32::from_num(lock_cost_u64)
+        .checked_div(price)
+        .unwrap_or_default())
+    .floor();
+
+    if alpha > U96F32::from_num(u64::MAX) {
+        u64::MAX
+    } else {
+        alpha.to_num::<u64>()
+    }
+}
+
+fn owner_alpha_from_lock_and_price(lock_cost_u64: u64, price: U96F32) -> u64 {
+    let total_alpha_u64 = total_registration_alpha_from_lock_and_price(lock_cost_u64, price);
+    total_alpha_u64.saturating_sub(total_alpha_u64 / 2)
+}
+
+fn pool_alpha_from_lock_and_price(lock_cost_u64: u64, price: U96F32) -> u64 {
+    total_registration_alpha_from_lock_and_price(lock_cost_u64, price) / 2
+}
+
+fn pool_tao_from_lock(lock_cost_u64: u64) -> u64 {
+    lock_cost_u64 / 4
+}
+
+fn recycled_tao_from_lock(lock_cost_u64: u64) -> u64 {
+    lock_cost_u64.saturating_sub(pool_tao_from_lock(lock_cost_u64))
 }

--- a/pallets/subtensor/src/tests/staking.rs
+++ b/pallets/subtensor/src/tests/staking.rs
@@ -40,6 +40,7 @@ fn test_add_stake_dispatch_info_ok() {
         assert_eq!(di.pays_fee, Pays::Yes,);
     });
 }
+
 #[test]
 fn test_add_stake_ok_no_emission() {
     new_test_ext(1).execute_with(|| {
@@ -66,10 +67,12 @@ fn test_add_stake_ok_no_emission() {
             TaoBalance::ZERO
         );
 
-        // Also total stake should be equal to the network initial lock
-        assert_eq!(
-            SubtensorModule::get_total_stake(),
-            SubtensorModule::get_network_min_lock()
+        // The legacy-normalized subnet should start with essentially the legacy initial lock.
+        let initial_total_stake = SubtensorModule::get_total_stake();
+        assert_abs_diff_eq!(
+            initial_total_stake,
+            SubtensorModule::get_network_min_lock(),
+            epsilon = 1.into()
         );
 
         // Transfer to hotkey account, and check if the result is ok
@@ -106,10 +109,11 @@ fn test_add_stake_ok_no_emission() {
             1.into()
         );
 
-        // Check if total stake has increased accordingly.
-        assert_eq!(
+        // Check if total stake increased by the staked TAO amount.
+        assert_abs_diff_eq!(
             SubtensorModule::get_total_stake(),
-            SubtensorModule::get_network_min_lock() + amount.into()
+            initial_total_stake + amount.into(),
+            epsilon = 1.into()
         );
     });
 }

--- a/pallets/subtensor/src/tests/subnet.rs
+++ b/pallets/subtensor/src/tests/subnet.rs
@@ -245,7 +245,7 @@ fn test_register_network_use_symbol_for_subnet_if_available() {
 
             assert_ok!(SubtensorModule::register_network(
                 <<Test as Config>::RuntimeOrigin>::signed(coldkey),
-                hotkey
+                hotkey,
             ));
 
             let netuid = match last_event() {
@@ -253,11 +253,10 @@ fn test_register_network_use_symbol_for_subnet_if_available() {
                 _ => panic!("Expected NetworkAdded event"),
             };
 
-            // Ensure the symbol correspond to the netuid has been set
+            remove_owner_registration_stake(netuid);
+
             let expected_symbol = SYMBOLS.get(usize::from(u16::from(netuid))).unwrap();
             assert_eq!(TokenSymbol::<Test>::get(netuid), *expected_symbol);
-
-            // Check registration allowed
             assert!(NetworkRegistrationAllowed::<Test>::get(netuid));
             assert!(NetworkPowRegistrationAllowed::<Test>::get(netuid));
         }
@@ -267,7 +266,6 @@ fn test_register_network_use_symbol_for_subnet_if_available() {
 #[test]
 fn test_register_network_use_next_available_symbol_if_symbol_for_subnet_is_taken() {
     new_test_ext(1).execute_with(|| {
-        // Register 50 networks (additionnaly to the root network)
         for i in 0..50 {
             let coldkey = U256::from(1_000_000 + i);
             let hotkey = U256::from(2_000_000 + i);
@@ -276,7 +274,7 @@ fn test_register_network_use_next_available_symbol_if_symbol_for_subnet_is_taken
 
             assert_ok!(SubtensorModule::register_network(
                 <<Test as Config>::RuntimeOrigin>::signed(coldkey),
-                hotkey
+                hotkey,
             ));
 
             let netuid = match last_event() {
@@ -284,19 +282,16 @@ fn test_register_network_use_next_available_symbol_if_symbol_for_subnet_is_taken
                 _ => panic!("Expected NetworkAdded event"),
             };
 
-            // Ensure the symbol correspond to the netuid has been set
+            remove_owner_registration_stake(netuid);
+
             let expected_symbol = SYMBOLS.get(usize::from(u16::from(netuid))).unwrap();
             assert_eq!(TokenSymbol::<Test>::get(netuid), *expected_symbol);
-
-            // Check registration allowed
             assert!(NetworkRegistrationAllowed::<Test>::get(netuid));
             assert!(NetworkPowRegistrationAllowed::<Test>::get(netuid));
         }
 
-        // Swap some of the network symbol for the network 25 to network 51 symbol (not registered yet)
         TokenSymbol::<Test>::insert(NetUid::from(25), SYMBOLS.get(51).unwrap().to_vec());
 
-        // Register a new network
         let coldkey = U256::from(1_000_000 + 50);
         let hotkey = U256::from(2_000_000 + 50);
         let cost = SubtensorModule::get_network_lock_cost();
@@ -304,16 +299,16 @@ fn test_register_network_use_next_available_symbol_if_symbol_for_subnet_is_taken
 
         assert_ok!(SubtensorModule::register_network(
             <<Test as Config>::RuntimeOrigin>::signed(coldkey),
-            hotkey
+            hotkey,
         ));
 
-        // Get netuid of the new network
         let netuid = match last_event() {
             RuntimeEvent::SubtensorModule(Event::<Test>::NetworkAdded(netuid, _)) => netuid,
             _ => panic!("Expected NetworkAdded event"),
         };
 
-        // We expect the symbol to be the one that was previously taken by network 25, before it was swapped
+        remove_owner_registration_stake(netuid);
+
         let expected_symbol = SYMBOLS.get(25).unwrap();
         assert_eq!(TokenSymbol::<Test>::get(netuid), *expected_symbol);
     });
@@ -322,8 +317,8 @@ fn test_register_network_use_next_available_symbol_if_symbol_for_subnet_is_taken
 #[test]
 fn test_register_network_use_default_symbol_if_all_symbols_are_taken() {
     new_test_ext(1).execute_with(|| {
-        // Register networks until we have exhausted all symbols
         SubtensorModule::set_max_subnets(SYMBOLS.len() as u16);
+
         for i in 0..(SYMBOLS.len() - 1) {
             let coldkey = U256::from(1_000_000 + i);
             let hotkey = U256::from(2_000_000 + i);
@@ -332,11 +327,17 @@ fn test_register_network_use_default_symbol_if_all_symbols_are_taken() {
 
             assert_ok!(SubtensorModule::register_network(
                 <<Test as Config>::RuntimeOrigin>::signed(coldkey),
-                hotkey
+                hotkey,
             ));
+
+            let netuid = match last_event() {
+                RuntimeEvent::SubtensorModule(Event::<Test>::NetworkAdded(netuid, _)) => netuid,
+                _ => panic!("Expected NetworkAdded event"),
+            };
+
+            remove_owner_registration_stake(netuid);
         }
 
-        // Register a new network
         let coldkey = U256::from(1_000_000 + 50);
         let hotkey = U256::from(2_000_000 + 50);
         let cost = SubtensorModule::get_network_lock_cost();
@@ -344,24 +345,23 @@ fn test_register_network_use_default_symbol_if_all_symbols_are_taken() {
 
         assert_ok!(SubtensorModule::register_network(
             <<Test as Config>::RuntimeOrigin>::signed(coldkey),
-            hotkey
+            hotkey,
         ));
 
-        // Get netuid of the new network
         let netuid = match last_event() {
             RuntimeEvent::SubtensorModule(Event::<Test>::NetworkAdded(netuid, _)) => netuid,
             _ => panic!("Expected NetworkAdded event"),
         };
+
+        remove_owner_registration_stake(netuid);
+
         assert_eq!(netuid, NetUid::from(SYMBOLS.len() as u16));
-
-        // We expect the symbol to be the default symbol
         assert_eq!(TokenSymbol::<Test>::get(netuid), *DEFAULT_SYMBOL);
-
-        // Check registration allowed
         assert!(NetworkRegistrationAllowed::<Test>::get(netuid));
         assert!(NetworkPowRegistrationAllowed::<Test>::get(netuid));
     });
 }
+
 // cargo test --package pallet-subtensor --lib -- tests::subnet::test_subtoken_enable --exact --show-output
 #[test]
 fn test_subtoken_enable() {


### PR DESCRIPTION
## Summary

This PR updates **subnet registration** so the **new subnet pool and the owner’s starting stake are both initialized from the same snapshot-priced registration seed**, using the **bottom-half median subnet alpha price**.

Previously, subnet registration only:
- locked the registration TAO,
- seeded the new subnet pool with `network_min_lock`,
- recycled the remainder,
- and set the subnet owner metadata.

With this change, registration now:
- computes the **bottom-half median subnet alpha price** from existing eligible subnets,
- injects **25% of the lock cost as TAO** into the new subnet pool,
- mints **snapshot-priced alpha against that seeded TAO amount**,
- injects that alpha into the pool as free alpha liquidity,
- grants the **same alpha amount again** to the subnet owner as **staked alpha**,
- and recycles the remaining locked TAO that is not used to seed the pool.

> **In one line:**  
> **Registering a subnet now seeds the pool with 25% of the lock cost in TAO, prices the pool alpha off the bottom-half median subnet market price, and grants the owner an equal amount of snapshot-priced alpha as initial stake.**

---