### PR TITLE
fix(epoch): emit decayed old bond entries absent from new in mat_ema_alpha_sparse

### DIFF
--- a/pallets/subtensor/src/epoch/math.rs
+++ b/pallets/subtensor/src/epoch/math.rs
@@ -1505,7 +1505,9 @@ pub fn mat_ema_alpha_sparse(
 
         // Add alpha_j * new_ij, clamp to [0, 1], and emit sparse entries > 0.
         let mut out_row: Vec<(u16, I32F32)> = Vec::new();
+        let mut new_cols = std::collections::BTreeSet::new();
         for &(j, new_val) in new_row.iter() {
+            new_cols.insert(j);
             if let (Some(&a), Some(&decayed)) =
                 (alpha_row.get(j as usize), decayed_values.get(j as usize))
             {
@@ -1516,6 +1518,15 @@ pub fn mat_ema_alpha_sparse(
                 }
             }
         }
+
+        // Emit decayed old entries for columns absent from new_row.
+        // This ensures old bonds decay gradually rather than dropping to zero instantly.
+        for (j, &decayed) in decayed_values.iter().enumerate() {
+            if !new_cols.contains(&(j as u16)) && decayed > zero {
+                out_row.push((j as u16, decayed));
+            }
+        }
+        out_row.sort_unstable_by_key(|&(j, _)| j);
 
         result.push(out_row);
     }

--- a/pallets/subtensor/src/tests/math.rs
+++ b/pallets/subtensor/src/tests/math.rs
@@ -2107,15 +2107,18 @@ fn test_math_sparse_mat_ema_alpha() {
     let alphas = vec_to_mat_fixed(&[0.1; 12], 4, false);
     let result = mat_ema_alpha_sparse(&new, &old, &alphas);
     assert_sparse_mat_compare(&result, &target, I32F32::from_num(1e-4));
+    // Old entry absent from new must decay via EMA rather than drop to zero instantly.
+    // With alpha=0.1: old[0][0]=1.0 absent from new => (1-0.1)*1.0 = 0.9
+    //                 new[1][0]=2.0 absent from old => 0.1*2.0 = 0.2
     let old: Vec<f32> = vec![1., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.];
     let new: Vec<f32> = vec![0., 0., 0., 0., 2., 0., 0., 0., 0., 0., 0., 0.];
-    let target: Vec<f32> = vec![0.0, 0., 0., 0., 0.2, 0., 0., 0., 0., 0., 0., 0.];
+    let target: Vec<f32> = vec![0.9, 0., 0., 0., 0.2, 0., 0., 0., 0., 0., 0., 0.];
     let old = vec_to_sparse_mat_fixed(&old, 4, false);
     let new = vec_to_sparse_mat_fixed(&new, 4, false);
     let target = vec_to_sparse_mat_fixed(&target, 4, false);
     let alphas = vec_to_mat_fixed(&[0.1; 12], 4, false);
     let result = mat_ema_alpha_sparse(&new, &old, &alphas);
-    assert_sparse_mat_compare(&result, &target, I32F32::from_num(1e-1));
+    assert_sparse_mat_compare(&result, &target, I32F32::from_num(1e-4));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- `mat_ema_alpha_sparse` only emitted sparse output entries present in the `new` matrix. Old bond entries absent from `new_row` had their decayed values computed (`(1 - alpha) * old_val`) but never emitted, causing bonds to drop to zero instantly instead of decaying gradually.
- This diverges from the dense equivalent `mat_ema_alpha` and breaks the bond decay semantics: when a validator removes weight to a miner, the bond should decay by `(1 - alpha)` per epoch, not zero immediately.
- Fix: after the `new_row` loop, iterate `decayed_values` for columns not in `new_row` and emit non-zero entries. Output is sorted by column index to maintain the sparse row invariant.
- Updated `test_math_sparse_mat_ema_alpha` to assert the correct value (`0.9` instead of `0.0` for `alpha=0.1`, `old=1.0`, `new=0.0`).

## Root cause

```rust
// Before: only iterates new_row, missing old-only entries
for &(j, new_val) in new_row.iter() {
    // emit alpha*new + (1-alpha)*old for columns in new
}
// old-only columns → decayed_values computed but never pushed to out_row
```

## Fix

```rust
// After: also emit decayed old entries for columns absent from new_row
let mut new_cols = std::collections::BTreeSet::new();
for &(j, new_val) in new_row.iter() {
    new_cols.insert(j);
    // ... existing logic ...
}
for (j, &decayed) in decayed_values.iter().enumerate() {
    if !new_cols.contains(&(j as u16)) && decayed > zero {
        out_row.push((j as u16, decayed));
    }
}
out_row.sort_unstable_by_key(|&(j, _)| j);
```

## Test plan

- [x] `cargo test -p pallet-subtensor -- mat_ema` — all 15 tests pass
- [x] `test_math_sparse_mat_ema_alpha` now correctly validates old-only-entry decay
- [x] All existing sparse EMA tests (`test_mat_ema_alpha_sparse_*`) continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)