### PR TITLE
Swap AutoParentDelegationEnabled on the hotkey swap for root subnet

### DIFF
--- a/pallets/subtensor/src/swap/swap_hotkey.rs
+++ b/pallets/subtensor/src/swap/swap_hotkey.rs
@@ -568,10 +568,10 @@ impl<T: Config> Pallet<T> {
                 }
             }
 
-            // 9. Transfer root claimable and root claimed only for the root subnet
-            // NOTE: we shouldn't transfer root claimable and root claimed for other subnets,
-            // otherwise root stakers won't be able to receive dividends.
             if netuid == NetUid::ROOT {
+                // 9. Transfer root claimable and root claimed only for the root subnet
+                // NOTE: we shouldn't transfer root claimable and root claimed for other subnets,
+                // otherwise root stakers won't be able to receive dividends.
                 Self::transfer_root_claimable_for_new_hotkey(old_hotkey, new_hotkey);
                 weight.saturating_accrue(T::DbWeight::get().reads_writes(2, 2));
 
@@ -597,6 +597,14 @@ impl<T: Config> Pallet<T> {
                         );
                         weight.saturating_accrue(T::DbWeight::get().reads_writes(2, 2));
                     }
+                }
+
+                // Transfer AutoParentDelegationEnabled flag from old_hotkey to new_hotkey.
+                // Only migrate if it was explicitly set, to preserve the storage default semantics.
+                if AutoParentDelegationEnabled::<T>::contains_key(old_hotkey) {
+                    let enabled = AutoParentDelegationEnabled::<T>::take(old_hotkey);
+                    AutoParentDelegationEnabled::<T>::insert(new_hotkey, enabled);
+                    weight.saturating_accrue(T::DbWeight::get().reads_writes(1, 2));
                 }
             }
         }

--- a/pallets/subtensor/src/tests/swap_hotkey_with_subnet.rs
+++ b/pallets/subtensor/src/tests/swap_hotkey_with_subnet.rs
@@ -3187,7 +3187,9 @@ fn test_swap_hotkey_auto_parent_delegation_transferred_on_root() {
 
         // Opt out of auto parent delegation on the old hotkey.
         AutoParentDelegationEnabled::<Test>::insert(old_hotkey, false);
-        assert!(AutoParentDelegationEnabled::<Test>::contains_key(old_hotkey));
+        assert!(AutoParentDelegationEnabled::<Test>::contains_key(
+            old_hotkey
+        ));
         assert!(!AutoParentDelegationEnabled::<Test>::get(old_hotkey));
 
         step_block(20);
@@ -3203,7 +3205,9 @@ fn test_swap_hotkey_auto_parent_delegation_transferred_on_root() {
         assert!(!AutoParentDelegationEnabled::<Test>::contains_key(
             old_hotkey
         ));
-        assert!(AutoParentDelegationEnabled::<Test>::contains_key(new_hotkey));
+        assert!(AutoParentDelegationEnabled::<Test>::contains_key(
+            new_hotkey
+        ));
         assert!(!AutoParentDelegationEnabled::<Test>::get(new_hotkey));
     });
 }
@@ -3236,7 +3240,9 @@ fn test_swap_hotkey_auto_parent_delegation_transferred_on_all_subnets() {
         assert!(!AutoParentDelegationEnabled::<Test>::contains_key(
             old_hotkey
         ));
-        assert!(AutoParentDelegationEnabled::<Test>::contains_key(new_hotkey));
+        assert!(AutoParentDelegationEnabled::<Test>::contains_key(
+            new_hotkey
+        ));
         assert!(!AutoParentDelegationEnabled::<Test>::get(new_hotkey));
     });
 }
@@ -3264,7 +3270,9 @@ fn test_swap_hotkey_auto_parent_delegation_not_transferred_on_non_root() {
         ));
 
         // Non-root subnet swap must not move the flag.
-        assert!(AutoParentDelegationEnabled::<Test>::contains_key(old_hotkey));
+        assert!(AutoParentDelegationEnabled::<Test>::contains_key(
+            old_hotkey
+        ));
         assert!(!AutoParentDelegationEnabled::<Test>::get(old_hotkey));
         assert!(!AutoParentDelegationEnabled::<Test>::contains_key(
             new_hotkey

--- a/pallets/subtensor/src/tests/swap_hotkey_with_subnet.rs
+++ b/pallets/subtensor/src/tests/swap_hotkey_with_subnet.rs
@@ -3173,3 +3173,101 @@ fn test_swap_hotkey_root_claims_changed_if_all_subnets() {
         );
     });
 }
+
+// SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --package pallet-subtensor --lib -- tests::swap_hotkey_with_subnet::test_swap_hotkey_auto_parent_delegation_transferred_on_root --exact --nocapture
+#[test]
+fn test_swap_hotkey_auto_parent_delegation_transferred_on_root() {
+    new_test_ext(1).execute_with(|| {
+        let owner_coldkey = U256::from(1001);
+        let old_hotkey = U256::from(1004);
+        let new_hotkey = U256::from(1005);
+
+        let _ = add_dynamic_network(&old_hotkey, &owner_coldkey);
+        SubtensorModule::add_balance_to_coldkey_account(&owner_coldkey, u64::MAX.into());
+
+        // Opt out of auto parent delegation on the old hotkey.
+        AutoParentDelegationEnabled::<Test>::insert(old_hotkey, false);
+        assert!(AutoParentDelegationEnabled::<Test>::contains_key(old_hotkey));
+        assert!(!AutoParentDelegationEnabled::<Test>::get(old_hotkey));
+
+        step_block(20);
+        assert_ok!(SubtensorModule::do_swap_hotkey(
+            RuntimeOrigin::signed(owner_coldkey),
+            &old_hotkey,
+            &new_hotkey,
+            Some(NetUid::ROOT),
+            false
+        ));
+
+        // Flag is moved to the new hotkey, cleared from the old one.
+        assert!(!AutoParentDelegationEnabled::<Test>::contains_key(
+            old_hotkey
+        ));
+        assert!(AutoParentDelegationEnabled::<Test>::contains_key(new_hotkey));
+        assert!(!AutoParentDelegationEnabled::<Test>::get(new_hotkey));
+    });
+}
+
+// SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --package pallet-subtensor --lib -- tests::swap_hotkey_with_subnet::test_swap_hotkey_auto_parent_delegation_transferred_on_all_subnets --exact --nocapture
+#[test]
+fn test_swap_hotkey_auto_parent_delegation_transferred_on_all_subnets() {
+    new_test_ext(1).execute_with(|| {
+        let owner_coldkey = U256::from(1001);
+        let old_hotkey = U256::from(1004);
+        let new_hotkey = U256::from(1005);
+
+        SubtokenEnabled::<Test>::insert(NetUid::ROOT, true);
+        NetworksAdded::<Test>::insert(NetUid::ROOT, true);
+
+        let _ = add_dynamic_network(&old_hotkey, &owner_coldkey);
+        SubtensorModule::add_balance_to_coldkey_account(&owner_coldkey, u64::MAX.into());
+
+        AutoParentDelegationEnabled::<Test>::insert(old_hotkey, false);
+
+        step_block(20);
+        assert_ok!(SubtensorModule::do_swap_hotkey(
+            RuntimeOrigin::signed(owner_coldkey),
+            &old_hotkey,
+            &new_hotkey,
+            None,
+            false
+        ));
+
+        assert!(!AutoParentDelegationEnabled::<Test>::contains_key(
+            old_hotkey
+        ));
+        assert!(AutoParentDelegationEnabled::<Test>::contains_key(new_hotkey));
+        assert!(!AutoParentDelegationEnabled::<Test>::get(new_hotkey));
+    });
+}
+
+// SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --package pallet-subtensor --lib -- tests::swap_hotkey_with_subnet::test_swap_hotkey_auto_parent_delegation_not_transferred_on_non_root --exact --nocapture
+#[test]
+fn test_swap_hotkey_auto_parent_delegation_not_transferred_on_non_root() {
+    new_test_ext(1).execute_with(|| {
+        let owner_coldkey = U256::from(1001);
+        let old_hotkey = U256::from(1004);
+        let new_hotkey = U256::from(1005);
+
+        let netuid = add_dynamic_network(&old_hotkey, &owner_coldkey);
+        SubtensorModule::add_balance_to_coldkey_account(&owner_coldkey, u64::MAX.into());
+
+        AutoParentDelegationEnabled::<Test>::insert(old_hotkey, false);
+
+        System::set_block_number(System::block_number() + HotkeySwapOnSubnetInterval::get());
+        assert_ok!(SubtensorModule::do_swap_hotkey(
+            RuntimeOrigin::signed(owner_coldkey),
+            &old_hotkey,
+            &new_hotkey,
+            Some(netuid),
+            false
+        ));
+
+        // Non-root subnet swap must not move the flag.
+        assert!(AutoParentDelegationEnabled::<Test>::contains_key(old_hotkey));
+        assert!(!AutoParentDelegationEnabled::<Test>::get(old_hotkey));
+        assert!(!AutoParentDelegationEnabled::<Test>::contains_key(
+            new_hotkey
+        ));
+    });
+}


### PR DESCRIPTION
## Description
On hotkey swap within the root subnet, transfer the AutoParentDelegationEnabled flag from the old hotkey to the new one so a validator does not silently lose their opt-out after a key swap.

## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.