### PR TITLE
Owner Alpha Stake Changes

### DIFF
--- a/pallets/subtensor/src/subnets/subnet.rs
+++ b/pallets/subtensor/src/subnets/subnet.rs
@@ -209,17 +209,50 @@ impl<T: Config> Pallet<T> {
         let symbol = Self::get_next_available_symbol(netuid_to_register);
         TokenSymbol::<T>::insert(netuid_to_register, symbol);
 
-        // Seed the new subnet pool at a 1:1 reserve ratio.
-        // Separately, grant the subnet owner outstanding alpha based on the TAO they actually spent
-        // on registration converted by the current median subnet alpha price.
-        let pool_initial_tao: TaoBalance = Self::get_network_min_lock();
-        let pool_initial_alpha: AlphaBalance = pool_initial_tao.to_u64().into();
-        let owner_alpha_stake: AlphaBalance =
-            U96F32::saturating_from_num(actual_tao_lock_amount.to_u64())
-                .safe_div(median_subnet_alpha_price)
-                .saturating_floor()
-                .saturating_to_num::<u64>()
-                .into();
+        // Registration seeding model:
+        //   L = actual_tao_lock_amount
+        //   P = median TAO price of alpha across active subnets
+        //   A = L / P
+        //
+        // Inject:
+        //   - L / 4 TAO into the TAO side of the pool
+        //   - A / 2 total alpha, split evenly between:
+        //       * pool alpha reserve
+        //       * owner staked alpha
+        //
+        // This means the owner's alpha comes out of the seeded A / 2 rather than
+        // being minted on top of it. Subject to integer rounding, this initializes
+        // the pool at the median price and gives the owner ~12.5% of L if they
+        // immediately fully unstake into the fresh pool.
+        let two = U96F32::saturating_from_num(2_u64);
+        let four = U96F32::saturating_from_num(4_u64);
+        let lock_amount_as_float = U96F32::saturating_from_num(actual_tao_lock_amount.to_u64());
+
+        let alpha_at_median_price = lock_amount_as_float.safe_div(median_subnet_alpha_price);
+
+        let pool_initial_tao: TaoBalance = lock_amount_as_float
+            .safe_div(four)
+            .saturating_floor()
+            .saturating_to_num::<u64>()
+            .into();
+
+        let total_created_alpha: AlphaBalance = alpha_at_median_price
+            .safe_div(two)
+            .saturating_floor()
+            .saturating_to_num::<u64>()
+            .into();
+
+        let owner_alpha_stake: AlphaBalance = alpha_at_median_price
+            .safe_div(four)
+            .saturating_floor()
+            .saturating_to_num::<u64>()
+            .into();
+
+        // The owner's alpha must come out of the seeded A / 2 rather than be
+        // minted on top of it. Any rounding dust remains in the pool.
+        let pool_initial_alpha: AlphaBalance =
+            total_created_alpha.saturating_sub(owner_alpha_stake);
+
         let actual_tao_lock_amount_less_pool_tao =
             actual_tao_lock_amount.saturating_sub(pool_initial_tao);
 
@@ -252,7 +285,7 @@ impl<T: Config> Pallet<T> {
         }
 
         if actual_tao_lock_amount > TaoBalance::ZERO && pool_initial_tao > TaoBalance::ZERO {
-            // Record in TotalStake the initial TAO in the pool.
+            // Record in TotalStake only the TAO actually injected into the subnet pool.
             Self::increase_total_stake(pool_initial_tao);
         }
 
@@ -280,7 +313,7 @@ impl<T: Config> Pallet<T> {
         log::info!("NetworkAdded( netuid:{netuid_to_register:?}, mechanism:{mechid:?} )");
         Self::deposit_event(Event::NetworkAdded(netuid_to_register, mechid));
 
-        // --- 19. Return success.
+        // --- 20. Return success.
         Ok(())
     }
 

--- a/pallets/subtensor/src/tests/coinbase.rs
+++ b/pallets/subtensor/src/tests/coinbase.rs
@@ -2394,28 +2394,42 @@ fn test_distribute_emission_no_miners_all_drained() {
     new_test_ext(1).execute_with(|| {
         let netuid = add_dynamic_network(&U256::from(1), &U256::from(2));
         remove_owner_registration_stake(netuid);
+
+        // Restore the pre-change test invariant that this subnet starts with an exact 1:1 spot price.
+        mock::setup_reserves(
+            netuid,
+            TaoBalance::from(1_000_000_000_000_u64),
+            AlphaBalance::from(1_000_000_000_000_u64),
+        );
+
         let hotkey = U256::from(3);
         let coldkey = U256::from(4);
-        let init_stake = 1;
+        let init_stake = 1_u64;
+
         SubtensorModule::set_burn(netuid, TaoBalance::from(0));
+        SubtensorModule::set_subnet_owner_cut(0_u16);
+
         register_ok_neuron(netuid, hotkey, coldkey, 0);
-        // Give non-zero stake
+
+        // Give non-zero stake.
         SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
             &hotkey,
             &coldkey,
             netuid,
             init_stake.into(),
         );
+
         assert_eq!(
             SubtensorModule::get_total_stake_for_hotkey(&hotkey),
-            init_stake.into()
+            TaoBalance::from(init_stake)
         );
 
         // Set the weight of root TAO to be 0%, so only alpha is effective.
         SubtensorModule::set_tao_weight(0);
 
         // Set the emission to be 1 million.
-        let emission = AlphaBalance::from(1_000_000);
+        let emission = AlphaBalance::from(1_000_000_u64);
+
         // Run drain pending without any miners.
         SubtensorModule::distribute_emission(
             netuid,
@@ -2425,14 +2439,12 @@ fn test_distribute_emission_no_miners_all_drained() {
             AlphaBalance::ZERO,
         );
 
-        // Get the new stake of the hotkey.
-        let new_stake = SubtensorModule::get_total_stake_for_hotkey(&hotkey);
         // We expect this neuron to get *all* the emission.
-        // Slight epsilon due to rounding (hotkey_take).
+        let new_stake = SubtensorModule::get_total_stake_for_hotkey(&hotkey);
         assert_abs_diff_eq!(
             new_stake,
-            u64::from(emission + init_stake.into()).into(),
-            epsilon = 1.into()
+            TaoBalance::from(init_stake + emission.to_u64()),
+            epsilon = TaoBalance::from(1_u64)
         );
     });
 }
@@ -2442,28 +2454,38 @@ fn test_distribute_emission_no_miners_all_drained() {
 fn test_distribute_emission_zero_emission() {
     new_test_ext(1).execute_with(|| {
         let netuid = add_dynamic_network_disable_commit_reveal(&U256::from(1), &U256::from(2));
+        remove_owner_registration_stake(netuid);
+
+        // Restore the pre-change test invariant that this subnet starts with an exact 1:1 spot price.
+        mock::setup_reserves(
+            netuid,
+            TaoBalance::from(1_000_000_000_000_u64),
+            AlphaBalance::from(1_000_000_000_000_u64),
+        );
+
         let hotkey = U256::from(3);
         let coldkey = U256::from(4);
         let miner_hk = U256::from(5);
         let miner_ck = U256::from(6);
         let init_stake: u64 = 100_000_000_000_000;
         let tempo = 2;
+
         SubtensorModule::set_tempo(netuid, tempo);
-        // Set weight-set limit to 0.
         SubtensorModule::set_weights_set_rate_limit(netuid, 0);
 
         register_ok_neuron(netuid, hotkey, coldkey, 0);
         register_ok_neuron(netuid, miner_hk, miner_ck, 0);
-        // Give non-zero stake
+
         SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
             &hotkey,
             &coldkey,
             netuid,
             init_stake.into(),
         );
+
         assert_eq!(
             SubtensorModule::get_total_stake_for_hotkey(&hotkey),
-            init_stake.into()
+            TaoBalance::from(init_stake)
         );
 
         // Set the weight of root TAO to be 0%, so only alpha is effective.
@@ -2474,7 +2496,7 @@ fn test_distribute_emission_zero_emission() {
         // Run epoch for initial setup.
         SubtensorModule::epoch(netuid, AlphaBalance::ZERO);
 
-        // Set weights on miner
+        // Set weights on miner.
         assert_ok!(SubtensorModule::set_weights(
             RuntimeOrigin::signed(hotkey),
             netuid,
@@ -2485,7 +2507,6 @@ fn test_distribute_emission_zero_emission() {
 
         run_to_block_no_epoch(netuid, 50);
 
-        // Clear incentive and dividends.
         Incentive::<Test>::remove(NetUidStorageIndex::from(netuid));
         Dividends::<Test>::remove(netuid);
 
@@ -2498,12 +2519,11 @@ fn test_distribute_emission_zero_emission() {
             AlphaBalance::ZERO,
         );
 
-        // Get the new stake of the hotkey.
+        // Stake should remain unchanged.
         let new_stake = SubtensorModule::get_total_stake_for_hotkey(&hotkey);
-        // We expect the stake to remain unchanged.
-        assert_eq!(new_stake, init_stake.into());
+        assert_eq!(new_stake, TaoBalance::from(init_stake));
 
-        // Check that the incentive and dividends are set by epoch.
+        // Epoch should still have rebuilt incentive/dividend state.
         assert!(
             Incentive::<Test>::get(NetUidStorageIndex::from(netuid))
                 .iter()
@@ -3968,32 +3988,33 @@ fn test_get_subnet_terms_alpha_emissions_cap() {
         let owner_hotkey = U256::from(10);
         let owner_coldkey = U256::from(11);
         let netuid = add_dynamic_network(&owner_hotkey, &owner_coldkey);
+
+        // Restore the original "price = 1.0" precondition explicitly.
+        mock::setup_reserves(
+            netuid,
+            TaoBalance::from(1_000_000_000_u64),
+            AlphaBalance::from(1_000_000_000_u64),
+        );
+
         let tao_block_emission: U96F32 = U96F32::saturating_from_num(
             SubtensorModule::get_block_emission()
                 .unwrap_or(TaoBalance::ZERO)
                 .to_u64(),
         );
 
-        // price = 1.0
-        // tao_block_emission = 1000000000
-        // tao_block_emission == alpha_emission_i
-        // alpha_in_i <= alpha_injection_cap
-        let emissions1 = U96F32::from_num(100_000_000);
-
+        let emissions1 = U96F32::from_num(100_000_000_u64);
         let subnet_emissions1 = BTreeMap::from([(netuid, emissions1)]);
-        let (_, alpha_in, _, _) = SubtensorModule::get_subnet_terms(&subnet_emissions1);
+        let (_, alpha_in_1, _, _) = SubtensorModule::get_subnet_terms(&subnet_emissions1);
 
-        assert_eq!(alpha_in.get(&netuid).copied().unwrap(), emissions1);
+        assert_eq!(alpha_in_1.get(&netuid).copied().unwrap(), emissions1);
 
-        // price = 1.0
-        // tao_block_emission = 1000000000
-        // tao_block_emission == alpha_emission_i
-        // alpha_in_i > alpha_injection_cap
-        let emissions2 = U96F32::from_num(10_000_000_000u64);
-
+        let emissions2 = U96F32::from_num(10_000_000_000_u64);
         let subnet_emissions2 = BTreeMap::from([(netuid, emissions2)]);
-        let (_, alpha_in, _, _) = SubtensorModule::get_subnet_terms(&subnet_emissions2);
+        let (_, alpha_in_2, _, _) = SubtensorModule::get_subnet_terms(&subnet_emissions2);
 
-        assert_eq!(alpha_in.get(&netuid).copied().unwrap(), tao_block_emission);
+        assert_eq!(
+            alpha_in_2.get(&netuid).copied().unwrap(),
+            tao_block_emission
+        );
     });
 }

--- a/pallets/subtensor/src/tests/networks.rs
+++ b/pallets/subtensor/src/tests/networks.rs
@@ -3,6 +3,7 @@
 use super::mock::*;
 use crate::migrations::migrate_network_immunity_period;
 use crate::*;
+use approx::assert_abs_diff_eq;
 use frame_support::{assert_err, assert_ok};
 use frame_system::Config;
 use sp_core::U256;
@@ -1735,23 +1736,32 @@ fn test_migrate_network_immunity_period() {
 #[test]
 fn test_register_subnet_low_lock_cost() {
     new_test_ext(1).execute_with(|| {
-        NetworkMinLockCost::<Test>::set(TaoBalance::from(1_000));
-        NetworkLastLockCost::<Test>::set(TaoBalance::from(1_000));
+        NetworkMinLockCost::<Test>::set(TaoBalance::from(1_000_u64));
+        NetworkLastLockCost::<Test>::set(TaoBalance::from(1_000_u64));
 
-        // Make sure lock cost is lower than 100 TAO
         let lock_cost = SubtensorModule::get_network_lock_cost();
-        assert!(lock_cost < 100_000_000_000_u64.into());
+        assert!(lock_cost < TaoBalance::from(100_000_000_000_u64));
 
         let subnet_owner_coldkey = U256::from(1);
         let subnet_owner_hotkey = U256::from(2);
         let netuid = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
         assert!(SubtensorModule::if_subnet_exist(netuid));
 
-        // Ensure that both Subnet TAO and Subnet Alpha In equal to (actual) lock_cost
-        assert_eq!(SubnetTAO::<Test>::get(netuid), lock_cost);
+        let actual_locked = SubtensorModule::get_subnet_locked_balance(netuid);
+        let actual_locked_u64 = actual_locked.to_u64();
+
+        let expected_pool_tao = TaoBalance::from(actual_locked_u64 / 4);
+        let expected_total_created_alpha = AlphaBalance::from(actual_locked_u64 / 2);
+        let expected_owner_alpha = AlphaBalance::from(actual_locked_u64 / 4);
+        let expected_pool_alpha = expected_total_created_alpha.saturating_sub(expected_owner_alpha);
+
+        assert!(actual_locked <= lock_cost);
+        assert_eq!(SubnetTAO::<Test>::get(netuid), expected_pool_tao);
+        assert_eq!(SubnetAlphaIn::<Test>::get(netuid), expected_pool_alpha);
+        assert_eq!(SubnetAlphaOut::<Test>::get(netuid), expected_owner_alpha);
         assert_eq!(
-            SubnetAlphaIn::<Test>::get(netuid),
-            lock_cost.to_u64().into()
+            SubtensorModule::get_alpha_issuance(netuid),
+            expected_total_created_alpha
         );
     })
 }
@@ -1764,20 +1774,29 @@ fn test_register_subnet_high_lock_cost() {
         NetworkMinLockCost::<Test>::set(lock_cost);
         NetworkLastLockCost::<Test>::set(lock_cost);
 
-        // Make sure lock cost is higher than 100 TAO
         let lock_cost = SubtensorModule::get_network_lock_cost();
-        assert!(lock_cost >= 1_000_000_000_000_u64.into());
+        assert!(lock_cost >= TaoBalance::from(1_000_000_000_000_u64));
 
         let subnet_owner_coldkey = U256::from(1);
         let subnet_owner_hotkey = U256::from(2);
         let netuid = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
         assert!(SubtensorModule::if_subnet_exist(netuid));
 
-        // Ensure that both Subnet TAO and Subnet Alpha In equal to 100 TAO
-        assert_eq!(SubnetTAO::<Test>::get(netuid), lock_cost);
+        let actual_locked = SubtensorModule::get_subnet_locked_balance(netuid);
+        let actual_locked_u64 = actual_locked.to_u64();
+
+        let expected_pool_tao = TaoBalance::from(actual_locked_u64 / 4);
+        let expected_total_created_alpha = AlphaBalance::from(actual_locked_u64 / 2);
+        let expected_owner_alpha = AlphaBalance::from(actual_locked_u64 / 4);
+        let expected_pool_alpha = expected_total_created_alpha.saturating_sub(expected_owner_alpha);
+
+        assert!(actual_locked <= lock_cost);
+        assert_eq!(SubnetTAO::<Test>::get(netuid), expected_pool_tao);
+        assert_eq!(SubnetAlphaIn::<Test>::get(netuid), expected_pool_alpha);
+        assert_eq!(SubnetAlphaOut::<Test>::get(netuid), expected_owner_alpha);
         assert_eq!(
-            SubnetAlphaIn::<Test>::get(netuid),
-            lock_cost.to_u64().into()
+            SubtensorModule::get_alpha_issuance(netuid),
+            expected_total_created_alpha
         );
     })
 }
@@ -2242,19 +2261,6 @@ fn dissolve_clears_all_mechanism_scoped_maps_for_all_mechanisms() {
     });
 }
 
-fn owner_alpha_from_lock_and_price(lock_cost_u64: u64, price: U96F32) -> u64 {
-    let alpha = (U96F32::from_num(lock_cost_u64)
-        .checked_div(price)
-        .unwrap_or_default())
-    .floor();
-
-    if alpha > U96F32::from_num(u64::MAX) {
-        u64::MAX
-    } else {
-        alpha.to_num::<u64>()
-    }
-}
-
 #[test]
 fn median_subnet_alpha_price_returns_one_when_no_eligible_subnet_prices() {
     new_test_ext(0).execute_with(|| {
@@ -2371,31 +2377,20 @@ fn median_subnet_alpha_price_averages_even_prices_and_ignores_root_zero_and_unad
 #[test]
 fn register_network_credits_owner_alpha_using_fallback_price_one_on_first_subnet() {
     new_test_ext(1).execute_with(|| {
+        System::set_block_number(1);
+
         let new_cold = U256::from(1001);
         let new_hot = U256::from(1002);
         let new_netuid = SubtensorModule::get_next_netuid();
 
         let lock_cost_u64: u64 = SubtensorModule::get_network_lock_cost().into();
         let pre_registration_median = SubtensorModule::get_median_subnet_alpha_price();
-        let expected_owner_alpha_u64 =
-            owner_alpha_from_lock_and_price(lock_cost_u64, pre_registration_median);
-        let expected_owner_alpha: AlphaBalance = expected_owner_alpha_u64.into();
 
-        let pool_initial_tao = SubtensorModule::get_network_min_lock();
-        let pool_initial_tao_u64 = pool_initial_tao.to_u64();
-        let expected_pool_alpha: AlphaBalance = pool_initial_tao_u64.into();
-        let expected_alpha_issuance: AlphaBalance = pool_initial_tao_u64
-            .saturating_add(expected_owner_alpha_u64)
-            .into();
-        let expected_recycled: TaoBalance =
-            lock_cost_u64.saturating_sub(pool_initial_tao_u64).into();
-
-        assert_eq!(pre_registration_median, U96F32::from_num(1u64));
-        assert_eq!(expected_owner_alpha_u64, lock_cost_u64);
+        assert_eq!(pre_registration_median, U96F32::from_num(1_u64));
 
         SubtensorModule::add_balance_to_coldkey_account(
             &new_cold,
-            lock_cost_u64.saturating_mul(2).into(),
+            TaoBalance::from(lock_cost_u64.saturating_mul(2)),
         );
 
         assert_ok!(SubtensorModule::do_register_network(
@@ -2405,15 +2400,142 @@ fn register_network_credits_owner_alpha_using_fallback_price_one_on_first_subnet
             None,
         ));
 
+        let actual_locked = SubtensorModule::get_subnet_locked_balance(new_netuid);
+        let actual_locked_u64 = actual_locked.to_u64();
+
+        let expected_pool_tao = TaoBalance::from(actual_locked_u64 / 4);
+        let expected_total_created_alpha = AlphaBalance::from(actual_locked_u64 / 2);
+        let expected_owner_alpha = AlphaBalance::from(actual_locked_u64 / 4);
+        let expected_pool_alpha = expected_total_created_alpha.saturating_sub(expected_owner_alpha);
+        let expected_recycled = actual_locked.saturating_sub(expected_pool_tao);
+
         assert!(SubtensorModule::if_subnet_exist(new_netuid));
         assert_eq!(TotalNetworks::<Test>::get(), 1);
         assert_eq!(SubnetOwner::<Test>::get(new_netuid), new_cold);
         assert_eq!(SubnetOwnerHotkey::<Test>::get(new_netuid), new_hot);
+        assert_eq!(SubnetLocked::<Test>::get(new_netuid), actual_locked);
+
+        assert_eq!(SubnetTAO::<Test>::get(new_netuid), expected_pool_tao);
+        assert_eq!(SubnetAlphaIn::<Test>::get(new_netuid), expected_pool_alpha);
         assert_eq!(
-            SubtensorModule::get_subnet_locked_balance(new_netuid),
-            TaoBalance::from(lock_cost_u64)
+            SubnetAlphaOut::<Test>::get(new_netuid),
+            expected_owner_alpha
         );
-        assert_eq!(SubnetTAO::<Test>::get(new_netuid), pool_initial_tao);
+
+        assert_eq!(
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+                &new_hot, &new_cold, new_netuid,
+            ),
+            expected_owner_alpha
+        );
+        assert_eq!(
+            TotalHotkeyAlpha::<Test>::get(new_hot, new_netuid),
+            expected_owner_alpha
+        );
+        assert_eq!(
+            SubtensorModule::get_alpha_issuance(new_netuid),
+            expected_total_created_alpha
+        );
+        assert_eq!(
+            RAORecycledForRegistration::<Test>::get(new_netuid),
+            expected_recycled
+        );
+        assert_eq!(SubnetTaoProvided::<Test>::get(new_netuid), TaoBalance::ZERO);
+        assert_eq!(
+            SubnetAlphaInProvided::<Test>::get(new_netuid),
+            AlphaBalance::ZERO
+        );
+
+        let new_subnet_price =
+            <Test as pallet::Config>::SwapInterface::current_alpha_price(new_netuid.into());
+        assert_abs_diff_eq!(
+            new_subnet_price.to_num::<f64>(),
+            1.0_f64,
+            epsilon = 1e-9_f64
+        );
+
+        System::assert_last_event(Event::NetworkAdded(new_netuid, 1).into());
+    });
+}
+
+#[test]
+fn register_network_credits_owner_alpha_from_even_median_and_excludes_new_subnet_price() {
+    new_test_ext(1).execute_with(|| {
+        System::set_block_number(1);
+
+        let n1 = add_dynamic_network(&U256::from(1201), &U256::from(1200));
+        let n2 = add_dynamic_network(&U256::from(1203), &U256::from(1202));
+
+        // Existing prices are {5, 2} -> pre-registration median is 3.5.
+        setup_reserves(n1, TaoBalance::from(500_u64), AlphaBalance::from(100_u64));
+        setup_reserves(n2, TaoBalance::from(200_u64), AlphaBalance::from(100_u64));
+
+        let pre_registration_median = SubtensorModule::get_median_subnet_alpha_price();
+        assert_abs_diff_eq!(
+            pre_registration_median.to_num::<f64>(),
+            3.5_f64,
+            epsilon = 1e-9_f64
+        );
+
+        let new_cold = U256::from(1300);
+        let new_hot = U256::from(1301);
+        let new_netuid = SubtensorModule::get_next_netuid();
+        let lock_cost_u64: u64 = SubtensorModule::get_network_lock_cost().into();
+
+        SubtensorModule::add_balance_to_coldkey_account(
+            &new_cold,
+            TaoBalance::from(lock_cost_u64.saturating_mul(2)),
+        );
+
+        assert_ok!(SubtensorModule::do_register_network(
+            RuntimeOrigin::signed(new_cold),
+            &new_hot,
+            1,
+            None,
+        ));
+
+        let actual_locked_u64 = SubtensorModule::get_subnet_locked_balance(new_netuid).to_u64();
+
+        let expected_pool_tao = TaoBalance::from(actual_locked_u64 / 4);
+
+        let expected_total_created_alpha_u64 = (U96F32::from_num(actual_locked_u64)
+            .checked_div(pre_registration_median)
+            .unwrap_or_default()
+            .checked_div(U96F32::from_num(2_u64))
+            .unwrap_or_default())
+        .floor()
+        .to_num::<u64>();
+
+        let expected_owner_alpha_u64 = (U96F32::from_num(actual_locked_u64)
+            .checked_div(pre_registration_median)
+            .unwrap_or_default()
+            .checked_div(U96F32::from_num(4_u64))
+            .unwrap_or_default())
+        .floor()
+        .to_num::<u64>();
+
+        let expected_total_created_alpha = AlphaBalance::from(expected_total_created_alpha_u64);
+        let expected_owner_alpha = AlphaBalance::from(expected_owner_alpha_u64);
+        let expected_pool_alpha = expected_total_created_alpha.saturating_sub(expected_owner_alpha);
+
+        let new_subnet_price =
+            <Test as pallet::Config>::SwapInterface::current_alpha_price(new_netuid.into());
+        let post_registration_median = SubtensorModule::get_median_subnet_alpha_price();
+
+        // Under the new seeding rule, the new subnet is initialized at the median price
+        // instead of at 1.0, so the live median stays ~3.5.
+        assert_abs_diff_eq!(
+            new_subnet_price.to_num::<f64>(),
+            pre_registration_median.to_num::<f64>(),
+            epsilon = 1e-9_f64
+        );
+        assert_abs_diff_eq!(
+            post_registration_median.to_num::<f64>(),
+            pre_registration_median.to_num::<f64>(),
+            epsilon = 1e-9_f64
+        );
+
+        assert_eq!(SubnetTAO::<Test>::get(new_netuid), expected_pool_tao);
         assert_eq!(SubnetAlphaIn::<Test>::get(new_netuid), expected_pool_alpha);
         assert_eq!(
             SubnetAlphaOut::<Test>::get(new_netuid),
@@ -2428,91 +2550,6 @@ fn register_network_credits_owner_alpha_using_fallback_price_one_on_first_subnet
         assert_eq!(
             TotalHotkeyAlpha::<Test>::get(new_hot, new_netuid),
             expected_owner_alpha
-        );
-        assert_eq!(
-            SubtensorModule::get_alpha_issuance(new_netuid),
-            expected_alpha_issuance
-        );
-        assert_eq!(
-            RAORecycledForRegistration::<Test>::get(new_netuid),
-            expected_recycled
-        );
-        assert_eq!(SubnetTaoProvided::<Test>::get(new_netuid), TaoBalance::ZERO);
-        assert_eq!(
-            SubnetAlphaInProvided::<Test>::get(new_netuid),
-            AlphaBalance::ZERO
-        );
-        System::assert_last_event(Event::NetworkAdded(new_netuid, 1).into());
-    });
-}
-
-#[test]
-fn register_network_credits_owner_alpha_from_even_median_and_excludes_new_subnet_price() {
-    new_test_ext(0).execute_with(|| {
-        let n1 = add_dynamic_network(&U256::from(1201), &U256::from(1200));
-        let n2 = add_dynamic_network(&U256::from(1203), &U256::from(1202));
-
-        // Existing prices are {5, 2} -> pre-registration median is 3.5.
-        setup_reserves(n1, TaoBalance::from(500u64), AlphaBalance::from(100u64));
-        setup_reserves(n2, TaoBalance::from(200u64), AlphaBalance::from(100u64));
-
-        let pre_registration_median = SubtensorModule::get_median_subnet_alpha_price();
-        assert_eq!(pre_registration_median, U96F32::from_num(3.5));
-
-        let new_cold = U256::from(1300);
-        let new_hot = U256::from(1301);
-        let new_netuid = SubtensorModule::get_next_netuid();
-        let lock_cost_u64: u64 = SubtensorModule::get_network_lock_cost().into();
-
-        let expected_owner_alpha_u64 =
-            owner_alpha_from_lock_and_price(lock_cost_u64, pre_registration_median);
-        let expected_owner_alpha: AlphaBalance = expected_owner_alpha_u64.into();
-
-        SubtensorModule::add_balance_to_coldkey_account(
-            &new_cold,
-            lock_cost_u64.saturating_mul(2).into(),
-        );
-
-        assert_ok!(SubtensorModule::do_register_network(
-            RuntimeOrigin::signed(new_cold),
-            &new_hot,
-            1,
-            None,
-        ));
-
-        // After registration, the new subnet exists and is seeded at price 1,
-        // so the live median becomes median({1, 2, 5}) = 2.
-        let new_subnet_price =
-            <Test as pallet::Config>::SwapInterface::current_alpha_price(new_netuid.into());
-        let post_registration_median = SubtensorModule::get_median_subnet_alpha_price();
-        let wrong_post_registration_owner_alpha_u64 =
-            owner_alpha_from_lock_and_price(lock_cost_u64, post_registration_median);
-        let wrong_post_registration_owner_alpha: AlphaBalance =
-            wrong_post_registration_owner_alpha_u64.into();
-
-        assert_eq!(new_subnet_price, U96F32::from_num(1u64));
-        assert_eq!(post_registration_median, U96F32::from_num(2u64));
-        assert_ne!(pre_registration_median, post_registration_median);
-
-        // The registration flow must use the pre-registration median snapshot (3.5),
-        // not the post-init median (2).
-        assert_eq!(
-            SubnetAlphaOut::<Test>::get(new_netuid),
-            expected_owner_alpha
-        );
-        assert_eq!(
-            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
-                &new_hot, &new_cold, new_netuid,
-            ),
-            expected_owner_alpha
-        );
-        assert_eq!(
-            TotalHotkeyAlpha::<Test>::get(new_hot, new_netuid),
-            expected_owner_alpha
-        );
-        assert_ne!(
-            SubnetAlphaOut::<Test>::get(new_netuid),
-            wrong_post_registration_owner_alpha
         );
     });
 }

--- a/pallets/subtensor/src/tests/recycle_alpha.rs
+++ b/pallets/subtensor/src/tests/recycle_alpha.rs
@@ -68,38 +68,36 @@ fn test_recycle_two_stakers() {
     new_test_ext(1).execute_with(|| {
         let coldkey = U256::from(1);
         let hotkey = U256::from(2);
-
         let other_coldkey = U256::from(3);
 
         let owner_coldkey = U256::from(1001);
         let owner_hotkey = U256::from(1002);
         let netuid = add_dynamic_network(&owner_hotkey, &owner_coldkey);
 
-        let initial_balance = 1_000_000_000;
+        let initial_balance = 1_000_000_000_u64;
         Balances::make_free_balance_be(&coldkey, initial_balance.into());
 
-        // associate coldkey and hotkey
         SubtensorModule::create_account_if_non_existent(&coldkey, &hotkey);
         register_ok_neuron(netuid, hotkey, coldkey, 0);
 
         assert!(SubtensorModule::if_subnet_exist(netuid));
 
-        // add stake to coldkey-hotkey pair so we can recycle it
-        let stake = 200_000;
-        let (expected_alpha, _) = mock::swap_tao_to_alpha(netuid, stake.into());
+        let stake = 200_000_u64;
+
+        // First staker.
         increase_stake_on_coldkey_hotkey_account(&coldkey, &hotkey, stake.into(), netuid);
 
-        // add some stake to other coldkey on same hotkey.
+        // Quote the second staker against the post-first-stake reserves.
+        let (expected_other_alpha, _) = mock::swap_tao_to_alpha(netuid, stake.into());
+
+        // Second staker.
         increase_stake_on_coldkey_hotkey_account(&other_coldkey, &hotkey, stake.into(), netuid);
 
-        // get initial total issuance and alpha out
         let initial_alpha = TotalHotkeyAlpha::<Test>::get(hotkey, netuid);
         let initial_net_alpha = SubnetAlphaOut::<Test>::get(netuid);
 
-        // amount to recycle
         let recycle_amount = AlphaBalance::from(stake / 2);
 
-        // recycle
         assert_ok!(SubtensorModule::recycle_alpha(
             RuntimeOrigin::signed(coldkey),
             hotkey,
@@ -111,17 +109,18 @@ fn test_recycle_two_stakers() {
         assert!(SubnetAlphaOut::<Test>::get(netuid) < initial_net_alpha);
         assert!(
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid)
-                < stake.into()
+                < AlphaBalance::from(stake)
         );
-        // Make sure the other coldkey has no change
+
+        // The other coldkey should remain unchanged.
         assert_abs_diff_eq!(
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
                 &hotkey,
                 &other_coldkey,
                 netuid
             ),
-            expected_alpha,
-            epsilon = 2.into()
+            expected_other_alpha,
+            epsilon = AlphaBalance::from(2_u64)
         );
 
         assert!(System::events().iter().any(|e| {
@@ -337,38 +336,36 @@ fn test_burn_two_stakers() {
     new_test_ext(1).execute_with(|| {
         let coldkey = U256::from(1);
         let hotkey = U256::from(2);
-
         let other_coldkey = U256::from(3);
 
         let owner_coldkey = U256::from(1001);
         let owner_hotkey = U256::from(1002);
         let netuid = add_dynamic_network(&owner_hotkey, &owner_coldkey);
 
-        let initial_balance = 1_000_000_000;
+        let initial_balance = 1_000_000_000_u64;
         Balances::make_free_balance_be(&coldkey, initial_balance.into());
 
-        // associate coldkey and hotkey
         SubtensorModule::create_account_if_non_existent(&coldkey, &hotkey);
         register_ok_neuron(netuid, hotkey, coldkey, 0);
 
         assert!(SubtensorModule::if_subnet_exist(netuid));
 
-        // add stake to coldkey-hotkey pair so we can recycle it
-        let stake = 200_000;
-        let (expected_alpha, _) = mock::swap_tao_to_alpha(netuid, stake.into());
+        let stake = 200_000_u64;
+
+        // First staker.
         increase_stake_on_coldkey_hotkey_account(&coldkey, &hotkey, stake.into(), netuid);
 
-        // add some stake to other coldkey on same hotkey.
+        // Quote the second staker against the post-first-stake reserves.
+        let (expected_other_alpha, _) = mock::swap_tao_to_alpha(netuid, stake.into());
+
+        // Second staker.
         increase_stake_on_coldkey_hotkey_account(&other_coldkey, &hotkey, stake.into(), netuid);
 
-        // get initial total issuance and alpha out
         let initial_alpha = TotalHotkeyAlpha::<Test>::get(hotkey, netuid);
         let initial_net_alpha = SubnetAlphaOut::<Test>::get(netuid);
 
-        // amount to recycle
         let burn_amount = AlphaBalance::from(stake / 2);
 
-        // burn from coldkey
         assert_ok!(SubtensorModule::burn_alpha(
             RuntimeOrigin::signed(coldkey),
             hotkey,
@@ -377,20 +374,21 @@ fn test_burn_two_stakers() {
         ));
 
         assert!(TotalHotkeyAlpha::<Test>::get(hotkey, netuid) < initial_alpha);
-        assert!(SubnetAlphaOut::<Test>::get(netuid) == initial_net_alpha);
+        assert_eq!(SubnetAlphaOut::<Test>::get(netuid), initial_net_alpha);
         assert!(
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid)
-                < stake.into()
+                < AlphaBalance::from(stake)
         );
-        // Make sure the other coldkey has no change
+
+        // The other coldkey should remain unchanged.
         assert_abs_diff_eq!(
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
                 &hotkey,
                 &other_coldkey,
                 netuid
             ),
-            expected_alpha,
-            epsilon = 2.into()
+            expected_other_alpha,
+            epsilon = AlphaBalance::from(2_u64)
         );
 
         assert!(System::events().iter().any(|e| {

--- a/pallets/subtensor/src/tests/staking.rs
+++ b/pallets/subtensor/src/tests/staking.rs
@@ -47,32 +47,30 @@ fn test_add_stake_ok_no_emission() {
         let coldkey_account_id = U256::from(55453);
         let amount = DefaultMinStake::<Test>::get().to_u64() * 10;
 
-        //add network
+        // add network
         let netuid = add_dynamic_network(&hotkey_account_id, &coldkey_account_id);
         remove_owner_registration_stake(netuid);
 
         mock::setup_reserves(
             netuid,
-            (amount * 1_000_000).into(),
-            (amount * 10_000_000).into(),
+            TaoBalance::from(amount * 1_000_000),
+            AlphaBalance::from(amount * 10_000_000),
         );
 
-        // Give it some $$$ in his coldkey balance
         SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, amount.into());
 
-        // Check we have zero staked before transfer
         assert_eq!(
             SubtensorModule::get_total_stake_for_hotkey(&hotkey_account_id),
             TaoBalance::ZERO
         );
 
-        // Also total stake should be equal to the network initial lock
+        let expected_initial_total_stake =
+            TaoBalance::from(SubtensorModule::get_subnet_locked_balance(netuid).to_u64() / 4);
         assert_eq!(
             SubtensorModule::get_total_stake(),
-            SubtensorModule::get_network_min_lock()
+            expected_initial_total_stake
         );
 
-        // Transfer to hotkey account, and check if the result is ok
         let (alpha_staked, fee) = mock::swap_tao_to_alpha(netuid, amount.into());
         assert_ok!(SubtensorModule::add_stake(
             RuntimeOrigin::signed(coldkey_account_id),
@@ -89,27 +87,24 @@ fn test_add_stake_ok_no_emission() {
 
         assert_abs_diff_eq!(
             SubtensorModule::get_total_stake_for_hotkey(&hotkey_account_id),
-            tao_expected + approx_fee, // swap returns value after fee, so we need to compensate it
-            epsilon = 10000.into(),
+            tao_expected + approx_fee,
+            epsilon = TaoBalance::from(10_000_u64),
         );
 
-        // Check if stake has increased
         assert_abs_diff_eq!(
             SubtensorModule::get_total_stake_for_hotkey(&hotkey_account_id),
-            (amount - fee).into(),
-            epsilon = 10000.into()
+            TaoBalance::from(amount - fee),
+            epsilon = TaoBalance::from(10_000_u64)
         );
 
-        // Check if balance has decreased
         assert_eq!(
             SubtensorModule::get_coldkey_balance(&coldkey_account_id),
-            1.into()
+            TaoBalance::from(1_u64)
         );
 
-        // Check if total stake has increased accordingly.
         assert_eq!(
             SubtensorModule::get_total_stake(),
-            SubtensorModule::get_network_min_lock() + amount.into()
+            expected_initial_total_stake + TaoBalance::from(amount)
         );
     });
 }
@@ -548,49 +543,96 @@ fn test_add_stake_partial_below_min_stake_fails() {
         let netuid = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
         register_ok_neuron(netuid, hotkey_account_id, coldkey_account_id, 192213123);
 
-        // Stake TAO amount is above min stake
         let min_stake = DefaultMinStake::<Test>::get();
         let amount = min_stake.to_u64() * 2;
+
         SubtensorModule::add_balance_to_coldkey_account(
             &coldkey_account_id,
             TaoBalance::from(amount) + ExistentialDeposit::get(),
         );
 
-        // Setup reserves
-        mock::setup_reserves(netuid, (amount * 10).into(), (amount * 10).into());
+        mock::setup_reserves(
+            netuid,
+            TaoBalance::from(amount * 10),
+            AlphaBalance::from(amount * 10),
+        );
 
-        // Force the swap to initialize
+        // Force the swap interface into an initialized state.
         SubtensorModule::swap_tao_for_alpha(
             netuid,
             TaoBalance::ZERO,
-            1_000_000_000_000_u64.into(),
+            TaoBalance::from(1_000_000_000_000_u64),
             false,
         )
         .unwrap();
 
-        // Get the current price
         let current_price =
             <Test as pallet::Config>::SwapInterface::current_alpha_price(netuid.into());
         assert!(current_price.to_num::<f64>() > 0.0);
 
-        // Set "max spend" to ~1 TAO around current price
-        let current_price_scaled = (current_price.to_num::<f64>() * 1_000_000_000_f64) as u64;
-        let max_spend = current_price_scaled.saturating_add(1);
+        // `limit_price` is in RAO per Alpha.
+        let current_price_rao_per_alpha =
+            (current_price.to_num::<f64>() * 1_000_000_000_f64) as u64;
 
-        // Add stake with partial flag on
+        let max_for_limit = |limit_rao_per_alpha: u64| -> Option<u64> {
+            SubtensorModule::get_max_amount_add(netuid, TaoBalance::from(limit_rao_per_alpha)).ok()
+        };
+
+        // Find the smallest limit price that allows a non-zero execution.
+        // That is the most reliable way to stay in the "partial execution exists,
+        // but it is still too small" region.
+        let mut lo = 0_u64; // known to be non-executable
+        let mut hi = current_price_rao_per_alpha.saturating_add(1);
+        let mut found_positive = false;
+        let mut step = 1_u64;
+
+        for _ in 0..64 {
+            if max_for_limit(hi).unwrap_or(0) > 0 {
+                found_positive = true;
+                break;
+            }
+            step = step.saturating_mul(2);
+            hi = current_price_rao_per_alpha.saturating_add(step);
+        }
+
+        assert!(
+            found_positive,
+            "failed to find a limit_price with non-zero executable amount"
+        );
+
+        while lo.saturating_add(1) < hi {
+            let mid = lo.saturating_add(hi.saturating_sub(lo) / 2);
+            if max_for_limit(mid).unwrap_or(0) > 0 {
+                hi = mid;
+            } else {
+                lo = mid;
+            }
+        }
+
+        let limit_price = TaoBalance::from(hi);
+        let max_amount = TaoBalance::from(
+            max_for_limit(hi).expect("smallest positive limit should yield executable amount"),
+        );
+
+        assert!(max_amount > TaoBalance::ZERO);
+        assert!(
+            max_amount < min_stake,
+            "test setup must produce a non-zero partial fill below DefaultMinStake; got max_amount={max_amount:?}, min_stake={min_stake:?}, limit_price={limit_price:?}, current_price={current_price:?}"
+        );
+
         assert_err!(
             SubtensorModule::add_stake_limit(
                 RuntimeOrigin::signed(coldkey_account_id),
                 hotkey_account_id,
                 netuid,
                 amount.into(),
-                max_spend.into(),
+                limit_price,
                 true
             ),
             Error::<Test>::AmountTooLow
         );
 
-        // Price should be unchanged on failure
+        // Failure path must not move price.
         let new_current_price =
             <Test as pallet::Config>::SwapInterface::current_alpha_price(netuid.into());
         assert_eq!(new_current_price, current_price);
@@ -4219,19 +4261,14 @@ fn test_remove_99_9989_per_cent_stake_leaves_a_little() {
         let subnet_owner_hotkey = U256::from(2);
         let hotkey_account_id = U256::from(581337);
         let coldkey_account_id = U256::from(81337);
-        let amount = 10_000_000_000;
+        let amount = 10_000_000_000_u64;
         let netuid = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
         register_ok_neuron(netuid, hotkey_account_id, coldkey_account_id, 192213123);
 
-        // Set fee rate to 0 so that alpha fee is not moved to block producer
-        // to avoid false success in this test
         pallet_subtensor_swap::FeeRate::<Test>::insert(netuid, 0);
 
-        // Give it some $$$ in his coldkey balance
         SubtensorModule::add_balance_to_coldkey_account(&coldkey_account_id, amount.into());
 
-        // Stake to hotkey account, and check if the result is ok
-        let (_, fee) = mock::swap_tao_to_alpha(netuid, amount.into());
         assert_ok!(SubtensorModule::add_stake(
             RuntimeOrigin::signed(coldkey_account_id),
             hotkey_account_id,
@@ -4239,45 +4276,54 @@ fn test_remove_99_9989_per_cent_stake_leaves_a_little() {
             amount.into()
         ));
 
-        // Remove 99.9989% stake
         remove_stake_rate_limit_for_tests(&hotkey_account_id, &coldkey_account_id, netuid);
-        let alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+
+        let alpha_before = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
             &hotkey_account_id,
             &coldkey_account_id,
             netuid,
         );
-        let fee =
-            mock::swap_alpha_to_tao(netuid, ((alpha.to_u64() as f64 * 0.99) as u64).into()).1 + fee;
+
+        let alpha_to_remove =
+            (U64F64::from_num(alpha_before.to_u64()) * U64F64::from_num(0.99)).to_num::<u64>();
+        let (expected_tao_returned, _) =
+            mock::swap_alpha_to_tao(netuid, AlphaBalance::from(alpha_to_remove));
+
         assert_ok!(SubtensorModule::remove_stake(
             RuntimeOrigin::signed(coldkey_account_id),
             hotkey_account_id,
             netuid,
-            (U64F64::from_num(alpha.to_u64()) * U64F64::from_num(0.99))
-                .to_num::<u64>()
-                .into()
+            AlphaBalance::from(alpha_to_remove)
         ));
 
-        // Check that all alpha was unstaked and 99% TAO balance was returned (less fees)
-        // let fee = <Test as Config>::SwapInterface::approx_fee_amount(netuid.into(), (amount as f64 * 0.99) as u64);
         assert_abs_diff_eq!(
-            SubtensorModule::get_coldkey_balance(&coldkey_account_id).to_u64(),
-            (amount as f64 * 0.99) as u64 - fee,
-            epsilon = amount / 1000,
+            SubtensorModule::get_coldkey_balance(&coldkey_account_id),
+            expected_tao_returned,
+            epsilon = TaoBalance::from(amount / 1000)
         );
-        assert_abs_diff_eq!(
-            SubtensorModule::get_total_stake_for_hotkey(&hotkey_account_id).to_u64(),
-            (amount as f64 * 0.01) as u64,
-            epsilon = amount / 1000,
-        );
+
         let new_alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
             &hotkey_account_id,
             &coldkey_account_id,
             netuid,
         );
+
+        let current_price =
+            <Test as pallet::Config>::SwapInterface::current_alpha_price(netuid.into());
+        let expected_remaining_tao_value = TaoBalance::from(
+            (U96F32::from_num(new_alpha.to_u64()) * current_price).to_num::<u64>(),
+        );
+
+        assert_abs_diff_eq!(
+            SubtensorModule::get_total_stake_for_hotkey(&hotkey_account_id),
+            expected_remaining_tao_value,
+            epsilon = TaoBalance::from(amount / 1000)
+        );
+
         assert_abs_diff_eq!(
             new_alpha,
-            AlphaBalance::from((alpha.to_u64() as f64 * 0.01) as u64),
-            epsilon = 10.into()
+            AlphaBalance::from((alpha_before.to_u64() as f64 * 0.01) as u64),
+            epsilon = AlphaBalance::from(10_u64)
         );
     });
 }

--- a/pallets/subtensor/src/tests/staking.rs
+++ b/pallets/subtensor/src/tests/staking.rs
@@ -610,9 +610,10 @@ fn test_add_stake_partial_below_min_stake_fails() {
         }
 
         let limit_price = TaoBalance::from(hi);
-        let max_amount = TaoBalance::from(
-            max_for_limit(hi).expect("smallest positive limit should yield executable amount"),
-        );
+        let max_amount = match max_for_limit(hi) {
+            Some(amount) => TaoBalance::from(amount),
+            None => panic!("smallest positive limit should yield executable amount"),
+        };
 
         assert!(max_amount > TaoBalance::ZERO);
         assert!(


### PR DESCRIPTION
## Summary

This PR updates **subnet registration** so the **new subnet pool and the owner’s starting stake are initialized from the same registration lock**, using the **current median subnet alpha price** as the pricing snapshot.

Previously, subnet registration only:
- locked the registration TAO,
- seeded the new subnet pool with `network_min_lock` at a 1:1 TAO/alpha initialization,
- recycled the remainder,
- and set the subnet owner metadata.

With this change, registration now:
- computes the **median subnet alpha price** from existing eligible subnets,
- converts the **full current registration lock cost** from TAO into alpha at that snapshot price, calling this amount `A`,
- injects **25% of the current lock cost as TAO** into the new subnet pool,
- injects **`A / 4` alpha** into the pool as free alpha liquidity,
- grants the **remaining `A / 4` alpha** to the subnet owner as **staked alpha**,
- records the owner grant in `SubnetAlphaOut`,
- and recycles the **remaining 75% of the locked TAO** that is not used to seed the pool.

This means the owner’s starting alpha comes **out of the seeded `A / 2` total alpha**, rather than being minted on top of it.

> **In one line:**  
> **Registering a subnet now prices the registration lock at the current median subnet alpha price, seeds the pool with 25% of the lock as TAO and `A / 4` alpha, grants the owner `A / 4` alpha as initial stake, and recycles the remaining locked TAO.**

---