### PR TITLE
Introduce netuid generation for storage cleaning

### DIFF
--- a/contract-tests/test/staking.precompile.approval.test.ts
+++ b/contract-tests/test/staking.precompile.approval.test.ts
@@ -11,6 +11,7 @@ import {
     forceSetBalanceToEthAddress, forceSetBalanceToSs58Address, addNewSubnetwork, burnedRegister,
     sendProxyCall,
     startCall,
+    getStake,
 } from "../src/subtensor"
 import { ETH_LOCAL_URL } from "../src/config";
 import { ISTAKING_ADDRESS, ISTAKING_V2_ADDRESS, IStakingABI, IStakingV2ABI } from "../src/contracts/staking"
@@ -57,7 +58,7 @@ describe("Test approval in staking precompile", () => {
             stakeNetuid = (await api.query.SubtensorModule.TotalNetworks.getValue()) - 1
             // the unit in V2 is RAO, not ETH
             let stakeBalance = tao(20)
-            const stakeBefore = await api.query.SubtensorModule.Alpha.getValue(convertPublicKeyToSs58(hotkey.publicKey), convertH160ToSS58(wallet1.address), stakeNetuid)
+            const stakeBefore = await getStake(api, convertPublicKeyToSs58(hotkey.publicKey), convertH160ToSS58(wallet1.address), stakeNetuid)
             const contract = new ethers.Contract(ISTAKING_V2_ADDRESS, IStakingV2ABI, wallet1);
             const tx = await contract.addStake(hotkey.publicKey, stakeBalance.toString(), stakeNetuid)
             await tx.wait()
@@ -67,7 +68,7 @@ describe("Test approval in staking precompile", () => {
             );
 
             assert.ok(stakeFromContract > stakeBefore)
-            const stakeAfter = await api.query.SubtensorModule.Alpha.getValue(convertPublicKeyToSs58(hotkey.publicKey), convertH160ToSS58(wallet1.address), stakeNetuid)
+            const stakeAfter = await getStake(api, convertPublicKeyToSs58(hotkey.publicKey), convertH160ToSS58(wallet1.address), stakeNetuid)
             assert.ok(stakeAfter > stakeBefore)
         }
     })

--- a/pallets/subtensor/src/coinbase/root.rs
+++ b/pallets/subtensor/src/coinbase/root.rs
@@ -534,6 +534,9 @@ impl<T: Config> Pallet<T> {
     pub fn get_network_registered_block(netuid: NetUid) -> u64 {
         NetworkRegisteredAt::<T>::get(netuid)
     }
+    pub fn get_netuid_generation(netuid: NetUid) -> u64 {
+        NetuidGeneration::<T>::get(netuid)
+    }
     pub fn get_network_immunity_period() -> u64 {
         NetworkImmunityPeriod::<T>::get()
     }

--- a/pallets/subtensor/src/coinbase/root.rs
+++ b/pallets/subtensor/src/coinbase/root.rs
@@ -534,8 +534,8 @@ impl<T: Config> Pallet<T> {
     pub fn get_network_registered_block(netuid: NetUid) -> u64 {
         NetworkRegisteredAt::<T>::get(netuid)
     }
-    pub fn get_netuid_generation(netuid: NetUid) -> u64 {
-        NetuidGeneration::<T>::get(netuid)
+    pub fn get_registered_subnet_counter(netuid: NetUid) -> u64 {
+        RegisteredSubnetCounter::<T>::get(netuid)
     }
     pub fn get_network_immunity_period() -> u64 {
         NetworkImmunityPeriod::<T>::get()

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1693,17 +1693,18 @@ pub mod pallet {
     pub type NetworkRegisteredAt<T: Config> =
         StorageMap<_, Identity, NetUid, u64, ValueQuery, DefaultNetworkRegisteredAt<T>>;
 
-    /// --- MAP ( netuid ) --> registration_generation
+    /// --- MAP ( netuid ) --> registered_subnet_counter
     ///
     /// Monotonic counter incremented on every successful `do_register_network`
     /// for a given netuid. Consumers that persist per-netuid state keyed by
     /// `(user, netuid)` (e.g. the staking precompile `AllowancesStorage`) can
-    /// mix the current generation into their storage key so that entries
+    /// mix the current counter value into their storage key so that entries
     /// written under a previous registration of the same netuid become
     /// unreachable after the netuid is re-registered, without requiring
     /// unbounded storage iteration on deregistration.
     #[pallet::storage]
-    pub type NetuidGeneration<T: Config> = StorageMap<_, Identity, NetUid, u64, ValueQuery>;
+    pub type RegisteredSubnetCounter<T: Config> =
+        StorageMap<_, Identity, NetUid, u64, ValueQuery>;
 
     /// --- MAP ( netuid ) --> pending_server_emission
     #[pallet::storage]

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1703,8 +1703,7 @@ pub mod pallet {
     /// unreachable after the netuid is re-registered, without requiring
     /// unbounded storage iteration on deregistration.
     #[pallet::storage]
-    pub type RegisteredSubnetCounter<T: Config> =
-        StorageMap<_, Identity, NetUid, u64, ValueQuery>;
+    pub type RegisteredSubnetCounter<T: Config> = StorageMap<_, Identity, NetUid, u64, ValueQuery>;
 
     /// --- MAP ( netuid ) --> pending_server_emission
     #[pallet::storage]

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1693,6 +1693,18 @@ pub mod pallet {
     pub type NetworkRegisteredAt<T: Config> =
         StorageMap<_, Identity, NetUid, u64, ValueQuery, DefaultNetworkRegisteredAt<T>>;
 
+    /// --- MAP ( netuid ) --> registration_generation
+    ///
+    /// Monotonic counter incremented on every successful `do_register_network`
+    /// for a given netuid. Consumers that persist per-netuid state keyed by
+    /// `(user, netuid)` (e.g. the staking precompile `AllowancesStorage`) can
+    /// mix the current generation into their storage key so that entries
+    /// written under a previous registration of the same netuid become
+    /// unreachable after the netuid is re-registered, without requiring
+    /// unbounded storage iteration on deregistration.
+    #[pallet::storage]
+    pub type NetuidGeneration<T: Config> = StorageMap<_, Identity, NetUid, u64, ValueQuery>;
+
     /// --- MAP ( netuid ) --> pending_server_emission
     #[pallet::storage]
     pub type PendingServerEmission<T> =

--- a/pallets/subtensor/src/subnets/subnet.rs
+++ b/pallets/subtensor/src/subnets/subnet.rs
@@ -204,6 +204,7 @@ impl<T: Config> Pallet<T> {
 
         // --- 15. Set the creation terms.
         NetworkRegisteredAt::<T>::insert(netuid_to_register, current_block);
+        NetuidGeneration::<T>::mutate(netuid_to_register, |g| *g = g.saturating_add(1));
 
         // --- 16. Set the symbol.
         let symbol = Self::get_next_available_symbol(netuid_to_register);

--- a/pallets/subtensor/src/subnets/subnet.rs
+++ b/pallets/subtensor/src/subnets/subnet.rs
@@ -204,9 +204,7 @@ impl<T: Config> Pallet<T> {
 
         // --- 15. Set the creation terms.
         NetworkRegisteredAt::<T>::insert(netuid_to_register, current_block);
-        RegisteredSubnetCounter::<T>::mutate(netuid_to_register, |c| {
-            *c = c.saturating_add(1)
-        });
+        RegisteredSubnetCounter::<T>::mutate(netuid_to_register, |c| *c = c.saturating_add(1));
 
         // --- 16. Set the symbol.
         let symbol = Self::get_next_available_symbol(netuid_to_register);

--- a/pallets/subtensor/src/subnets/subnet.rs
+++ b/pallets/subtensor/src/subnets/subnet.rs
@@ -204,7 +204,9 @@ impl<T: Config> Pallet<T> {
 
         // --- 15. Set the creation terms.
         NetworkRegisteredAt::<T>::insert(netuid_to_register, current_block);
-        NetuidGeneration::<T>::mutate(netuid_to_register, |g| *g = g.saturating_add(1));
+        RegisteredSubnetCounter::<T>::mutate(netuid_to_register, |c| {
+            *c = c.saturating_add(1)
+        });
 
         // --- 16. Set the symbol.
         let symbol = Self::get_next_available_symbol(netuid_to_register);

--- a/pallets/subtensor/src/tests/networks.rs
+++ b/pallets/subtensor/src/tests/networks.rs
@@ -2634,7 +2634,7 @@ fn register_network_non_associated_hotkey_does_not_withdraw_or_write_owner_alpha
 }
 
 #[test]
-fn netuid_generation_bumps_on_first_registration() {
+fn registered_subnet_counter_bumps_on_first_registration() {
     new_test_ext(1).execute_with(|| {
         let cold = U256::from(1);
         let hot = U256::from(2);
@@ -2642,27 +2642,27 @@ fn netuid_generation_bumps_on_first_registration() {
         let netuid = add_dynamic_network(&hot, &cold);
 
         assert_eq!(
-            SubtensorModule::get_netuid_generation(netuid),
+            SubtensorModule::get_registered_subnet_counter(netuid),
             1,
-            "first registration of a netuid must leave generation == 1"
+            "first registration of a netuid must leave counter == 1"
         );
     });
 }
 
 #[test]
-fn netuid_generation_is_independent_per_netuid() {
+fn registered_subnet_counter_is_independent_per_netuid() {
     new_test_ext(1).execute_with(|| {
         let n1 = add_dynamic_network(&U256::from(10), &U256::from(11));
         let n2 = add_dynamic_network(&U256::from(20), &U256::from(21));
 
         assert_ne!(n1, n2);
-        assert_eq!(SubtensorModule::get_netuid_generation(n1), 1);
-        assert_eq!(SubtensorModule::get_netuid_generation(n2), 1);
+        assert_eq!(SubtensorModule::get_registered_subnet_counter(n1), 1);
+        assert_eq!(SubtensorModule::get_registered_subnet_counter(n2), 1);
     });
 }
 
 #[test]
-fn netuid_generation_survives_dissolve_and_bumps_on_reregistration() {
+fn registered_subnet_counter_survives_dissolve_and_bumps_on_reregistration() {
     new_test_ext(1).execute_with(|| {
         // Force reuse of the same netuid on re-registration by pinning the
         // active subnet cap so the next registration must prune.
@@ -2671,31 +2671,31 @@ fn netuid_generation_survives_dissolve_and_bumps_on_reregistration() {
         let owner_cold = U256::from(100);
         let owner_hot = U256::from(101);
         let netuid = add_dynamic_network(&owner_hot, &owner_cold);
-        assert_eq!(SubtensorModule::get_netuid_generation(netuid), 1);
+        assert_eq!(SubtensorModule::get_registered_subnet_counter(netuid), 1);
 
-        // Dissolve: generation is intentionally *not* cleared — stale
-        // consumers can still detect the pre-dereg lifetime if they stored
-        // the generation they observed at approval time.
+        // Dissolve: counter is intentionally *not* cleared — stale consumers
+        // can still detect the pre-dereg lifetime if they stored the counter
+        // value they observed at approval time.
         assert_ok!(SubtensorModule::do_dissolve_network(netuid));
         assert!(!SubtensorModule::if_subnet_exist(netuid));
         assert_eq!(
-            SubtensorModule::get_netuid_generation(netuid),
+            SubtensorModule::get_registered_subnet_counter(netuid),
             1,
-            "dissolve must not clear or reset the generation"
+            "dissolve must not clear or reset the counter"
         );
 
         // Re-register. With the cap pinned, the prune selector reuses the
-        // freed netuid; the generation bumps to 2 so that any state still
-        // keyed to gen=1 becomes unreachable under the new registration.
+        // freed netuid; the counter bumps to 2 so that any state still keyed
+        // to the prior value becomes unreachable under the new registration.
         let reg_netuid = add_dynamic_network(&owner_hot, &owner_cold);
         assert_eq!(
             reg_netuid, netuid,
             "the pruned netuid should be reused under the subnet cap"
         );
         assert_eq!(
-            SubtensorModule::get_netuid_generation(netuid),
+            SubtensorModule::get_registered_subnet_counter(netuid),
             2,
-            "re-registration must bump generation"
+            "re-registration must bump counter"
         );
     });
 }

--- a/pallets/subtensor/src/tests/networks.rs
+++ b/pallets/subtensor/src/tests/networks.rs
@@ -2632,3 +2632,70 @@ fn register_network_non_associated_hotkey_does_not_withdraw_or_write_owner_alpha
         );
     });
 }
+
+#[test]
+fn netuid_generation_bumps_on_first_registration() {
+    new_test_ext(1).execute_with(|| {
+        let cold = U256::from(1);
+        let hot = U256::from(2);
+
+        let netuid = add_dynamic_network(&hot, &cold);
+
+        assert_eq!(
+            SubtensorModule::get_netuid_generation(netuid),
+            1,
+            "first registration of a netuid must leave generation == 1"
+        );
+    });
+}
+
+#[test]
+fn netuid_generation_is_independent_per_netuid() {
+    new_test_ext(1).execute_with(|| {
+        let n1 = add_dynamic_network(&U256::from(10), &U256::from(11));
+        let n2 = add_dynamic_network(&U256::from(20), &U256::from(21));
+
+        assert_ne!(n1, n2);
+        assert_eq!(SubtensorModule::get_netuid_generation(n1), 1);
+        assert_eq!(SubtensorModule::get_netuid_generation(n2), 1);
+    });
+}
+
+#[test]
+fn netuid_generation_survives_dissolve_and_bumps_on_reregistration() {
+    new_test_ext(1).execute_with(|| {
+        // Force reuse of the same netuid on re-registration by pinning the
+        // active subnet cap so the next registration must prune.
+        SubtensorModule::set_max_subnets(2);
+
+        let owner_cold = U256::from(100);
+        let owner_hot = U256::from(101);
+        let netuid = add_dynamic_network(&owner_hot, &owner_cold);
+        assert_eq!(SubtensorModule::get_netuid_generation(netuid), 1);
+
+        // Dissolve: generation is intentionally *not* cleared — stale
+        // consumers can still detect the pre-dereg lifetime if they stored
+        // the generation they observed at approval time.
+        assert_ok!(SubtensorModule::do_dissolve_network(netuid));
+        assert!(!SubtensorModule::if_subnet_exist(netuid));
+        assert_eq!(
+            SubtensorModule::get_netuid_generation(netuid),
+            1,
+            "dissolve must not clear or reset the generation"
+        );
+
+        // Re-register. With the cap pinned, the prune selector reuses the
+        // freed netuid; the generation bumps to 2 so that any state still
+        // keyed to gen=1 becomes unreachable under the new registration.
+        let reg_netuid = add_dynamic_network(&owner_hot, &owner_cold);
+        assert_eq!(
+            reg_netuid, netuid,
+            "the pruned netuid should be reused under the subnet cap"
+        );
+        assert_eq!(
+            SubtensorModule::get_netuid_generation(netuid),
+            2,
+            "re-registration must bump generation"
+        );
+    });
+}

--- a/precompiles/src/staking.rs
+++ b/precompiles/src/staking.rs
@@ -66,7 +66,7 @@ pub type AllowancesStorage = StorageDoubleMap<
     // For each approver (EVM address as only EVM-natives need the precompile)
     Blake2_128Concat,
     H160,
-    // For each (spender, netuid, generation) triple — the generation tag invalidates
+    // For each (spender, netuid, counter) triple — the counter tag invalidates
     // entries written under a previous registration of the same netuid.
     Blake2_128Concat,
     (H160, u16, u64),
@@ -481,11 +481,11 @@ where
         Ok(stake.to_u64().into())
     }
 
-    /// Current registration generation for `netuid`, used as part of the
+    /// Current registration counter for `netuid`, used as part of the
     /// `AllowancesStorage` secondary key to invalidate approvals granted
     /// for a previous registration of the same netuid.
-    fn current_netuid_generation(netuid: u16) -> u64 {
-        pallet_subtensor::Pallet::<R>::get_netuid_generation(netuid.into())
+    fn current_subnet_counter(netuid: u16) -> u64 {
+        pallet_subtensor::Pallet::<R>::get_registered_subnet_counter(netuid.into())
     }
 
     #[precompile::public("approve(address,uint256,uint256)")]
@@ -495,19 +495,19 @@ where
         origin_netuid: U256,
         amount_alpha: U256,
     ) -> EvmResult<()> {
-        // AllowancesStorage write + NetuidGeneration read
+        // AllowancesStorage write + RegisteredSubnetCounter read
         handle.record_cost(RuntimeHelper::<R>::db_read_gas_cost())?;
         handle.record_cost(RuntimeHelper::<R>::db_write_gas_cost())?;
 
         let approver = handle.context().caller;
         let spender = spender_address.0;
         let netuid = try_u16_from_u256(origin_netuid)?;
-        let generation = Self::current_netuid_generation(netuid);
+        let counter = Self::current_subnet_counter(netuid);
 
         if amount_alpha.is_zero() {
-            AllowancesStorage::remove(approver, (spender, netuid, generation));
+            AllowancesStorage::remove(approver, (spender, netuid, counter));
         } else {
-            AllowancesStorage::insert(approver, (spender, netuid, generation), amount_alpha);
+            AllowancesStorage::insert(approver, (spender, netuid, counter), amount_alpha);
         }
 
         Ok(())
@@ -521,17 +521,17 @@ where
         spender_address: Address,
         origin_netuid: U256,
     ) -> EvmResult<U256> {
-        // AllowancesStorage read + NetuidGeneration read
+        // AllowancesStorage read + RegisteredSubnetCounter read
         handle.record_cost(RuntimeHelper::<R>::db_read_gas_cost())?;
         handle.record_cost(RuntimeHelper::<R>::db_read_gas_cost())?;
 
         let spender = spender_address.0;
         let netuid = try_u16_from_u256(origin_netuid)?;
-        let generation = Self::current_netuid_generation(netuid);
+        let counter = Self::current_subnet_counter(netuid);
 
         Ok(AllowancesStorage::get(
             source_address.0,
-            (spender, netuid, generation),
+            (spender, netuid, counter),
         ))
     }
 
@@ -546,7 +546,7 @@ where
             return Ok(());
         }
 
-        // AllowancesStorage read + write + NetuidGeneration read
+        // AllowancesStorage read + write + RegisteredSubnetCounter read
         handle.record_cost(RuntimeHelper::<R>::db_read_gas_cost())?;
         handle.record_cost(RuntimeHelper::<R>::db_read_gas_cost())?;
         handle.record_cost(RuntimeHelper::<R>::db_write_gas_cost())?;
@@ -554,9 +554,9 @@ where
         let approver = handle.context().caller;
         let spender = spender_address.0;
         let netuid = try_u16_from_u256(origin_netuid)?;
-        let generation = Self::current_netuid_generation(netuid);
+        let counter = Self::current_subnet_counter(netuid);
 
-        let approval_key = (spender, netuid, generation);
+        let approval_key = (spender, netuid, counter);
 
         let current_amount = AllowancesStorage::get(approver, approval_key);
         let new_amount = current_amount.saturating_add(amount_alpha_increase);
@@ -577,7 +577,7 @@ where
             return Ok(());
         }
 
-        // AllowancesStorage read + write + NetuidGeneration read
+        // AllowancesStorage read + write + RegisteredSubnetCounter read
         handle.record_cost(RuntimeHelper::<R>::db_read_gas_cost())?;
         handle.record_cost(RuntimeHelper::<R>::db_read_gas_cost())?;
         handle.record_cost(RuntimeHelper::<R>::db_write_gas_cost())?;
@@ -585,9 +585,9 @@ where
         let approver = handle.context().caller;
         let spender = spender_address.0;
         let netuid = try_u16_from_u256(origin_netuid)?;
-        let generation = Self::current_netuid_generation(netuid);
+        let counter = Self::current_subnet_counter(netuid);
 
-        let approval_key = (spender, netuid, generation);
+        let approval_key = (spender, netuid, counter);
 
         let current_amount = AllowancesStorage::get(approver, approval_key);
         let new_amount = current_amount.saturating_sub(amount_alpha_decrease);
@@ -612,13 +612,13 @@ where
             return Ok(());
         }
 
-        // AllowancesStorage read + write + NetuidGeneration read
+        // AllowancesStorage read + write + RegisteredSubnetCounter read
         handle.record_cost(RuntimeHelper::<R>::db_read_gas_cost())?;
         handle.record_cost(RuntimeHelper::<R>::db_read_gas_cost())?;
         handle.record_cost(RuntimeHelper::<R>::db_write_gas_cost())?;
 
-        let generation = Self::current_netuid_generation(netuid);
-        let approval_key = (spender, netuid, generation);
+        let counter = Self::current_subnet_counter(netuid);
+        let approval_key = (spender, netuid, counter);
 
         let current_amount = AllowancesStorage::get(approver, approval_key);
         let Some(new_amount) = current_amount.checked_sub(amount) else {

--- a/precompiles/src/staking.rs
+++ b/precompiles/src/staking.rs
@@ -66,9 +66,10 @@ pub type AllowancesStorage = StorageDoubleMap<
     // For each approver (EVM address as only EVM-natives need the precompile)
     Blake2_128Concat,
     H160,
-    // For each pair of (spender, netuid) (EVM address as only EVM-natives need the precompile)
+    // For each (spender, netuid, generation) triple — the generation tag invalidates
+    // entries written under a previous registration of the same netuid.
     Blake2_128Concat,
-    (H160, u16),
+    (H160, u16, u64),
     // Allowed amount
     U256,
     ValueQuery,
@@ -480,6 +481,13 @@ where
         Ok(stake.to_u64().into())
     }
 
+    /// Current registration generation for `netuid`, used as part of the
+    /// `AllowancesStorage` secondary key to invalidate approvals granted
+    /// for a previous registration of the same netuid.
+    fn current_netuid_generation(netuid: u16) -> u64 {
+        pallet_subtensor::Pallet::<R>::get_netuid_generation(netuid.into())
+    }
+
     #[precompile::public("approve(address,uint256,uint256)")]
     fn approve(
         handle: &mut impl PrecompileHandle,
@@ -487,17 +495,19 @@ where
         origin_netuid: U256,
         amount_alpha: U256,
     ) -> EvmResult<()> {
-        // AllowancesStorage write
+        // AllowancesStorage write + NetuidGeneration read
+        handle.record_cost(RuntimeHelper::<R>::db_read_gas_cost())?;
         handle.record_cost(RuntimeHelper::<R>::db_write_gas_cost())?;
 
         let approver = handle.context().caller;
         let spender = spender_address.0;
         let netuid = try_u16_from_u256(origin_netuid)?;
+        let generation = Self::current_netuid_generation(netuid);
 
         if amount_alpha.is_zero() {
-            AllowancesStorage::remove(approver, (spender, netuid));
+            AllowancesStorage::remove(approver, (spender, netuid, generation));
         } else {
-            AllowancesStorage::insert(approver, (spender, netuid), amount_alpha);
+            AllowancesStorage::insert(approver, (spender, netuid, generation), amount_alpha);
         }
 
         Ok(())
@@ -511,13 +521,18 @@ where
         spender_address: Address,
         origin_netuid: U256,
     ) -> EvmResult<U256> {
-        // AllowancesStorage read
+        // AllowancesStorage read + NetuidGeneration read
+        handle.record_cost(RuntimeHelper::<R>::db_read_gas_cost())?;
         handle.record_cost(RuntimeHelper::<R>::db_read_gas_cost())?;
 
         let spender = spender_address.0;
         let netuid = try_u16_from_u256(origin_netuid)?;
+        let generation = Self::current_netuid_generation(netuid);
 
-        Ok(AllowancesStorage::get(source_address.0, (spender, netuid)))
+        Ok(AllowancesStorage::get(
+            source_address.0,
+            (spender, netuid, generation),
+        ))
     }
 
     #[precompile::public("increaseAllowance(address,uint256,uint256)")]
@@ -531,15 +546,17 @@ where
             return Ok(());
         }
 
-        // AllowancesStorage read + write
+        // AllowancesStorage read + write + NetuidGeneration read
+        handle.record_cost(RuntimeHelper::<R>::db_read_gas_cost())?;
         handle.record_cost(RuntimeHelper::<R>::db_read_gas_cost())?;
         handle.record_cost(RuntimeHelper::<R>::db_write_gas_cost())?;
 
         let approver = handle.context().caller;
         let spender = spender_address.0;
         let netuid = try_u16_from_u256(origin_netuid)?;
+        let generation = Self::current_netuid_generation(netuid);
 
-        let approval_key = (spender, netuid);
+        let approval_key = (spender, netuid, generation);
 
         let current_amount = AllowancesStorage::get(approver, approval_key);
         let new_amount = current_amount.saturating_add(amount_alpha_increase);
@@ -560,15 +577,17 @@ where
             return Ok(());
         }
 
-        // AllowancesStorage read + write
+        // AllowancesStorage read + write + NetuidGeneration read
+        handle.record_cost(RuntimeHelper::<R>::db_read_gas_cost())?;
         handle.record_cost(RuntimeHelper::<R>::db_read_gas_cost())?;
         handle.record_cost(RuntimeHelper::<R>::db_write_gas_cost())?;
 
         let approver = handle.context().caller;
         let spender = spender_address.0;
         let netuid = try_u16_from_u256(origin_netuid)?;
+        let generation = Self::current_netuid_generation(netuid);
 
-        let approval_key = (spender, netuid);
+        let approval_key = (spender, netuid, generation);
 
         let current_amount = AllowancesStorage::get(approver, approval_key);
         let new_amount = current_amount.saturating_sub(amount_alpha_decrease);
@@ -593,11 +612,13 @@ where
             return Ok(());
         }
 
-        // AllowancesStorage read + write
+        // AllowancesStorage read + write + NetuidGeneration read
+        handle.record_cost(RuntimeHelper::<R>::db_read_gas_cost())?;
         handle.record_cost(RuntimeHelper::<R>::db_read_gas_cost())?;
         handle.record_cost(RuntimeHelper::<R>::db_write_gas_cost())?;
 
-        let approval_key = (spender, netuid);
+        let generation = Self::current_netuid_generation(netuid);
+        let approval_key = (spender, netuid, generation);
 
         let current_amount = AllowancesStorage::get(approver, approval_key);
         let Some(new_amount) = current_amount.checked_sub(amount) else {


### PR DESCRIPTION
## Description

Iterating an unbounded `StorageDoubleMap` is unsafe, so instead of clearing state, we make stale state unreachable.

## Design

- New storage `pallet_subtensor::NetuidGeneration: Map<NetUid, u64>`, bumped on every `do_register_network`.
- `AllowancesStorage` secondary key changes from `(spender, netuid)` to `(spender, netuid, generation)`.
- `approve`, `allowance`, `increaseAllowance`, `decreaseAllowance`, and `transferStakeFrom` read the current generation from `pallet_subtensor` and mix it into the key.
- After a `netuid` is deregistered and re-registered, the generation differs, so entries written under the previous lifetime land at an unreachable key, and all reads through the precompile default to `0` (`ValueQuery`).
- No iteration, no cleanup hook, no block-time risk.


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.