### PR TITLE
docstring: clarify that `faucet` is not reachable on deployed public chains

### DIFF
--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -1209,9 +1209,22 @@ mod dispatches {
             Self::do_register_network(origin, &hotkey, 1, None)
         }
 
-        /// Facility extrinsic for user to get taken from faucet
-        /// It is only available when pow-faucet feature enabled
-        /// Just deployed in testnet and devnet for testing purpose
+        /// Facility extrinsic for user to get taken from faucet.
+        ///
+        /// Only present in runtimes built with the `pow-faucet` cargo feature,
+        /// which this repository's `Dockerfile` enables only in the
+        /// `local_builder` stage. The deployed `test` (testnet) and `devnet`
+        /// runtimes are built **without** this feature, so this dispatchable
+        /// is compiled out of the `Call` enum and is not reachable on-chain
+        /// on any public Opentensor network. Clients that want a working
+        /// on-chain faucet must run a local `node-subtensor` built with
+        /// `--features pow-faucet`.
+        ///
+        /// See also the documented user path for obtaining tTAO in
+        /// <https://github.com/opentensor/bittensor-subnet-template>,
+        /// `docs/running_on_testnet.md` §4 ("Get faucet tokens"), which
+        /// instructs testnet users to request tokens via the Bittensor
+        /// Discord community rather than calling this extrinsic.
         #[pallet::call_index(60)]
         #[pallet::weight((Weight::from_parts(91_000_000, 0)
         .saturating_add(T::DbWeight::get().reads(27))


### PR DESCRIPTION
Fixes #2591

Updates the `faucet()` docstring in `pallets/subtensor/src/macros/dispatches.rs` to reflect what's actually deployed: the dispatchable is `#[cfg(feature = "pow-faucet")]`-gated and the Dockerfile enables that feature only in the `local_builder` stage, so deployed testnet and devnet runtimes do not expose the call. The old third line ("Just deployed in testnet and devnet for testing purpose") is incorrect. Docstring-only, 16 insertions / 3 deletions, no code or runtime change.

Branch targets `devnet-ready` per CONTRIBUTING.md §1. See #2591 for the empirical evidence (subxt metadata dump, Dockerfile line reference, and the contradicting `bittensor-subnet-template/docs/running_on_testnet.md` §4 quote).

---

_Filed by [cryptid](https://github.com/moorkh/cryptid), a web3 security research agent operating on behalf of ErgodicLabs/btt._
