### PR TITLE
Owner Alpha Stake Updates

### DIFF
--- a/pallets/subtensor/src/subnets/subnet.rs
+++ b/pallets/subtensor/src/subnets/subnet.rs
@@ -209,23 +209,37 @@ impl<T: Config> Pallet<T> {
         let symbol = Self::get_next_available_symbol(netuid_to_register);
         TokenSymbol::<T>::insert(netuid_to_register, symbol);
 
-        // Seed the new subnet pool at a 1:1 reserve ratio.
-        // Separately, grant the subnet owner outstanding alpha based on the TAO they actually spent
-        // on registration converted by the current median subnet alpha price.
+        // Keep the locked TAO in the pool instead of recycling the excess.
+        // Mint the owner alpha separately at the median subnet alpha price.
+        // Size the pool alpha reserve from the total TAO reserve at that same price.
         let pool_initial_tao: TaoBalance = Self::get_network_min_lock();
-        let pool_initial_alpha: AlphaBalance = pool_initial_tao.to_u64().into();
+        let total_pool_tao: TaoBalance = if actual_tao_lock_amount >= pool_initial_tao {
+            actual_tao_lock_amount
+        } else {
+            pool_initial_tao
+        };
+        let owner_alpha_tao_equivalent: TaoBalance =
+            total_pool_tao.saturating_sub(pool_initial_tao);
+
+        let total_pool_alpha: AlphaBalance = U96F32::saturating_from_num(total_pool_tao.to_u64())
+            .safe_div(median_subnet_alpha_price)
+            .saturating_floor()
+            .saturating_to_num::<u64>()
+            .into();
+
         let owner_alpha_stake: AlphaBalance =
-            U96F32::saturating_from_num(actual_tao_lock_amount.to_u64())
+            U96F32::saturating_from_num(owner_alpha_tao_equivalent.to_u64())
                 .safe_div(median_subnet_alpha_price)
                 .saturating_floor()
                 .saturating_to_num::<u64>()
                 .into();
-        let actual_tao_lock_amount_less_pool_tao =
-            actual_tao_lock_amount.saturating_sub(pool_initial_tao);
+
+        // With the full lock retained in the reserve, this will normally be zero.
+        let tao_recycled_for_registration = actual_tao_lock_amount.saturating_sub(total_pool_tao);
 
         // Core pool + ownership
-        SubnetTAO::<T>::insert(netuid_to_register, pool_initial_tao);
-        SubnetAlphaIn::<T>::insert(netuid_to_register, pool_initial_alpha);
+        SubnetTAO::<T>::insert(netuid_to_register, total_pool_tao);
+        SubnetAlphaIn::<T>::insert(netuid_to_register, total_pool_alpha);
         SubnetOwner::<T>::insert(netuid_to_register, coldkey.clone());
         SubnetOwnerHotkey::<T>::insert(netuid_to_register, hotkey.clone());
         SubnetLocked::<T>::insert(netuid_to_register, actual_tao_lock_amount);
@@ -233,12 +247,9 @@ impl<T: Config> Pallet<T> {
         SubnetAlphaInProvided::<T>::insert(netuid_to_register, AlphaBalance::ZERO);
         SubnetAlphaOut::<T>::insert(netuid_to_register, owner_alpha_stake);
         SubnetVolume::<T>::insert(netuid_to_register, 0u128);
-        RAORecycledForRegistration::<T>::insert(
-            netuid_to_register,
-            actual_tao_lock_amount_less_pool_tao,
-        );
+        RAORecycledForRegistration::<T>::insert(netuid_to_register, tao_recycled_for_registration);
 
-        if owner_alpha_stake > AlphaBalance::ZERO {
+        if !owner_alpha_stake.is_zero() {
             Self::increase_stake_for_hotkey_and_coldkey_on_subnet(
                 hotkey,
                 &coldkey,
@@ -247,13 +258,13 @@ impl<T: Config> Pallet<T> {
             );
         }
 
-        if actual_tao_lock_amount_less_pool_tao > TaoBalance::ZERO {
-            Self::recycle_tao(actual_tao_lock_amount_less_pool_tao);
+        if tao_recycled_for_registration > TaoBalance::ZERO {
+            Self::recycle_tao(tao_recycled_for_registration);
         }
 
-        if actual_tao_lock_amount > TaoBalance::ZERO && pool_initial_tao > TaoBalance::ZERO {
+        if total_pool_tao > TaoBalance::ZERO {
             // Record in TotalStake the initial TAO in the pool.
-            Self::increase_total_stake(pool_initial_tao);
+            Self::increase_total_stake(total_pool_tao);
         }
 
         // --- 17. Add the identity if it exists
@@ -280,7 +291,7 @@ impl<T: Config> Pallet<T> {
         log::info!("NetworkAdded( netuid:{netuid_to_register:?}, mechanism:{mechid:?} )");
         Self::deposit_event(Event::NetworkAdded(netuid_to_register, mechid));
 
-        // --- 19. Return success.
+        // --- 20. Return success.
         Ok(())
     }
 

--- a/pallets/subtensor/src/tests/networks.rs
+++ b/pallets/subtensor/src/tests/networks.rs
@@ -2369,7 +2369,7 @@ fn median_subnet_alpha_price_averages_even_prices_and_ignores_root_zero_and_unad
 }
 
 #[test]
-fn register_network_credits_owner_alpha_using_fallback_price_one_on_first_subnet() {
+fn register_network_seeds_first_subnet_from_fallback_price_one_and_keeps_lock_in_pool() {
     new_test_ext(1).execute_with(|| {
         let new_cold = U256::from(1001);
         let new_hot = U256::from(1002);
@@ -2377,21 +2377,33 @@ fn register_network_credits_owner_alpha_using_fallback_price_one_on_first_subnet
 
         let lock_cost_u64: u64 = SubtensorModule::get_network_lock_cost().into();
         let pre_registration_median = SubtensorModule::get_median_subnet_alpha_price();
-        let expected_owner_alpha_u64 =
-            owner_alpha_from_lock_and_price(lock_cost_u64, pre_registration_median);
-        let expected_owner_alpha: AlphaBalance = expected_owner_alpha_u64.into();
 
         let pool_initial_tao = SubtensorModule::get_network_min_lock();
         let pool_initial_tao_u64 = pool_initial_tao.to_u64();
-        let expected_pool_alpha: AlphaBalance = pool_initial_tao_u64.into();
-        let expected_alpha_issuance: AlphaBalance = pool_initial_tao_u64
+        let total_pool_tao_u64 = lock_cost_u64.max(pool_initial_tao_u64);
+        let owner_alpha_tao_equivalent_u64 =
+            total_pool_tao_u64.saturating_sub(pool_initial_tao_u64);
+
+        let expected_pool_alpha_u64 =
+            owner_alpha_from_lock_and_price(total_pool_tao_u64, pre_registration_median);
+        let expected_pool_alpha: AlphaBalance = expected_pool_alpha_u64.into();
+
+        let expected_owner_alpha_u64 = owner_alpha_from_lock_and_price(
+            owner_alpha_tao_equivalent_u64,
+            pre_registration_median,
+        );
+        let expected_owner_alpha: AlphaBalance = expected_owner_alpha_u64.into();
+
+        let expected_alpha_issuance: AlphaBalance = expected_pool_alpha_u64
             .saturating_add(expected_owner_alpha_u64)
             .into();
-        let expected_recycled: TaoBalance =
-            lock_cost_u64.saturating_sub(pool_initial_tao_u64).into();
+
+        let expected_recycled: TaoBalance = lock_cost_u64.saturating_sub(total_pool_tao_u64).into();
 
         assert_eq!(pre_registration_median, U96F32::from_num(1u64));
-        assert_eq!(expected_owner_alpha_u64, lock_cost_u64);
+        assert_eq!(expected_pool_alpha_u64, total_pool_tao_u64);
+        assert_eq!(expected_owner_alpha_u64, owner_alpha_tao_equivalent_u64);
+        assert_eq!(expected_recycled, TaoBalance::ZERO);
 
         SubtensorModule::add_balance_to_coldkey_account(
             &new_cold,
@@ -2413,7 +2425,11 @@ fn register_network_credits_owner_alpha_using_fallback_price_one_on_first_subnet
             SubtensorModule::get_subnet_locked_balance(new_netuid),
             TaoBalance::from(lock_cost_u64)
         );
-        assert_eq!(SubnetTAO::<Test>::get(new_netuid), pool_initial_tao);
+
+        assert_eq!(
+            SubnetTAO::<Test>::get(new_netuid),
+            TaoBalance::from(total_pool_tao_u64)
+        );
         assert_eq!(SubnetAlphaIn::<Test>::get(new_netuid), expected_pool_alpha);
         assert_eq!(
             SubnetAlphaOut::<Test>::get(new_netuid),
@@ -2442,12 +2458,18 @@ fn register_network_credits_owner_alpha_using_fallback_price_one_on_first_subnet
             SubnetAlphaInProvided::<Test>::get(new_netuid),
             AlphaBalance::ZERO
         );
+
+        assert_eq!(
+            <Test as pallet::Config>::SwapInterface::current_alpha_price(new_netuid.into()),
+            U96F32::from_num(1u64)
+        );
+
         System::assert_last_event(Event::NetworkAdded(new_netuid, 1).into());
     });
 }
 
 #[test]
-fn register_network_credits_owner_alpha_from_even_median_and_excludes_new_subnet_price() {
+fn register_network_seeds_new_subnet_from_even_median_snapshot() {
     new_test_ext(0).execute_with(|| {
         let n1 = add_dynamic_network(&U256::from(1201), &U256::from(1200));
         let n2 = add_dynamic_network(&U256::from(1203), &U256::from(1202));
@@ -2462,11 +2484,24 @@ fn register_network_credits_owner_alpha_from_even_median_and_excludes_new_subnet
         let new_cold = U256::from(1300);
         let new_hot = U256::from(1301);
         let new_netuid = SubtensorModule::get_next_netuid();
-        let lock_cost_u64: u64 = SubtensorModule::get_network_lock_cost().into();
 
-        let expected_owner_alpha_u64 =
-            owner_alpha_from_lock_and_price(lock_cost_u64, pre_registration_median);
+        let lock_cost_u64: u64 = SubtensorModule::get_network_lock_cost().into();
+        let pool_initial_tao_u64 = SubtensorModule::get_network_min_lock().to_u64();
+        let total_pool_tao_u64 = lock_cost_u64.max(pool_initial_tao_u64);
+        let owner_alpha_tao_equivalent_u64 =
+            total_pool_tao_u64.saturating_sub(pool_initial_tao_u64);
+
+        let expected_pool_alpha_u64 =
+            owner_alpha_from_lock_and_price(total_pool_tao_u64, pre_registration_median);
+        let expected_pool_alpha: AlphaBalance = expected_pool_alpha_u64.into();
+
+        let expected_owner_alpha_u64 = owner_alpha_from_lock_and_price(
+            owner_alpha_tao_equivalent_u64,
+            pre_registration_median,
+        );
         let expected_owner_alpha: AlphaBalance = expected_owner_alpha_u64.into();
+
+        let expected_recycled: TaoBalance = lock_cost_u64.saturating_sub(total_pool_tao_u64).into();
 
         SubtensorModule::add_balance_to_coldkey_account(
             &new_cold,
@@ -2480,22 +2515,23 @@ fn register_network_credits_owner_alpha_from_even_median_and_excludes_new_subnet
             None,
         ));
 
-        // After registration, the new subnet exists and is seeded at price 1,
-        // so the live median becomes median({1, 2, 5}) = 2.
         let new_subnet_price =
             <Test as pallet::Config>::SwapInterface::current_alpha_price(new_netuid.into());
         let post_registration_median = SubtensorModule::get_median_subnet_alpha_price();
-        let wrong_post_registration_owner_alpha_u64 =
-            owner_alpha_from_lock_and_price(lock_cost_u64, post_registration_median);
-        let wrong_post_registration_owner_alpha: AlphaBalance =
-            wrong_post_registration_owner_alpha_u64.into();
 
-        assert_eq!(new_subnet_price, U96F32::from_num(1u64));
-        assert_eq!(post_registration_median, U96F32::from_num(2u64));
-        assert_ne!(pre_registration_median, post_registration_median);
+        assert!(SubtensorModule::if_subnet_exist(new_netuid));
+        assert_eq!(SubnetOwner::<Test>::get(new_netuid), new_cold);
+        assert_eq!(SubnetOwnerHotkey::<Test>::get(new_netuid), new_hot);
+        assert_eq!(
+            SubtensorModule::get_subnet_locked_balance(new_netuid),
+            TaoBalance::from(lock_cost_u64)
+        );
 
-        // The registration flow must use the pre-registration median snapshot (3.5),
-        // not the post-init median (2).
+        assert_eq!(
+            SubnetTAO::<Test>::get(new_netuid),
+            TaoBalance::from(total_pool_tao_u64)
+        );
+        assert_eq!(SubnetAlphaIn::<Test>::get(new_netuid), expected_pool_alpha);
         assert_eq!(
             SubnetAlphaOut::<Test>::get(new_netuid),
             expected_owner_alpha
@@ -2510,9 +2546,24 @@ fn register_network_credits_owner_alpha_from_even_median_and_excludes_new_subnet
             TotalHotkeyAlpha::<Test>::get(new_hot, new_netuid),
             expected_owner_alpha
         );
+        assert_eq!(
+            RAORecycledForRegistration::<Test>::get(new_netuid),
+            expected_recycled
+        );
+
+        // The new subnet is seeded from the pre-registration median snapshot,
+        // so it is no longer initialized at the old 1:1 seed price.
+        assert_ne!(new_subnet_price, U96F32::from_num(1u64));
+        assert!(new_subnet_price >= pre_registration_median);
+
+        // With prices {2, seeded_price, 5}, the live median becomes the new subnet price.
+        assert_eq!(post_registration_median, new_subnet_price);
+
+        // A 1:1 seed would have alpha_in == tao_in, which should not happen here.
+        let wrong_price_one_pool_alpha: AlphaBalance = total_pool_tao_u64.into();
         assert_ne!(
-            SubnetAlphaOut::<Test>::get(new_netuid),
-            wrong_post_registration_owner_alpha
+            SubnetAlphaIn::<Test>::get(new_netuid),
+            wrong_price_one_pool_alpha
         );
     });
 }


### PR DESCRIPTION
## Summary

This PR updates **subnet registration** so the new subnet is initialized from a **pre-registration median subnet alpha price snapshot**, while the registration lock is retained in the subnet reserve instead of being mostly recycled.

Previously, subnet registration only:
- locked the registration TAO,
- seeded the new subnet pool with `network_min_lock`,
- initialized the pool at a 1:1 reserve ratio,
- recycled the remainder.

The owner did **not** receive any initial alpha stake from the registration flow.

With this change:
- the current **median subnet alpha price** is snapshotted before the new subnet is created,
- the subnet TAO reserve is set to `max(registration_lock, network_min_lock)`,
- the subnet alpha reserve is sized from that TAO reserve at the snapshotted median price,
- the owner receives **separately minted staked alpha** at that same median price,
- and the recycled registration TAO is now normally zero.

> **In one line:**  
> **Registering a subnet now retains the registration lock in the subnet reserve, opens the subnet at the median subnet alpha price, and grants the owner initial staked alpha priced off that same median.**

---