### PR TITLE
docs(subtensor): fix stale faucet() docstring + remove dead cfg branch

### DIFF
--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -1253,9 +1253,14 @@ mod dispatches {
             Self::do_register_network(origin, &hotkey, 1, None)
         }
 
-        /// Facility extrinsic for user to get taken from faucet
-        /// It is only available when pow-faucet feature enabled
-        /// Just deployed in testnet and devnet for testing purpose
+        /// Facility extrinsic to acquire TAO from a proof-of-work faucet.
+        ///
+        /// Only compiled into runtimes built with `--features pow-faucet`. The
+        /// production testnet and devnet images are built without this feature
+        /// (see the `Dockerfile` — only the `local_builder` stage enables it),
+        /// so this dispatchable is absent from the on-chain `Call` enum on the
+        /// deployed public networks and is intended for local development
+        /// runtimes only.
         #[pallet::call_index(60)]
         #[pallet::weight((Weight::from_parts(91_000_000, 0)
         .saturating_add(T::DbWeight::get().reads(27))
@@ -1267,11 +1272,7 @@ mod dispatches {
             nonce: u64,
             work: Vec<u8>,
         ) -> DispatchResult {
-            if cfg!(feature = "pow-faucet") {
-                return Self::do_faucet(origin, block_number, nonce, work);
-            }
-
-            Err(Error::<T>::FaucetDisabled.into())
+            Self::do_faucet(origin, block_number, nonce, work)
         }
 
         /// Remove a user's subnetwork


### PR DESCRIPTION
Closes #2591.

## Context

The `faucet()` dispatchable in [`pallets/subtensor/src/macros/dispatches.rs`](https://github.com/opentensor/subtensor/blob/main/pallets/subtensor/src/macros/dispatches.rs) carries this docstring:

```
/// Facility extrinsic for user to get taken from faucet
/// It is only available when pow-faucet feature enabled
/// Just deployed in testnet and devnet for testing purpose
```

The last line is stale. The call is `#[cfg(feature = \"pow-faucet\")]`-gated, and the `pow-faucet` feature is only enabled in the `local_builder` Docker stage (`Dockerfile` L86). The public testnet and devnet runtimes are built without it, so the dispatchable is absent from the on-chain `Call` enum on both networks (per the metadata evidence in #2591). Downstream tooling that trusts the docstring builds a working PoW pipeline only to fail at submission time with a `pallet-call-not-found` error.

## Changes

1. **Docstring rewrite** — replaces the stale last line with an explicit note that the call is only compiled into runtimes built with `--features pow-faucet`, that the public testnet/devnet images do not include it, and that it is intended for local development runtimes.

2. **Dead-code removal** inside the function body:
   ```rust
   // before
   pub fn faucet(...) -> DispatchResult {
       if cfg!(feature = \"pow-faucet\") {
           return Self::do_faucet(origin, block_number, nonce, work);
       }
       Err(Error::<T>::FaucetDisabled.into())
   }
   ```
   The function is already `#[cfg(feature = \"pow-faucet\")]` at the item level, so `cfg!(feature = \"pow-faucet\")` inside the body is unconditionally true and the `Err` arm is unreachable. Simplified to a direct `Self::do_faucet(...)` call.

   `FaucetDisabled` is left in `Error<T>` for backward compatibility — it is also referenced by a commented-out guard in [`subnets/registration.rs`](https://github.com/opentensor/subtensor/blob/main/pallets/subtensor/src/subnets/registration.rs) and removing it could break downstream error-decoding clients.

## Behavioral impact

None. Builds without `pow-faucet` don't see the dispatchable; builds with it exercise the same `Self::do_faucet(...)` path that was always reached. `#[pallet::call_index(60)]` and the weight attribute are preserved, so on-chain extrinsic compatibility is unchanged.

## Out of scope

Option (b) from #2591 (enabling `pow-faucet` on the testnet Docker build) is not addressed here — that's a policy call about whether the public testnet runtime should ship a dispatchable that mints TAO, and the filer explicitly said either fix is acceptable. Happy to follow up in a separate PR if maintainers want to restore the historical `btcli wallet faucet` UX against testnet.