### PR TITLE
feat(subtensor): reset subnet identity on subnet create

### DIFF
--- a/pallets/subtensor/src/subnets/subnet.rs
+++ b/pallets/subtensor/src/subnets/subnet.rs
@@ -235,15 +235,30 @@ impl<T: Config> Pallet<T> {
             Self::increase_total_stake(pool_initial_tao);
         }
 
-        // --- 17. Add the identity if it exists
-        if let Some(identity_value) = identity {
-            ensure!(
-                Self::is_valid_subnet_identity(&identity_value),
-                Error::<T>::InvalidIdentity
-            );
+        // --- 17. Set or reset the subnet identity.
+        //
+        // If the caller provided identity info, validate and store it.
+        // Otherwise clear any identity that may still be attached to this
+        // netuid slot from a previous owner — storage migrations or older
+        // code paths can leave orphaned `SubnetIdentitiesV3` entries which
+        // would otherwise leak into the newly-created subnet and mislead
+        // participants about what the subnet is about (see issue #2572).
+        match identity {
+            Some(identity_value) => {
+                ensure!(
+                    Self::is_valid_subnet_identity(&identity_value),
+                    Error::<T>::InvalidIdentity
+                );
 
-            SubnetIdentitiesV3::<T>::insert(netuid_to_register, identity_value);
-            Self::deposit_event(Event::SubnetIdentitySet(netuid_to_register));
+                SubnetIdentitiesV3::<T>::insert(netuid_to_register, identity_value);
+                Self::deposit_event(Event::SubnetIdentitySet(netuid_to_register));
+            }
+            None => {
+                if SubnetIdentitiesV3::<T>::contains_key(netuid_to_register) {
+                    SubnetIdentitiesV3::<T>::remove(netuid_to_register);
+                    Self::deposit_event(Event::SubnetIdentityRemoved(netuid_to_register));
+                }
+            }
         }
 
         // --- 18. Emit the NetworkAdded event.

--- a/pallets/subtensor/src/tests/networks.rs
+++ b/pallets/subtensor/src/tests/networks.rs
@@ -1435,6 +1435,123 @@ fn register_network_fails_before_prune_keeps_existing() {
     });
 }
 
+// Regression for https://github.com/opentensor/subtensor/issues/2572:
+// a stale `SubnetIdentitiesV3` entry on a netuid slot that is about to be
+// assigned to a new subnet must be cleared when the new owner does not
+// provide identity information of their own.
+#[test]
+fn register_network_with_none_identity_clears_stale_entry() {
+    new_test_ext(0).execute_with(|| {
+        let expected_netuid = SubtensorModule::get_next_netuid();
+
+        let stale_identity = SubnetIdentityOfV3 {
+            subnet_name: b"Previous Owner".to_vec(),
+            github_repo: b"https://github.com/previous/subnet".to_vec(),
+            subnet_contact: b"previous@example.com".to_vec(),
+            subnet_url: b"https://previous.example.com".to_vec(),
+            discord: b"previous#1234".to_vec(),
+            description: b"left over from a prior owner".to_vec(),
+            logo_url: b"https://previous.example.com/logo.png".to_vec(),
+            additional: b"stale".to_vec(),
+        };
+        SubnetIdentitiesV3::<Test>::insert(expected_netuid, stale_identity);
+        assert!(SubnetIdentitiesV3::<Test>::contains_key(expected_netuid));
+
+        let caller_cold = U256::from(61);
+        let caller_hot = U256::from(62);
+        let lock_cost: u64 = SubtensorModule::get_network_lock_cost().into();
+        SubtensorModule::add_balance_to_coldkey_account(&caller_cold, lock_cost.into());
+
+        assert_ok!(SubtensorModule::do_register_network(
+            RuntimeOrigin::signed(caller_cold),
+            &caller_hot,
+            1,
+            None,
+        ));
+
+        assert_eq!(SubnetOwner::<Test>::get(expected_netuid), caller_cold);
+        assert!(
+            !SubnetIdentitiesV3::<Test>::contains_key(expected_netuid),
+            "stale identity must be cleared when the new owner provides None",
+        );
+    });
+}
+
+// Companion to `register_network_with_none_identity_clears_stale_entry`:
+// when the new owner *does* provide identity info, it must simply replace
+// the stale entry (not be treated as a no-op, not panic).
+#[test]
+fn register_network_with_some_identity_overwrites_stale_entry() {
+    new_test_ext(0).execute_with(|| {
+        let expected_netuid = SubtensorModule::get_next_netuid();
+
+        let stale_identity = SubnetIdentityOfV3 {
+            subnet_name: b"Previous Owner".to_vec(),
+            github_repo: b"https://github.com/previous/subnet".to_vec(),
+            subnet_contact: b"previous@example.com".to_vec(),
+            subnet_url: b"https://previous.example.com".to_vec(),
+            discord: b"previous#1234".to_vec(),
+            description: b"left over from a prior owner".to_vec(),
+            logo_url: b"https://previous.example.com/logo.png".to_vec(),
+            additional: b"stale".to_vec(),
+        };
+        SubnetIdentitiesV3::<Test>::insert(expected_netuid, stale_identity);
+
+        let new_identity = SubnetIdentityOfV3 {
+            subnet_name: b"Brand New Subnet".to_vec(),
+            github_repo: b"https://github.com/new/subnet".to_vec(),
+            subnet_contact: b"new@example.com".to_vec(),
+            subnet_url: b"https://new.example.com".to_vec(),
+            discord: b"new#5678".to_vec(),
+            description: b"a fresh subnet".to_vec(),
+            logo_url: b"https://new.example.com/logo.png".to_vec(),
+            additional: b"fresh".to_vec(),
+        };
+
+        let caller_cold = U256::from(71);
+        let caller_hot = U256::from(72);
+        let lock_cost: u64 = SubtensorModule::get_network_lock_cost().into();
+        SubtensorModule::add_balance_to_coldkey_account(&caller_cold, lock_cost.into());
+
+        assert_ok!(SubtensorModule::do_register_network(
+            RuntimeOrigin::signed(caller_cold),
+            &caller_hot,
+            1,
+            Some(new_identity.clone()),
+        ));
+
+        let stored = SubnetIdentitiesV3::<Test>::get(expected_netuid)
+            .expect("new identity should be stored");
+        assert_eq!(stored, new_identity);
+    });
+}
+
+// Complement to `register_network_with_none_identity_clears_stale_entry`:
+// if the netuid slot had no stale identity to begin with, registering
+// with `None` must leave the storage map untouched (and must not emit
+// a spurious `SubnetIdentityRemoved` event).
+#[test]
+fn register_network_with_none_identity_no_op_when_slot_empty() {
+    new_test_ext(0).execute_with(|| {
+        let expected_netuid = SubtensorModule::get_next_netuid();
+        assert!(!SubnetIdentitiesV3::<Test>::contains_key(expected_netuid));
+
+        let caller_cold = U256::from(81);
+        let caller_hot = U256::from(82);
+        let lock_cost: u64 = SubtensorModule::get_network_lock_cost().into();
+        SubtensorModule::add_balance_to_coldkey_account(&caller_cold, lock_cost.into());
+
+        assert_ok!(SubtensorModule::do_register_network(
+            RuntimeOrigin::signed(caller_cold),
+            &caller_hot,
+            1,
+            None,
+        ));
+
+        assert!(!SubnetIdentitiesV3::<Test>::contains_key(expected_netuid));
+    });
+}
+
 #[test]
 fn test_migrate_network_immunity_period() {
     new_test_ext(0).execute_with(|| {


### PR DESCRIPTION
## Summary

Closes #2572.

`do_register_network` previously only *set* a `SubnetIdentityV3` entry when the caller passed `Some(identity)` and left the storage map untouched otherwise. Storage migrations and legacy code paths can leave an orphan `SubnetIdentitiesV3` entry on a netuid slot that later gets assigned to a new owner; that orphan then leaks into the fresh subnet and misrepresents what the subnet is about (wrong name, wrong GitHub repo, wrong Discord, etc.).

This PR makes the `identity` argument authoritative, matching the natural intuition of "the caller of `register_network` fully owns the resulting subnet's presentation":

- `Some(identity)` — validate and insert (existing behavior, unchanged).
- `None` — if an entry already exists for the target netuid, remove it and emit `SubnetIdentityRemoved`; no-op if the slot is already empty.

No runtime migration required — the fix is forward-only and only kicks in when `do_register_network` is called, so existing subnets are unaffected.

## Changes

- `pallets/subtensor/src/subnets/subnet.rs` — step 17 of `do_register_network` now uses a `match identity` instead of `if let Some(..)`, with a `None` branch that clears any stale `SubnetIdentitiesV3` entry and emits the existing `SubnetIdentityRemoved` event (already used by `do_dissolve_network` in `coinbase/root.rs`).
- `pallets/subtensor/src/tests/networks.rs` — three regression tests:
  - `register_network_with_none_identity_clears_stale_entry` — pre-inserts a stale `SubnetIdentityV3` at the predicted next netuid, calls `do_register_network(..., None)`, asserts the entry is gone.
  - `register_network_with_some_identity_overwrites_stale_entry` — same setup but passes `Some(new_identity)`, asserts the stored entry equals `new_identity`.
  - `register_network_with_none_identity_no_op_when_slot_empty` — registers with `None` against an empty slot, asserts no `SubnetIdentitiesV3` entry is created.

## Test plan

- [x] `cargo check -p pallet-subtensor`
- [ ] `cargo test -p pallet-subtensor --features pow-faucet -- tests::networks::register_network_with_none_identity_clears_stale_entry`
- [ ] `cargo test -p pallet-subtensor --features pow-faucet -- tests::networks::register_network_with_some_identity_overwrites_stale_entry`
- [ ] `cargo test -p pallet-subtensor --features pow-faucet -- tests::networks::register_network_with_none_identity_no_op_when_slot_empty`
- [ ] Full `cargo test -p pallet-subtensor` (CI)

## Notes

- `SubnetIdentityRemoved` event is already emitted by `do_dissolve_network` when a subnet is torn down, so consumers that index events should already handle it gracefully.
- The new `None`-branch behavior only *removes* stale state; it can never overwrite a caller's current subnet identity, since it runs inside `do_register_network` which creates the subnet.
- Fixes the user-visible symptom of a newly registered subnet appearing with a previous owner's `subnet_name` / `github_repo` / `discord` until the new owner manually calls `set_subnet_identity`.