### PR TITLE
chore(docs): unify rustdoc style across pallet-subtensor

### DIFF
--- a/pallets/subtensor/src/coinbase/root.rs
+++ b/pallets/subtensor/src/coinbase/root.rs
@@ -27,7 +27,7 @@ impl<T: Config> Pallet<T> {
     ///
     /// This function retrieves the total number of root network validators.
     ///
-    /// # Returns:
+    /// # Returns
     /// * 'u16': The total number of root network validators
     ///
     pub fn get_num_root_validators() -> u16 {
@@ -38,7 +38,7 @@ impl<T: Config> Pallet<T> {
     ///
     /// This function retrieves the max validators count of root network.
     ///
-    /// # Returns:
+    /// # Returns
     /// * 'u16': The max validators count of root network.
     ///
     pub fn get_max_root_validators() -> u16 {
@@ -49,10 +49,10 @@ impl<T: Config> Pallet<T> {
     ///
     /// It's important to check for invalid UIDs to ensure data integrity and avoid referencing nonexistent subnets.
     ///
-    /// # Arguments:
+    /// # Arguments
     /// * 'uids': A reference to a vector of UIDs to check.
     ///
-    /// # Returns:
+    /// # Returns
     /// * 'bool': 'true' if any of the UIDs are invalid, 'false' otherwise.
     ///
     pub fn contains_invalid_root_uids(netuids: &[NetUid]) -> bool {
@@ -70,11 +70,11 @@ impl<T: Config> Pallet<T> {
     /// This function is responsible for registering the hotkey of a user.
     /// The root key with the least stake if pruned in the event of a filled network.
     ///
-    /// # Arguments:
+    /// # Arguments
     /// * 'origin': Represents the origin of the call.
     /// * 'hotkey': The hotkey that the user wants to register to the root network.
     ///
-    /// # Returns:
+    /// # Returns
     /// * 'DispatchResult': A result type indicating success or failure of the registration.
     ///
     pub fn do_root_register(origin: OriginFor<T>, hotkey: T::AccountId) -> DispatchResult {
@@ -192,14 +192,14 @@ impl<T: Config> Pallet<T> {
 
     /// Facilitates the removal of a user's subnetwork.
     ///
-    /// # Args:
+    /// # Arguments
     /// * 'origin': ('T::RuntimeOrigin'): The calling origin. Must be signed.
     /// * 'netuid': ('u16'): The unique identifier of the network to be removed.
     ///
-    /// # Event:
+    /// # Events
     /// * 'NetworkRemoved': Emitted when a network is successfully removed.
     ///
-    /// # Raises:
+    /// # Errors
     /// * 'MechanismDoesNotExist': If the specified network does not exist.
     /// * 'NotSubnetOwner': If the caller does not own the specified subnet.
     ///
@@ -500,7 +500,7 @@ impl<T: Config> Pallet<T> {
     ///
     /// If the calculated lock cost is less than the minimum lock cost, the minimum lock cost is returned.
     ///
-    /// # Returns:
+    /// # Returns
     ///  * 'u64':
     ///     - The lock cost for the network.
     ///

--- a/pallets/subtensor/src/coinbase/root.rs
+++ b/pallets/subtensor/src/coinbase/root.rs
@@ -28,7 +28,7 @@ impl<T: Config> Pallet<T> {
     /// This function retrieves the total number of root network validators.
     ///
     /// # Returns
-    /// * 'u16': The total number of root network validators
+    /// * `u16`: The total number of root network validators.
     ///
     pub fn get_num_root_validators() -> u16 {
         Self::get_subnetwork_n(NetUid::ROOT)
@@ -39,7 +39,7 @@ impl<T: Config> Pallet<T> {
     /// This function retrieves the max validators count of root network.
     ///
     /// # Returns
-    /// * 'u16': The max validators count of root network.
+    /// * `u16`: The max validators count of root network.
     ///
     pub fn get_max_root_validators() -> u16 {
         Self::get_max_allowed_uids(NetUid::ROOT)
@@ -50,10 +50,10 @@ impl<T: Config> Pallet<T> {
     /// It's important to check for invalid UIDs to ensure data integrity and avoid referencing nonexistent subnets.
     ///
     /// # Arguments
-    /// * 'uids': A reference to a vector of UIDs to check.
+    /// * `uids`: A reference to a vector of UIDs to check.
     ///
     /// # Returns
-    /// * 'bool': 'true' if any of the UIDs are invalid, 'false' otherwise.
+    /// * `bool`: 'true' if any of the UIDs are invalid, 'false' otherwise.
     ///
     pub fn contains_invalid_root_uids(netuids: &[NetUid]) -> bool {
         for netuid in netuids {
@@ -71,11 +71,11 @@ impl<T: Config> Pallet<T> {
     /// The root key with the least stake if pruned in the event of a filled network.
     ///
     /// # Arguments
-    /// * 'origin': Represents the origin of the call.
-    /// * 'hotkey': The hotkey that the user wants to register to the root network.
+    /// * `origin`: Represents the origin of the call.
+    /// * `hotkey`: The hotkey that the user wants to register to the root network.
     ///
     /// # Returns
-    /// * 'DispatchResult': A result type indicating success or failure of the registration.
+    /// * `DispatchResult`: A result type indicating success or failure of the registration.
     ///
     pub fn do_root_register(origin: OriginFor<T>, hotkey: T::AccountId) -> DispatchResult {
         // --- 0. Get the unique identifier (UID) for the root network.
@@ -193,8 +193,8 @@ impl<T: Config> Pallet<T> {
     /// Facilitates the removal of a user's subnetwork.
     ///
     /// # Arguments
-    /// * 'origin': ('T::RuntimeOrigin'): The calling origin. Must be signed.
-    /// * 'netuid': ('u16'): The unique identifier of the network to be removed.
+    /// * `origin`: ('T::RuntimeOrigin'): The calling origin. Must be signed.
+    /// * `netuid`: ('u16'): The unique identifier of the network to be removed.
     ///
     /// # Events
     /// * 'NetworkRemoved': Emitted when a network is successfully removed.
@@ -501,8 +501,7 @@ impl<T: Config> Pallet<T> {
     /// If the calculated lock cost is less than the minimum lock cost, the minimum lock cost is returned.
     ///
     /// # Returns
-    ///  * 'u64':
-    ///     - The lock cost for the network.
+    /// * `u64`: The lock cost for the network.
     ///
     pub fn get_network_lock_cost() -> TaoBalance {
         let last_lock = Self::get_network_last_lock();

--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -780,9 +780,9 @@ impl<T: Config> Pallet<T> {
     /// The hotkey also gets a portion based on its own stake contribution, this is added to the childkey take.
     ///
     /// # Arguments
-    /// * `hotkye` - The hotkey to distribute out from.
-    /// * `netuid` - The netuid we are computing on.
-    /// * `dividends` - the dividends to distribute.
+    /// * `hotkye`: The hotkey to distribute out from.
+    /// * `netuid`: The netuid we are computing on.
+    /// * `dividends`: the dividends to distribute.
     ///
     /// # Returns
     /// * dividend_tuples: `Vec<(T::AccountId, u64)>` - Vector of (hotkey, divs) for each parent including self.
@@ -924,10 +924,10 @@ impl<T: Config> Pallet<T> {
     /// Checks if the epoch should run for a given subnet based on the current block.
     ///
     /// # Arguments
-    /// * `netuid` - The unique identifier of the subnet.
+    /// * `netuid`: The unique identifier of the subnet.
     ///
     /// # Returns
-    /// * `bool` - True if the epoch should run, false otherwise.
+    /// * `bool`: True if the epoch should run, false otherwise.
     pub fn should_run_epoch(netuid: NetUid, current_block: u64) -> bool {
         Self::blocks_until_next_epoch(netuid, Self::get_tempo(netuid), current_block) == 0
     }

--- a/pallets/subtensor/src/epoch/math.rs
+++ b/pallets/subtensor/src/epoch/math.rs
@@ -1350,7 +1350,9 @@ pub fn mat_vec_mul_sparse(
 }
 
 /// Clamp the input value between high and low.
-/// Note: assumes high > low
+///
+/// # Note
+/// Assumes `high > low`.
 pub fn clamp_value(value: I32F32, low: I32F32, high: I32F32) -> I32F32 {
     // First, clamp the value to ensure it does not exceed the upper bound (high).
     // If the value is greater than 'high', it will be set to 'high'.

--- a/pallets/subtensor/src/epoch/run_epoch.rs
+++ b/pallets/subtensor/src/epoch/run_epoch.rs
@@ -548,14 +548,11 @@ impl<T: Config> Pallet<T> {
     /// returns the emissions for uids/hotkeys in a given `netuid`.
     ///
     /// # Arguments
-    ///  * 'netuid': ( u16 ):
-    ///     - The network to distribute the emission onto.
+    /// * `netuid`: The network to distribute the emission onto.
     ///
-    ///  * 'rao_emission': ( u64 ):
-    ///     - The total emission for the epoch.
+    /// * `rao_emission`: The total emission for the epoch.
     ///
-    ///  * 'debug' ( bool ):
-    ///     - Print debugging outputs.
+    /// * `debug`: Print debugging outputs.
     ///
     pub fn epoch_mechanism(
         netuid: NetUid,
@@ -1195,9 +1192,9 @@ impl<T: Config> Pallet<T> {
     /// Compute the Exponential Moving Average (EMA) of bonds using a normal alpha value for a sparse matrix.
     ///
     /// # Arguments
-    /// * `bonds_delta` - A vector of bond deltas.
-    /// * `bonds` - A vector of bonds.
-    /// * `netuid` - The network ID.
+    /// * `bonds_delta`: A vector of bond deltas.
+    /// * `bonds`: A vector of bonds.
+    /// * `netuid`: The network ID.
     ///
     /// # Returns
     /// A vector of EMA bonds.
@@ -1231,9 +1228,9 @@ impl<T: Config> Pallet<T> {
     /// Compute the Exponential Moving Average (EMA) of bonds using a normal alpha value.
     ///
     /// # Arguments
-    /// * `bonds_delta` - A vector of bond deltas.
-    /// * `bonds` - A vector of bonds.
-    /// * `netuid` - The network ID.
+    /// * `bonds_delta`: A vector of bond deltas.
+    /// * `bonds`: A vector of bonds.
+    /// * `netuid`: The network ID.
     ///
     /// # Returns
     /// A vector of EMA bonds.
@@ -1265,11 +1262,11 @@ impl<T: Config> Pallet<T> {
     /// Compute the Exponential Moving Average (EMA) of bonds based on the Liquid Alpha setting
     ///
     /// # Arguments
-    /// * `netuid` - The network ID.
-    /// * `weights` - A vector of weights.
-    /// * `bonds` - A vector of bonds.
-    /// * `consensus` - A vector of consensus values.
-    /// * `active_stake` - A vector of active stake values.
+    /// * `netuid`: The network ID.
+    /// * `weights`: A vector of weights.
+    /// * `bonds`: A vector of bonds.
+    /// * `consensus`: A vector of consensus values.
+    /// * `active_stake`: A vector of active stake values.
     ///
     /// # Returns
     /// A vector of EMA bonds.
@@ -1305,11 +1302,11 @@ impl<T: Config> Pallet<T> {
     /// Compute the Exponential Moving Average (EMA) of bonds based on the Liquid Alpha setting for a sparse matrix.
     ///
     /// # Arguments
-    /// * `netuid` - The network ID.
-    /// * `weights` - A vector of weights.
-    /// * `bonds` - A vector of bonds.
-    /// * `consensus` - A vector of consensus values.
-    /// * `active_stake` - A vector of active stake values.
+    /// * `netuid`: The network ID.
+    /// * `weights`: A vector of weights.
+    /// * `bonds`: A vector of bonds.
+    /// * `consensus`: A vector of consensus values.
+    /// * `active_stake`: A vector of active stake values.
     ///
     /// # Returns
     /// A vector of EMA bonds.
@@ -1348,10 +1345,10 @@ impl<T: Config> Pallet<T> {
     /// There is a separate alpha param for each validator-miner binding
     ///
     /// # Arguments
-    /// * `netuid` - The network ID.
-    /// * `weights` - A vector of weights.
-    /// * `bonds` - A vector of bonds.
-    /// * `consensus` - A vector of consensus values.
+    /// * `netuid`: The network ID.
+    /// * `weights`: A vector of weights.
+    /// * `bonds`: A vector of bonds.
+    /// * `consensus`: A vector of consensus values.
     ///
     /// # Returns
     /// A matrix of alphas
@@ -1401,10 +1398,10 @@ impl<T: Config> Pallet<T> {
     /// There is a separate alpha param for each validator-miner binding
     ///
     /// # Arguments
-    /// * `netuid` - The network ID.
-    /// * `weights` - A vector of weights.
-    /// * `bonds` - A vector of bonds.
-    /// * `consensus` - A vector of consensus values.
+    /// * `netuid`: The network ID.
+    /// * `weights`: A vector of weights.
+    /// * `bonds`: A vector of bonds.
+    /// * `consensus`: A vector of consensus values.
     ///
     /// # Returns
     /// A dense matrix of alphas

--- a/pallets/subtensor/src/epoch/run_epoch.rs
+++ b/pallets/subtensor/src/epoch/run_epoch.rs
@@ -547,7 +547,7 @@ impl<T: Config> Pallet<T> {
     /// Calculates reward consensus values, then updates rank, trust, consensus, incentive, dividend, pruning_score, emission and bonds, and
     /// returns the emissions for uids/hotkeys in a given `netuid`.
     ///
-    /// # Args:
+    /// # Arguments
     ///  * 'netuid': ( u16 ):
     ///     - The network to distribute the emission onto.
     ///
@@ -1194,12 +1194,12 @@ impl<T: Config> Pallet<T> {
 
     /// Compute the Exponential Moving Average (EMA) of bonds using a normal alpha value for a sparse matrix.
     ///
-    /// # Args:
+    /// # Arguments
     /// * `bonds_delta` - A vector of bond deltas.
     /// * `bonds` - A vector of bonds.
     /// * `netuid` - The network ID.
     ///
-    /// # Returns:
+    /// # Returns
     /// A vector of EMA bonds.
     pub fn compute_ema_bonds_normal_sparse(
         bonds_delta: &[Vec<(u16, I32F32)>],
@@ -1230,12 +1230,12 @@ impl<T: Config> Pallet<T> {
 
     /// Compute the Exponential Moving Average (EMA) of bonds using a normal alpha value.
     ///
-    /// # Args:
+    /// # Arguments
     /// * `bonds_delta` - A vector of bond deltas.
     /// * `bonds` - A vector of bonds.
     /// * `netuid` - The network ID.
     ///
-    /// # Returns:
+    /// # Returns
     /// A vector of EMA bonds.
     pub fn compute_ema_bonds_normal(
         bonds_delta: &[Vec<I32F32>],
@@ -1264,14 +1264,14 @@ impl<T: Config> Pallet<T> {
 
     /// Compute the Exponential Moving Average (EMA) of bonds based on the Liquid Alpha setting
     ///
-    /// # Args:
+    /// # Arguments
     /// * `netuid` - The network ID.
     /// * `weights` - A vector of weights.
     /// * `bonds` - A vector of bonds.
     /// * `consensus` - A vector of consensus values.
     /// * `active_stake` - A vector of active stake values.
     ///
-    /// # Returns:
+    /// # Returns
     /// A vector of EMA bonds.
     pub fn compute_bonds(
         netuid: NetUid,
@@ -1304,14 +1304,14 @@ impl<T: Config> Pallet<T> {
 
     /// Compute the Exponential Moving Average (EMA) of bonds based on the Liquid Alpha setting for a sparse matrix.
     ///
-    /// # Args:
+    /// # Arguments
     /// * `netuid` - The network ID.
     /// * `weights` - A vector of weights.
     /// * `bonds` - A vector of bonds.
     /// * `consensus` - A vector of consensus values.
     /// * `active_stake` - A vector of active stake values.
     ///
-    /// # Returns:
+    /// # Returns
     /// A vector of EMA bonds.
     pub fn compute_bonds_sparse(
         netuid_index: NetUidStorageIndex,
@@ -1347,13 +1347,13 @@ impl<T: Config> Pallet<T> {
     /// Compute liquid alphas matrix
     /// There is a separate alpha param for each validator-miner binding
     ///
-    /// # Args:
+    /// # Arguments
     /// * `netuid` - The network ID.
     /// * `weights` - A vector of weights.
     /// * `bonds` - A vector of bonds.
     /// * `consensus` - A vector of consensus values.
     ///
-    /// # Returns:
+    /// # Returns
     /// A matrix of alphas
     pub fn compute_liquid_alpha_values(
         netuid: NetUid,
@@ -1400,13 +1400,13 @@ impl<T: Config> Pallet<T> {
     /// Compute liquid alphas sparse matrix
     /// There is a separate alpha param for each validator-miner binding
     ///
-    /// # Args:
+    /// # Arguments
     /// * `netuid` - The network ID.
     /// * `weights` - A vector of weights.
     /// * `bonds` - A vector of bonds.
     /// * `consensus` - A vector of consensus values.
     ///
-    /// # Returns:
+    /// # Returns
     /// A dense matrix of alphas
     pub fn compute_liquid_alpha_values_sparse(
         netuid: NetUid,

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -328,9 +328,7 @@ pub mod pallet {
         Recycle,
     }
 
-    /// ============================
-    /// ==== Staking + Accounts ====
-    /// ============================
+    /// Staking + Accounts
 
     #[derive(
         Encode, Decode, Default, TypeInfo, Clone, PartialEq, Eq, Debug, DecodeWithMemTracking,
@@ -1117,7 +1115,7 @@ pub mod pallet {
     pub type DissolveNetworkScheduleDuration<T: Config> =
         StorageValue<_, BlockNumberFor<T>, ValueQuery, DefaultDissolveNetworkScheduleDuration<T>>;
 
-    /// --- DMap ( netuid, coldkey ) --> blocknumber | last hotkey swap on network.
+    /// DMap ( netuid, coldkey ) --> blocknumber | last hotkey swap on network.
     #[pallet::storage]
     pub type LastHotkeySwapOnNetuid<T: Config> = StorageDoubleMap<
         _,
@@ -1134,9 +1132,7 @@ pub mod pallet {
     #[pallet::storage]
     pub type NextStakeJobId<T> = StorageValue<_, u64, ValueQuery, DefaultZeroU64<T>>;
 
-    /// ============================
-    /// ==== Staking Variables ====
-    /// ============================
+    /// Staking Variables
     /// The Subtensor [`TotalIssuance`] represents the total issuance of tokens on the Bittensor network.
     ///
     /// It is comprised of three parts:
@@ -1146,27 +1142,27 @@ pub mod pallet {
     ///
     /// Eventually, Bittensor should migrate to using Holds afterwhich time we will not require this
     /// separate accounting.
-    /// --- ITEM --> Global weight
+    /// ITEM --> Global weight
     #[pallet::storage]
     pub type TaoWeight<T> = StorageValue<_, u64, ValueQuery, DefaultTaoWeight<T>>;
 
-    /// --- ITEM --> CK burn
+    /// ITEM --> CK burn
     #[pallet::storage]
     pub type CKBurn<T> = StorageValue<_, u64, ValueQuery, DefaultCKBurn<T>>;
 
-    /// --- ITEM ( default_delegate_take )
+    /// ITEM ( default_delegate_take )
     #[pallet::storage]
     pub type MaxDelegateTake<T> = StorageValue<_, u16, ValueQuery, DefaultDelegateTake<T>>;
 
-    /// --- ITEM ( min_delegate_take )
+    /// ITEM ( min_delegate_take )
     #[pallet::storage]
     pub type MinDelegateTake<T> = StorageValue<_, u16, ValueQuery, DefaultMinDelegateTake<T>>;
 
-    /// --- ITEM ( default_childkey_take )
+    /// ITEM ( default_childkey_take )
     #[pallet::storage]
     pub type MaxChildkeyTake<T> = StorageValue<_, u16, ValueQuery, DefaultMaxChildKeyTake<T>>;
 
-    /// --- ITEM ( min_childkey_take )
+    /// ITEM ( min_childkey_take )
     #[pallet::storage]
     pub type MinChildkeyTake<T> = StorageValue<_, u16, ValueQuery, DefaultMinChildKeyTake<T>>;
 
@@ -1231,7 +1227,7 @@ pub mod pallet {
         DefaultAccountLinkage<T>,
     >;
 
-    /// --- DMAP ( netuid, hotkey ) --> u64 | Last alpha dividend this hotkey got on tempo.
+    /// DMAP ( netuid, hotkey ) --> u64 | Last alpha dividend this hotkey got on tempo.
     #[pallet::storage]
     pub type AlphaDividendsPerSubnet<T: Config> = StorageDoubleMap<
         _,
@@ -1244,7 +1240,7 @@ pub mod pallet {
         DefaultZeroAlpha<T>,
     >;
 
-    /// --- DMAP ( netuid, hotkey ) --> u64 | Last root alpha dividend this hotkey got on tempo.
+    /// DMAP ( netuid, hotkey ) --> u64 | Last root alpha dividend this hotkey got on tempo.
     #[pallet::storage]
     pub type RootAlphaDividendsPerSubnet<T: Config> = StorageDoubleMap<
         _,
@@ -1257,14 +1253,12 @@ pub mod pallet {
         DefaultZeroAlpha<T>,
     >;
 
-    /// ==================
-    /// ==== Coinbase ====
-    /// ==================
-    /// --- ITEM ( global_block_emission )
+    /// Coinbase
+    /// ITEM ( global_block_emission )
     #[pallet::storage]
     pub type BlockEmission<T> = StorageValue<_, u64, ValueQuery, DefaultBlockEmission<T>>;
 
-    /// --- DMap ( hot, netuid ) --> emission | last hotkey emission on network.
+    /// DMap ( hot, netuid ) --> emission | last hotkey emission on network.
     #[pallet::storage]
     pub type LastHotkeyEmissionOnNetuid<T: Config> = StorageDoubleMap<
         _,
@@ -1276,9 +1270,7 @@ pub mod pallet {
         ValueQuery,
         DefaultZeroAlpha<T>,
     >;
-    /// ==========================
-    /// ==== Staking Counters ====
-    /// ==========================
+    /// Staking Counters
     /// The Subtensor [`TotalIssuance`] represents the total issuance of tokens on the Bittensor network.
     ///
     /// It is comprised of three parts:
@@ -1288,88 +1280,88 @@ pub mod pallet {
     ///
     /// Eventually, Bittensor should migrate to using Holds afterwhich time we will not require this
     /// separate accounting.
-    /// --- ITEM ( maximum_number_of_networks )
+    /// ITEM ( maximum_number_of_networks )
     #[pallet::storage]
     pub type SubnetLimit<T> = StorageValue<_, u16, ValueQuery, DefaultSubnetLimit<T>>;
 
-    /// --- ITEM ( total_issuance )
+    /// ITEM ( total_issuance )
     #[pallet::storage]
     pub type TotalIssuance<T> = StorageValue<_, TaoBalance, ValueQuery, DefaultTotalIssuance<T>>;
 
-    /// --- ITEM ( total_stake )
+    /// ITEM ( total_stake )
     #[pallet::storage]
     pub type TotalStake<T> = StorageValue<_, TaoBalance, ValueQuery, DefaultZeroTao<T>>;
 
-    /// --- ITEM ( moving_alpha ) -- subnet moving alpha.
+    /// ITEM ( moving_alpha ) -- subnet moving alpha.
     #[pallet::storage]
     pub type SubnetMovingAlpha<T> = StorageValue<_, I96F32, ValueQuery, DefaultMovingAlpha<T>>;
 
-    /// --- MAP ( netuid ) --> moving_price | The subnet moving price.
+    /// MAP ( netuid ) --> moving_price | The subnet moving price.
     #[pallet::storage]
     pub type SubnetMovingPrice<T: Config> =
         StorageMap<_, Identity, NetUid, I96F32, ValueQuery, DefaultMovingPrice<T>>;
 
-    /// --- MAP ( netuid ) --> root_prop | The subnet root proportion.
+    /// MAP ( netuid ) --> root_prop | The subnet root proportion.
     #[pallet::storage]
     pub type RootProp<T: Config> =
         StorageMap<_, Identity, NetUid, U96F32, ValueQuery, DefaultRootProp<T>>;
 
-    /// --- MAP ( netuid ) --> total_volume | The total amount of TAO bought and sold since the start of the network.
+    /// MAP ( netuid ) --> total_volume | The total amount of TAO bought and sold since the start of the network.
     #[pallet::storage]
     pub type SubnetVolume<T: Config> =
         StorageMap<_, Identity, NetUid, u128, ValueQuery, DefaultZeroU128<T>>;
 
-    /// --- MAP ( netuid ) --> tao_in_subnet | Returns the amount of TAO in the subnet.
+    /// MAP ( netuid ) --> tao_in_subnet | Returns the amount of TAO in the subnet.
     #[pallet::storage]
     pub type SubnetTAO<T: Config> =
         StorageMap<_, Identity, NetUid, TaoBalance, ValueQuery, DefaultZeroTao<T>>;
 
-    /// --- MAP ( netuid ) --> tao_in_user_subnet | Returns the amount of TAO in the subnet reserve provided by users as liquidity.
+    /// MAP ( netuid ) --> tao_in_user_subnet | Returns the amount of TAO in the subnet reserve provided by users as liquidity.
     #[pallet::storage]
     pub type SubnetTaoProvided<T: Config> =
         StorageMap<_, Identity, NetUid, TaoBalance, ValueQuery, DefaultZeroTao<T>>;
 
-    /// --- MAP ( netuid ) --> alpha_in_emission | Returns the amount of alph in  emission into the pool per block.
+    /// MAP ( netuid ) --> alpha_in_emission | Returns the amount of alph in  emission into the pool per block.
     #[pallet::storage]
     pub type SubnetAlphaInEmission<T: Config> =
         StorageMap<_, Identity, NetUid, AlphaBalance, ValueQuery, DefaultZeroAlpha<T>>;
 
-    /// --- MAP ( netuid ) --> alpha_out_emission | Returns the amount of alpha out emission into the network per block.
+    /// MAP ( netuid ) --> alpha_out_emission | Returns the amount of alpha out emission into the network per block.
     #[pallet::storage]
     pub type SubnetAlphaOutEmission<T: Config> =
         StorageMap<_, Identity, NetUid, AlphaBalance, ValueQuery, DefaultZeroAlpha<T>>;
 
-    /// --- MAP ( netuid ) --> tao_in_emission | Returns the amount of tao emitted into this subent on the last block.
+    /// MAP ( netuid ) --> tao_in_emission | Returns the amount of tao emitted into this subent on the last block.
     #[pallet::storage]
     pub type SubnetTaoInEmission<T: Config> =
         StorageMap<_, Identity, NetUid, TaoBalance, ValueQuery, DefaultZeroTao<T>>;
 
-    /// --- MAP ( netuid ) --> alpha_supply_in_pool | Returns the amount of alpha in the pool.
+    /// MAP ( netuid ) --> alpha_supply_in_pool | Returns the amount of alpha in the pool.
     #[pallet::storage]
     pub type SubnetAlphaIn<T: Config> =
         StorageMap<_, Identity, NetUid, AlphaBalance, ValueQuery, DefaultZeroAlpha<T>>;
 
-    /// --- MAP ( netuid ) --> alpha_supply_user_in_pool | Returns the amount of alpha in the pool provided by users as liquidity.
+    /// MAP ( netuid ) --> alpha_supply_user_in_pool | Returns the amount of alpha in the pool provided by users as liquidity.
     #[pallet::storage]
     pub type SubnetAlphaInProvided<T: Config> =
         StorageMap<_, Identity, NetUid, AlphaBalance, ValueQuery, DefaultZeroAlpha<T>>;
 
-    /// --- MAP ( netuid ) --> alpha_supply_in_subnet | Returns the amount of alpha in the subnet.
+    /// MAP ( netuid ) --> alpha_supply_in_subnet | Returns the amount of alpha in the subnet.
     #[pallet::storage]
     pub type SubnetAlphaOut<T: Config> =
         StorageMap<_, Identity, NetUid, AlphaBalance, ValueQuery, DefaultZeroAlpha<T>>;
 
-    /// --- MAP ( cold ) --> Vec<hot> | Maps coldkey to hotkeys that stake to it
+    /// MAP ( cold ) --> Vec<hot> | Maps coldkey to hotkeys that stake to it
     #[pallet::storage]
     pub type StakingHotkeys<T: Config> =
         StorageMap<_, Blake2_128Concat, T::AccountId, Vec<T::AccountId>, ValueQuery>;
 
-    /// --- MAP ( cold ) --> Vec<hot> | Returns the vector of hotkeys controlled by this coldkey.
+    /// MAP ( cold ) --> Vec<hot> | Returns the vector of hotkeys controlled by this coldkey.
     #[pallet::storage]
     pub type OwnedHotkeys<T: Config> =
         StorageMap<_, Blake2_128Concat, T::AccountId, Vec<T::AccountId>, ValueQuery>;
 
-    /// --- DMAP ( cold, netuid )--> hot | Returns the hotkey a coldkey will autostake to with mining rewards.
+    /// DMAP ( cold, netuid )--> hot | Returns the hotkey a coldkey will autostake to with mining rewards.
     #[pallet::storage]
     pub type AutoStakeDestination<T: Config> = StorageDoubleMap<
         _,
@@ -1381,7 +1373,7 @@ pub mod pallet {
         OptionQuery,
     >;
 
-    /// --- DMAP ( hot, netuid )--> Vec<cold> | Returns a list of coldkeys that are autostaking to a hotkey
+    /// DMAP ( hot, netuid )--> Vec<cold> | Returns a list of coldkeys that are autostaking to a hotkey
     #[pallet::storage]
     pub type AutoStakeDestinationColdkeys<T: Config> = StorageDoubleMap<
         _,
@@ -1415,7 +1407,7 @@ pub mod pallet {
     pub type ColdkeySwapDisputes<T: Config> =
         StorageMap<_, Twox64Concat, T::AccountId, BlockNumberFor<T>, OptionQuery>;
 
-    /// --- DMAP ( hot, netuid ) --> alpha | Returns the total amount of alpha a hotkey owns.
+    /// DMAP ( hot, netuid ) --> alpha | Returns the total amount of alpha a hotkey owns.
     #[pallet::storage]
     pub type TotalHotkeyAlpha<T: Config> = StorageDoubleMap<
         _,
@@ -1428,7 +1420,7 @@ pub mod pallet {
         DefaultZeroAlpha<T>,
     >;
 
-    /// --- DMAP ( hot, netuid ) --> alpha | Returns the total amount of alpha a hotkey owned in the last epoch.
+    /// DMAP ( hot, netuid ) --> alpha | Returns the total amount of alpha a hotkey owned in the last epoch.
     #[pallet::storage]
     pub type TotalHotkeyAlphaLastEpoch<T: Config> = StorageDoubleMap<
         _,
@@ -1454,7 +1446,7 @@ pub mod pallet {
         DefaultSharePoolZero<T>,
     >;
 
-    /// --- NMAP ( hot, cold, netuid ) --> alpha | Returns the alpha shares for a hotkey, coldkey, netuid triplet.
+    /// NMAP ( hot, cold, netuid ) --> alpha | Returns the alpha shares for a hotkey, coldkey, netuid triplet.
     #[pallet::storage]
     pub type Alpha<T: Config> = StorageNMap<
         _,
@@ -1479,7 +1471,7 @@ pub mod pallet {
         ValueQuery,
     >;
 
-    /// --- NMAP ( hot, cold, netuid ) --> alpha | Returns the alpha shares for a hotkey, coldkey, netuid triplet, stores SafeFloat.
+    /// NMAP ( hot, cold, netuid ) --> alpha | Returns the alpha shares for a hotkey, coldkey, netuid triplet, stores SafeFloat.
     #[pallet::storage]
     pub type AlphaV2<T: Config> = StorageNMap<
         _,
@@ -1502,17 +1494,17 @@ pub mod pallet {
     pub type AlphaV2MapLastKey<T: Config> =
         StorageValue<_, Option<Vec<u8>>, ValueQuery, DefaultAlphaIterationLastKey<T>>;
 
-    /// --- MAP ( netuid ) --> token_symbol | Returns the token symbol for a subnet.
+    /// MAP ( netuid ) --> token_symbol | Returns the token symbol for a subnet.
     #[pallet::storage]
     pub type TokenSymbol<T: Config> =
         StorageMap<_, Identity, NetUid, Vec<u8>, ValueQuery, DefaultUnicodeVecU8<T>>;
 
-    /// --- MAP ( netuid ) --> subnet_tao_flow | Returns the TAO inflow-outflow balance.
+    /// MAP ( netuid ) --> subnet_tao_flow | Returns the TAO inflow-outflow balance.
     #[pallet::storage]
     pub type SubnetTaoFlow<T: Config> =
         StorageMap<_, Identity, NetUid, i64, ValueQuery, DefaultZeroI64<T>>;
 
-    /// --- MAP ( netuid ) --> subnet_ema_tao_flow | Returns the EMA of TAO inflow-outflow balance.
+    /// MAP ( netuid ) --> subnet_ema_tao_flow | Returns the EMA of TAO inflow-outflow balance.
     #[pallet::storage]
     pub type SubnetEmaTaoFlow<T: Config> =
         StorageMap<_, Identity, NetUid, (u64, I64F64), OptionQuery>;
@@ -1523,7 +1515,7 @@ pub mod pallet {
         I64F64::saturating_from_num(0)
     }
     #[pallet::storage]
-    /// --- ITEM --> TAO Flow Cutoff
+    /// ITEM --> TAO Flow Cutoff
     pub type TaoFlowCutoff<T: Config> = StorageValue<_, I64F64, ValueQuery, DefaultFlowCutoff<T>>;
     #[pallet::type_value]
     /// Default value for flow normalization exponent.
@@ -1531,7 +1523,7 @@ pub mod pallet {
         U64F64::saturating_from_num(1)
     }
     #[pallet::storage]
-    /// --- ITEM --> Flow Normalization Exponent (p)
+    /// ITEM --> Flow Normalization Exponent (p)
     pub type FlowNormExponent<T: Config> =
         StorageValue<_, U64F64, ValueQuery, DefaultFlowNormExponent<T>>;
     #[pallet::type_value]
@@ -1549,23 +1541,21 @@ pub mod pallet {
         216_000
     }
     #[pallet::storage]
-    /// --- ITEM --> Flow EMA smoothing factor (flow alpha), u64 normalized
+    /// ITEM --> Flow EMA smoothing factor (flow alpha), u64 normalized
     pub type FlowEmaSmoothingFactor<T: Config> =
         StorageValue<_, u64, ValueQuery, DefaultFlowEmaSmoothingFactor<T>>;
 
-    /// ============================
-    /// ==== Global Parameters =====
-    /// ============================
-    /// --- StorageItem Global Used Work.
+    /// Global Parameters
+    /// StorageItem Global Used Work.
     #[pallet::storage]
     pub type UsedWork<T: Config> = StorageMap<_, Identity, Vec<u8>, u64, ValueQuery>;
 
-    /// --- ITEM( global_max_registrations_per_block )
+    /// ITEM( global_max_registrations_per_block )
     #[pallet::storage]
     pub type MaxRegistrationsPerBlock<T> =
         StorageMap<_, Identity, NetUid, u16, ValueQuery, DefaultMaxRegistrationsPerBlock<T>>;
 
-    /// --- ITEM( total_number_of_existing_networks )
+    /// ITEM( total_number_of_existing_networks )
     #[pallet::storage]
     pub type TotalNetworks<T> = StorageValue<_, u16, ValueQuery>;
 
@@ -1601,7 +1591,7 @@ pub mod pallet {
     #[pallet::storage]
     pub type NetworkRateLimit<T> = StorageValue<_, u64, ValueQuery, DefaultNetworkRateLimit<T>>;
 
-    /// --- ITEM( nominator_min_required_stake ) --- Factor of DefaultMinStake in per-mill format.
+    /// ITEM( nominator_min_required_stake ) --- Factor of DefaultMinStake in per-mill format.
     #[pallet::storage]
     pub type NominatorMinRequiredStake<T> = StorageValue<_, u64, ValueQuery, DefaultZeroU64<T>>;
 
@@ -1610,62 +1600,54 @@ pub mod pallet {
     pub type WeightsVersionKeyRateLimit<T> =
         StorageValue<_, u64, ValueQuery, DefaultWeightsVersionKeyRateLimit<T>>;
 
-    /// ============================
-    /// ==== Rate Limiting =====
-    /// ============================
-    /// --- MAP ( RateLimitKey ) --> Block number in which the last rate limited operation occured
+    /// Rate Limiting
+    /// MAP ( RateLimitKey ) --> Block number in which the last rate limited operation occured
     #[pallet::storage]
     pub type LastRateLimitedBlock<T: Config> =
         StorageMap<_, Identity, RateLimitKey<T::AccountId>, u64, ValueQuery, DefaultZeroU64<T>>;
 
-    /// ============================
-    /// ==== Subnet Locks =====
-    /// ============================
-    /// --- MAP ( netuid ) --> transfer_toggle
+    /// Subnet Locks
+    /// MAP ( netuid ) --> transfer_toggle
     #[pallet::storage]
     pub type TransferToggle<T: Config> =
         StorageMap<_, Identity, NetUid, bool, ValueQuery, DefaultTrue<T>>;
 
-    /// --- MAP ( netuid ) --> total_subnet_locked
+    /// MAP ( netuid ) --> total_subnet_locked
     #[pallet::storage]
     pub type SubnetLocked<T: Config> =
         StorageMap<_, Identity, NetUid, TaoBalance, ValueQuery, DefaultZeroTao<T>>;
 
-    /// --- MAP ( netuid ) --> largest_locked
+    /// MAP ( netuid ) --> largest_locked
     #[pallet::storage]
     pub type LargestLocked<T: Config> =
         StorageMap<_, Identity, NetUid, u64, ValueQuery, DefaultZeroU64<T>>;
 
-    /// =================
-    /// ==== Tempos =====
-    /// =================
-    /// --- MAP ( netuid ) --> tempo
+    /// Tempos
+    /// MAP ( netuid ) --> tempo
     #[pallet::storage]
     pub type Tempo<T> = StorageMap<_, Identity, NetUid, u16, ValueQuery, DefaultTempo<T>>;
 
-    /// ============================
-    /// ==== Subnet Parameters =====
-    /// ============================
-    /// --- MAP ( netuid ) --> block number of first emission
+    /// Subnet Parameters
+    /// MAP ( netuid ) --> block number of first emission
     #[pallet::storage]
     pub type FirstEmissionBlockNumber<T: Config> =
         StorageMap<_, Identity, NetUid, u64, OptionQuery>;
 
-    /// --- MAP ( netuid ) --> subnet mechanism
+    /// MAP ( netuid ) --> subnet mechanism
     #[pallet::storage]
     pub type SubnetMechanism<T: Config> =
         StorageMap<_, Identity, NetUid, u16, ValueQuery, DefaultZeroU16<T>>;
 
-    /// --- MAP ( netuid ) --> subnetwork_n (Number of UIDs in the network).
+    /// MAP ( netuid ) --> subnetwork_n (Number of UIDs in the network).
     #[pallet::storage]
     pub type SubnetworkN<T: Config> = StorageMap<_, Identity, NetUid, u16, ValueQuery, DefaultN<T>>;
 
-    /// --- MAP ( netuid ) --> network_is_added
+    /// MAP ( netuid ) --> network_is_added
     #[pallet::storage]
     pub type NetworksAdded<T: Config> =
         StorageMap<_, Identity, NetUid, bool, ValueQuery, DefaultNeworksAdded<T>>;
 
-    /// --- DMAP ( hotkey, netuid ) --> bool
+    /// DMAP ( hotkey, netuid ) --> bool
     #[pallet::storage]
     pub type IsNetworkMember<T: Config> = StorageDoubleMap<
         _,
@@ -1678,22 +1660,22 @@ pub mod pallet {
         DefaultIsNetworkMember<T>,
     >;
 
-    /// --- MAP ( netuid ) --> network_registration_allowed
+    /// MAP ( netuid ) --> network_registration_allowed
     #[pallet::storage]
     pub type NetworkRegistrationAllowed<T: Config> =
         StorageMap<_, Identity, NetUid, bool, ValueQuery, DefaultRegistrationAllowed<T>>;
 
-    /// --- MAP ( netuid ) --> network_pow_allowed
+    /// MAP ( netuid ) --> network_pow_allowed
     #[pallet::storage]
     pub type NetworkPowRegistrationAllowed<T: Config> =
         StorageMap<_, Identity, NetUid, bool, ValueQuery, DefaultRegistrationAllowed<T>>;
 
-    /// --- MAP ( netuid ) --> block_created
+    /// MAP ( netuid ) --> block_created
     #[pallet::storage]
     pub type NetworkRegisteredAt<T: Config> =
         StorageMap<_, Identity, NetUid, u64, ValueQuery, DefaultNetworkRegisteredAt<T>>;
 
-    /// --- MAP ( netuid ) --> registered_subnet_counter
+    /// MAP ( netuid ) --> registered_subnet_counter
     ///
     /// Monotonic counter incremented on every successful `do_register_network`
     /// for a given netuid. Consumers that persist per-netuid state keyed by
@@ -1705,100 +1687,100 @@ pub mod pallet {
     #[pallet::storage]
     pub type RegisteredSubnetCounter<T: Config> = StorageMap<_, Identity, NetUid, u64, ValueQuery>;
 
-    /// --- MAP ( netuid ) --> pending_server_emission
+    /// MAP ( netuid ) --> pending_server_emission
     #[pallet::storage]
     pub type PendingServerEmission<T> =
         StorageMap<_, Identity, NetUid, AlphaBalance, ValueQuery, DefaultZeroAlpha<T>>;
 
-    /// --- MAP ( netuid ) --> pending_validator_emission
+    /// MAP ( netuid ) --> pending_validator_emission
     #[pallet::storage]
     pub type PendingValidatorEmission<T> =
         StorageMap<_, Identity, NetUid, AlphaBalance, ValueQuery, DefaultZeroAlpha<T>>;
 
-    /// --- MAP ( netuid ) --> pending_root_alpha_emission
+    /// MAP ( netuid ) --> pending_root_alpha_emission
     #[pallet::storage]
     pub type PendingRootAlphaDivs<T> =
         StorageMap<_, Identity, NetUid, AlphaBalance, ValueQuery, DefaultZeroAlpha<T>>;
 
-    /// --- MAP ( netuid ) --> pending_owner_cut
+    /// MAP ( netuid ) --> pending_owner_cut
     #[pallet::storage]
     pub type PendingOwnerCut<T> =
         StorageMap<_, Identity, NetUid, AlphaBalance, ValueQuery, DefaultZeroAlpha<T>>;
 
-    /// --- MAP ( netuid ) --> blocks_since_last_step
+    /// MAP ( netuid ) --> blocks_since_last_step
     #[pallet::storage]
     pub type BlocksSinceLastStep<T> =
         StorageMap<_, Identity, NetUid, u64, ValueQuery, DefaultBlocksSinceLastStep<T>>;
 
-    /// --- MAP ( netuid ) --> last_mechanism_step_block
+    /// MAP ( netuid ) --> last_mechanism_step_block
     #[pallet::storage]
     pub type LastMechansimStepBlock<T> =
         StorageMap<_, Identity, NetUid, u64, ValueQuery, DefaultLastMechanismStepBlock<T>>;
 
-    /// --- MAP ( netuid ) --> subnet_owner
+    /// MAP ( netuid ) --> subnet_owner
     #[pallet::storage]
     pub type SubnetOwner<T: Config> =
         StorageMap<_, Identity, NetUid, T::AccountId, ValueQuery, DefaultSubnetOwner<T>>;
 
-    /// --- MAP ( netuid ) --> subnet_owner_hotkey
+    /// MAP ( netuid ) --> subnet_owner_hotkey
     #[pallet::storage]
     pub type SubnetOwnerHotkey<T: Config> =
         StorageMap<_, Identity, NetUid, T::AccountId, ValueQuery, DefaultSubnetOwner<T>>;
 
-    /// --- MAP ( netuid ) --> recycle_or_burn
+    /// MAP ( netuid ) --> recycle_or_burn
     #[pallet::storage]
     pub type RecycleOrBurn<T: Config> =
         StorageMap<_, Identity, NetUid, RecycleOrBurnEnum, ValueQuery, DefaultRecycleOrBurn<T>>;
 
-    /// --- MAP ( netuid ) --> serving_rate_limit
+    /// MAP ( netuid ) --> serving_rate_limit
     #[pallet::storage]
     pub type ServingRateLimit<T> =
         StorageMap<_, Identity, NetUid, u64, ValueQuery, DefaultServingRateLimit<T>>;
 
-    /// --- MAP ( netuid ) --> Rho
+    /// MAP ( netuid ) --> Rho
     #[pallet::storage]
     pub type Rho<T> = StorageMap<_, Identity, NetUid, u16, ValueQuery, DefaultRho<T>>;
 
-    /// --- MAP ( netuid ) --> AlphaSigmoidSteepness
+    /// MAP ( netuid ) --> AlphaSigmoidSteepness
     #[pallet::storage]
     pub type AlphaSigmoidSteepness<T> =
         StorageMap<_, Identity, NetUid, i16, ValueQuery, DefaultAlphaSigmoidSteepness<T>>;
 
-    /// --- MAP ( netuid ) --> Kappa
+    /// MAP ( netuid ) --> Kappa
     #[pallet::storage]
     pub type Kappa<T> = StorageMap<_, Identity, NetUid, u16, ValueQuery, DefaultKappa<T>>;
 
-    /// --- MAP ( netuid ) --> registrations_this_interval
+    /// MAP ( netuid ) --> registrations_this_interval
     #[pallet::storage]
     pub type RegistrationsThisInterval<T: Config> =
         StorageMap<_, Identity, NetUid, u16, ValueQuery>;
 
-    /// --- MAP ( netuid ) --> pow_registrations_this_interval
+    /// MAP ( netuid ) --> pow_registrations_this_interval
     #[pallet::storage]
     pub type POWRegistrationsThisInterval<T: Config> =
         StorageMap<_, Identity, NetUid, u16, ValueQuery>;
 
-    /// --- MAP ( netuid ) --> burn_registrations_this_interval
+    /// MAP ( netuid ) --> burn_registrations_this_interval
     #[pallet::storage]
     pub type BurnRegistrationsThisInterval<T: Config> =
         StorageMap<_, Identity, NetUid, u16, ValueQuery>;
 
-    /// --- MAP ( netuid ) --> min_allowed_uids
+    /// MAP ( netuid ) --> min_allowed_uids
     #[pallet::storage]
     pub type MinAllowedUids<T> =
         StorageMap<_, Identity, NetUid, u16, ValueQuery, DefaultMinAllowedUids<T>>;
 
-    /// --- MAP ( netuid ) --> max_allowed_uids
+    /// MAP ( netuid ) --> max_allowed_uids
     #[pallet::storage]
     pub type MaxAllowedUids<T> =
         StorageMap<_, Identity, NetUid, u16, ValueQuery, DefaultMaxAllowedUids<T>>;
 
-    /// --- MAP ( netuid ) --> immunity_period
+    /// MAP ( netuid ) --> immunity_period
     #[pallet::storage]
     pub type ImmunityPeriod<T> =
         StorageMap<_, Identity, NetUid, u16, ValueQuery, DefaultImmunityPeriod<T>>;
 
-    /// --- MAP ( netuid ) --> activity_cutoff
+    /// MAP ( netuid ) --> activity_cutoff
     #[pallet::storage]
     pub type ActivityCutoff<T> =
         StorageMap<_, Identity, NetUid, u16, ValueQuery, DefaultActivityCutoff<T>>;
@@ -1808,120 +1790,120 @@ pub mod pallet {
         u16::MAX
     }
 
-    /// --- MAP ( netuid ) --> max_weight_limit
+    /// MAP ( netuid ) --> max_weight_limit
     #[pallet::storage]
     pub type MaxWeightsLimit<T> =
         StorageMap<_, Identity, NetUid, u16, ValueQuery, DefaultMaxWeightsLimit<T>>;
 
-    /// --- MAP ( netuid ) --> weights_version_key
+    /// MAP ( netuid ) --> weights_version_key
     #[pallet::storage]
     pub type WeightsVersionKey<T> =
         StorageMap<_, Identity, NetUid, u64, ValueQuery, DefaultWeightsVersionKey<T>>;
 
-    /// --- MAP ( netuid ) --> min_allowed_weights
+    /// MAP ( netuid ) --> min_allowed_weights
     #[pallet::storage]
     pub type MinAllowedWeights<T> =
         StorageMap<_, Identity, NetUid, u16, ValueQuery, DefaultMinAllowedWeights<T>>;
 
-    /// --- MAP ( netuid ) --> max_allowed_validators
+    /// MAP ( netuid ) --> max_allowed_validators
     #[pallet::storage]
     pub type MaxAllowedValidators<T> =
         StorageMap<_, Identity, NetUid, u16, ValueQuery, DefaultMaxAllowedValidators<T>>;
 
-    /// --- MAP ( netuid ) --> adjustment_interval
+    /// MAP ( netuid ) --> adjustment_interval
     #[pallet::storage]
     pub type AdjustmentInterval<T> =
         StorageMap<_, Identity, NetUid, u16, ValueQuery, DefaultAdjustmentInterval<T>>;
 
-    /// --- MAP ( netuid ) --> bonds_moving_average
+    /// MAP ( netuid ) --> bonds_moving_average
     #[pallet::storage]
     pub type BondsMovingAverage<T> =
         StorageMap<_, Identity, NetUid, u64, ValueQuery, DefaultBondsMovingAverage<T>>;
 
-    /// --- MAP ( netuid ) --> bonds_penalty
+    /// MAP ( netuid ) --> bonds_penalty
     #[pallet::storage]
     pub type BondsPenalty<T> =
         StorageMap<_, Identity, NetUid, u16, ValueQuery, DefaultBondsPenalty<T>>;
 
-    /// --- MAP ( netuid ) --> bonds_reset
+    /// MAP ( netuid ) --> bonds_reset
     #[pallet::storage]
     pub type BondsResetOn<T> =
         StorageMap<_, Identity, NetUid, bool, ValueQuery, DefaultBondsResetOn<T>>;
 
-    /// --- MAP ( netuid ) --> weights_set_rate_limit
+    /// MAP ( netuid ) --> weights_set_rate_limit
     #[pallet::storage]
     pub type WeightsSetRateLimit<T> =
         StorageMap<_, Identity, NetUid, u64, ValueQuery, DefaultWeightsSetRateLimit<T>>;
 
-    /// --- MAP ( netuid ) --> validator_prune_len
+    /// MAP ( netuid ) --> validator_prune_len
     #[pallet::storage]
     pub type ValidatorPruneLen<T> =
         StorageMap<_, Identity, NetUid, u64, ValueQuery, DefaultValidatorPruneLen<T>>;
 
-    /// --- MAP ( netuid ) --> scaling_law_power
+    /// MAP ( netuid ) --> scaling_law_power
     #[pallet::storage]
     pub type ScalingLawPower<T> =
         StorageMap<_, Identity, NetUid, u16, ValueQuery, DefaultScalingLawPower<T>>;
 
-    /// --- MAP ( netuid ) --> target_registrations_this_interval
+    /// MAP ( netuid ) --> target_registrations_this_interval
     #[pallet::storage]
     pub type TargetRegistrationsPerInterval<T> =
         StorageMap<_, Identity, NetUid, u16, ValueQuery, DefaultTargetRegistrationsPerInterval<T>>;
 
-    /// --- MAP ( netuid ) --> adjustment_alpha
+    /// MAP ( netuid ) --> adjustment_alpha
     #[pallet::storage]
     pub type AdjustmentAlpha<T: Config> =
         StorageMap<_, Identity, NetUid, u64, ValueQuery, DefaultAdjustmentAlpha<T>>;
 
-    /// --- MAP ( netuid ) --> commit reveal v2 weights are enabled
+    /// MAP ( netuid ) --> commit reveal v2 weights are enabled
     #[pallet::storage]
     pub type CommitRevealWeightsEnabled<T> =
         StorageMap<_, Identity, NetUid, bool, ValueQuery, DefaultCommitRevealWeightsEnabled<T>>;
 
-    /// --- MAP ( netuid ) --> Burn
+    /// MAP ( netuid ) --> Burn
     #[pallet::storage]
     pub type Burn<T> = StorageMap<_, Identity, NetUid, TaoBalance, ValueQuery, DefaultBurn<T>>;
 
-    /// --- MAP ( netuid ) --> Difficulty
+    /// MAP ( netuid ) --> Difficulty
     #[pallet::storage]
     pub type Difficulty<T> = StorageMap<_, Identity, NetUid, u64, ValueQuery, DefaultDifficulty<T>>;
 
-    /// --- MAP ( netuid ) --> MinBurn
+    /// MAP ( netuid ) --> MinBurn
     #[pallet::storage]
     pub type MinBurn<T> =
         StorageMap<_, Identity, NetUid, TaoBalance, ValueQuery, DefaultMinBurn<T>>;
 
-    /// --- MAP ( netuid ) --> MaxBurn
+    /// MAP ( netuid ) --> MaxBurn
     #[pallet::storage]
     pub type MaxBurn<T> =
         StorageMap<_, Identity, NetUid, TaoBalance, ValueQuery, DefaultMaxBurn<T>>;
 
-    /// --- MAP ( netuid ) --> MinDifficulty
+    /// MAP ( netuid ) --> MinDifficulty
     #[pallet::storage]
     pub type MinDifficulty<T> =
         StorageMap<_, Identity, NetUid, u64, ValueQuery, DefaultMinDifficulty<T>>;
 
-    /// --- MAP ( netuid ) --> MaxDifficulty
+    /// MAP ( netuid ) --> MaxDifficulty
     #[pallet::storage]
     pub type MaxDifficulty<T> =
         StorageMap<_, Identity, NetUid, u64, ValueQuery, DefaultMaxDifficulty<T>>;
 
-    /// --- MAP ( netuid ) -->  Block at last adjustment.
+    /// MAP ( netuid ) -->  Block at last adjustment.
     #[pallet::storage]
     pub type LastAdjustmentBlock<T> =
         StorageMap<_, Identity, NetUid, u64, ValueQuery, DefaultLastAdjustmentBlock<T>>;
 
-    /// --- MAP ( netuid ) --> Registrations of this Block.
+    /// MAP ( netuid ) --> Registrations of this Block.
     #[pallet::storage]
     pub type RegistrationsThisBlock<T> =
         StorageMap<_, Identity, NetUid, u16, ValueQuery, DefaultRegistrationsThisBlock<T>>;
 
-    /// --- MAP ( netuid ) --> Halving time of average moving price.
+    /// MAP ( netuid ) --> Halving time of average moving price.
     #[pallet::storage]
     pub type EMAPriceHalvingBlocks<T> =
         StorageMap<_, Identity, NetUid, u64, ValueQuery, DefaultEMAPriceMovingBlocks<T>>;
 
-    /// --- MAP ( netuid ) --> global_RAO_recycled_for_registration
+    /// MAP ( netuid ) --> global_RAO_recycled_for_registration
     #[pallet::storage]
     pub type RAORecycledForRegistration<T> = StorageMap<
         _,
@@ -1932,26 +1914,26 @@ pub mod pallet {
         DefaultRAORecycledForRegistration<T>,
     >;
 
-    /// --- ITEM ( tx_rate_limit )
+    /// ITEM ( tx_rate_limit )
     #[pallet::storage]
     pub type TxRateLimit<T> = StorageValue<_, u64, ValueQuery, DefaultTxRateLimit<T>>;
 
-    /// --- ITEM ( tx_delegate_take_rate_limit )
+    /// ITEM ( tx_delegate_take_rate_limit )
     #[pallet::storage]
     pub type TxDelegateTakeRateLimit<T> =
         StorageValue<_, u64, ValueQuery, DefaultTxDelegateTakeRateLimit<T>>;
 
-    /// --- ITEM ( tx_childkey_take_rate_limit )
+    /// ITEM ( tx_childkey_take_rate_limit )
     #[pallet::storage]
     pub type TxChildkeyTakeRateLimit<T> =
         StorageValue<_, u64, ValueQuery, DefaultTxChildKeyTakeRateLimit<T>>;
 
-    /// --- MAP ( netuid ) --> Whether or not Liquid Alpha is enabled
+    /// MAP ( netuid ) --> Whether or not Liquid Alpha is enabled
     #[pallet::storage]
     pub type LiquidAlphaOn<T> =
         StorageMap<_, Blake2_128Concat, NetUid, bool, ValueQuery, DefaultLiquidAlpha<T>>;
 
-    /// --- MAP ( netuid ) --> Whether or not Yuma3 is enabled
+    /// MAP ( netuid ) --> Whether or not Yuma3 is enabled
     #[pallet::storage]
     pub type Yuma3On<T> =
         StorageMap<_, Blake2_128Concat, NetUid, bool, ValueQuery, DefaultYuma3<T>>;
@@ -1961,7 +1943,7 @@ pub mod pallet {
     pub type AlphaValues<T> =
         StorageMap<_, Identity, NetUid, (u16, u16), ValueQuery, DefaultAlphaValues<T>>;
 
-    /// --- MAP ( netuid ) --> If subtoken trading enabled
+    /// MAP ( netuid ) --> If subtoken trading enabled
     #[pallet::storage]
     pub type SubtokenEnabled<T> =
         StorageMap<_, Identity, NetUid, bool, ValueQuery, DefaultFalse<T>>;
@@ -1982,28 +1964,28 @@ pub mod pallet {
     }
 
     #[pallet::storage]
-    /// --- DMAP ( netuid, hotkey ) --> voting_power | EMA of stake for voting
+    /// DMAP ( netuid, hotkey ) --> voting_power | EMA of stake for voting
     /// This tracks stake EMA updated every epoch when VotingPowerTrackingEnabled is true.
     /// Used by smart contracts to determine validator voting power for subnet governance.
     pub type VotingPower<T: Config> =
         StorageDoubleMap<_, Identity, NetUid, Blake2_128Concat, T::AccountId, u64, ValueQuery>;
 
     #[pallet::storage]
-    /// --- MAP ( netuid ) --> bool | Whether voting power tracking is enabled for this subnet.
+    /// MAP ( netuid ) --> bool | Whether voting power tracking is enabled for this subnet.
     /// When enabled, VotingPower EMA is updated every epoch. Default is false.
     /// When disabled with disable_at_block set, tracking continues until that block.
     pub type VotingPowerTrackingEnabled<T: Config> =
         StorageMap<_, Identity, NetUid, bool, ValueQuery, DefaultFalse<T>>;
 
     #[pallet::storage]
-    /// --- MAP ( netuid ) --> block_number | Block at which voting power tracking will be disabled.
+    /// MAP ( netuid ) --> block_number | Block at which voting power tracking will be disabled.
     /// When set (non-zero), tracking continues until this block, then automatically disables
     /// and clears VotingPower entries for the subnet. Provides a 14-day grace period.
     pub type VotingPowerDisableAtBlock<T: Config> =
         StorageMap<_, Identity, NetUid, u64, ValueQuery>;
 
     #[pallet::storage]
-    /// --- MAP ( netuid ) --> u64 | EMA alpha value for voting power calculation.
+    /// MAP ( netuid ) --> u64 | EMA alpha value for voting power calculation.
     /// Higher alpha = faster response to stake changes.
     /// Stored as u64 with 18 decimal precision (1.0 = 10^18).
     /// Only settable by sudo/root.
@@ -2028,25 +2010,23 @@ pub mod pallet {
         1
     }
 
-    /// --- MAP ( netuid ) --> Burn key limit
+    /// MAP ( netuid ) --> Burn key limit
     #[pallet::storage]
     pub type ImmuneOwnerUidsLimit<T> =
         StorageMap<_, Identity, NetUid, u16, ValueQuery, DefaultImmuneOwnerUidsLimit<T>>;
 
-    /// =======================================
-    /// ==== Subnetwork Consensus Storage  ====
-    /// =======================================
-    /// --- DMAP ( netuid ) --> stake_weight | weight for stake used in YC.
+    /// Subnetwork Consensus Storage
+    /// DMAP ( netuid ) --> stake_weight | weight for stake used in YC.
     #[pallet::storage]
     pub type StakeWeight<T: Config> =
         StorageMap<_, Identity, NetUid, Vec<u16>, ValueQuery, EmptyU16Vec<T>>;
 
-    /// --- DMAP ( netuid, hotkey ) --> uid
+    /// DMAP ( netuid, hotkey ) --> uid
     #[pallet::storage]
     pub type Uids<T: Config> =
         StorageDoubleMap<_, Identity, NetUid, Blake2_128Concat, T::AccountId, u16, OptionQuery>;
 
-    /// --- DMAP ( netuid, uid ) --> hotkey
+    /// DMAP ( netuid, uid ) --> hotkey
     #[pallet::storage]
     pub type Keys<T: Config> = StorageDoubleMap<
         _,
@@ -2059,51 +2039,51 @@ pub mod pallet {
         DefaultKey<T>,
     >;
 
-    /// --- MAP ( netuid ) --> (hotkey, se, ve)
+    /// MAP ( netuid ) --> (hotkey, se, ve)
     #[pallet::storage]
     pub type LoadedEmission<T: Config> =
         StorageMap<_, Identity, NetUid, Vec<(T::AccountId, u64, u64)>, OptionQuery>;
 
-    /// --- MAP ( netuid ) --> active
+    /// MAP ( netuid ) --> active
     #[pallet::storage]
     pub type Active<T: Config> =
         StorageMap<_, Identity, NetUid, Vec<bool>, ValueQuery, EmptyBoolVec<T>>;
 
-    /// --- MAP ( netuid ) --> consensus
+    /// MAP ( netuid ) --> consensus
     #[pallet::storage]
     pub type Consensus<T: Config> =
         StorageMap<_, Identity, NetUid, Vec<u16>, ValueQuery, EmptyU16Vec<T>>;
 
-    /// --- MAP ( netuid ) --> incentive
+    /// MAP ( netuid ) --> incentive
     #[pallet::storage]
     pub type Incentive<T: Config> =
         StorageMap<_, Identity, NetUidStorageIndex, Vec<u16>, ValueQuery, EmptyU16Vec<T>>;
 
-    /// --- MAP ( netuid ) --> dividends
+    /// MAP ( netuid ) --> dividends
     #[pallet::storage]
     pub type Dividends<T: Config> =
         StorageMap<_, Identity, NetUid, Vec<u16>, ValueQuery, EmptyU16Vec<T>>;
 
-    /// --- MAP ( netuid ) --> emission
+    /// MAP ( netuid ) --> emission
     #[pallet::storage]
     pub type Emission<T: Config> = StorageMap<_, Identity, NetUid, Vec<AlphaBalance>, ValueQuery>;
 
-    /// --- MAP ( netuid ) --> last_update
+    /// MAP ( netuid ) --> last_update
     #[pallet::storage]
     pub type LastUpdate<T: Config> =
         StorageMap<_, Identity, NetUidStorageIndex, Vec<u64>, ValueQuery, EmptyU64Vec<T>>;
 
-    /// --- MAP ( netuid ) --> validator_trust
+    /// MAP ( netuid ) --> validator_trust
     #[pallet::storage]
     pub type ValidatorTrust<T: Config> =
         StorageMap<_, Identity, NetUid, Vec<u16>, ValueQuery, EmptyU16Vec<T>>;
 
-    /// --- MAP ( netuid ) --> validator_permit
+    /// MAP ( netuid ) --> validator_permit
     #[pallet::storage]
     pub type ValidatorPermit<T: Config> =
         StorageMap<_, Identity, NetUid, Vec<bool>, ValueQuery, EmptyBoolVec<T>>;
 
-    /// --- DMAP ( netuid, uid ) --> weights
+    /// DMAP ( netuid, uid ) --> weights
     #[pallet::storage]
     pub type Weights<T: Config> = StorageDoubleMap<
         _,
@@ -2116,7 +2096,7 @@ pub mod pallet {
         DefaultWeights<T>,
     >;
 
-    /// --- DMAP ( netuid, uid ) --> bonds
+    /// DMAP ( netuid, uid ) --> bonds
     #[pallet::storage]
     pub type Bonds<T: Config> = StorageDoubleMap<
         _,
@@ -2129,7 +2109,7 @@ pub mod pallet {
         DefaultBonds<T>,
     >;
 
-    /// --- DMAP ( netuid, uid ) --> block_at_registration
+    /// DMAP ( netuid, uid ) --> block_at_registration
     #[pallet::storage]
     pub type BlockAtRegistration<T: Config> = StorageDoubleMap<
         _,
@@ -2142,7 +2122,7 @@ pub mod pallet {
         DefaultBlockAtRegistration<T>,
     >;
 
-    /// --- MAP ( netuid, hotkey ) --> axon_info
+    /// MAP ( netuid, hotkey ) --> axon_info
     #[pallet::storage]
     pub type Axons<T: Config> = StorageDoubleMap<
         _,
@@ -2154,7 +2134,7 @@ pub mod pallet {
         OptionQuery,
     >;
 
-    /// --- MAP ( netuid, hotkey ) --> certificate
+    /// MAP ( netuid, hotkey ) --> certificate
     #[pallet::storage]
     pub type NeuronCertificates<T: Config> = StorageDoubleMap<
         _,
@@ -2166,7 +2146,7 @@ pub mod pallet {
         OptionQuery,
     >;
 
-    /// --- MAP ( netuid, hotkey ) --> prometheus_info
+    /// MAP ( netuid, hotkey ) --> prometheus_info
     #[pallet::storage]
     pub type Prometheus<T: Config> = StorageDoubleMap<
         _,
@@ -2178,20 +2158,18 @@ pub mod pallet {
         OptionQuery,
     >;
 
-    /// --- MAP ( coldkey ) --> identity
+    /// MAP ( coldkey ) --> identity
     #[pallet::storage]
     pub type IdentitiesV2<T: Config> =
         StorageMap<_, Blake2_128Concat, T::AccountId, ChainIdentityOfV2, OptionQuery>;
 
-    /// --- MAP ( netuid ) --> SubnetIdentityOfV3
+    /// MAP ( netuid ) --> SubnetIdentityOfV3
     #[pallet::storage]
     pub type SubnetIdentitiesV3<T: Config> =
         StorageMap<_, Blake2_128Concat, NetUid, SubnetIdentityOfV3, OptionQuery>;
 
-    /// =================================
-    /// ==== Axon / Promo Endpoints =====
-    /// =================================
-    /// --- NMAP ( hot, netuid, name ) --> last_block | Returns the last block of a transaction for a given key, netuid, and name.
+    /// Axon / Promo Endpoints
+    /// NMAP ( hot, netuid, name ) --> last_block | Returns the last block of a transaction for a given key, netuid, and name.
     #[pallet::storage]
     pub type TransactionKeyLastBlock<T: Config> = StorageNMap<
         _,
@@ -2204,19 +2182,19 @@ pub mod pallet {
         ValueQuery,
     >;
 
-    /// --- MAP ( key ) --> last_block
+    /// MAP ( key ) --> last_block
     #[deprecated]
     #[pallet::storage]
     pub type LastTxBlock<T: Config> =
         StorageMap<_, Identity, T::AccountId, u64, ValueQuery, DefaultLastTxBlock<T>>;
 
-    /// --- MAP ( key ) --> last_tx_block_childkey_take
+    /// MAP ( key ) --> last_tx_block_childkey_take
     #[deprecated]
     #[pallet::storage]
     pub type LastTxBlockChildKeyTake<T: Config> =
         StorageMap<_, Identity, T::AccountId, u64, ValueQuery, DefaultLastTxBlock<T>>;
 
-    /// --- MAP ( key ) --> last_tx_block_delegate_take
+    /// MAP ( key ) --> last_tx_block_delegate_take
     #[deprecated]
     #[pallet::storage]
     pub type LastTxBlockDelegateTake<T: Config> =
@@ -2227,7 +2205,7 @@ pub mod pallet {
     #[pallet::storage]
     pub type StakeThreshold<T> = StorageValue<_, u64, ValueQuery, DefaultStakeThreshold<T>>;
 
-    /// --- MAP (netuid, who) --> VecDeque<(hash, commit_block, first_reveal_block, last_reveal_block)> | Stores a queue of commits for an account on a given netuid.
+    /// MAP (netuid, who) --> VecDeque<(hash, commit_block, first_reveal_block, last_reveal_block)> | Stores a queue of commits for an account on a given netuid.
     #[pallet::storage]
     pub type WeightCommits<T: Config> = StorageDoubleMap<
         _,
@@ -2258,7 +2236,10 @@ pub mod pallet {
     >;
 
     /// MAP (netuid, epoch) → VecDeque<(who, ciphertext, reveal_round)>
-    /// DEPRECATED for CRV3WeightCommitsV2
+    ///
+    /// # Note
+    ///
+    /// Superseded by [`CRV3WeightCommitsV2`]; retained for migration only.
     #[pallet::storage]
     pub type CRV3WeightCommits<T: Config> = StorageDoubleMap<
         _,
@@ -2275,7 +2256,10 @@ pub mod pallet {
     >;
 
     /// MAP (netuid, epoch) → VecDeque<(who, commit_block, ciphertext, reveal_round)>
-    /// DEPRECATED for TimelockedWeightCommits
+    ///
+    /// # Note
+    ///
+    /// Superseded by [`TimelockedWeightCommits`]; retained for migration only.
     #[pallet::storage]
     pub type CRV3WeightCommitsV2<T: Config> = StorageDoubleMap<
         _,
@@ -2292,12 +2276,12 @@ pub mod pallet {
         ValueQuery,
     >;
 
-    /// --- Map (netuid) --> Number of epochs allowed for commit reveal periods
+    /// Map (netuid) --> Number of epochs allowed for commit reveal periods
     #[pallet::storage]
     pub type RevealPeriodEpochs<T: Config> =
         StorageMap<_, Twox64Concat, NetUid, u64, ValueQuery, DefaultRevealPeriodEpochs<T>>;
 
-    /// --- Map (coldkey, hotkey) --> u64 the last block at which stake was added/removed.
+    /// Map (coldkey, hotkey) --> u64 the last block at which stake was added/removed.
     #[pallet::storage]
     pub type LastColdkeyHotkeyStakeBlock<T: Config> = StorageDoubleMap<
         _,
@@ -2370,42 +2354,38 @@ pub mod pallet {
     #[pallet::storage] // --- Value --> num_root_claim | Number of coldkeys to claim each auto-claim.
     pub type NumRootClaim<T: Config> = StorageValue<_, u64, ValueQuery, DefaultNumRootClaim<T>>;
 
-    /// =============================
-    /// ==== EVM related storage ====
-    /// =============================
-    /// --- DMAP (netuid, uid) --> (H160, last_block_where_ownership_was_proven)
+    /// EVM related storage
+    /// DMAP (netuid, uid) --> (H160, last_block_where_ownership_was_proven)
     #[pallet::storage]
     pub type AssociatedEvmAddress<T: Config> =
         StorageDoubleMap<_, Twox64Concat, NetUid, Twox64Concat, u16, (H160, u64), OptionQuery>;
 
-    /// ========================
-    /// ==== Subnet Leasing ====
-    /// ========================
-    /// --- MAP ( lease_id ) --> subnet lease | The subnet lease for a given lease id.
+    /// Subnet Leasing
+    /// MAP ( lease_id ) --> subnet lease | The subnet lease for a given lease id.
     #[pallet::storage]
     pub type SubnetLeases<T: Config> =
         StorageMap<_, Twox64Concat, LeaseId, SubnetLeaseOf<T>, OptionQuery>;
 
-    /// --- DMAP ( lease_id, contributor ) --> shares | The shares of a contributor for a given lease.
+    /// DMAP ( lease_id, contributor ) --> shares | The shares of a contributor for a given lease.
     #[pallet::storage]
     pub type SubnetLeaseShares<T: Config> =
         StorageDoubleMap<_, Twox64Concat, LeaseId, Identity, T::AccountId, U64F64, ValueQuery>;
 
-    /// --- MAP ( netuid ) --> lease_id | The lease id for a given netuid.
+    /// MAP ( netuid ) --> lease_id | The lease id for a given netuid.
     #[pallet::storage]
     pub type SubnetUidToLeaseId<T: Config> =
         StorageMap<_, Twox64Concat, NetUid, LeaseId, OptionQuery>;
 
-    /// --- ITEM ( next_lease_id ) | The next lease id.
+    /// ITEM ( next_lease_id ) | The next lease id.
     #[pallet::storage]
     pub type NextSubnetLeaseId<T: Config> = StorageValue<_, LeaseId, ValueQuery, ConstU32<0>>;
 
-    /// --- MAP ( lease_id ) --> accumulated_dividends | The accumulated dividends for a given lease that needs to be distributed.
+    /// MAP ( lease_id ) --> accumulated_dividends | The accumulated dividends for a given lease that needs to be distributed.
     #[pallet::storage]
     pub type AccumulatedLeaseDividends<T: Config> =
         StorageMap<_, Twox64Concat, LeaseId, AlphaBalance, ValueQuery, DefaultZeroAlpha<T>>;
 
-    /// --- ITEM ( CommitRevealWeightsVersion )
+    /// ITEM ( CommitRevealWeightsVersion )
     #[pallet::storage]
     pub type CommitRevealWeightsVersion<T> =
         StorageValue<_, u16, ValueQuery, DefaultCommitRevealWeightsVersion<T>>;
@@ -2415,14 +2395,12 @@ pub mod pallet {
     pub type NetworkRegistrationStartBlock<T> =
         StorageValue<_, u64, ValueQuery, DefaultNetworkRegistrationStartBlock<T>>;
 
-    /// --- MAP ( netuid ) --> minimum required number of non-immortal & non-immune UIDs
+    /// MAP ( netuid ) --> minimum required number of non-immortal & non-immune UIDs
     #[pallet::storage]
     pub type MinNonImmuneUids<T: Config> =
         StorageMap<_, Identity, NetUid, u16, ValueQuery, DefaultMinNonImmuneUids<T>>;
 
-    /// ============================
-    /// ==== Subnet Mechanisms =====
-    /// ============================
+    /// Subnet Mechanisms
     /// -- ITEM (Default number of sub-subnets)
     #[pallet::type_value]
     pub fn DefaultMechanismCount<T: Config>() -> MechId {
@@ -2452,27 +2430,27 @@ pub mod pallet {
         prod_or_fast!(7_200, 1)
     }
 
-    /// --- MAP ( netuid ) --> Current number of subnet mechanisms
+    /// MAP ( netuid ) --> Current number of subnet mechanisms
     #[pallet::storage]
     pub type MechanismCountCurrent<T: Config> =
         StorageMap<_, Twox64Concat, NetUid, MechId, ValueQuery, DefaultMechanismCount<T>>;
 
-    /// --- MAP ( netuid ) --> Normalized vector of emission split proportion between subnet mechanisms
+    /// MAP ( netuid ) --> Normalized vector of emission split proportion between subnet mechanisms
     #[pallet::storage]
     pub type MechanismEmissionSplit<T: Config> =
         StorageMap<_, Twox64Concat, NetUid, Vec<u16>, OptionQuery>;
 
-    /// --- MAP ( netuid ) --> BurnHalfLife (blocks)
+    /// MAP ( netuid ) --> BurnHalfLife (blocks)
     #[pallet::storage]
     pub type BurnHalfLife<T> =
         StorageMap<_, Identity, NetUid, u16, ValueQuery, DefaultBurnHalfLife<T>>;
 
-    /// --- MAP ( netuid ) --> BurnIncreaseMult
+    /// MAP ( netuid ) --> BurnIncreaseMult
     #[pallet::storage]
     pub type BurnIncreaseMult<T> =
         StorageMap<_, Identity, NetUid, U64F64, ValueQuery, DefaultBurnIncreaseMult<T>>;
 
-    /// --- MAP ( hotkey ) --> parent_delegation_enabled
+    /// MAP ( hotkey ) --> parent_delegation_enabled
     ///
     /// When `true`, this root validator allows auto parent delegation.
     /// Defaults to `true`; validators can opt out at any time
@@ -2487,10 +2465,8 @@ pub mod pallet {
         DefaultAutoParentDelegationEnabled<T>, // default = true
     >;
 
-    /// ==================
-    /// ==== Genesis =====
-    /// ==================
-    /// --- Storage for migration run status
+    /// Genesis
+    /// Storage for migration run status
     #[pallet::storage]
     pub type HasMigrationRun<T: Config> = StorageMap<_, Identity, Vec<u8>, bool, ValueQuery>;
 

--- a/pallets/subtensor/src/macros/config.rs
+++ b/pallets/subtensor/src/macros/config.rs
@@ -69,9 +69,7 @@ mod config {
         /// Weight information for extrinsics in this pallet.
         type WeightInfo: crate::weights::WeightInfo;
 
-        /// =================================
-        /// ==== Initial Value Constants ====
-        /// =================================
+        /// Initial Value Constants
 
         /// Initial currency issuance.
         #[pallet::constant]

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2198,10 +2198,13 @@ mod dispatches {
         ///
         /// The dispatch origin of this call must be the original coldkey that made the announcement.
         ///
-        /// - `new_coldkey_hash`: The hash of the new coldkey using BlakeTwo256.
+        /// # Arguments
         ///
-        /// The `ColdkeySwapAnnounced` event is emitted on successful announcement.
+        /// * `new_coldkey_hash`: The hash of the new coldkey using BlakeTwo256.
         ///
+        /// # Events
+        ///
+        /// * `ColdkeySwapAnnounced`: Emitted on successful announcement.
         #[pallet::call_index(125)]
         #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::announce_coldkey_swap())]
         pub fn announce_coldkey_swap(
@@ -2236,10 +2239,14 @@ mod dispatches {
         ///
         /// The dispatch origin of this call must be the original coldkey that made the announcement.
         ///
-        /// - `new_coldkey`: The new coldkey to swap to. The BlakeTwo256 hash of the new coldkey must be
+        /// # Arguments
+        ///
+        /// * `new_coldkey`: The new coldkey to swap to. The BlakeTwo256 hash of the new coldkey must be
         ///   the same as the announced coldkey hash.
         ///
-        /// The `ColdkeySwapped` event is emitted on successful swap.
+        /// # Events
+        ///
+        /// * `ColdkeySwapped`: Emitted on successful swap.
         #[pallet::call_index(126)]
         #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::swap_coldkey_announced())]
         pub fn swap_coldkey_announced(
@@ -2269,8 +2276,9 @@ mod dispatches {
         /// This will prevent any further actions on the coldkey swap
         /// until triumvirate step in to resolve the issue.
         ///
-        /// - `coldkey`: The coldkey to dispute the swap for.
+        /// # Arguments
         ///
+        /// * `coldkey`: The coldkey to dispute the swap for.
         #[pallet::call_index(127)]
         #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::dispute_coldkey_swap())]
         pub fn dispute_coldkey_swap(origin: OriginFor<T>) -> DispatchResult {
@@ -2296,8 +2304,9 @@ mod dispatches {
         ///
         /// The dispatch origin of this call must be root.
         ///
-        /// - `coldkey`: The coldkey to reset the swap for.
+        /// # Arguments
         ///
+        /// * `coldkey`: The coldkey to reset the swap for.
         #[pallet::call_index(128)]
         #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::reset_coldkey_swap())]
         pub fn reset_coldkey_swap(origin: OriginFor<T>, coldkey: T::AccountId) -> DispatchResult {

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -36,7 +36,7 @@ mod dispatches {
         /// elements is larger or smaller than the amount of elements * u16_max, all elements
         /// will be corrected for this deviation.
         ///
-        /// # Args:
+        /// # Arguments
         /// * `origin`: (<T as frame_system::Config>Origin):
         ///     - The caller, a hotkey who wishes to set their weights.
         ///
@@ -53,11 +53,11 @@ mod dispatches {
         /// * 'version_key' ( u64 ):
         /// 	- The network version key to check if the validator is up to date.
         ///
-        /// # Event:
+        /// # Events
         /// * WeightsSet;
         /// 	- On successfully setting the weights on chain.
         ///
-        /// # Raises:
+        /// # Errors
         /// * 'MechanismDoesNotExist':
         /// 	- Attempting to set weights on a non-existent network.
         ///
@@ -110,7 +110,7 @@ mod dispatches {
         /// elements is larger or smaller than the amount of elements * u16_max, all elements
         /// will be corrected for this deviation.
         ///
-        /// # Args:
+        /// # Arguments
         /// * `origin`: (<T as frame_system::Config>Origin):
         ///     - The caller, a hotkey who wishes to set their weights.
         ///
@@ -130,11 +130,11 @@ mod dispatches {
         /// * 'version_key' ( u64 ):
         /// 	- The network version key to check if the validator is up to date.
         ///
-        /// # Event:
+        /// # Events
         /// * WeightsSet;
         /// 	- On successfully setting the weights on chain.
         ///
-        /// # Raises:
+        /// # Errors
         /// * 'MechanismDoesNotExist':
         /// 	- Attempting to set weights on a non-existent network.
         ///
@@ -179,7 +179,7 @@ mod dispatches {
 
         /// Allows a hotkey to set weights for multiple netuids as a batch.
         ///
-        /// # Args:
+        /// # Arguments
         /// * `origin`: (<T as frame_system::Config>Origin):
         ///     - The caller, a hotkey who wishes to set their weights.
         ///
@@ -192,7 +192,7 @@ mod dispatches {
         /// * `version_keys` (Vec<Compact<u64>>):
         /// 	- The network version keys to check if the validator is up to date.
         ///
-        /// # Event:
+        /// # Events
         /// * WeightsSet;
         /// 	- On successfully setting the weights on chain.
         /// * BatchWeightsCompleted;
@@ -215,7 +215,7 @@ mod dispatches {
 
         /// Used to commit a hash of your weight values to later be revealed.
         ///
-        /// # Args:
+        /// # Arguments
         /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
         ///   - The signature of the committing hotkey.
         ///
@@ -225,7 +225,7 @@ mod dispatches {
         /// * `commit_hash` (`H256`):
         ///   - The hash representing the committed weights.
         ///
-        /// # Raises:
+        /// # Errors
         /// * `CommitRevealDisabled`:
         ///   - Attempting to commit when the commit-reveal mechanism is disabled.
         ///
@@ -244,7 +244,7 @@ mod dispatches {
 
         /// Used to commit a hash of your weight values to later be revealed for mechanisms.
         ///
-        /// # Args:
+        /// # Arguments
         /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
         ///   - The signature of the committing hotkey.
         ///
@@ -257,7 +257,7 @@ mod dispatches {
         /// * `commit_hash` (`H256`):
         ///   - The hash representing the committed weights.
         ///
-        /// # Raises:
+        /// # Errors
         /// * `CommitRevealDisabled`:
         ///   - Attempting to commit when the commit-reveal mechanism is disabled.
         ///
@@ -279,7 +279,7 @@ mod dispatches {
 
         /// Allows a hotkey to commit weight hashes for multiple netuids as a batch.
         ///
-        /// # Args:
+        /// # Arguments
         /// * `origin`: (<T as frame_system::Config>Origin):
         ///     - The caller, a hotkey who wishes to set their weights.
         ///
@@ -289,7 +289,7 @@ mod dispatches {
         /// * `commit_hashes` (Vec<H256>):
         /// 	- The commit hashes to commit.
         ///
-        /// # Event:
+        /// # Events
         /// * WeightsSet;
         /// 	- On successfully setting the weights on chain.
         /// * BatchWeightsCompleted;
@@ -311,7 +311,7 @@ mod dispatches {
 
         /// Used to reveal the weights for a previously committed hash.
         ///
-        /// # Args:
+        /// # Arguments
         /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
         ///   - The signature of the revealing hotkey.
         ///
@@ -330,7 +330,7 @@ mod dispatches {
         /// * `version_key` (`u64`):
         ///   - The network version key.
         ///
-        /// # Raises:
+        /// # Errors
         /// * `CommitRevealDisabled`:
         ///   - Attempting to reveal weights when the commit-reveal mechanism is disabled.
         ///
@@ -361,7 +361,7 @@ mod dispatches {
 
         /// Used to reveal the weights for a previously committed hash for mechanisms.
         ///
-        /// # Args:
+        /// # Arguments
         /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
         ///   - The signature of the revealing hotkey.
         ///
@@ -383,7 +383,7 @@ mod dispatches {
         /// * `version_key` (`u64`):
         ///   - The network version key.
         ///
-        /// # Raises:
+        /// # Errors
         /// * `CommitRevealDisabled`:
         ///   - Attempting to reveal weights when the commit-reveal mechanism is disabled.
         ///
@@ -425,7 +425,7 @@ mod dispatches {
 
         /// Used to commit encrypted commit-reveal v3 weight values to later be revealed.
         ///
-        /// # Args:
+        /// # Arguments
         /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
         ///   - The committing hotkey.
         ///
@@ -445,7 +445,7 @@ mod dispatches {
         ///    - The drand reveal round which will be avaliable during epoch `n+1` from the current
         ///      epoch.
         ///
-        /// # Raises:
+        /// # Errors
         /// * `CommitRevealV3Disabled`:
         ///   - Attempting to commit when the commit-reveal mechanism is disabled.
         ///
@@ -467,7 +467,7 @@ mod dispatches {
 
         /// Used to commit encrypted commit-reveal v3 weight values to later be revealed for mechanisms.
         ///
-        /// # Args:
+        /// # Arguments
         /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
         ///   - The committing hotkey.
         ///
@@ -490,7 +490,7 @@ mod dispatches {
         ///    - The drand reveal round which will be avaliable during epoch `n+1` from the current
         ///      epoch.
         ///
-        /// # Raises:
+        /// # Errors
         /// * `CommitRevealV3Disabled`:
         ///   - Attempting to commit when the commit-reveal mechanism is disabled.
         ///
@@ -520,7 +520,7 @@ mod dispatches {
 
         /// The implementation for batch revealing committed weights.
         ///
-        /// # Args:
+        /// # Arguments
         /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
         ///   - The signature of the revealing hotkey.
         ///
@@ -539,7 +539,7 @@ mod dispatches {
         /// * `version_keys` (`Vec<u64>`):
         ///   - A list of network version keys.
         ///
-        /// # Raises:
+        /// # Errors
         /// * `CommitRevealDisabled`:
         ///   - Attempting to reveal weights when the commit-reveal mechanism is disabled.
         ///
@@ -579,7 +579,7 @@ mod dispatches {
 
         /// Allows delegates to decrease its take value.
         ///
-        /// # Args:
+        /// # Arguments
         /// * 'origin': (<T as frame_system::Config>::Origin):
         /// 	- The signature of the caller's coldkey.
         ///
@@ -596,11 +596,11 @@ mod dispatches {
         ///        the the parameter is calculated as [65535 * T]. For example, 1% would be
         ///        [0.01 * 65535] = [655.35] = 655
         ///
-        /// # Event:
+        /// # Events
         /// * TakeDecreased;
         /// 	- On successfully setting a decreased take for this hotkey.
         ///
-        /// # Raises:
+        /// # Errors
         /// * 'NotRegistered':
         /// 	- The hotkey we are delegating is not registered on the network.
         ///
@@ -622,7 +622,7 @@ mod dispatches {
 
         /// Allows delegates to increase its take value. This call is rate-limited.
         ///
-        /// # Args:
+        /// # Arguments
         /// * 'origin': (<T as frame_system::Config>::Origin):
         /// 	- The signature of the caller's coldkey.
         ///
@@ -636,11 +636,11 @@ mod dispatches {
         ///        the the parameter is calculated as [65535 * T]. For example, 1% would be
         ///        [0.01 * 65535] = [655.35] = 655
         ///
-        /// # Event:
+        /// # Events
         /// * TakeIncreased;
         /// 	- On successfully setting a increased take for this hotkey.
         ///
-        /// # Raises:
+        /// # Errors
         /// * 'NotRegistered':
         /// 	- The hotkey we are delegating is not registered on the network.
         ///
@@ -666,7 +666,7 @@ mod dispatches {
         /// Note: the coldkey account may own the hotkey, in which case they are
         /// delegating to themselves.
         ///
-        /// # Args:
+        /// # Arguments
         ///  * 'origin': (<T as frame_system::Config>Origin):
         /// 	- The signature of the caller's coldkey.
         ///
@@ -679,11 +679,11 @@ mod dispatches {
         ///  * 'amount_staked' (u64):
         /// 	- The amount of stake to be added to the hotkey staking account.
         ///
-        /// # Event:
+        /// # Events
         ///  * StakeAdded;
         /// 	- On the successfully adding stake to a global account.
         ///
-        /// # Raises:
+        /// # Errors
         ///  * 'NotEnoughBalanceToStake':
         /// 	- Not enough balance on the coldkey to add onto the global account.
         ///
@@ -708,7 +708,7 @@ mod dispatches {
         /// from the coldkey account attached to the neuron metadata. Only this key
         /// has permission to make staking and unstaking requests.
         ///
-        /// # Args:
+        /// # Arguments
         /// * 'origin': (<T as frame_system::Config>Origin):
         /// 	- The signature of the caller's coldkey.
         ///
@@ -721,11 +721,11 @@ mod dispatches {
         /// * 'amount_unstaked' (u64):
         /// 	- The amount of stake to be added to the hotkey staking account.
         ///
-        /// # Event:
+        /// # Events
         /// * StakeRemoved;
         /// 	- On the successfully removing stake from the hotkey account.
         ///
-        /// # Raises:
+        /// # Errors
         /// * 'NotRegistered':
         /// 	- Thrown if the account we are attempting to unstake from is non existent.
         ///
@@ -751,7 +751,7 @@ mod dispatches {
         /// Serves or updates axon /prometheus information for the neuron associated with the caller. If the caller is
         /// already registered the metadata is updated. If the caller is not registered this call throws NotRegistered.
         ///
-        /// # Args:
+        /// # Arguments
         /// * 'origin': (<T as frame_system::Config>Origin):
         /// 	- The signature of the caller.
         ///
@@ -779,11 +779,11 @@ mod dispatches {
         /// * 'placeholder2' (u8):
         /// 	- Placeholder for further extra params.
         ///
-        /// # Event:
+        /// # Events
         /// * AxonServed;
         /// 	- On successfully serving the axon info.
         ///
-        /// # Raises:
+        /// # Errors
         /// * 'MechanismDoesNotExist':
         /// 	- Attempting to set weights on a non-existent network.
         ///
@@ -830,7 +830,7 @@ mod dispatches {
         /// Serves or updates axon /prometheus information for the neuron associated with the caller. If the caller is
         /// already registered the metadata is updated. If the caller is not registered this call throws NotRegistered.
         ///
-        /// # Args:
+        /// # Arguments
         /// * 'origin': (<T as frame_system::Config>Origin):
         /// 	- The signature of the caller.
         ///
@@ -861,11 +861,11 @@ mod dispatches {
         /// * 'certificate' (Vec<u8>):
         ///     - TLS certificate for inter neuron communitation.
         ///
-        /// # Event:
+        /// # Events
         /// * AxonServed;
         /// 	- On successfully serving the axon info.
         ///
-        /// # Raises:
+        /// # Errors
         /// * 'MechanismDoesNotExist':
         /// 	- Attempting to set weights on a non-existent network.
         ///
@@ -910,7 +910,7 @@ mod dispatches {
         }
 
         /// Set prometheus information for the neuron.
-        /// # Args:
+        /// # Arguments
         /// * 'origin': (<T as frame_system::Config>Origin):
         /// 	- The signature of the calling hotkey.
         ///
@@ -944,7 +944,7 @@ mod dispatches {
 
         /// Registers a new neuron to the subnetwork.
         ///
-        /// # Args:
+        /// # Arguments
         /// * 'origin': (<T as frame_system::Config>Origin):
         /// 	- The signature of the calling hotkey.
         ///
@@ -966,11 +966,11 @@ mod dispatches {
         /// * 'coldkey' ( T::AccountId ):
         /// 	- Associated coldkey account.
         ///
-        /// # Event:
+        /// # Events
         /// * NeuronRegistered;
         /// 	- On successfully registering a uid to a neuron slot on a subnetwork.
         ///
-        /// # Raises:
+        /// # Errors
         /// * 'MechanismDoesNotExist':
         /// 	- Attempting to register to a non existent network.
         ///
@@ -1099,7 +1099,7 @@ mod dispatches {
         /// The childkey take determines the proportion of stake that the hotkey keeps for itself
         /// when distributing stake to its children.
         ///
-        /// # Arguments:
+        /// # Arguments
         /// * `origin` (<T as frame_system::Config>::RuntimeOrigin):
         ///     - The signature of the calling coldkey. Setting childkey take can only be done by the coldkey.
         ///
@@ -1110,11 +1110,11 @@ mod dispatches {
         ///     - The new childkey take value. This is a percentage represented as a value between 0 and 10000,
         ///       where 10000 represents 100%.
         ///
-        /// # Events:
+        /// # Events
         /// * `ChildkeyTakeSet`:
         ///     - On successfully setting the childkey take for a hotkey.
         ///
-        /// # Errors:
+        /// # Errors
         /// * `NonAssociatedColdKey`:
         ///     - The coldkey does not own the hotkey.
         /// * `InvalidChildkeyTake`:
@@ -1142,11 +1142,11 @@ mod dispatches {
         ///
         /// This function can only be called by the root origin.
         ///
-        /// # Arguments:
+        /// # Arguments
         /// * `origin` - The origin of the call, must be root.
         /// * `tx_rate_limit` - The new rate limit in blocks.
         ///
-        /// # Errors:
+        /// # Errors
         /// * `BadOrigin` - If the origin is not root.
         ///
         #[pallet::call_index(69)]
@@ -1164,11 +1164,11 @@ mod dispatches {
         ///
         /// This function can only be called by the root origin.
         ///
-        /// # Arguments:
+        /// # Arguments
         /// * `origin` - The origin of the call, must be root.
         /// * `take` - The new minimum childkey take value.
         ///
-        /// # Errors:
+        /// # Errors
         /// * `BadOrigin` - If the origin is not root.
         ///
         #[pallet::call_index(76)]
@@ -1185,11 +1185,11 @@ mod dispatches {
         ///
         /// This function can only be called by the root origin.
         ///
-        /// # Arguments:
+        /// # Arguments
         /// * `origin` - The origin of the call, must be root.
         /// * `take` - The new maximum childkey take value.
         ///
-        /// # Errors:
+        /// # Errors
         /// * `BadOrigin` - If the origin is not root.
         ///
         #[pallet::call_index(77)]
@@ -1250,7 +1250,7 @@ mod dispatches {
         /// This function allows a coldkey to set a single child for a given hotkey on a specified network.
         /// The proportion of the hotkey's stake to be allocated to the child is also specified.
         ///
-        /// # Arguments:
+        /// # Arguments
         /// * `origin` (<T as frame_system::Config>::RuntimeOrigin):
         ///     - The signature of the calling coldkey. Setting a hotkey child can only be done by the coldkey.
         ///
@@ -1266,11 +1266,11 @@ mod dispatches {
         /// * `proportion` (u64):
         ///     - Proportion of the hotkey's stake to be given to the child, the value must be u64 normalized.
         ///
-        /// # Events:
+        /// # Events
         /// * `ChildAddedSingular`:
         ///     - On successfully registering a child to a hotkey.
         ///
-        /// # Errors:
+        /// # Errors
         /// * `MechanismDoesNotExist`:
         ///     - Attempting to register to a non-existent network.
         /// * `RegistrationNotPermittedOnRootSubnet`:
@@ -1280,7 +1280,7 @@ mod dispatches {
         /// * `HotKeyAccountNotExists`:
         ///     - The hotkey account does not exist.
         ///
-        /// # Detailed Explanation of Checks:
+        /// # Note
         /// 1. **Signature Verification**: Ensures that the caller has signed the transaction, verifying the coldkey.
         /// 2. **Root Network Check**: Ensures that the delegation is not on the root network, as child hotkeys are not valid on the root.
         /// 3. **Network Existence Check**: Ensures that the specified network exists.
@@ -1318,7 +1318,7 @@ mod dispatches {
         }
 
         /// Set prometheus information for the neuron.
-        /// # Args:
+        /// # Arguments
         /// * 'origin': (<T as frame_system::Config>Origin):
         /// 	- The signature of the calling hotkey.
         ///
@@ -1362,7 +1362,7 @@ mod dispatches {
         }
 
         /// Set the identity information for a subnet.
-        /// # Args:
+        /// # Arguments
         /// * `origin` - (<T as frame_system::Config>::Origin):
         ///     - The signature of the calling coldkey, which must be the owner of the subnet.
         ///
@@ -1418,18 +1418,18 @@ mod dispatches {
 
         /// The implementation for the extrinsic unstake_all: Removes all stake from a hotkey account across all subnets and adds it onto a coldkey.
         ///
-        /// # Args:
+        /// # Arguments
         /// * `origin` - (<T as frame_system::Config>::Origin):
         ///     - The signature of the caller's coldkey.
         ///
         /// * `hotkey` (T::AccountId):
         ///     - The associated hotkey account.
         ///
-        /// # Event:
+        /// # Events
         /// * StakeRemoved;
         ///     - On the successfully removing stake from the hotkey account.
         ///
-        /// # Raises:
+        /// # Errors
         /// * `NotRegistered`:
         ///     - Thrown if the account we are attempting to unstake from is non existent.
         ///
@@ -1449,18 +1449,18 @@ mod dispatches {
 
         /// The implementation for the extrinsic unstake_all: Removes all stake from a hotkey account across all subnets and adds it onto a coldkey.
         ///
-        /// # Args:
+        /// # Arguments
         /// * `origin` - (<T as frame_system::Config>::Origin):
         ///     - The signature of the caller's coldkey.
         ///
         /// * `hotkey` (T::AccountId):
         ///     - The associated hotkey account.
         ///
-        /// # Event:
+        /// # Events
         /// * StakeRemoved;
         ///     - On the successfully removing stake from the hotkey account.
         ///
-        /// # Raises:
+        /// # Errors
         /// * `NotRegistered`:
         ///     - Thrown if the account we are attempting to unstake from is non existent.
         ///
@@ -1480,7 +1480,7 @@ mod dispatches {
 
         /// The implementation for the extrinsic move_stake: Moves specified amount of stake from a hotkey to another across subnets.
         ///
-        /// # Args:
+        /// # Arguments
         /// * `origin` - (<T as frame_system::Config>::Origin):
         ///     - The signature of the caller's coldkey.
         ///
@@ -1605,7 +1605,7 @@ mod dispatches {
         /// price, the staking order may execute only partially or not execute
         /// at all.
         ///
-        /// # Args:
+        /// # Arguments
         ///  * 'origin': (<T as frame_system::Config>Origin):
         /// 	- The signature of the caller's coldkey.
         ///
@@ -1625,11 +1625,11 @@ mod dispatches {
         /// 	- Allows partial execution of the amount. If set to false, this becomes
         ///       fill or kill type or order.
         ///
-        /// # Event:
+        /// # Events
         ///  * StakeAdded;
         /// 	- On the successfully adding stake to a global account.
         ///
-        /// # Raises:
+        /// # Errors
         ///  * 'NotEnoughBalanceToStake':
         /// 	- Not enough balance on the coldkey to add onto the global account.
         ///
@@ -1668,7 +1668,7 @@ mod dispatches {
         /// price, the staking order may execute only partially or not execute
         /// at all.
         ///
-        /// # Args:
+        /// # Arguments
         /// * 'origin': (<T as frame_system::Config>Origin):
         /// 	- The signature of the caller's coldkey.
         ///
@@ -1688,11 +1688,11 @@ mod dispatches {
         ///     - Allows partial execution of the amount. If set to false, this becomes
         ///       fill or kill type or order.
         ///
-        /// # Event:
+        /// # Events
         /// * StakeRemoved;
         /// 	- On the successfully removing stake from the hotkey account.
         ///
-        /// # Raises:
+        /// # Errors
         /// * 'NotRegistered':
         /// 	- Thrown if the account we are attempting to unstake from is non existent.
         ///
@@ -1916,7 +1916,7 @@ mod dispatches {
         ///
         /// The leftover cap is refunded to the contributors and the beneficiary.
         ///
-        /// # Args:
+        /// # Arguments
         /// * `origin` - (<T as frame_system::Config>::Origin):
         ///     - The signature of the caller's coldkey.
         ///
@@ -1942,7 +1942,7 @@ mod dispatches {
         ///
         /// **The hotkey must be owned by the beneficiary coldkey.**
         ///
-        /// # Args:
+        /// # Arguments
         /// * `origin` - (<T as frame_system::Config>::Origin):
         ///     - The signature of the caller's coldkey.
         ///
@@ -1996,7 +1996,7 @@ mod dispatches {
 
         /// Used to commit timelock encrypted commit-reveal weight values to later be revealed.
         ///
-        /// # Args:
+        /// # Arguments
         /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
         ///   - The committing hotkey.
         ///
@@ -2041,7 +2041,7 @@ mod dispatches {
         /// The caller selects a hotkey where all future rewards
         /// will be automatically staked.
         ///
-        /// # Args:
+        /// # Arguments
         /// * `origin` - (<T as frame_system::Config>::Origin):
         ///     - The signature of the caller's coldkey.
         ///
@@ -2094,7 +2094,7 @@ mod dispatches {
         /// Used to commit timelock encrypted commit-reveal weight values to later be revealed for
         /// a mechanism.
         ///
-        /// # Args:
+        /// # Arguments
         /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
         ///   - The committing hotkey.
         ///
@@ -2153,15 +2153,15 @@ mod dispatches {
         }
 
         /// Claims the root emissions for a coldkey.
-        /// # Args:
+        /// # Arguments
         /// * 'origin': (<T as frame_system::Config>Origin):
         /// 	- The signature of the caller's coldkey.
         ///
-        /// # Event:
+        /// # Events
         /// * RootClaimed;
         /// 	- On the successfully claiming the root emissions for a coldkey.
         ///
-        /// # Raises:
+        /// # Errors
         ///
         #[pallet::call_index(121)]
         #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::claim_root())]
@@ -2184,11 +2184,11 @@ mod dispatches {
         }
 
         /// Sets the root claim type for the coldkey.
-        /// # Args:
+        /// # Arguments
         /// * 'origin': (<T as frame_system::Config>Origin):
         /// 	- The signature of the caller's coldkey.
         ///
-        /// # Event:
+        /// # Events
         /// * RootClaimTypeSet;
         /// 	- On the successfully setting the root claim type for the coldkey.
         ///
@@ -2374,11 +2374,11 @@ mod dispatches {
         /// When enabled, voting power EMA is updated every epoch for all validators.
         /// Voting power starts at 0 and increases over epochs.
         ///
-        /// # Arguments:
+        /// # Arguments
         /// * `origin` - The origin of the call, must be subnet owner or root.
         /// * `netuid` - The subnet to enable voting power tracking for.
         ///
-        /// # Errors:
+        /// # Errors
         /// * `SubnetNotExist` - If the subnet does not exist.
         /// * `NotSubnetOwner` - If the caller is not the subnet owner or root.
         #[pallet::call_index(129)]
@@ -2399,11 +2399,11 @@ mod dispatches {
         /// Voting power tracking will continue for 14 days (grace period) after this call,
         /// then automatically disable and clear all VotingPower entries for the subnet.
         ///
-        /// # Arguments:
+        /// # Arguments
         /// * `origin` - The origin of the call, must be subnet owner or root.
         /// * `netuid` - The subnet to schedule disabling voting power tracking for.
         ///
-        /// # Errors:
+        /// # Errors
         /// * `SubnetNotExist` - If the subnet does not exist.
         /// * `NotSubnetOwner` - If the caller is not the subnet owner or root.
         /// * `VotingPowerTrackingNotEnabled` - If voting power tracking is not enabled.
@@ -2425,12 +2425,12 @@ mod dispatches {
         /// Higher alpha = faster response to stake changes.
         /// Alpha is stored as u64 with 18 decimal precision (1.0 = 10^18).
         ///
-        /// # Arguments:
+        /// # Arguments
         /// * `origin` - The origin of the call, must be root.
         /// * `netuid` - The subnet to set the alpha for.
         /// * `alpha` - The new alpha value (u64 with 18 decimal precision).
         ///
-        /// # Errors:
+        /// # Errors
         /// * `BadOrigin` - If the origin is not root.
         /// * `SubnetNotExist` - If the subnet does not exist.
         /// * `InvalidVotingPowerEmaAlpha` - If alpha is greater than 10^18 (1.0).

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -54,33 +54,24 @@ mod dispatches {
         /// 	- The network version key to check if the validator is up to date.
         ///
         /// # Events
-        /// * WeightsSet;
-        /// 	- On successfully setting the weights on chain.
+        /// * 'WeightsSet': On successfully setting the weights on chain.
         ///
         /// # Errors
-        /// * 'MechanismDoesNotExist':
-        /// 	- Attempting to set weights on a non-existent network.
+        /// * 'MechanismDoesNotExist': Attempting to set weights on a non-existent network.
         ///
-        /// * 'NotRegistered':
-        /// 	- Attempting to set weights from a non registered account.
+        /// * 'NotRegistered': Attempting to set weights from a non registered account.
         ///
-        /// * 'WeightVecNotEqualSize':
-        /// 	- Attempting to set weights with uids not of same length.
+        /// * 'WeightVecNotEqualSize': Attempting to set weights with uids not of same length.
         ///
-        /// * 'DuplicateUids':
-        /// 	- Attempting to set weights with duplicate uids.
+        /// * 'DuplicateUids': Attempting to set weights with duplicate uids.
         ///
-        ///     * 'UidsLengthExceedUidsInSubNet':
-        /// 	- Attempting to set weights above the max allowed uids.
+        /// * 'UidsLengthExceedUidsInSubNet': Attempting to set weights above the max allowed uids.
         ///
-        /// * 'UidVecContainInvalidOne':
-        /// 	- Attempting to set weights with invalid uids.
+        /// * 'UidVecContainInvalidOne': Attempting to set weights with invalid uids.
         ///
-        /// * 'WeightVecLengthIsLow':
-        /// 	- Attempting to set weights with fewer weights than min.
+        /// * 'WeightVecLengthIsLow': Attempting to set weights with fewer weights than min.
         ///
-        /// * 'MaxWeightExceeded':
-        /// 	- Attempting to set weights with max value exceeding limit.
+        /// * 'MaxWeightExceeded': Attempting to set weights with max value exceeding limit.
         #[pallet::call_index(0)]
         #[pallet::weight((<T as crate::pallet::Config>::WeightInfo::set_weights(), DispatchClass::Normal, Pays::No))]
         pub fn set_weights(
@@ -131,33 +122,24 @@ mod dispatches {
         /// 	- The network version key to check if the validator is up to date.
         ///
         /// # Events
-        /// * WeightsSet;
-        /// 	- On successfully setting the weights on chain.
+        /// * 'WeightsSet': On successfully setting the weights on chain.
         ///
         /// # Errors
-        /// * 'MechanismDoesNotExist':
-        /// 	- Attempting to set weights on a non-existent network.
+        /// * 'MechanismDoesNotExist': Attempting to set weights on a non-existent network.
         ///
-        /// * 'NotRegistered':
-        /// 	- Attempting to set weights from a non registered account.
+        /// * 'NotRegistered': Attempting to set weights from a non registered account.
         ///
-        /// * 'WeightVecNotEqualSize':
-        /// 	- Attempting to set weights with uids not of same length.
+        /// * 'WeightVecNotEqualSize': Attempting to set weights with uids not of same length.
         ///
-        /// * 'DuplicateUids':
-        /// 	- Attempting to set weights with duplicate uids.
+        /// * 'DuplicateUids': Attempting to set weights with duplicate uids.
         ///
-        ///     * 'UidsLengthExceedUidsInSubNet':
-        /// 	- Attempting to set weights above the max allowed uids.
+        /// * 'UidsLengthExceedUidsInSubNet': Attempting to set weights above the max allowed uids.
         ///
-        /// * 'UidVecContainInvalidOne':
-        /// 	- Attempting to set weights with invalid uids.
+        /// * 'UidVecContainInvalidOne': Attempting to set weights with invalid uids.
         ///
-        /// * 'WeightVecLengthIsLow':
-        /// 	- Attempting to set weights with fewer weights than min.
+        /// * 'WeightVecLengthIsLow': Attempting to set weights with fewer weights than min.
         ///
-        /// * 'MaxWeightExceeded':
-        /// 	- Attempting to set weights with max value exceeding limit.
+        /// * 'MaxWeightExceeded': Attempting to set weights with max value exceeding limit.
         #[pallet::call_index(119)]
         #[pallet::weight((Weight::from_parts(15_540_000_000, 0)
         .saturating_add(T::DbWeight::get().reads(4111))
@@ -193,14 +175,10 @@ mod dispatches {
         /// 	- The network version keys to check if the validator is up to date.
         ///
         /// # Events
-        /// * WeightsSet;
-        /// 	- On successfully setting the weights on chain.
-        /// * BatchWeightsCompleted;
-        /// 	- On success of the batch.
-        /// * BatchCompletedWithErrors;
-        /// 	- On failure of any of the weights in the batch.
-        /// * BatchWeightItemFailed;
-        /// 	- On failure for each failed item in the batch.
+        /// * 'WeightsSet': On successfully setting the weights on chain.
+        /// * 'BatchWeightsCompleted': On success of the batch.
+        /// * 'BatchCompletedWithErrors': On failure of any of the weights in the batch.
+        /// * 'BatchWeightItemFailed': On failure for each failed item in the batch.
         ///
         #[pallet::call_index(80)]
         #[pallet::weight((<T as crate::pallet::Config>::WeightInfo::batch_set_weights(), DispatchClass::Normal, Pays::No))]
@@ -290,14 +268,10 @@ mod dispatches {
         /// 	- The commit hashes to commit.
         ///
         /// # Events
-        /// * WeightsSet;
-        /// 	- On successfully setting the weights on chain.
-        /// * BatchWeightsCompleted;
-        /// 	- On success of the batch.
-        /// * BatchCompletedWithErrors;
-        /// 	- On failure of any of the weights in the batch.
-        /// * BatchWeightItemFailed;
-        /// 	- On failure for each failed item in the batch.
+        /// * 'WeightsSet': On successfully setting the weights on chain.
+        /// * 'BatchWeightsCompleted': On success of the batch.
+        /// * 'BatchCompletedWithErrors': On failure of any of the weights in the batch.
+        /// * 'BatchWeightItemFailed': On failure for each failed item in the batch.
         ///
         #[pallet::call_index(100)]
         #[pallet::weight((<T as crate::pallet::Config>::WeightInfo::batch_commit_weights(), DispatchClass::Normal, Pays::No))]
@@ -597,18 +571,14 @@ mod dispatches {
         ///        [0.01 * 65535] = [655.35] = 655
         ///
         /// # Events
-        /// * TakeDecreased;
-        /// 	- On successfully setting a decreased take for this hotkey.
+        /// * 'TakeDecreased': On successfully setting a decreased take for this hotkey.
         ///
         /// # Errors
-        /// * 'NotRegistered':
-        /// 	- The hotkey we are delegating is not registered on the network.
+        /// * 'NotRegistered': The hotkey we are delegating is not registered on the network.
         ///
-        /// * 'NonAssociatedColdKey':
-        /// 	- The hotkey we are delegating is not owned by the calling coldkey.
+        /// * 'NonAssociatedColdKey': The hotkey we are delegating is not owned by the calling coldkey.
         ///
-        /// * 'DelegateTakeTooLow':
-        /// 	- The delegate is setting a take which is not lower than the previous.
+        /// * 'DelegateTakeTooLow': The delegate is setting a take which is not lower than the previous.
         ///
         #[pallet::call_index(65)]
         #[pallet::weight((<T as crate::pallet::Config>::WeightInfo::decrease_take(), DispatchClass::Normal, Pays::No))]
@@ -637,18 +607,14 @@ mod dispatches {
         ///        [0.01 * 65535] = [655.35] = 655
         ///
         /// # Events
-        /// * TakeIncreased;
-        /// 	- On successfully setting a increased take for this hotkey.
+        /// * 'TakeIncreased': On successfully setting a increased take for this hotkey.
         ///
         /// # Errors
-        /// * 'NotRegistered':
-        /// 	- The hotkey we are delegating is not registered on the network.
+        /// * 'NotRegistered': The hotkey we are delegating is not registered on the network.
         ///
-        /// * 'NonAssociatedColdKey':
-        /// 	- The hotkey we are delegating is not owned by the calling coldkey.
+        /// * 'NonAssociatedColdKey': The hotkey we are delegating is not owned by the calling coldkey.
         ///
-        /// * 'DelegateTakeTooHigh':
-        /// 	- The delegate is setting a take which is not greater than the previous.
+        /// * 'DelegateTakeTooHigh': The delegate is setting a take which is not greater than the previous.
         ///
         #[pallet::call_index(66)]
         #[pallet::weight((<T as crate::pallet::Config>::WeightInfo::increase_take(), DispatchClass::Normal, Pays::No))]
@@ -680,18 +646,14 @@ mod dispatches {
         /// 	- The amount of stake to be added to the hotkey staking account.
         ///
         /// # Events
-        ///  * StakeAdded;
-        /// 	- On the successfully adding stake to a global account.
+        /// * 'StakeAdded': On the successfully adding stake to a global account.
         ///
         /// # Errors
-        ///  * 'NotEnoughBalanceToStake':
-        /// 	- Not enough balance on the coldkey to add onto the global account.
+        /// * 'NotEnoughBalanceToStake': Not enough balance on the coldkey to add onto the global account.
         ///
-        ///  * 'NonAssociatedColdKey':
-        /// 	- The calling coldkey is not associated with this hotkey.
+        /// * 'NonAssociatedColdKey': The calling coldkey is not associated with this hotkey.
         ///
-        ///  * 'BalanceWithdrawalError':
-        ///  	- Errors stemming from transaction pallet.
+        /// * 'BalanceWithdrawalError': Errors stemming from transaction pallet.
         ///
         #[pallet::call_index(2)]
         #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::add_stake())]
@@ -722,18 +684,14 @@ mod dispatches {
         /// 	- The amount of stake to be added to the hotkey staking account.
         ///
         /// # Events
-        /// * StakeRemoved;
-        /// 	- On the successfully removing stake from the hotkey account.
+        /// * 'StakeRemoved': On the successfully removing stake from the hotkey account.
         ///
         /// # Errors
-        /// * 'NotRegistered':
-        /// 	- Thrown if the account we are attempting to unstake from is non existent.
+        /// * 'NotRegistered': Thrown if the account we are attempting to unstake from is non existent.
         ///
-        /// * 'NonAssociatedColdKey':
-        /// 	- Thrown if the coldkey does not own the hotkey we are unstaking from.
+        /// * 'NonAssociatedColdKey': Thrown if the coldkey does not own the hotkey we are unstaking from.
         ///
-        /// * 'NotEnoughStakeToWithdraw':
-        /// 	- Thrown if there is not enough stake on the hotkey to withdwraw this amount.
+        /// * 'NotEnoughStakeToWithdraw': Thrown if there is not enough stake on the hotkey to withdwraw this amount.
         ///
         #[pallet::call_index(3)]
         #[pallet::weight((Weight::from_parts(196_800_000, 0)
@@ -780,24 +738,18 @@ mod dispatches {
         /// 	- Placeholder for further extra params.
         ///
         /// # Events
-        /// * AxonServed;
-        /// 	- On successfully serving the axon info.
+        /// * 'AxonServed': On successfully serving the axon info.
         ///
         /// # Errors
-        /// * 'MechanismDoesNotExist':
-        /// 	- Attempting to set weights on a non-existent network.
+        /// * 'MechanismDoesNotExist': Attempting to set weights on a non-existent network.
         ///
-        /// * 'NotRegistered':
-        /// 	- Attempting to set weights from a non registered account.
+        /// * 'NotRegistered': Attempting to set weights from a non registered account.
         ///
-        /// * 'InvalidIpType':
-        /// 	- The ip type is not 4 or 6.
+        /// * 'InvalidIpType': The ip type is not 4 or 6.
         ///
-        /// * 'InvalidIpAddress':
-        /// 	- The numerically encoded ip address does not resolve to a proper ip.
+        /// * 'InvalidIpAddress': The numerically encoded ip address does not resolve to a proper ip.
         ///
-        /// * 'ServingRateLimitExceeded':
-        /// 	- Attempting to set prometheus information withing the rate limit min.
+        /// * 'ServingRateLimitExceeded': Attempting to set prometheus information withing the rate limit min.
         ///
         #[pallet::call_index(4)]
         #[pallet::weight((<T as crate::pallet::Config>::WeightInfo::serve_axon(), DispatchClass::Normal, Pays::No))]
@@ -862,24 +814,18 @@ mod dispatches {
         ///     - TLS certificate for inter neuron communitation.
         ///
         /// # Events
-        /// * AxonServed;
-        /// 	- On successfully serving the axon info.
+        /// * 'AxonServed': On successfully serving the axon info.
         ///
         /// # Errors
-        /// * 'MechanismDoesNotExist':
-        /// 	- Attempting to set weights on a non-existent network.
+        /// * 'MechanismDoesNotExist': Attempting to set weights on a non-existent network.
         ///
-        /// * 'NotRegistered':
-        /// 	- Attempting to set weights from a non registered account.
+        /// * 'NotRegistered': Attempting to set weights from a non registered account.
         ///
-        /// * 'InvalidIpType':
-        /// 	- The ip type is not 4 or 6.
+        /// * 'InvalidIpType': The ip type is not 4 or 6.
         ///
-        /// * 'InvalidIpAddress':
-        /// 	- The numerically encoded ip address does not resolve to a proper ip.
+        /// * 'InvalidIpAddress': The numerically encoded ip address does not resolve to a proper ip.
         ///
-        /// * 'ServingRateLimitExceeded':
-        /// 	- Attempting to set prometheus information withing the rate limit min.
+        /// * 'ServingRateLimitExceeded': Attempting to set prometheus information withing the rate limit min.
         ///
         #[pallet::call_index(40)]
         #[pallet::weight((<T as crate::pallet::Config>::WeightInfo::serve_axon_tls(), DispatchClass::Normal, Pays::No))]
@@ -967,27 +913,20 @@ mod dispatches {
         /// 	- Associated coldkey account.
         ///
         /// # Events
-        /// * NeuronRegistered;
-        /// 	- On successfully registering a uid to a neuron slot on a subnetwork.
+        /// * 'NeuronRegistered': On successfully registering a uid to a neuron slot on a subnetwork.
         ///
         /// # Errors
-        /// * 'MechanismDoesNotExist':
-        /// 	- Attempting to register to a non existent network.
+        /// * 'MechanismDoesNotExist': Attempting to register to a non existent network.
         ///
-        /// * 'TooManyRegistrationsThisBlock':
-        /// 	- This registration exceeds the total allowed on this network this block.
+        /// * 'TooManyRegistrationsThisBlock': This registration exceeds the total allowed on this network this block.
         ///
-        /// * 'HotKeyAlreadyRegisteredInSubNet':
-        /// 	- The hotkey is already registered on this network.
+        /// * 'HotKeyAlreadyRegisteredInSubNet': The hotkey is already registered on this network.
         ///
-        /// * 'InvalidWorkBlock':
-        /// 	- The work has been performed on a stale, future, or non existent block.
+        /// * 'InvalidWorkBlock': The work has been performed on a stale, future, or non existent block.
         ///
-        /// * 'InvalidDifficulty':
-        /// 	- The work does not match the difficulty.
+        /// * 'InvalidDifficulty': The work does not match the difficulty.
         ///
-        /// * 'InvalidSeal':
-        /// 	- The seal is incorrect.
+        /// * 'InvalidSeal': The seal is incorrect.
         ///
         #[pallet::call_index(6)]
         #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::register())]
@@ -1147,7 +1086,7 @@ mod dispatches {
         /// * `tx_rate_limit` - The new rate limit in blocks.
         ///
         /// # Errors
-        /// * `BadOrigin` - If the origin is not root.
+        /// * 'BadOrigin': If the origin is not root.
         ///
         #[pallet::call_index(69)]
         #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::sudo_set_tx_childkey_take_rate_limit())]
@@ -1169,7 +1108,7 @@ mod dispatches {
         /// * `take` - The new minimum childkey take value.
         ///
         /// # Errors
-        /// * `BadOrigin` - If the origin is not root.
+        /// * 'BadOrigin': If the origin is not root.
         ///
         #[pallet::call_index(76)]
         #[pallet::weight(Weight::from_parts(6_000, 0)
@@ -1190,7 +1129,7 @@ mod dispatches {
         /// * `take` - The new maximum childkey take value.
         ///
         /// # Errors
-        /// * `BadOrigin` - If the origin is not root.
+        /// * 'BadOrigin': If the origin is not root.
         ///
         #[pallet::call_index(77)]
         #[pallet::weight(Weight::from_parts(6_000, 0)
@@ -1426,8 +1365,7 @@ mod dispatches {
         ///     - The associated hotkey account.
         ///
         /// # Events
-        /// * StakeRemoved;
-        ///     - On the successfully removing stake from the hotkey account.
+        /// * 'StakeRemoved': On the successfully removing stake from the hotkey account.
         ///
         /// # Errors
         /// * `NotRegistered`:
@@ -1457,8 +1395,7 @@ mod dispatches {
         ///     - The associated hotkey account.
         ///
         /// # Events
-        /// * StakeRemoved;
-        ///     - On the successfully removing stake from the hotkey account.
+        /// * 'StakeRemoved': On the successfully removing stake from the hotkey account.
         ///
         /// # Errors
         /// * `NotRegistered`:
@@ -1631,18 +1568,14 @@ mod dispatches {
         ///       fill or kill type or order.
         ///
         /// # Events
-        ///  * StakeAdded;
-        /// 	- On the successfully adding stake to a global account.
+        /// * 'StakeAdded': On the successfully adding stake to a global account.
         ///
         /// # Errors
-        ///  * 'NotEnoughBalanceToStake':
-        /// 	- Not enough balance on the coldkey to add onto the global account.
+        /// * 'NotEnoughBalanceToStake': Not enough balance on the coldkey to add onto the global account.
         ///
-        ///  * 'NonAssociatedColdKey':
-        /// 	- The calling coldkey is not associated with this hotkey.
+        /// * 'NonAssociatedColdKey': The calling coldkey is not associated with this hotkey.
         ///
-        ///  * 'BalanceWithdrawalError':
-        ///  	- Errors stemming from transaction pallet.
+        /// * 'BalanceWithdrawalError': Errors stemming from transaction pallet.
         ///
         #[pallet::call_index(88)]
         #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::add_stake_limit())]
@@ -1694,18 +1627,14 @@ mod dispatches {
         ///       fill or kill type or order.
         ///
         /// # Events
-        /// * StakeRemoved;
-        /// 	- On the successfully removing stake from the hotkey account.
+        /// * 'StakeRemoved': On the successfully removing stake from the hotkey account.
         ///
         /// # Errors
-        /// * 'NotRegistered':
-        /// 	- Thrown if the account we are attempting to unstake from is non existent.
+        /// * 'NotRegistered': Thrown if the account we are attempting to unstake from is non existent.
         ///
-        /// * 'NonAssociatedColdKey':
-        /// 	- Thrown if the coldkey does not own the hotkey we are unstaking from.
+        /// * 'NonAssociatedColdKey': Thrown if the coldkey does not own the hotkey we are unstaking from.
         ///
-        /// * 'NotEnoughStakeToWithdraw':
-        /// 	- Thrown if there is not enough stake on the hotkey to withdwraw this amount.
+        /// * 'NotEnoughStakeToWithdraw': Thrown if there is not enough stake on the hotkey to withdwraw this amount.
         ///
         #[pallet::call_index(89)]
         #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::remove_stake_limit())]
@@ -2166,8 +2095,7 @@ mod dispatches {
         /// 	- The signature of the caller's coldkey.
         ///
         /// # Events
-        /// * RootClaimed;
-        /// 	- On the successfully claiming the root emissions for a coldkey.
+        /// * 'RootClaimed': On the successfully claiming the root emissions for a coldkey.
         ///
         /// # Errors
         ///
@@ -2197,8 +2125,7 @@ mod dispatches {
         /// 	- The signature of the caller's coldkey.
         ///
         /// # Events
-        /// * RootClaimTypeSet;
-        /// 	- On the successfully setting the root claim type for the coldkey.
+        /// * 'RootClaimTypeSet': On the successfully setting the root claim type for the coldkey.
         ///
         #[pallet::call_index(122)]
         #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::set_root_claim_type())]
@@ -2387,8 +2314,8 @@ mod dispatches {
         /// * `netuid` - The subnet to enable voting power tracking for.
         ///
         /// # Errors
-        /// * `SubnetNotExist` - If the subnet does not exist.
-        /// * `NotSubnetOwner` - If the caller is not the subnet owner or root.
+        /// * 'SubnetNotExist': If the subnet does not exist.
+        /// * 'NotSubnetOwner': If the caller is not the subnet owner or root.
         #[pallet::call_index(129)]
         #[pallet::weight(Weight::from_parts(10_000, 0)
         .saturating_add(T::DbWeight::get().reads(2))
@@ -2412,9 +2339,9 @@ mod dispatches {
         /// * `netuid` - The subnet to schedule disabling voting power tracking for.
         ///
         /// # Errors
-        /// * `SubnetNotExist` - If the subnet does not exist.
-        /// * `NotSubnetOwner` - If the caller is not the subnet owner or root.
-        /// * `VotingPowerTrackingNotEnabled` - If voting power tracking is not enabled.
+        /// * 'SubnetNotExist': If the subnet does not exist.
+        /// * 'NotSubnetOwner': If the caller is not the subnet owner or root.
+        /// * 'VotingPowerTrackingNotEnabled': If voting power tracking is not enabled.
         #[pallet::call_index(130)]
         #[pallet::weight(Weight::from_parts(10_000, 0)
         .saturating_add(T::DbWeight::get().reads(2))
@@ -2439,9 +2366,9 @@ mod dispatches {
         /// * `alpha` - The new alpha value (u64 with 18 decimal precision).
         ///
         /// # Errors
-        /// * `BadOrigin` - If the origin is not root.
-        /// * `SubnetNotExist` - If the subnet does not exist.
-        /// * `InvalidVotingPowerEmaAlpha` - If alpha is greater than 10^18 (1.0).
+        /// * 'BadOrigin': If the origin is not root.
+        /// * 'SubnetNotExist': If the subnet does not exist.
+        /// * 'InvalidVotingPowerEmaAlpha': If alpha is greater than 10^18 (1.0).
         #[pallet::call_index(131)]
         #[pallet::weight(Weight::from_parts(6_000, 0)
         .saturating_add(T::DbWeight::get().reads(1))

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -31,10 +31,12 @@ mod dispatches {
         /// probabilities. The specific weights determine how inflation propagates outward
         /// from this peer.
         ///
-        /// Note: The 16 bit integers weights should represent 1.0 as the max u16.
-        /// However, the function normalizes all integers to u16_max anyway. This means that if the sum of all
-        /// elements is larger or smaller than the amount of elements * u16_max, all elements
-        /// will be corrected for this deviation.
+        /// # Note
+        /// The 16-bit integer weights should represent 1.0 as the max u16.
+        /// However, the function normalizes all integers to u16_max anyway.
+        /// This means that if the sum of all elements is larger or smaller
+        /// than the amount of elements * u16_max, all elements will be
+        /// corrected for this deviation.
         ///
         /// # Arguments
         /// * `origin`: (<T as frame_system::Config>Origin):
@@ -96,10 +98,12 @@ mod dispatches {
         /// probabilities. The specific weights determine how inflation propagates outward
         /// from this peer.
         ///
-        /// Note: The 16 bit integers weights should represent 1.0 as the max u16.
-        /// However, the function normalizes all integers to u16_max anyway. This means that if the sum of all
-        /// elements is larger or smaller than the amount of elements * u16_max, all elements
-        /// will be corrected for this deviation.
+        /// # Note
+        /// The 16-bit integer weights should represent 1.0 as the max u16.
+        /// However, the function normalizes all integers to u16_max anyway.
+        /// This means that if the sum of all elements is larger or smaller
+        /// than the amount of elements * u16_max, all elements will be
+        /// corrected for this deviation.
         ///
         /// # Arguments
         /// * `origin`: (<T as frame_system::Config>Origin):
@@ -629,7 +633,8 @@ mod dispatches {
         /// Adds stake to a hotkey. The call is made from a coldkey account.
         /// This delegates stake to the hotkey.
         ///
-        /// Note: the coldkey account may own the hotkey, in which case they are
+        /// # Note
+        /// The coldkey account may own the hotkey, in which case they are
         /// delegating to themselves.
         ///
         /// # Arguments
@@ -1245,7 +1250,9 @@ mod dispatches {
 
         /// Schedules a coldkey swap operation to be executed at a future block.
         ///
-        /// WARNING: This function is deprecated, please migrate to `announce_coldkey_swap`/`coldkey_swap`
+        /// # Note
+        /// This function is deprecated; please migrate to
+        /// `announce_coldkey_swap` / `coldkey_swap`.
         #[pallet::call_index(73)]
         #[pallet::weight(T::DbWeight::get().reads(5))]
         #[deprecated(note = "Deprecated, please migrate to `announce_coldkey_swap`/`coldkey_swap`")]

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -1531,12 +1531,15 @@ mod dispatches {
         /// * `alpha_amount` - The amount of stake to transfer.
         ///
         /// # Errors
-        /// Returns an error if:
-        /// * The origin is not signed by the correct coldkey.
-        /// * Either subnet does not exist.
-        /// * The hotkey does not exist.
-        /// * There is insufficient stake on `(origin_coldkey, hotkey, origin_netuid)`.
-        /// * The transfer amount is below the minimum stake requirement.
+        /// * 'BadOrigin': The transaction is not signed by `origin_coldkey`.
+        /// * 'SubnetNotExists': Either `origin_netuid` or `destination_netuid` does not exist.
+        /// * 'SubtokenDisabled': The subtoken on either subnet is disabled.
+        /// * 'HotKeyAccountNotExists': The `hotkey` account does not exist.
+        /// * 'NotEnoughStakeToWithdraw': The `(origin_coldkey, hotkey, origin_netuid)` position has less stake than `alpha_amount`.
+        /// * 'AmountTooLow': The resulting TAO-equivalent amount is below `DefaultMinStake`.
+        /// * 'InsufficientLiquidity': Swap simulation or execution fails on the origin/destination subnet.
+        /// * 'TransferDisallowed': Transfers are currently disabled on the origin or destination subnet.
+        /// * 'StakingOperationRateLimitExceeded': The caller hit the per-account staking operation rate limit.
         ///
         /// # Events
         /// May emit a `StakeTransferred` event on success.
@@ -1570,12 +1573,14 @@ mod dispatches {
         /// * `alpha_amount` - The amount of stake to swap.
         ///
         /// # Errors
-        /// Returns an error if:
-        /// * The transaction is not signed by the correct coldkey (i.e., `coldkey_owns_hotkey` fails).
-        /// * Either `origin_netuid` or `destination_netuid` does not exist.
-        /// * The hotkey does not exist.
-        /// * There is insufficient stake on `(coldkey, hotkey, origin_netuid)`.
-        /// * The swap amount is below the minimum stake requirement.
+        /// * 'BadOrigin': The transaction is not signed by the coldkey that owns `hotkey`.
+        /// * 'SubnetNotExists': Either `origin_netuid` or `destination_netuid` does not exist.
+        /// * 'SubtokenDisabled': The subtoken on either subnet is disabled.
+        /// * 'HotKeyAccountNotExists': The specified `hotkey` does not exist.
+        /// * 'NotEnoughStakeToWithdraw': The `(coldkey, hotkey, origin_netuid)` position has less stake than `alpha_amount`.
+        /// * 'AmountTooLow': The resulting TAO-equivalent amount is below `DefaultMinStake`.
+        /// * 'InsufficientLiquidity': Swap simulation or execution fails on the origin/destination subnet.
+        /// * 'StakingOperationRateLimitExceeded': The caller hit the per-account staking operation rate limit.
         ///
         /// # Events
         /// May emit a `StakeSwapped` event on success.
@@ -1734,12 +1739,16 @@ mod dispatches {
         /// * `allow_partial` - Allows partial execution of the amount. If set to false, this becomes fill or kill type or order.
         ///
         /// # Errors
-        /// Returns an error if:
-        /// * The transaction is not signed by the correct coldkey (i.e., `coldkey_owns_hotkey` fails).
-        /// * Either `origin_netuid` or `destination_netuid` does not exist.
-        /// * The hotkey does not exist.
-        /// * There is insufficient stake on `(coldkey, hotkey, origin_netuid)`.
-        /// * The swap amount is below the minimum stake requirement.
+        /// * 'BadOrigin': The transaction is not signed by the coldkey that owns `hotkey`.
+        /// * 'SubnetNotExists': Either `origin_netuid` or `destination_netuid` does not exist.
+        /// * 'SubtokenDisabled': The subtoken on either subnet is disabled.
+        /// * 'HotKeyAccountNotExists': The specified `hotkey` does not exist.
+        /// * 'NotEnoughStakeToWithdraw': The `(coldkey, hotkey, origin_netuid)` position has less stake than `alpha_amount`.
+        /// * 'AmountTooLow': The resulting TAO-equivalent amount is below `DefaultMinStake`.
+        /// * 'InsufficientLiquidity': Swap simulation or execution fails on the origin/destination subnet.
+        /// * 'SlippageTooHigh': `allow_partial` is false and `alpha_amount` would exceed the `limit_price` slippage bound.
+        /// * 'ZeroMaxStakeAmount': `limit_price` forces a zero maximum executable amount.
+        /// * 'StakingOperationRateLimitExceeded': The caller hit the per-account staking operation rate limit.
         ///
         /// # Events
         /// May emit a `StakeSwapped` event on success.
@@ -1815,14 +1824,14 @@ mod dispatches {
         /// * `signature` - A signed message by the `evm_key` containing the `hotkey` and the hashed `block_number`.
         ///
         /// # Errors
-        /// Returns an error if:
-        /// * The transaction is not signed.
-        /// * The hotkey does not belong to the subnet identified by the netuid.
-        /// * The EVM key cannot be recovered from the signature.
-        /// * The EVM key recovered from the signature does not match the given EVM key.
+        /// * 'BadOrigin': The transaction is not signed.
+        /// * 'NonAssociatedColdKey': The signing coldkey does not own the provided `hotkey` on `netuid`.
+        /// * 'UnableToRecoverPublicKey': The EVM public key cannot be recovered from the signature.
+        /// * 'InvalidRecoveredPublicKey': The recovered EVM public key does not match `evm_key`.
+        /// * 'EvmKeyAssociateRateLimitExceeded': The caller hit the EVM-key association rate limit.
         ///
         /// # Events
-        /// May emit a `EvmKeyAssociated` event on success
+        /// May emit an `EvmKeyAssociated` event on success.
         #[pallet::call_index(93)]
         #[pallet::weight((
             Weight::from_parts(3_000_000, 0).saturating_add(T::DbWeight::get().reads_writes(2, 1)),
@@ -1969,10 +1978,9 @@ mod dispatches {
         /// * `symbol` - The symbol to set for the subnet.
         ///
         /// # Errors
-        /// Returns an error if:
-        /// * The transaction is not signed by the subnet owner.
-        /// * The symbol does not exist.
-        /// * The symbol is already in use by another subnet.
+        /// * 'BadOrigin': The transaction is not signed by the subnet owner or root.
+        /// * 'SymbolDoesNotExist': The requested `symbol` is not in the canonical symbol table.
+        /// * 'SymbolAlreadyInUse': The `symbol` is already assigned to another subnet.
         ///
         /// # Events
         /// Emits a `SymbolUpdated` event on success.

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -23,7 +23,7 @@ mod dispatches {
     impl<T: Config> Pallet<T> {
         #![deny(clippy::expect_used)]
 
-        /// --- Sets the caller weights for the incentive mechanism. The call can be
+        /// Sets the caller weights for the incentive mechanism. The call can be
         /// made from the hotkey account so is potentially insecure, however, the damage
         /// of changing weights is minimal if caught early. This function includes all the
         /// checks that the passed weights meet the requirements. Stored as u16s they represent
@@ -97,7 +97,7 @@ mod dispatches {
             }
         }
 
-        /// --- Sets the caller weights for the incentive mechanism for mechanisms. The call
+        /// Sets the caller weights for the incentive mechanism for mechanisms. The call
         /// can be made from the hotkey account so is potentially insecure, however, the damage
         /// of changing weights is minimal if caught early. This function includes all the
         /// checks that the passed weights meet the requirements. Stored as u16s they represent
@@ -177,7 +177,7 @@ mod dispatches {
             }
         }
 
-        /// --- Allows a hotkey to set weights for multiple netuids as a batch.
+        /// Allows a hotkey to set weights for multiple netuids as a batch.
         ///
         /// # Args:
         /// * `origin`: (<T as frame_system::Config>Origin):
@@ -213,7 +213,7 @@ mod dispatches {
             Self::do_batch_set_weights(origin, netuids, weights, version_keys)
         }
 
-        /// ---- Used to commit a hash of your weight values to later be revealed.
+        /// Used to commit a hash of your weight values to later be revealed.
         ///
         /// # Args:
         /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
@@ -242,7 +242,7 @@ mod dispatches {
             Self::do_commit_weights(origin, netuid, commit_hash)
         }
 
-        /// ---- Used to commit a hash of your weight values to later be revealed for mechanisms.
+        /// Used to commit a hash of your weight values to later be revealed for mechanisms.
         ///
         /// # Args:
         /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
@@ -277,7 +277,7 @@ mod dispatches {
             Self::do_commit_mechanism_weights(origin, netuid, mecid, commit_hash)
         }
 
-        /// --- Allows a hotkey to commit weight hashes for multiple netuids as a batch.
+        /// Allows a hotkey to commit weight hashes for multiple netuids as a batch.
         ///
         /// # Args:
         /// * `origin`: (<T as frame_system::Config>Origin):
@@ -309,7 +309,7 @@ mod dispatches {
             Self::do_batch_commit_weights(origin, netuids, commit_hashes)
         }
 
-        /// ---- Used to reveal the weights for a previously committed hash.
+        /// Used to reveal the weights for a previously committed hash.
         ///
         /// # Args:
         /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
@@ -359,7 +359,7 @@ mod dispatches {
             Self::do_reveal_weights(origin, netuid, uids, values, salt, version_key)
         }
 
-        /// ---- Used to reveal the weights for a previously committed hash for mechanisms.
+        /// Used to reveal the weights for a previously committed hash for mechanisms.
         ///
         /// # Args:
         /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
@@ -423,7 +423,7 @@ mod dispatches {
             )
         }
 
-        /// ---- Used to commit encrypted commit-reveal v3 weight values to later be revealed.
+        /// Used to commit encrypted commit-reveal v3 weight values to later be revealed.
         ///
         /// # Args:
         /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
@@ -465,7 +465,7 @@ mod dispatches {
         //     Self::do_commit_timelocked_weights(origin, netuid, commit, reveal_round, 4)
         // }
 
-        /// ---- Used to commit encrypted commit-reveal v3 weight values to later be revealed for mechanisms.
+        /// Used to commit encrypted commit-reveal v3 weight values to later be revealed for mechanisms.
         ///
         /// # Args:
         /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
@@ -518,7 +518,7 @@ mod dispatches {
             )
         }
 
-        /// ---- The implementation for batch revealing committed weights.
+        /// The implementation for batch revealing committed weights.
         ///
         /// # Args:
         /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
@@ -577,7 +577,7 @@ mod dispatches {
             )
         }
 
-        /// --- Allows delegates to decrease its take value.
+        /// Allows delegates to decrease its take value.
         ///
         /// # Args:
         /// * 'origin': (<T as frame_system::Config>::Origin):
@@ -620,7 +620,7 @@ mod dispatches {
             Self::do_decrease_take(origin, hotkey, take)
         }
 
-        /// --- Allows delegates to increase its take value. This call is rate-limited.
+        /// Allows delegates to increase its take value. This call is rate-limited.
         ///
         /// # Args:
         /// * 'origin': (<T as frame_system::Config>::Origin):
@@ -660,7 +660,7 @@ mod dispatches {
             Self::do_increase_take(origin, hotkey, take)
         }
 
-        /// --- Adds stake to a hotkey. The call is made from a coldkey account.
+        /// Adds stake to a hotkey. The call is made from a coldkey account.
         /// This delegates stake to the hotkey.
         ///
         /// Note: the coldkey account may own the hotkey, in which case they are
@@ -909,7 +909,7 @@ mod dispatches {
             )
         }
 
-        /// ---- Set prometheus information for the neuron.
+        /// Set prometheus information for the neuron.
         /// # Args:
         /// * 'origin': (<T as frame_system::Config>Origin):
         /// 	- The signature of the calling hotkey.
@@ -942,7 +942,7 @@ mod dispatches {
             Self::do_serve_prometheus(origin, netuid, version, ip, port, ip_type)
         }
 
-        /// ---- Registers a new neuron to the subnetwork.
+        /// Registers a new neuron to the subnetwork.
         ///
         /// # Args:
         /// * 'origin': (<T as frame_system::Config>Origin):
@@ -1021,7 +1021,7 @@ mod dispatches {
             Self::do_register(origin, netuid, hotkey)
         }
 
-        /// ---- The extrinsic for user to change its hotkey in subnet or all subnets.
+        /// The extrinsic for user to change its hotkey in subnet or all subnets.
         ///
         /// # Arguments
         /// * `origin` - The origin of the transaction (must be signed by the coldkey).
@@ -1043,7 +1043,7 @@ mod dispatches {
             Self::do_swap_hotkey(origin, &hotkey, &new_hotkey, netuid, false)
         }
 
-        /// ---- The extrinsic for user to change its hotkey in subnet or all subnets. This extrinsic is
+        /// The extrinsic for user to change its hotkey in subnet or all subnets. This extrinsic is
         /// similar to swap_hotkey, but with keep_stake parameter bo be able to keep the stake when swapping
         /// a root key to a child key
         ///
@@ -1317,7 +1317,7 @@ mod dispatches {
             Err(Error::<T>::Deprecated.into())
         }
 
-        /// ---- Set prometheus information for the neuron.
+        /// Set prometheus information for the neuron.
         /// # Args:
         /// * 'origin': (<T as frame_system::Config>Origin):
         /// 	- The signature of the calling hotkey.
@@ -1361,7 +1361,7 @@ mod dispatches {
             )
         }
 
-        /// ---- Set the identity information for a subnet.
+        /// Set the identity information for a subnet.
         /// # Args:
         /// * `origin` - (<T as frame_system::Config>::Origin):
         ///     - The signature of the calling coldkey, which must be the owner of the subnet.
@@ -1416,7 +1416,7 @@ mod dispatches {
             Self::do_register_network(origin, &hotkey, 1, identity)
         }
 
-        /// ---- The implementation for the extrinsic unstake_all: Removes all stake from a hotkey account across all subnets and adds it onto a coldkey.
+        /// The implementation for the extrinsic unstake_all: Removes all stake from a hotkey account across all subnets and adds it onto a coldkey.
         ///
         /// # Args:
         /// * `origin` - (<T as frame_system::Config>::Origin):
@@ -1447,7 +1447,7 @@ mod dispatches {
             Self::do_unstake_all(origin, hotkey)
         }
 
-        /// ---- The implementation for the extrinsic unstake_all: Removes all stake from a hotkey account across all subnets and adds it onto a coldkey.
+        /// The implementation for the extrinsic unstake_all: Removes all stake from a hotkey account across all subnets and adds it onto a coldkey.
         ///
         /// # Args:
         /// * `origin` - (<T as frame_system::Config>::Origin):
@@ -1478,7 +1478,7 @@ mod dispatches {
             Self::do_unstake_all_alpha(origin, hotkey)
         }
 
-        /// ---- The implementation for the extrinsic move_stake: Moves specified amount of stake from a hotkey to another across subnets.
+        /// The implementation for the extrinsic move_stake: Moves specified amount of stake from a hotkey to another across subnets.
         ///
         /// # Args:
         /// * `origin` - (<T as frame_system::Config>::Origin):
@@ -1597,7 +1597,7 @@ mod dispatches {
             )
         }
 
-        /// --- Adds stake to a hotkey on a subnet with a price limit.
+        /// Adds stake to a hotkey on a subnet with a price limit.
         /// This extrinsic allows to specify the limit price for alpha token
         /// at which or better (lower) the staking should execute.
         ///
@@ -1660,7 +1660,7 @@ mod dispatches {
             .map(|_| ())
         }
 
-        /// --- Removes stake from a hotkey on a subnet with a price limit.
+        /// Removes stake from a hotkey on a subnet with a price limit.
         /// This extrinsic allows to specify the limit price for alpha token
         /// at which or better (higher) the staking should execute.
         ///
@@ -1994,7 +1994,7 @@ mod dispatches {
             Ok(())
         }
 
-        /// ---- Used to commit timelock encrypted commit-reveal weight values to later be revealed.
+        /// Used to commit timelock encrypted commit-reveal weight values to later be revealed.
         ///
         /// # Args:
         /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
@@ -2091,7 +2091,7 @@ mod dispatches {
             Ok(())
         }
 
-        /// ---- Used to commit timelock encrypted commit-reveal weight values to later be revealed for
+        /// Used to commit timelock encrypted commit-reveal weight values to later be revealed for
         /// a mechanism.
         ///
         /// # Args:
@@ -2152,7 +2152,7 @@ mod dispatches {
             Self::do_dissolve_network(netuid)
         }
 
-        /// --- Claims the root emissions for a coldkey.
+        /// Claims the root emissions for a coldkey.
         /// # Args:
         /// * 'origin': (<T as frame_system::Config>Origin):
         /// 	- The signature of the caller's coldkey.
@@ -2183,7 +2183,7 @@ mod dispatches {
             Ok((Some(weight), Pays::Yes).into())
         }
 
-        /// --- Sets the root claim type for the coldkey.
+        /// Sets the root claim type for the coldkey.
         /// # Args:
         /// * 'origin': (<T as frame_system::Config>Origin):
         /// 	- The signature of the caller's coldkey.
@@ -2210,7 +2210,7 @@ mod dispatches {
             Ok(())
         }
 
-        /// --- Sets root claim number (sudo extrinsic). Zero disables auto-claim.
+        /// Sets root claim number (sudo extrinsic). Zero disables auto-claim.
         #[pallet::call_index(123)]
         #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::sudo_set_num_root_claims())]
         pub fn sudo_set_num_root_claims(origin: OriginFor<T>, new_value: u64) -> DispatchResult {
@@ -2226,7 +2226,7 @@ mod dispatches {
             Ok(())
         }
 
-        /// --- Sets root claim threshold for subnet (sudo or owner origin).
+        /// Sets root claim threshold for subnet (sudo or owner origin).
         #[pallet::call_index(124)]
         #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::sudo_set_root_claim_threshold())]
         pub fn sudo_set_root_claim_threshold(
@@ -2447,7 +2447,7 @@ mod dispatches {
             Self::do_set_voting_power_ema_alpha(netuid, alpha)
         }
 
-        /// --- The extrinsic is a combination of add_stake(add_stake_limit) and burn_alpha. We buy
+        /// The extrinsic is a combination of add_stake(add_stake_limit) and burn_alpha. We buy
         /// alpha token first and immediately burn the acquired amount of alpha (aka Subnet buyback).
         #[pallet::call_index(132)]
         #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::add_stake_burn())]
@@ -2507,7 +2507,7 @@ mod dispatches {
             Self::do_register_limit(origin, netuid, hotkey, limit_price)
         }
 
-        /// --- Allows a root validator to toggle auto parent delegation
+        /// Allows a root validator to toggle auto parent delegation
         /// for new subnets owner hotkey
         #[pallet::call_index(135)]
         #[pallet::weight((<T as crate::pallet::Config>::WeightInfo::set_auto_parent_delegation_enabled(), DispatchClass::Normal, Pays::Yes))]

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -39,21 +39,16 @@ mod dispatches {
         /// corrected for this deviation.
         ///
         /// # Arguments
-        /// * `origin`: (<T as frame_system::Config>Origin):
-        ///     - The caller, a hotkey who wishes to set their weights.
+        /// * `origin`: The caller, a hotkey who wishes to set their weights.
         ///
-        /// * `netuid` (u16):
-        /// 	- The network uid we are setting these weights on.
+        /// * `netuid`: The network uid we are setting these weights on.
         ///
-        /// * `dests` (Vec<u16>):
-        /// 	- The edge endpoint for the weight, i.e. j for w_ij.
+        /// * `dests`: The edge endpoint for the weight, i.e. j for w_ij.
         ///
-        /// * 'weights' (Vec<u16>):
-        /// 	- The u16 integer encoded weights. Interpreted as rational
+        /// * `weights`: The u16 integer encoded weights. Interpreted as rational.
         ///     values in the range [0,1]. They must sum to in32::MAX.
         ///
-        /// * 'version_key' ( u64 ):
-        /// 	- The network version key to check if the validator is up to date.
+        /// * `version_key`: The network version key to check if the validator is up to date.
         ///
         /// # Events
         /// * 'WeightsSet': On successfully setting the weights on chain.
@@ -106,24 +101,18 @@ mod dispatches {
         /// corrected for this deviation.
         ///
         /// # Arguments
-        /// * `origin`: (<T as frame_system::Config>Origin):
-        ///     - The caller, a hotkey who wishes to set their weights.
+        /// * `origin`: The caller, a hotkey who wishes to set their weights.
         ///
-        /// * `netuid` (u16):
-        /// 	- The network uid we are setting these weights on.
+        /// * `netuid`: The network uid we are setting these weights on.
         ///
-        /// * `mecid` (`u8`):
-        ///   - The u8 mechnism identifier.
+        /// * `mecid`: The u8 mechnism identifier.
         ///
-        /// * `dests` (Vec<u16>):
-        /// 	- The edge endpoint for the weight, i.e. j for w_ij.
+        /// * `dests`: The edge endpoint for the weight, i.e. j for w_ij.
         ///
-        /// * 'weights' (Vec<u16>):
-        /// 	- The u16 integer encoded weights. Interpreted as rational
+        /// * `weights`: The u16 integer encoded weights. Interpreted as rational.
         ///     values in the range [0,1]. They must sum to in32::MAX.
         ///
-        /// * 'version_key' ( u64 ):
-        /// 	- The network version key to check if the validator is up to date.
+        /// * `version_key`: The network version key to check if the validator is up to date.
         ///
         /// # Events
         /// * 'WeightsSet': On successfully setting the weights on chain.
@@ -166,17 +155,13 @@ mod dispatches {
         /// Allows a hotkey to set weights for multiple netuids as a batch.
         ///
         /// # Arguments
-        /// * `origin`: (<T as frame_system::Config>Origin):
-        ///     - The caller, a hotkey who wishes to set their weights.
+        /// * `origin`: The caller, a hotkey who wishes to set their weights.
         ///
-        /// * `netuids` (Vec<Compact<u16>>):
-        /// 	- The network uids we are setting these weights on.
+        /// * `netuids`: The network uids we are setting these weights on.
         ///
-        /// * `weights` (Vec<Vec<(Compact<u16>, Compact<u16>)>):
-        /// 	- The weights to set for each network. [(uid, weight), ...]
+        /// * `weights`: The weights to set for each network. [(uid, weight), ...].
         ///
-        /// * `version_keys` (Vec<Compact<u64>>):
-        /// 	- The network version keys to check if the validator is up to date.
+        /// * `version_keys`: The network version keys to check if the validator is up to date.
         ///
         /// # Events
         /// * 'WeightsSet': On successfully setting the weights on chain.
@@ -198,21 +183,16 @@ mod dispatches {
         /// Used to commit a hash of your weight values to later be revealed.
         ///
         /// # Arguments
-        /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
-        ///   - The signature of the committing hotkey.
+        /// * `origin`: The signature of the committing hotkey.
         ///
-        /// * `netuid` (`u16`):
-        ///   - The u16 network identifier.
+        /// * `netuid`: The u16 network identifier.
         ///
-        /// * `commit_hash` (`H256`):
-        ///   - The hash representing the committed weights.
+        /// * `commit_hash`: The hash representing the committed weights.
         ///
         /// # Errors
-        /// * `CommitRevealDisabled`:
-        ///   - Attempting to commit when the commit-reveal mechanism is disabled.
+        /// * 'CommitRevealDisabled': Attempting to commit when the commit-reveal mechanism is disabled.
         ///
-        /// * `TooManyUnrevealedCommits`:
-        ///   - Attempting to commit when the user has more than the allowed limit of unrevealed commits.
+        /// * 'TooManyUnrevealedCommits': Attempting to commit when the user has more than the allowed limit of unrevealed commits.
         ///
         #[pallet::call_index(96)]
         #[pallet::weight((<T as crate::pallet::Config>::WeightInfo::commit_weights(), DispatchClass::Normal, Pays::No))]
@@ -227,24 +207,18 @@ mod dispatches {
         /// Used to commit a hash of your weight values to later be revealed for mechanisms.
         ///
         /// # Arguments
-        /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
-        ///   - The signature of the committing hotkey.
+        /// * `origin`: The signature of the committing hotkey.
         ///
-        /// * `netuid` (`u16`):
-        ///   - The u16 network identifier.
+        /// * `netuid`: The u16 network identifier.
         ///
-        /// * `mecid` (`u8`):
-        ///   - The u8 mechanism identifier.
+        /// * `mecid`: The u8 mechanism identifier.
         ///
-        /// * `commit_hash` (`H256`):
-        ///   - The hash representing the committed weights.
+        /// * `commit_hash`: The hash representing the committed weights.
         ///
         /// # Errors
-        /// * `CommitRevealDisabled`:
-        ///   - Attempting to commit when the commit-reveal mechanism is disabled.
+        /// * 'CommitRevealDisabled': Attempting to commit when the commit-reveal mechanism is disabled.
         ///
-        /// * `TooManyUnrevealedCommits`:
-        ///   - Attempting to commit when the user has more than the allowed limit of unrevealed commits.
+        /// * 'TooManyUnrevealedCommits': Attempting to commit when the user has more than the allowed limit of unrevealed commits.
         ///
         #[pallet::call_index(115)]
         #[pallet::weight((Weight::from_parts(55_130_000, 0)
@@ -262,14 +236,11 @@ mod dispatches {
         /// Allows a hotkey to commit weight hashes for multiple netuids as a batch.
         ///
         /// # Arguments
-        /// * `origin`: (<T as frame_system::Config>Origin):
-        ///     - The caller, a hotkey who wishes to set their weights.
+        /// * `origin`: The caller, a hotkey who wishes to set their weights.
         ///
-        /// * `netuids` (Vec<Compact<u16>>):
-        /// 	- The network uids we are setting these weights on.
+        /// * `netuids`: The network uids we are setting these weights on.
         ///
-        /// * `commit_hashes` (Vec<H256>):
-        /// 	- The commit hashes to commit.
+        /// * `commit_hashes`: The commit hashes to commit.
         ///
         /// # Events
         /// * 'WeightsSet': On successfully setting the weights on chain.
@@ -290,39 +261,28 @@ mod dispatches {
         /// Used to reveal the weights for a previously committed hash.
         ///
         /// # Arguments
-        /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
-        ///   - The signature of the revealing hotkey.
+        /// * `origin`: The signature of the revealing hotkey.
         ///
-        /// * `netuid` (`u16`):
-        ///   - The u16 network identifier.
+        /// * `netuid`: The u16 network identifier.
         ///
-        /// * `uids` (`Vec<u16>`):
-        ///   - The uids for the weights being revealed.
+        /// * `uids`: The uids for the weights being revealed.
         ///
-        /// * `values` (`Vec<u16>`):
-        ///   - The values of the weights being revealed.
+        /// * `values`: The values of the weights being revealed.
         ///
-        /// * `salt` (`Vec<u16>`):
-        ///   - The salt used to generate the commit hash.
+        /// * `salt`: The salt used to generate the commit hash.
         ///
-        /// * `version_key` (`u64`):
-        ///   - The network version key.
+        /// * `version_key`: The network version key.
         ///
         /// # Errors
-        /// * `CommitRevealDisabled`:
-        ///   - Attempting to reveal weights when the commit-reveal mechanism is disabled.
+        /// * 'CommitRevealDisabled': Attempting to reveal weights when the commit-reveal mechanism is disabled.
         ///
-        /// * `NoWeightsCommitFound`:
-        ///   - Attempting to reveal weights without an existing commit.
+        /// * 'NoWeightsCommitFound': Attempting to reveal weights without an existing commit.
         ///
-        /// * `ExpiredWeightCommit`:
-        ///   - Attempting to reveal a weight commit that has expired.
+        /// * 'ExpiredWeightCommit': Attempting to reveal a weight commit that has expired.
         ///
-        /// * `RevealTooEarly`:
-        ///   - Attempting to reveal weights outside the valid reveal period.
+        /// * 'RevealTooEarly': Attempting to reveal weights outside the valid reveal period.
         ///
-        /// * `InvalidRevealCommitHashNotMatch`:
-        ///   - The revealed hash does not match any committed hash.
+        /// * 'InvalidRevealCommitHashNotMatch': The revealed hash does not match any committed hash.
         ///
         #[pallet::call_index(97)]
         #[pallet::weight((<T as crate::pallet::Config>::WeightInfo::reveal_weights(), DispatchClass::Normal, Pays::No))]
@@ -340,42 +300,30 @@ mod dispatches {
         /// Used to reveal the weights for a previously committed hash for mechanisms.
         ///
         /// # Arguments
-        /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
-        ///   - The signature of the revealing hotkey.
+        /// * `origin`: The signature of the revealing hotkey.
         ///
-        /// * `netuid` (`u16`):
-        ///   - The u16 network identifier.
+        /// * `netuid`: The u16 network identifier.
         ///
-        /// * `mecid` (`u8`):
-        ///   - The u8 mechanism identifier.
+        /// * `mecid`: The u8 mechanism identifier.
         ///
-        /// * `uids` (`Vec<u16>`):
-        ///   - The uids for the weights being revealed.
+        /// * `uids`: The uids for the weights being revealed.
         ///
-        /// * `values` (`Vec<u16>`):
-        ///   - The values of the weights being revealed.
+        /// * `values`: The values of the weights being revealed.
         ///
-        /// * `salt` (`Vec<u16>`):
-        ///   - The salt used to generate the commit hash.
+        /// * `salt`: The salt used to generate the commit hash.
         ///
-        /// * `version_key` (`u64`):
-        ///   - The network version key.
+        /// * `version_key`: The network version key.
         ///
         /// # Errors
-        /// * `CommitRevealDisabled`:
-        ///   - Attempting to reveal weights when the commit-reveal mechanism is disabled.
+        /// * 'CommitRevealDisabled': Attempting to reveal weights when the commit-reveal mechanism is disabled.
         ///
-        /// * `NoWeightsCommitFound`:
-        ///   - Attempting to reveal weights without an existing commit.
+        /// * 'NoWeightsCommitFound': Attempting to reveal weights without an existing commit.
         ///
-        /// * `ExpiredWeightCommit`:
-        ///   - Attempting to reveal a weight commit that has expired.
+        /// * 'ExpiredWeightCommit': Attempting to reveal a weight commit that has expired.
         ///
-        /// * `RevealTooEarly`:
-        ///   - Attempting to reveal weights outside the valid reveal period.
+        /// * 'RevealTooEarly': Attempting to reveal weights outside the valid reveal period.
         ///
-        /// * `InvalidRevealCommitHashNotMatch`:
-        ///   - The revealed hash does not match any committed hash.
+        /// * 'InvalidRevealCommitHashNotMatch': The revealed hash does not match any committed hash.
         ///
         #[pallet::call_index(116)]
         #[pallet::weight((Weight::from_parts(122_000_000, 0)
@@ -404,14 +352,11 @@ mod dispatches {
         /// Used to commit encrypted commit-reveal v3 weight values to later be revealed.
         ///
         /// # Arguments
-        /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
-        ///   - The committing hotkey.
+        /// * `origin`: The committing hotkey.
         ///
-        /// * `netuid` (`u16`):
-        ///   - The u16 network identifier.
+        /// * `netuid`: The u16 network identifier.
         ///
-        /// * `commit` (`Vec<u8>`):
-        ///   - The encrypted compressed commit.
+        /// * `commit`: The encrypted compressed commit.
         ///     The steps for this are:
         ///     1. Instantiate [`WeightsTlockPayload`]
         ///     2. Serialize it using the `parity_scale_codec::Encode` trait
@@ -424,11 +369,9 @@ mod dispatches {
         ///      epoch.
         ///
         /// # Errors
-        /// * `CommitRevealV3Disabled`:
-        ///   - Attempting to commit when the commit-reveal mechanism is disabled.
+        /// * 'CommitRevealV3Disabled': Attempting to commit when the commit-reveal mechanism is disabled.
         ///
-        /// * `TooManyUnrevealedCommits`:
-        ///   - Attempting to commit when the user has more than the allowed limit of unrevealed commits.
+        /// * 'TooManyUnrevealedCommits': Attempting to commit when the user has more than the allowed limit of unrevealed commits.
         ///
         // #[pallet::call_index(99)]
         // #[pallet::weight((Weight::from_parts(77_750_000, 0)
@@ -446,17 +389,13 @@ mod dispatches {
         /// Used to commit encrypted commit-reveal v3 weight values to later be revealed for mechanisms.
         ///
         /// # Arguments
-        /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
-        ///   - The committing hotkey.
+        /// * `origin`: The committing hotkey.
         ///
-        /// * `netuid` (`u16`):
-        ///   - The u16 network identifier.
+        /// * `netuid`: The u16 network identifier.
         ///
-        /// * `mecid` (`u8`):
-        ///   - The u8 mechanism identifier.
+        /// * `mecid`: The u8 mechanism identifier.
         ///
-        /// * `commit` (`Vec<u8>`):
-        ///   - The encrypted compressed commit.
+        /// * `commit`: The encrypted compressed commit.
         ///     The steps for this are:
         ///     1. Instantiate [`WeightsTlockPayload`]
         ///     2. Serialize it using the `parity_scale_codec::Encode` trait
@@ -469,11 +408,9 @@ mod dispatches {
         ///      epoch.
         ///
         /// # Errors
-        /// * `CommitRevealV3Disabled`:
-        ///   - Attempting to commit when the commit-reveal mechanism is disabled.
+        /// * 'CommitRevealV3Disabled': Attempting to commit when the commit-reveal mechanism is disabled.
         ///
-        /// * `TooManyUnrevealedCommits`:
-        ///   - Attempting to commit when the user has more than the allowed limit of unrevealed commits.
+        /// * 'TooManyUnrevealedCommits': Attempting to commit when the user has more than the allowed limit of unrevealed commits.
         ///
         #[pallet::call_index(117)]
         #[pallet::weight((Weight::from_parts(77_750_000, 0)
@@ -499,42 +436,30 @@ mod dispatches {
         /// The implementation for batch revealing committed weights.
         ///
         /// # Arguments
-        /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
-        ///   - The signature of the revealing hotkey.
+        /// * `origin`: The signature of the revealing hotkey.
         ///
-        /// * `netuid` (`u16`):
-        ///   - The u16 network identifier.
+        /// * `netuid`: The u16 network identifier.
         ///
-        /// * `uids_list` (`Vec<Vec<u16>>`):
-        ///   - A list of uids for each set of weights being revealed.
+        /// * `uids_list`: A list of uids for each set of weights being revealed.
         ///
-        /// * `values_list` (`Vec<Vec<u16>>`):
-        ///   - A list of values for each set of weights being revealed.
+        /// * `values_list`: A list of values for each set of weights being revealed.
         ///
-        /// * `salts_list` (`Vec<Vec<u16>>`):
-        ///   - A list of salts used to generate the commit hashes.
+        /// * `salts_list`: A list of salts used to generate the commit hashes.
         ///
-        /// * `version_keys` (`Vec<u64>`):
-        ///   - A list of network version keys.
+        /// * `version_keys`: A list of network version keys.
         ///
         /// # Errors
-        /// * `CommitRevealDisabled`:
-        ///   - Attempting to reveal weights when the commit-reveal mechanism is disabled.
+        /// * 'CommitRevealDisabled': Attempting to reveal weights when the commit-reveal mechanism is disabled.
         ///
-        /// * `NoWeightsCommitFound`:
-        ///   - Attempting to reveal weights without an existing commit.
+        /// * 'NoWeightsCommitFound': Attempting to reveal weights without an existing commit.
         ///
-        /// * `ExpiredWeightCommit`:
-        ///   - Attempting to reveal a weight commit that has expired.
+        /// * 'ExpiredWeightCommit': Attempting to reveal a weight commit that has expired.
         ///
-        /// * `RevealTooEarly`:
-        ///   - Attempting to reveal weights outside the valid reveal period.
+        /// * 'RevealTooEarly': Attempting to reveal weights outside the valid reveal period.
         ///
-        /// * `InvalidRevealCommitHashNotMatch`:
-        ///   - The revealed hash does not match any committed hash.
+        /// * 'InvalidRevealCommitHashNotMatch': The revealed hash does not match any committed hash.
         ///
-        /// * `InvalidInputLengths`:
-        ///   - The input vectors are of mismatched lengths.
+        /// * 'InvalidInputLengths': The input vectors are of mismatched lengths.
         #[pallet::call_index(98)]
         #[pallet::weight((<T as crate::pallet::Config>::WeightInfo::batch_reveal_weights(), DispatchClass::Normal, Pays::No))]
         pub fn batch_reveal_weights(
@@ -558,17 +483,13 @@ mod dispatches {
         /// Allows delegates to decrease its take value.
         ///
         /// # Arguments
-        /// * 'origin': (<T as frame_system::Config>::Origin):
-        /// 	- The signature of the caller's coldkey.
+        /// * `origin`: The signature of the caller's coldkey.
         ///
-        /// * 'hotkey' (T::AccountId):
-        /// 	- The hotkey we are delegating (must be owned by the coldkey.)
+        /// * `hotkey`: The hotkey we are delegating (must be owned by the coldkey.).
         ///
-        /// * 'netuid' (u16):
-        /// 	- Subnet ID to decrease take for
+        /// * `netuid`: Subnet ID to decrease take for.
         ///
-        /// * 'take' (u16):
-        /// 	- The new stake proportion that this hotkey takes from delegations.
+        /// * `take`: The new stake proportion that this hotkey takes from delegations.
         ///        The new value can be between 0 and 11_796 and should be strictly
         ///        lower than the previous value. It T is the new value (rational number),
         ///        the the parameter is calculated as [65535 * T]. For example, 1% would be
@@ -597,14 +518,11 @@ mod dispatches {
         /// Allows delegates to increase its take value. This call is rate-limited.
         ///
         /// # Arguments
-        /// * 'origin': (<T as frame_system::Config>::Origin):
-        /// 	- The signature of the caller's coldkey.
+        /// * `origin`: The signature of the caller's coldkey.
         ///
-        /// * 'hotkey' (T::AccountId):
-        /// 	- The hotkey we are delegating (must be owned by the coldkey.)
+        /// * `hotkey`: The hotkey we are delegating (must be owned by the coldkey.).
         ///
-        /// * 'take' (u16):
-        /// 	- The new stake proportion that this hotkey takes from delegations.
+        /// * `take`: The new stake proportion that this hotkey takes from delegations.
         ///        The new value can be between 0 and 11_796 and should be strictly
         ///        greater than the previous value. T is the new value (rational number),
         ///        the the parameter is calculated as [65535 * T]. For example, 1% would be
@@ -638,17 +556,13 @@ mod dispatches {
         /// delegating to themselves.
         ///
         /// # Arguments
-        ///  * 'origin': (<T as frame_system::Config>Origin):
-        /// 	- The signature of the caller's coldkey.
+        /// * `origin`: The signature of the caller's coldkey.
         ///
-        ///  * 'hotkey' (T::AccountId):
-        /// 	- The associated hotkey account.
+        /// * `hotkey`: The associated hotkey account.
         ///
-        /// * 'netuid' (u16):
-        ///     - Subnetwork UID
+        /// * `netuid`: Subnetwork UID.
         ///
-        ///  * 'amount_staked' (u64):
-        /// 	- The amount of stake to be added to the hotkey staking account.
+        /// * `amount_staked`: The amount of stake to be added to the hotkey staking account.
         ///
         /// # Events
         /// * 'StakeAdded': On the successfully adding stake to a global account.
@@ -676,17 +590,13 @@ mod dispatches {
         /// has permission to make staking and unstaking requests.
         ///
         /// # Arguments
-        /// * 'origin': (<T as frame_system::Config>Origin):
-        /// 	- The signature of the caller's coldkey.
+        /// * `origin`: The signature of the caller's coldkey.
         ///
-        /// * 'hotkey' (T::AccountId):
-        /// 	- The associated hotkey account.
+        /// * `hotkey`: The associated hotkey account.
         ///
-        /// * 'netuid' (u16):
-        ///     - Subnetwork UID
+        /// * `netuid`: Subnetwork UID.
         ///
-        /// * 'amount_unstaked' (u64):
-        /// 	- The amount of stake to be added to the hotkey staking account.
+        /// * `amount_unstaked`: The amount of stake to be added to the hotkey staking account.
         ///
         /// # Events
         /// * 'StakeRemoved': On the successfully removing stake from the hotkey account.
@@ -715,32 +625,23 @@ mod dispatches {
         /// already registered the metadata is updated. If the caller is not registered this call throws NotRegistered.
         ///
         /// # Arguments
-        /// * 'origin': (<T as frame_system::Config>Origin):
-        /// 	- The signature of the caller.
+        /// * `origin`: The signature of the caller.
         ///
-        /// * 'netuid' (u16):
-        /// 	- The u16 network identifier.
+        /// * `netuid`: The u16 network identifier.
         ///
-        /// * 'version' (u64):
-        /// 	- The bittensor version identifier.
+        /// * `version`: The bittensor version identifier.
         ///
-        /// * 'ip' (u64):
-        /// 	- The endpoint ip information as a u128 encoded integer.
+        /// * `ip`: The endpoint ip information as a u128 encoded integer.
         ///
-        /// * 'port' (u16):
-        /// 	- The endpoint port information as a u16 encoded integer.
+        /// * `port`: The endpoint port information as a u16 encoded integer.
         ///
-        /// * 'ip_type' (u8):
-        /// 	- The endpoint ip version as a u8, 4 or 6.
+        /// * `ip_type`: The endpoint ip version as a u8, 4 or 6.
         ///
-        /// * 'protocol' (u8):
-        /// 	- UDP:1 or TCP:0
+        /// * `protocol`: UDP:1 or TCP:0.
         ///
-        /// * 'placeholder1' (u8):
-        /// 	- Placeholder for further extra params.
+        /// * `placeholder1`: Placeholder for further extra params.
         ///
-        /// * 'placeholder2' (u8):
-        /// 	- Placeholder for further extra params.
+        /// * `placeholder2`: Placeholder for further extra params.
         ///
         /// # Events
         /// * 'AxonServed': On successfully serving the axon info.
@@ -788,35 +689,25 @@ mod dispatches {
         /// already registered the metadata is updated. If the caller is not registered this call throws NotRegistered.
         ///
         /// # Arguments
-        /// * 'origin': (<T as frame_system::Config>Origin):
-        /// 	- The signature of the caller.
+        /// * `origin`: The signature of the caller.
         ///
-        /// * 'netuid' (u16):
-        /// 	- The u16 network identifier.
+        /// * `netuid`: The u16 network identifier.
         ///
-        /// * 'version' (u64):
-        /// 	- The bittensor version identifier.
+        /// * `version`: The bittensor version identifier.
         ///
-        /// * 'ip' (u64):
-        /// 	- The endpoint ip information as a u128 encoded integer.
+        /// * `ip`: The endpoint ip information as a u128 encoded integer.
         ///
-        /// * 'port' (u16):
-        /// 	- The endpoint port information as a u16 encoded integer.
+        /// * `port`: The endpoint port information as a u16 encoded integer.
         ///
-        /// * 'ip_type' (u8):
-        /// 	- The endpoint ip version as a u8, 4 or 6.
+        /// * `ip_type`: The endpoint ip version as a u8, 4 or 6.
         ///
-        /// * 'protocol' (u8):
-        /// 	- UDP:1 or TCP:0
+        /// * `protocol`: UDP:1 or TCP:0.
         ///
-        /// * 'placeholder1' (u8):
-        /// 	- Placeholder for further extra params.
+        /// * `placeholder1`: Placeholder for further extra params.
         ///
-        /// * 'placeholder2' (u8):
-        /// 	- Placeholder for further extra params.
+        /// * `placeholder2`: Placeholder for further extra params.
         ///
-        /// * 'certificate' (Vec<u8>):
-        ///     - TLS certificate for inter neuron communitation.
+        /// * `certificate`: TLS certificate for inter neuron communitation.
         ///
         /// # Events
         /// * 'AxonServed': On successfully serving the axon info.
@@ -862,23 +753,17 @@ mod dispatches {
 
         /// Set prometheus information for the neuron.
         /// # Arguments
-        /// * 'origin': (<T as frame_system::Config>Origin):
-        /// 	- The signature of the calling hotkey.
+        /// * `origin`: The signature of the calling hotkey.
         ///
-        /// * 'netuid' (u16):
-        /// 	- The u16 network identifier.
+        /// * `netuid`: The u16 network identifier.
         ///
-        /// * 'version' (u16):
-        /// 	-  The bittensor version identifier.
+        /// * `version`: The bittensor version identifier.
         ///
-        /// * 'ip' (u128):
-        /// 	- The prometheus ip information as a u128 encoded integer.
+        /// * `ip`: The prometheus ip information as a u128 encoded integer.
         ///
-        /// * 'port' (u16):
-        /// 	- The prometheus port information as a u16 encoded integer.
+        /// * `port`: The prometheus port information as a u16 encoded integer.
         ///
-        /// * 'ip_type' (u8):
-        /// 	- The ip type v4 or v6.
+        /// * `ip_type`: The ip type v4 or v6.
         ///
         #[pallet::call_index(5)]
         #[pallet::weight((<T as crate::pallet::Config>::WeightInfo::serve_prometheus(), DispatchClass::Normal, Pays::No))]
@@ -896,26 +781,19 @@ mod dispatches {
         /// Registers a new neuron to the subnetwork.
         ///
         /// # Arguments
-        /// * 'origin': (<T as frame_system::Config>Origin):
-        /// 	- The signature of the calling hotkey.
+        /// * `origin`: The signature of the calling hotkey.
         ///
-        /// * 'netuid' (u16):
-        /// 	- The u16 network identifier.
+        /// * `netuid`: The u16 network identifier.
         ///
-        /// * 'block_number' ( u64 ):
-        /// 	- Block hash used to prove work done.
+        /// * `block_number`: Block hash used to prove work done.
         ///
-        /// * 'nonce' ( u64 ):
-        /// 	- Positive integer nonce used in POW.
+        /// * `nonce`: Positive integer nonce used in POW.
         ///
-        /// * 'work' ( Vec<u8> ):
-        /// 	- Vector encoded bytes representing work done.
+        /// * `work`: Vector encoded bytes representing work done.
         ///
-        /// * 'hotkey' ( T::AccountId ):
-        /// 	- Hotkey to be registered to the network.
+        /// * `hotkey`: Hotkey to be registered to the network.
         ///
-        /// * 'coldkey' ( T::AccountId ):
-        /// 	- Associated coldkey account.
+        /// * `coldkey`: Associated coldkey account.
         ///
         /// # Events
         /// * 'NeuronRegistered': On successfully registering a uid to a neuron slot on a subnetwork.
@@ -968,10 +846,10 @@ mod dispatches {
         /// The extrinsic for user to change its hotkey in subnet or all subnets.
         ///
         /// # Arguments
-        /// * `origin` - The origin of the transaction (must be signed by the coldkey).
-        /// * `hotkey` - The old hotkey to be swapped.
-        /// * `new_hotkey` - The new hotkey to replace the old one.
-        /// * `netuid` - Optional subnet ID. If `Some`, swap only on that subnet; if `None`, swap on all subnets.
+        /// * `origin`: The origin of the transaction (must be signed by the coldkey).
+        /// * `hotkey`: The old hotkey to be swapped.
+        /// * `new_hotkey`: The new hotkey to replace the old one.
+        /// * `netuid`: Optional subnet ID. If `Some`, swap only on that subnet; if `None`, swap on all subnets.
         ///   is transferred to the new hotkey.
         #[deprecated(
             note = "Please use swap_hotkey_v2 instead. This extrinsic will be removed some time after June 2026."
@@ -992,11 +870,11 @@ mod dispatches {
         /// a root key to a child key
         ///
         /// # Arguments
-        /// * `origin` - The origin of the transaction (must be signed by the coldkey).
-        /// * `hotkey` - The old hotkey to be swapped.
-        /// * `new_hotkey` - The new hotkey to replace the old one.
-        /// * `netuid` - Optional subnet ID. If `Some`, swap only on that subnet; if `None`, swap on all subnets.
-        /// * `keep_stake` - If `true`, stake remains on the old hotkey and the rest metadata
+        /// * `origin`: The origin of the transaction (must be signed by the coldkey).
+        /// * `hotkey`: The old hotkey to be swapped.
+        /// * `new_hotkey`: The new hotkey to replace the old one.
+        /// * `netuid`: Optional subnet ID. If `Some`, swap only on that subnet; if `None`, swap on all subnets.
+        /// * `keep_stake`: If `true`, stake remains on the old hotkey and the rest metadata.
         ///   is transferred to the new hotkey.
         #[pallet::call_index(72)]
         #[pallet::weight((Weight::from_parts(275_300_000, 0)
@@ -1044,27 +922,19 @@ mod dispatches {
         /// when distributing stake to its children.
         ///
         /// # Arguments
-        /// * `origin` (<T as frame_system::Config>::RuntimeOrigin):
-        ///     - The signature of the calling coldkey. Setting childkey take can only be done by the coldkey.
+        /// * `origin`: The signature of the calling coldkey. Setting childkey take can only be done by the coldkey.
         ///
-        /// * `hotkey` (T::AccountId):
-        ///     - The hotkey for which the childkey take will be set.
+        /// * `hotkey`: The hotkey for which the childkey take will be set.
         ///
-        /// * `take` (u16):
-        ///     - The new childkey take value. This is a percentage represented as a value between 0 and 10000,
-        ///       where 10000 represents 100%.
+        /// * `take`: The new childkey take value. This is a percentage represented as a value between 0 and 10000, where 10000 represents 100%.
         ///
         /// # Events
-        /// * `ChildkeyTakeSet`:
-        ///     - On successfully setting the childkey take for a hotkey.
+        /// * 'ChildkeyTakeSet': On successfully setting the childkey take for a hotkey.
         ///
         /// # Errors
-        /// * `NonAssociatedColdKey`:
-        ///     - The coldkey does not own the hotkey.
-        /// * `InvalidChildkeyTake`:
-        ///     - The provided take value is invalid (greater than the maximum allowed take).
-        /// * `TxChildkeyTakeRateLimitExceeded`:
-        ///     - The rate limit for changing childkey take has been exceeded.
+        /// * 'NonAssociatedColdKey': The coldkey does not own the hotkey.
+        /// * 'InvalidChildkeyTake': The provided take value is invalid (greater than the maximum allowed take).
+        /// * 'TxChildkeyTakeRateLimitExceeded': The rate limit for changing childkey take has been exceeded.
         ///
         #[pallet::call_index(75)]
         #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::set_childkey_take())]
@@ -1087,8 +957,8 @@ mod dispatches {
         /// This function can only be called by the root origin.
         ///
         /// # Arguments
-        /// * `origin` - The origin of the call, must be root.
-        /// * `tx_rate_limit` - The new rate limit in blocks.
+        /// * `origin`: The origin of the call, must be root.
+        /// * `tx_rate_limit`: The new rate limit in blocks.
         ///
         /// # Errors
         /// * 'BadOrigin': If the origin is not root.
@@ -1109,8 +979,8 @@ mod dispatches {
         /// This function can only be called by the root origin.
         ///
         /// # Arguments
-        /// * `origin` - The origin of the call, must be root.
-        /// * `take` - The new minimum childkey take value.
+        /// * `origin`: The origin of the call, must be root.
+        /// * `take`: The new minimum childkey take value.
         ///
         /// # Errors
         /// * 'BadOrigin': If the origin is not root.
@@ -1130,8 +1000,8 @@ mod dispatches {
         /// This function can only be called by the root origin.
         ///
         /// # Arguments
-        /// * `origin` - The origin of the call, must be root.
-        /// * `take` - The new maximum childkey take value.
+        /// * `origin`: The origin of the call, must be root.
+        /// * `take`: The new maximum childkey take value.
         ///
         /// # Errors
         /// * 'BadOrigin': If the origin is not root.
@@ -1195,34 +1065,24 @@ mod dispatches {
         /// The proportion of the hotkey's stake to be allocated to the child is also specified.
         ///
         /// # Arguments
-        /// * `origin` (<T as frame_system::Config>::RuntimeOrigin):
-        ///     - The signature of the calling coldkey. Setting a hotkey child can only be done by the coldkey.
+        /// * `origin`: The signature of the calling coldkey. Setting a hotkey child can only be done by the coldkey.
         ///
-        /// * `hotkey` (T::AccountId):
-        ///     - The hotkey which will be assigned the child.
+        /// * `hotkey`: The hotkey which will be assigned the child.
         ///
-        /// * `child` (T::AccountId):
-        ///     - The child which will be assigned to the hotkey.
+        /// * `child`: The child which will be assigned to the hotkey.
         ///
-        /// * `netuid` (u16):
-        ///     - The u16 network identifier where the childkey will exist.
+        /// * `netuid`: The u16 network identifier where the childkey will exist.
         ///
-        /// * `proportion` (u64):
-        ///     - Proportion of the hotkey's stake to be given to the child, the value must be u64 normalized.
+        /// * `proportion`: Proportion of the hotkey's stake to be given to the child, the value must be u64 normalized.
         ///
         /// # Events
-        /// * `ChildAddedSingular`:
-        ///     - On successfully registering a child to a hotkey.
+        /// * 'ChildAddedSingular': On successfully registering a child to a hotkey.
         ///
         /// # Errors
-        /// * `MechanismDoesNotExist`:
-        ///     - Attempting to register to a non-existent network.
-        /// * `RegistrationNotPermittedOnRootSubnet`:
-        ///     - Attempting to register a child on the root network.
-        /// * `NonAssociatedColdKey`:
-        ///     - The coldkey does not own the hotkey or the child is the same as the hotkey.
-        /// * `HotKeyAccountNotExists`:
-        ///     - The hotkey account does not exist.
+        /// * 'MechanismDoesNotExist': Attempting to register to a non-existent network.
+        /// * 'RegistrationNotPermittedOnRootSubnet': Attempting to register a child on the root network.
+        /// * 'NonAssociatedColdKey': The coldkey does not own the hotkey or the child is the same as the hotkey.
+        /// * 'HotKeyAccountNotExists': The hotkey account does not exist.
         ///
         /// # Note
         /// 1. **Signature Verification**: Ensures that the caller has signed the transaction, verifying the coldkey.
@@ -1265,23 +1125,17 @@ mod dispatches {
 
         /// Set prometheus information for the neuron.
         /// # Arguments
-        /// * 'origin': (<T as frame_system::Config>Origin):
-        /// 	- The signature of the calling hotkey.
+        /// * `origin`: The signature of the calling hotkey.
         ///
-        /// * 'netuid' (u16):
-        /// 	- The u16 network identifier.
+        /// * `netuid`: The u16 network identifier.
         ///
-        /// * 'version' (u16):
-        /// 	-  The bittensor version identifier.
+        /// * `version`: The bittensor version identifier.
         ///
-        /// * 'ip' (u128):
-        /// 	- The prometheus ip information as a u128 encoded integer.
+        /// * `ip`: The prometheus ip information as a u128 encoded integer.
         ///
-        /// * 'port' (u16):
-        /// 	- The prometheus port information as a u16 encoded integer.
+        /// * `port`: The prometheus port information as a u16 encoded integer.
         ///
-        /// * 'ip_type' (u8):
-        /// 	- The ip type v4 or v6.
+        /// * `ip_type`: The ip type v4 or v6.
         ///
         #[pallet::call_index(68)]
         #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::set_identity())]
@@ -1309,20 +1163,15 @@ mod dispatches {
 
         /// Set the identity information for a subnet.
         /// # Arguments
-        /// * `origin` - (<T as frame_system::Config>::Origin):
-        ///     - The signature of the calling coldkey, which must be the owner of the subnet.
+        /// * `origin`: The signature of the calling coldkey, which must be the owner of the subnet.
         ///
-        /// * `netuid` (u16):
-        ///     - The unique network identifier of the subnet.
+        /// * `netuid`: The unique network identifier of the subnet.
         ///
-        /// * `subnet_name` (Vec<u8>):
-        ///     - The name of the subnet.
+        /// * `subnet_name`: The name of the subnet.
         ///
-        /// * `github_repo` (Vec<u8>):
-        ///     - The GitHub repository associated with the subnet identity.
+        /// * `github_repo`: The GitHub repository associated with the subnet identity.
         ///
-        /// * `subnet_contact` (Vec<u8>):
-        ///     - The contact information for the subnet.
+        /// * `subnet_contact`: The contact information for the subnet.
         #[pallet::call_index(78)]
         #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::set_subnet_identity())]
         pub fn set_subnet_identity(
@@ -1365,27 +1214,21 @@ mod dispatches {
         /// The implementation for the extrinsic unstake_all: Removes all stake from a hotkey account across all subnets and adds it onto a coldkey.
         ///
         /// # Arguments
-        /// * `origin` - (<T as frame_system::Config>::Origin):
-        ///     - The signature of the caller's coldkey.
+        /// * `origin`: The signature of the caller's coldkey.
         ///
-        /// * `hotkey` (T::AccountId):
-        ///     - The associated hotkey account.
+        /// * `hotkey`: The associated hotkey account.
         ///
         /// # Events
         /// * 'StakeRemoved': On the successfully removing stake from the hotkey account.
         ///
         /// # Errors
-        /// * `NotRegistered`:
-        ///     - Thrown if the account we are attempting to unstake from is non existent.
+        /// * 'NotRegistered': Thrown if the account we are attempting to unstake from is non existent.
         ///
-        /// * `NonAssociatedColdKey`:
-        ///     - Thrown if the coldkey does not own the hotkey we are unstaking from.
+        /// * 'NonAssociatedColdKey': Thrown if the coldkey does not own the hotkey we are unstaking from.
         ///
-        /// * `NotEnoughStakeToWithdraw`:
-        ///     - Thrown if there is not enough stake on the hotkey to withdraw this amount.
+        /// * 'NotEnoughStakeToWithdraw': Thrown if there is not enough stake on the hotkey to withdraw this amount.
         ///
-        /// * `TxRateLimitExceeded`:
-        ///     - Thrown if key has hit transaction rate limit
+        /// * 'TxRateLimitExceeded': Thrown if key has hit transaction rate limit.
         #[pallet::call_index(83)]
         #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::unstake_all())]
         pub fn unstake_all(origin: OriginFor<T>, hotkey: T::AccountId) -> DispatchResult {
@@ -1395,27 +1238,21 @@ mod dispatches {
         /// The implementation for the extrinsic unstake_all: Removes all stake from a hotkey account across all subnets and adds it onto a coldkey.
         ///
         /// # Arguments
-        /// * `origin` - (<T as frame_system::Config>::Origin):
-        ///     - The signature of the caller's coldkey.
+        /// * `origin`: The signature of the caller's coldkey.
         ///
-        /// * `hotkey` (T::AccountId):
-        ///     - The associated hotkey account.
+        /// * `hotkey`: The associated hotkey account.
         ///
         /// # Events
         /// * 'StakeRemoved': On the successfully removing stake from the hotkey account.
         ///
         /// # Errors
-        /// * `NotRegistered`:
-        ///     - Thrown if the account we are attempting to unstake from is non existent.
+        /// * 'NotRegistered': Thrown if the account we are attempting to unstake from is non existent.
         ///
-        /// * `NonAssociatedColdKey`:
-        ///     - Thrown if the coldkey does not own the hotkey we are unstaking from.
+        /// * 'NonAssociatedColdKey': Thrown if the coldkey does not own the hotkey we are unstaking from.
         ///
-        /// * `NotEnoughStakeToWithdraw`:
-        ///     - Thrown if there is not enough stake on the hotkey to withdraw this amount.
+        /// * 'NotEnoughStakeToWithdraw': Thrown if there is not enough stake on the hotkey to withdraw this amount.
         ///
-        /// * `TxRateLimitExceeded`:
-        ///     - Thrown if key has hit transaction rate limit
+        /// * 'TxRateLimitExceeded': Thrown if key has hit transaction rate limit.
         #[pallet::call_index(84)]
         #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::unstake_all_alpha())]
         pub fn unstake_all_alpha(origin: OriginFor<T>, hotkey: T::AccountId) -> DispatchResult {
@@ -1425,23 +1262,17 @@ mod dispatches {
         /// The implementation for the extrinsic move_stake: Moves specified amount of stake from a hotkey to another across subnets.
         ///
         /// # Arguments
-        /// * `origin` - (<T as frame_system::Config>::Origin):
-        ///     - The signature of the caller's coldkey.
+        /// * `origin`: The signature of the caller's coldkey.
         ///
-        /// * `origin_hotkey` (T::AccountId):
-        ///     - The hotkey account to move stake from.
+        /// * `origin_hotkey`: The hotkey account to move stake from.
         ///
-        /// * `destination_hotkey` (T::AccountId):
-        ///     - The hotkey account to move stake to.
+        /// * `destination_hotkey`: The hotkey account to move stake to.
         ///
-        /// * `origin_netuid` (T::AccountId):
-        ///     - The subnet ID to move stake from.
+        /// * `origin_netuid`: The subnet ID to move stake from.
         ///
-        /// * `destination_netuid` (T::AccountId):
-        ///     - The subnet ID to move stake to.
+        /// * `destination_netuid`: The subnet ID to move stake to.
         ///
-        /// * `alpha_amount` (T::AccountId):
-        ///     - The alpha stake amount to move.
+        /// * `alpha_amount`: The alpha stake amount to move.
         ///
         #[pallet::call_index(85)]
         #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::move_stake())]
@@ -1467,12 +1298,12 @@ mod dispatches {
         /// while keeping the same hotkey.
         ///
         /// # Arguments
-        /// * `origin` - The origin of the transaction, which must be signed by the `origin_coldkey`.
-        /// * `destination_coldkey` - The coldkey to which the stake is transferred.
-        /// * `hotkey` - The hotkey associated with the stake.
-        /// * `origin_netuid` - The network/subnet ID to move stake from.
-        /// * `destination_netuid` - The network/subnet ID to move stake to (for cross-subnet transfer).
-        /// * `alpha_amount` - The amount of stake to transfer.
+        /// * `origin`: The origin of the transaction, which must be signed by the `origin_coldkey`.
+        /// * `destination_coldkey`: The coldkey to which the stake is transferred.
+        /// * `hotkey`: The hotkey associated with the stake.
+        /// * `origin_netuid`: The network/subnet ID to move stake from.
+        /// * `destination_netuid`: The network/subnet ID to move stake to (for cross-subnet transfer).
+        /// * `alpha_amount`: The amount of stake to transfer.
         ///
         /// # Errors
         /// * 'BadOrigin': The transaction is not signed by `origin_coldkey`.
@@ -1510,11 +1341,11 @@ mod dispatches {
         /// Swaps a specified amount of stake from one subnet to another, while keeping the same coldkey and hotkey.
         ///
         /// # Arguments
-        /// * `origin` - The origin of the transaction, which must be signed by the coldkey that owns the `hotkey`.
-        /// * `hotkey` - The hotkey whose stake is being swapped.
-        /// * `origin_netuid` - The network/subnet ID from which stake is removed.
-        /// * `destination_netuid` - The network/subnet ID to which stake is added.
-        /// * `alpha_amount` - The amount of stake to swap.
+        /// * `origin`: The origin of the transaction, which must be signed by the coldkey that owns the `hotkey`.
+        /// * `hotkey`: The hotkey whose stake is being swapped.
+        /// * `origin_netuid`: The network/subnet ID from which stake is removed.
+        /// * `destination_netuid`: The network/subnet ID to which stake is added.
+        /// * `alpha_amount`: The amount of stake to swap.
         ///
         /// # Errors
         /// * 'BadOrigin': The transaction is not signed by the coldkey that owns `hotkey`.
@@ -1555,23 +1386,17 @@ mod dispatches {
         /// at all.
         ///
         /// # Arguments
-        ///  * 'origin': (<T as frame_system::Config>Origin):
-        /// 	- The signature of the caller's coldkey.
+        /// * `origin`: The signature of the caller's coldkey.
         ///
-        ///  * 'hotkey' (T::AccountId):
-        /// 	- The associated hotkey account.
+        /// * `hotkey`: The associated hotkey account.
         ///
-        /// * 'netuid' (u16):
-        ///     - Subnetwork UID
+        /// * `netuid`: Subnetwork UID.
         ///
-        ///  * 'amount_staked' (u64):
-        /// 	- The amount of stake to be added to the hotkey staking account.
+        /// * `amount_staked`: The amount of stake to be added to the hotkey staking account.
         ///
-        ///  * 'limit_price' (u64):
-        /// 	- The limit price expressed in units of RAO per one Alpha.
+        /// * `limit_price`: The limit price expressed in units of RAO per one Alpha.
         ///
-        ///  * 'allow_partial' (bool):
-        /// 	- Allows partial execution of the amount. If set to false, this becomes
+        /// * `allow_partial`: Allows partial execution of the amount. If set to false, this becomes.
         ///       fill or kill type or order.
         ///
         /// # Events
@@ -1614,23 +1439,17 @@ mod dispatches {
         /// at all.
         ///
         /// # Arguments
-        /// * 'origin': (<T as frame_system::Config>Origin):
-        /// 	- The signature of the caller's coldkey.
+        /// * `origin`: The signature of the caller's coldkey.
         ///
-        /// * 'hotkey' (T::AccountId):
-        /// 	- The associated hotkey account.
+        /// * `hotkey`: The associated hotkey account.
         ///
-        /// * 'netuid' (u16):
-        ///     - Subnetwork UID
+        /// * `netuid`: Subnetwork UID.
         ///
-        /// * 'amount_unstaked' (u64):
-        /// 	- The amount of stake to be added to the hotkey staking account.
+        /// * `amount_unstaked`: The amount of stake to be added to the hotkey staking account.
         ///
-        ///  * 'limit_price' (u64):
-        ///     - The limit price expressed in units of RAO per one Alpha.
+        /// * `limit_price`: The limit price expressed in units of RAO per one Alpha.
         ///
-        ///  * 'allow_partial' (bool):
-        ///     - Allows partial execution of the amount. If set to false, this becomes
+        /// * `allow_partial`: Allows partial execution of the amount. If set to false, this becomes.
         ///       fill or kill type or order.
         ///
         /// # Events
@@ -1666,13 +1485,13 @@ mod dispatches {
         /// Swaps a specified amount of stake from one subnet to another, while keeping the same coldkey and hotkey.
         ///
         /// # Arguments
-        /// * `origin` - The origin of the transaction, which must be signed by the coldkey that owns the `hotkey`.
-        /// * `hotkey` - The hotkey whose stake is being swapped.
-        /// * `origin_netuid` - The network/subnet ID from which stake is removed.
-        /// * `destination_netuid` - The network/subnet ID to which stake is added.
-        /// * `alpha_amount` - The amount of stake to swap.
-        /// * `limit_price` - The limit price expressed in units of RAO per one Alpha.
-        /// * `allow_partial` - Allows partial execution of the amount. If set to false, this becomes fill or kill type or order.
+        /// * `origin`: The origin of the transaction, which must be signed by the coldkey that owns the `hotkey`.
+        /// * `hotkey`: The hotkey whose stake is being swapped.
+        /// * `origin_netuid`: The network/subnet ID from which stake is removed.
+        /// * `destination_netuid`: The network/subnet ID to which stake is added.
+        /// * `alpha_amount`: The amount of stake to swap.
+        /// * `limit_price`: The limit price expressed in units of RAO per one Alpha.
+        /// * `allow_partial`: Allows partial execution of the amount. If set to false, this becomes fill or kill type or order.
         ///
         /// # Errors
         /// * 'BadOrigin': The transaction is not signed by the coldkey that owns `hotkey`.
@@ -1713,8 +1532,8 @@ mod dispatches {
         /// Attempts to associate a hotkey with a coldkey.
         ///
         /// # Arguments
-        /// * `origin` - The origin of the transaction, which must be signed by the coldkey that owns the `hotkey`.
-        /// * `hotkey` - The hotkey to associate with the coldkey.
+        /// * `origin`: The origin of the transaction, which must be signed by the coldkey that owns the `hotkey`.
+        /// * `hotkey`: The hotkey to associate with the coldkey.
         ///
         /// # Note
         /// Will charge based on the weight even if the hotkey is already associated with a coldkey.
@@ -1731,8 +1550,8 @@ mod dispatches {
         /// Initiates a call on a subnet.
         ///
         /// # Arguments
-        /// * `origin` - The origin of the call, which must be signed by the subnet owner.
-        /// * `netuid` - The unique identifier of the subnet on which the call is being initiated.
+        /// * `origin`: The origin of the call, which must be signed by the subnet owner.
+        /// * `netuid`: The unique identifier of the subnet on which the call is being initiated.
         ///
         /// # Events
         /// Emits a `FirstEmissionBlockNumberSet` event on success.
@@ -1753,11 +1572,11 @@ mod dispatches {
         /// ```
         ///
         /// # Arguments
-        /// * `origin` - The origin of the transaction, which must be signed by the `hotkey`.
-        /// * `netuid` - The netuid that the `hotkey` belongs to.
-        /// * `evm_key` - The EVM key to associate with the `hotkey`.
-        /// * `block_number` - The block number used in the `signature`.
-        /// * `signature` - A signed message by the `evm_key` containing the `hotkey` and the hashed `block_number`.
+        /// * `origin`: The origin of the transaction, which must be signed by the `hotkey`.
+        /// * `netuid`: The netuid that the `hotkey` belongs to.
+        /// * `evm_key`: The EVM key to associate with the `hotkey`.
+        /// * `block_number`: The block number used in the `signature`.
+        /// * `signature`: A signed message by the `evm_key` containing the `hotkey` and the hashed `block_number`.
         ///
         /// # Errors
         /// * 'BadOrigin': The transaction is not signed.
@@ -1787,10 +1606,10 @@ mod dispatches {
         /// Recycles alpha from a cold/hot key pair, reducing AlphaOut on a subnet
         ///
         /// # Arguments
-        /// * `origin` - The origin of the call (must be signed by the coldkey)
-        /// * `hotkey` - The hotkey account
-        /// * `amount` - The amount of alpha to recycle
-        /// * `netuid` - The subnet ID
+        /// * `origin`: The origin of the call (must be signed by the coldkey).
+        /// * `hotkey`: The hotkey account.
+        /// * `amount`: The amount of alpha to recycle.
+        /// * `netuid`: The subnet ID.
         ///
         /// # Events
         /// Emits a `TokensRecycled` event on success.
@@ -1808,10 +1627,10 @@ mod dispatches {
         /// Burns alpha from a cold/hot key pair without reducing `AlphaOut`
         ///
         /// # Arguments
-        /// * `origin` - The origin of the call (must be signed by the coldkey)
-        /// * `hotkey` - The hotkey account
-        /// * `amount` - The amount of alpha to burn
-        /// * `netuid` - The subnet ID
+        /// * `origin`: The origin of the call (must be signed by the coldkey).
+        /// * `hotkey`: The hotkey account.
+        /// * `amount`: The amount of alpha to burn.
+        /// * `netuid`: The subnet ID.
         ///
         /// # Events
         /// Emits a `TokensBurned` event on success.
@@ -1862,14 +1681,11 @@ mod dispatches {
         /// The leftover cap is refunded to the contributors and the beneficiary.
         ///
         /// # Arguments
-        /// * `origin` - (<T as frame_system::Config>::Origin):
-        ///     - The signature of the caller's coldkey.
+        /// * `origin`: The signature of the caller's coldkey.
         ///
-        /// * `emissions_share` (Percent):
-        ///     - The share of the emissions that the contributors will receive as dividends.
+        /// * `emissions_share`: The share of the emissions that the contributors will receive as dividends.
         ///
-        /// * `end_block` (Option<BlockNumberFor<T>>):
-        ///     - The block at which the lease will end. If not defined, the lease is perpetual.
+        /// * `end_block`: The block at which the lease will end. If not defined, the lease is perpetual.
         #[pallet::call_index(110)]
         #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::register_leased_network(T::MaxContributors::get()))]
         pub fn register_leased_network(
@@ -1888,14 +1704,11 @@ mod dispatches {
         /// **The hotkey must be owned by the beneficiary coldkey.**
         ///
         /// # Arguments
-        /// * `origin` - (<T as frame_system::Config>::Origin):
-        ///     - The signature of the caller's coldkey.
+        /// * `origin`: The signature of the caller's coldkey.
         ///
-        /// * `lease_id` (LeaseId):
-        ///     - The ID of the lease to terminate.
+        /// * `lease_id`: The ID of the lease to terminate.
         ///
-        /// * `hotkey` (T::AccountId):
-        ///     - The hotkey of the beneficiary to mark as subnet owner hotkey.
+        /// * `hotkey`: The hotkey of the beneficiary to mark as subnet owner hotkey.
         #[pallet::call_index(111)]
         #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::terminate_lease(T::MaxContributors::get()))]
         pub fn terminate_lease(
@@ -1909,9 +1722,9 @@ mod dispatches {
         /// Updates the symbol for a subnet.
         ///
         /// # Arguments
-        /// * `origin` - The origin of the call, which must be the subnet owner or root.
-        /// * `netuid` - The unique identifier of the subnet on which the symbol is being set.
-        /// * `symbol` - The symbol to set for the subnet.
+        /// * `origin`: The origin of the call, which must be the subnet owner or root.
+        /// * `netuid`: The unique identifier of the subnet on which the symbol is being set.
+        /// * `symbol`: The symbol to set for the subnet.
         ///
         /// # Errors
         /// * 'BadOrigin': The transaction is not signed by the subnet owner or root.
@@ -1941,14 +1754,11 @@ mod dispatches {
         /// Used to commit timelock encrypted commit-reveal weight values to later be revealed.
         ///
         /// # Arguments
-        /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
-        ///   - The committing hotkey.
+        /// * `origin`: The committing hotkey.
         ///
-        /// * `netuid` (`u16`):
-        ///   - The u16 network identifier.
+        /// * `netuid`: The u16 network identifier.
         ///
-        /// * `commit` (`Vec<u8>`):
-        ///   - The encrypted compressed commit.
+        /// * `commit`: The encrypted compressed commit.
         ///     The steps for this are:
         ///     1. Instantiate [`WeightsTlockPayload`]
         ///     2. Serialize it using the `parity_scale_codec::Encode` trait
@@ -1986,11 +1796,9 @@ mod dispatches {
         /// will be automatically staked.
         ///
         /// # Arguments
-        /// * `origin` - (<T as frame_system::Config>::Origin):
-        ///     - The signature of the caller's coldkey.
+        /// * `origin`: The signature of the caller's coldkey.
         ///
-        /// * `hotkey` (T::AccountId):
-        ///     - The hotkey account to designate as the autostake destination.
+        /// * `hotkey`: The hotkey account to designate as the autostake destination.
         #[pallet::call_index(114)]
         #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::set_coldkey_auto_stake_hotkey())]
         pub fn set_coldkey_auto_stake_hotkey(
@@ -2039,17 +1847,13 @@ mod dispatches {
         /// a mechanism.
         ///
         /// # Arguments
-        /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
-        ///   - The committing hotkey.
+        /// * `origin`: The committing hotkey.
         ///
-        /// * `netuid` (`u16`):
-        ///   - The u16 network identifier.
+        /// * `netuid`: The u16 network identifier.
         ///
-        /// * `mecid` (`u8`):
-        ///   - The u8 mechanism identifier.
+        /// * `mecid`: The u8 mechanism identifier.
         ///
-        /// * `commit` (`Vec<u8>`):
-        ///   - The encrypted compressed commit.
+        /// * `commit`: The encrypted compressed commit.
         ///     The steps for this are:
         ///     1. Instantiate [`WeightsTlockPayload`]
         ///     2. Serialize it using the `parity_scale_codec::Encode` trait
@@ -2098,8 +1902,7 @@ mod dispatches {
 
         /// Claims the root emissions for a coldkey.
         /// # Arguments
-        /// * 'origin': (<T as frame_system::Config>Origin):
-        /// 	- The signature of the caller's coldkey.
+        /// * `origin`: The signature of the caller's coldkey.
         ///
         /// # Events
         /// * 'RootClaimed': On the successfully claiming the root emissions for a coldkey.
@@ -2128,8 +1931,7 @@ mod dispatches {
 
         /// Sets the root claim type for the coldkey.
         /// # Arguments
-        /// * 'origin': (<T as frame_system::Config>Origin):
-        /// 	- The signature of the caller's coldkey.
+        /// * `origin`: The signature of the caller's coldkey.
         ///
         /// # Events
         /// * 'RootClaimTypeSet': On the successfully setting the root claim type for the coldkey.
@@ -2204,7 +2006,7 @@ mod dispatches {
         ///
         /// # Events
         ///
-        /// * `ColdkeySwapAnnounced`: Emitted on successful announcement.
+        /// * 'ColdkeySwapAnnounced': Emitted on successful announcement.
         #[pallet::call_index(125)]
         #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::announce_coldkey_swap())]
         pub fn announce_coldkey_swap(
@@ -2241,12 +2043,12 @@ mod dispatches {
         ///
         /// # Arguments
         ///
-        /// * `new_coldkey`: The new coldkey to swap to. The BlakeTwo256 hash of the new coldkey must be
+        /// * `new_coldkey`: The new coldkey to swap to. The BlakeTwo256 hash of the new coldkey must be.
         ///   the same as the announced coldkey hash.
         ///
         /// # Events
         ///
-        /// * `ColdkeySwapped`: Emitted on successful swap.
+        /// * 'ColdkeySwapped': Emitted on successful swap.
         #[pallet::call_index(126)]
         #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::swap_coldkey_announced())]
         pub fn swap_coldkey_announced(
@@ -2326,8 +2128,8 @@ mod dispatches {
         /// Voting power starts at 0 and increases over epochs.
         ///
         /// # Arguments
-        /// * `origin` - The origin of the call, must be subnet owner or root.
-        /// * `netuid` - The subnet to enable voting power tracking for.
+        /// * `origin`: The origin of the call, must be subnet owner or root.
+        /// * `netuid`: The subnet to enable voting power tracking for.
         ///
         /// # Errors
         /// * 'SubnetNotExist': If the subnet does not exist.
@@ -2351,8 +2153,8 @@ mod dispatches {
         /// then automatically disable and clear all VotingPower entries for the subnet.
         ///
         /// # Arguments
-        /// * `origin` - The origin of the call, must be subnet owner or root.
-        /// * `netuid` - The subnet to schedule disabling voting power tracking for.
+        /// * `origin`: The origin of the call, must be subnet owner or root.
+        /// * `netuid`: The subnet to schedule disabling voting power tracking for.
         ///
         /// # Errors
         /// * 'SubnetNotExist': If the subnet does not exist.
@@ -2377,9 +2179,9 @@ mod dispatches {
         /// Alpha is stored as u64 with 18 decimal precision (1.0 = 10^18).
         ///
         /// # Arguments
-        /// * `origin` - The origin of the call, must be root.
-        /// * `netuid` - The subnet to set the alpha for.
-        /// * `alpha` - The new alpha value (u64 with 18 decimal precision).
+        /// * `origin`: The origin of the call, must be root.
+        /// * `netuid`: The subnet to set the alpha for.
+        /// * `alpha`: The new alpha value (u64 with 18 decimal precision).
         ///
         /// # Errors
         /// * 'BadOrigin': If the origin is not root.

--- a/pallets/subtensor/src/macros/errors.rs
+++ b/pallets/subtensor/src/macros/errors.rs
@@ -24,8 +24,7 @@ mod errors {
         /// Request to stake, unstake or subscribe is made by a coldkey that is not associated with
         /// the hotkey account.
         NonAssociatedColdKey,
-        /// DEPRECATED: Stake amount to withdraw is zero.
-        // StakeToWithdrawIsZero,
+        // StakeToWithdrawIsZero (deprecated, kept commented out for historical reference).
         /// The caller does not have enought stake to perform this action.
         NotEnoughStake,
         /// The caller is requesting removing more stake than there exists in the staking account.

--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -46,12 +46,13 @@ mod events {
         NeuronRegistered(NetUid, u16, T::AccountId),
         /// multiple uids have been concurrently registered.
         BulkNeuronsRegistered(u16, u16),
-        /// FIXME: Not used yet
+        // FIXME: Not used yet.
+        /// bulk balances have been set (placeholder: this event is currently unused).
         BulkBalancesSet(u16, u16),
         /// max allowed uids has been set for a subnetwork.
         MaxAllowedUidsSet(NetUid, u16),
+        /// max weight limit has been set for a subnet.
         #[deprecated(note = "Max weight limit is now a constant and this event is unused")]
-        /// DEPRECATED: max weight limit updates are no longer supported.
         MaxWeightLimitSet(NetUid, u16),
         /// the difficulty has been set for a subnet.
         DifficultySet(NetUid, u64),

--- a/pallets/subtensor/src/rpc_info/show_subnet.rs
+++ b/pallets/subtensor/src/rpc_info/show_subnet.rs
@@ -46,7 +46,7 @@ impl<T: Config> Pallet<T> {
     ///
     /// # Arguments
     ///
-    /// * `hotkeys` - A vector of hotkeys (account IDs) for which the emission history is to be retrieved.
+    /// * `hotkeys`: A vector of hotkeys (account IDs) for which the emission history is to be retrieved.
     ///
     /// # Returns
     ///
@@ -74,7 +74,7 @@ impl<T: Config> Pallet<T> {
     ///
     /// # Arguments
     ///
-    /// * `netuid` - The unique identifier of the subnet for which the state is to be retrieved.
+    /// * `netuid`: The unique identifier of the subnet for which the state is to be retrieved.
     ///
     /// # Returns
     ///

--- a/pallets/subtensor/src/staking/add_stake.rs
+++ b/pallets/subtensor/src/staking/add_stake.rs
@@ -7,7 +7,7 @@ use super::*;
 impl<T: Config> Pallet<T> {
     /// The implementation for the extrinsic add_stake: Adds stake to a hotkey account.
     ///
-    /// # Args:
+    /// # Arguments
     /// * 'origin': (<T as frame_system::Config>RuntimeOrigin):
     ///     -  The signature of the caller's coldkey.
     ///
@@ -20,11 +20,11 @@ impl<T: Config> Pallet<T> {
     /// * 'stake_to_be_added' (u64):
     ///     -  The amount of stake to be added to the hotkey staking account.
     ///
-    /// # Event:
+    /// # Events
     /// * StakeAdded;
     ///     -  On the successfully adding stake to a global account.
     ///
-    /// # Raises:
+    /// # Errors
     /// * 'NotEnoughBalanceToStake':
     ///     -  Not enough balance on the coldkey to add onto the global account.
     ///
@@ -83,7 +83,7 @@ impl<T: Config> Pallet<T> {
     /// The implementation for the extrinsic add_stake_limit: Adds stake to a hotkey
     /// account on a subnet with price limit.
     ///
-    /// # Args:
+    /// # Arguments
     /// * 'origin': (<T as frame_system::Config>RuntimeOrigin):
     ///     -  The signature of the caller's coldkey.
     ///
@@ -103,11 +103,11 @@ impl<T: Config> Pallet<T> {
     ///     - Allows partial execution of the amount. If set to false, this becomes
     ///       fill or kill type or order.
     ///
-    /// # Event:
+    /// # Events
     /// * StakeAdded;
     ///     -  On the successfully adding stake to a global account.
     ///
-    /// # Raises:
+    /// # Errors
     /// * 'NotEnoughBalanceToStake':
     ///     -  Not enough balance on the coldkey to add onto the global account.
     ///

--- a/pallets/subtensor/src/staking/add_stake.rs
+++ b/pallets/subtensor/src/staking/add_stake.rs
@@ -8,17 +8,13 @@ impl<T: Config> Pallet<T> {
     /// The implementation for the extrinsic add_stake: Adds stake to a hotkey account.
     ///
     /// # Arguments
-    /// * 'origin': (<T as frame_system::Config>RuntimeOrigin):
-    ///     -  The signature of the caller's coldkey.
+    /// * `origin`: The signature of the caller's coldkey.
     ///
-    /// * 'hotkey' (T::AccountId):
-    ///     -  The associated hotkey account.
+    /// * `hotkey`: The associated hotkey account.
     ///
-    /// * 'netuid' (u16):
-    ///     - Subnetwork UID
+    /// * `netuid`: Subnetwork UID.
     ///
-    /// * 'stake_to_be_added' (u64):
-    ///     -  The amount of stake to be added to the hotkey staking account.
+    /// * `stake_to_be_added`: The amount of stake to be added to the hotkey staking account.
     ///
     /// # Events
     /// * 'StakeAdded': On the successfully adding stake to a global account.
@@ -79,24 +75,17 @@ impl<T: Config> Pallet<T> {
     /// account on a subnet with price limit.
     ///
     /// # Arguments
-    /// * 'origin': (<T as frame_system::Config>RuntimeOrigin):
-    ///     -  The signature of the caller's coldkey.
+    /// * `origin`: The signature of the caller's coldkey.
     ///
-    /// * 'hotkey' (T::AccountId):
-    ///     -  The associated hotkey account.
+    /// * `hotkey`: The associated hotkey account.
     ///
-    /// * 'netuid' (u16):
-    ///     - Subnetwork UID
+    /// * `netuid`: Subnetwork UID.
     ///
-    /// * 'stake_to_be_added' (u64):
-    ///     -  The amount of stake to be added to the hotkey staking account.
+    /// * `stake_to_be_added`: The amount of stake to be added to the hotkey staking account.
     ///
-    ///  * 'limit_price' (u64):
-    ///     - The limit price expressed in units of RAO per one Alpha.
+    /// * `limit_price`: The limit price expressed in units of RAO per one Alpha.
     ///
-    ///  * 'allow_partial' (bool):
-    ///     - Allows partial execution of the amount. If set to false, this becomes
-    ///       fill or kill type or order.
+    /// * `allow_partial`: Allows partial execution of the amount. If set to false, this becomes a fill-or-kill order.
     ///
     /// # Events
     /// * 'StakeAdded': On the successfully adding stake to a global account.

--- a/pallets/subtensor/src/staking/add_stake.rs
+++ b/pallets/subtensor/src/staking/add_stake.rs
@@ -21,21 +21,16 @@ impl<T: Config> Pallet<T> {
     ///     -  The amount of stake to be added to the hotkey staking account.
     ///
     /// # Events
-    /// * StakeAdded;
-    ///     -  On the successfully adding stake to a global account.
+    /// * 'StakeAdded': On the successfully adding stake to a global account.
     ///
     /// # Errors
-    /// * 'NotEnoughBalanceToStake':
-    ///     -  Not enough balance on the coldkey to add onto the global account.
+    /// * 'NotEnoughBalanceToStake': Not enough balance on the coldkey to add onto the global account.
     ///
-    /// * 'NonAssociatedColdKey':
-    ///     -  The calling coldkey is not associated with this hotkey.
+    /// * 'NonAssociatedColdKey': The calling coldkey is not associated with this hotkey.
     ///
-    /// * 'BalanceWithdrawalError':
-    ///     -  Errors stemming from transaction pallet.
+    /// * 'BalanceWithdrawalError': Errors stemming from transaction pallet.
     ///
-    /// * 'TxRateLimitExceeded':
-    ///     -  Thrown if key has hit transaction rate limit
+    /// * 'TxRateLimitExceeded': Thrown if key has hit transaction rate limit.
     ///
     pub fn do_add_stake(
         origin: OriginFor<T>,
@@ -104,21 +99,16 @@ impl<T: Config> Pallet<T> {
     ///       fill or kill type or order.
     ///
     /// # Events
-    /// * StakeAdded;
-    ///     -  On the successfully adding stake to a global account.
+    /// * 'StakeAdded': On the successfully adding stake to a global account.
     ///
     /// # Errors
-    /// * 'NotEnoughBalanceToStake':
-    ///     -  Not enough balance on the coldkey to add onto the global account.
+    /// * 'NotEnoughBalanceToStake': Not enough balance on the coldkey to add onto the global account.
     ///
-    /// * 'NonAssociatedColdKey':
-    ///     -  The calling coldkey is not associated with this hotkey.
+    /// * 'NonAssociatedColdKey': The calling coldkey is not associated with this hotkey.
     ///
-    /// * 'BalanceWithdrawalError':
-    ///     -  Errors stemming from transaction pallet.
+    /// * 'BalanceWithdrawalError': Errors stemming from transaction pallet.
     ///
-    /// * 'TxRateLimitExceeded':
-    ///     -  Thrown if key has hit transaction rate limit
+    /// * 'TxRateLimitExceeded': Thrown if key has hit transaction rate limit.
     ///
     pub fn do_add_stake_limit(
         origin: OriginFor<T>,

--- a/pallets/subtensor/src/staking/add_stake.rs
+++ b/pallets/subtensor/src/staking/add_stake.rs
@@ -5,7 +5,7 @@ use subtensor_swap_interface::{Order, SwapHandler};
 use super::*;
 
 impl<T: Config> Pallet<T> {
-    /// ---- The implementation for the extrinsic add_stake: Adds stake to a hotkey account.
+    /// The implementation for the extrinsic add_stake: Adds stake to a hotkey account.
     ///
     /// # Args:
     /// * 'origin': (<T as frame_system::Config>RuntimeOrigin):
@@ -80,7 +80,7 @@ impl<T: Config> Pallet<T> {
         )
     }
 
-    /// ---- The implementation for the extrinsic add_stake_limit: Adds stake to a hotkey
+    /// The implementation for the extrinsic add_stake_limit: Adds stake to a hotkey
     /// account on a subnet with price limit.
     ///
     /// # Args:

--- a/pallets/subtensor/src/staking/decrease_take.rs
+++ b/pallets/subtensor/src/staking/decrease_take.rs
@@ -3,7 +3,7 @@ use super::*;
 impl<T: Config> Pallet<T> {
     /// The implementation for the extrinsic decrease_take
     ///
-    /// # Args:
+    /// # Arguments
     /// * 'origin': (<T as frame_system::Config>::RuntimeOrigin):
     ///     - The signature of the caller's coldkey.
     ///
@@ -13,11 +13,11 @@ impl<T: Config> Pallet<T> {
     /// * 'take' (u16):
     ///     - The stake proportion that this hotkey takes from delegations for subnet ID.
     ///
-    /// # Event:
+    /// # Events
     /// * TakeDecreased;
     ///     - On successfully setting a decreased take for this hotkey.
     ///
-    /// # Raises:
+    /// # Errors
     /// * 'NotRegistered':
     ///     - The hotkey we are delegating is not registered on the network.
     ///

--- a/pallets/subtensor/src/staking/decrease_take.rs
+++ b/pallets/subtensor/src/staking/decrease_take.rs
@@ -4,14 +4,11 @@ impl<T: Config> Pallet<T> {
     /// The implementation for the extrinsic decrease_take
     ///
     /// # Arguments
-    /// * 'origin': (<T as frame_system::Config>::RuntimeOrigin):
-    ///     - The signature of the caller's coldkey.
+    /// * `origin`: The signature of the caller's coldkey.
     ///
-    /// * 'hotkey' (T::AccountId):
-    ///     - The hotkey we are delegating (must be owned by the coldkey.)
+    /// * `hotkey`: The hotkey we are delegating (must be owned by the coldkey.).
     ///
-    /// * 'take' (u16):
-    ///     - The stake proportion that this hotkey takes from delegations for subnet ID.
+    /// * `take`: The stake proportion that this hotkey takes from delegations for subnet ID.
     ///
     /// # Events
     /// * 'TakeDecreased': On successfully setting a decreased take for this hotkey.

--- a/pallets/subtensor/src/staking/decrease_take.rs
+++ b/pallets/subtensor/src/staking/decrease_take.rs
@@ -14,18 +14,14 @@ impl<T: Config> Pallet<T> {
     ///     - The stake proportion that this hotkey takes from delegations for subnet ID.
     ///
     /// # Events
-    /// * TakeDecreased;
-    ///     - On successfully setting a decreased take for this hotkey.
+    /// * 'TakeDecreased': On successfully setting a decreased take for this hotkey.
     ///
     /// # Errors
-    /// * 'NotRegistered':
-    ///     - The hotkey we are delegating is not registered on the network.
+    /// * 'NotRegistered': The hotkey we are delegating is not registered on the network.
     ///
-    /// * 'NonAssociatedColdKey':
-    ///     - The hotkey we are delegating is not owned by the calling coldket.
+    /// * 'NonAssociatedColdKey': The hotkey we are delegating is not owned by the calling coldket.
     ///
-    /// * 'DelegateTakeTooLow':
-    ///     - The delegate is setting a take which is not lower than the previous.
+    /// * 'DelegateTakeTooLow': The delegate is setting a take which is not lower than the previous.
     ///
     pub fn do_decrease_take(
         origin: OriginFor<T>,

--- a/pallets/subtensor/src/staking/decrease_take.rs
+++ b/pallets/subtensor/src/staking/decrease_take.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 impl<T: Config> Pallet<T> {
-    /// ---- The implementation for the extrinsic decrease_take
+    /// The implementation for the extrinsic decrease_take
     ///
     /// # Args:
     /// * 'origin': (<T as frame_system::Config>::RuntimeOrigin):

--- a/pallets/subtensor/src/staking/helpers.rs
+++ b/pallets/subtensor/src/staking/helpers.rs
@@ -162,7 +162,7 @@ impl<T: Config> Pallet<T> {
     /// Returns the coldkey owning this hotkey. This function should only be called for active accounts.
     ///
     /// # Arguments
-    /// * `hotkey` - The hotkey account ID.
+    /// * `hotkey`: The hotkey account ID.
     ///
     /// # Returns
     /// The coldkey account ID that owns the hotkey.
@@ -173,7 +173,7 @@ impl<T: Config> Pallet<T> {
     /// Returns the hotkey take.
     ///
     /// # Arguments
-    /// * `hotkey` - The hotkey account ID.
+    /// * `hotkey`: The hotkey account ID.
     ///
     /// # Returns
     /// The take value of the hotkey.
@@ -188,7 +188,7 @@ impl<T: Config> Pallet<T> {
     /// Returns true if the hotkey account has been created.
     ///
     /// # Arguments
-    /// * `hotkey` - The hotkey account ID.
+    /// * `hotkey`: The hotkey account ID.
     ///
     /// # Returns
     /// True if the hotkey account exists, false otherwise.
@@ -199,8 +199,8 @@ impl<T: Config> Pallet<T> {
     /// Returns true if the passed coldkey owns the hotkey.
     ///
     /// # Arguments
-    /// * `coldkey` - The coldkey account ID.
-    /// * `hotkey` - The hotkey account ID.
+    /// * `coldkey`: The coldkey account ID.
+    /// * `hotkey`: The hotkey account ID.
     ///
     /// # Returns
     /// True if the coldkey owns the hotkey, false otherwise.

--- a/pallets/subtensor/src/staking/increase_take.rs
+++ b/pallets/subtensor/src/staking/increase_take.rs
@@ -14,21 +14,16 @@ impl<T: Config> Pallet<T> {
     ///     - The stake proportion that this hotkey takes from delegations for subnet ID.
     ///
     /// # Events
-    /// * TakeIncreased;
-    ///     - On successfully setting a increased take for this hotkey.
+    /// * 'TakeIncreased': On successfully setting a increased take for this hotkey.
     ///
     /// # Errors
-    /// * 'NotRegistered':
-    ///     - The hotkey we are delegating is not registered on the network.
+    /// * 'NotRegistered': The hotkey we are delegating is not registered on the network.
     ///
-    /// * 'NonAssociatedColdKey':
-    ///     - The hotkey we are delegating is not owned by the calling coldket.
+    /// * 'NonAssociatedColdKey': The hotkey we are delegating is not owned by the calling coldket.
     ///
-    /// * 'TxRateLimitExceeded':
-    ///     - Thrown if key has hit transaction rate limit
+    /// * 'TxRateLimitExceeded': Thrown if key has hit transaction rate limit.
     ///
-    /// * 'DelegateTakeTooLow':
-    ///     - The delegate is setting a take which is not greater than the previous.
+    /// * 'DelegateTakeTooLow': The delegate is setting a take which is not greater than the previous.
     ///
     pub fn do_increase_take(
         origin: OriginFor<T>,

--- a/pallets/subtensor/src/staking/increase_take.rs
+++ b/pallets/subtensor/src/staking/increase_take.rs
@@ -4,14 +4,11 @@ impl<T: Config> Pallet<T> {
     /// The implementation for the extrinsic increase_take
     ///
     /// # Arguments
-    /// * 'origin': (<T as frame_system::Config>::RuntimeOrigin):
-    ///     - The signature of the caller's coldkey.
+    /// * `origin`: The signature of the caller's coldkey.
     ///
-    /// * 'hotkey' (T::AccountId):
-    ///     - The hotkey we are delegating (must be owned by the coldkey.)
+    /// * `hotkey`: The hotkey we are delegating (must be owned by the coldkey.).
     ///
-    /// * 'take' (u16):
-    ///     - The stake proportion that this hotkey takes from delegations for subnet ID.
+    /// * `take`: The stake proportion that this hotkey takes from delegations for subnet ID.
     ///
     /// # Events
     /// * 'TakeIncreased': On successfully setting a increased take for this hotkey.

--- a/pallets/subtensor/src/staking/increase_take.rs
+++ b/pallets/subtensor/src/staking/increase_take.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 impl<T: Config> Pallet<T> {
-    /// ---- The implementation for the extrinsic increase_take
+    /// The implementation for the extrinsic increase_take
     ///
     /// # Args:
     /// * 'origin': (<T as frame_system::Config>::RuntimeOrigin):

--- a/pallets/subtensor/src/staking/increase_take.rs
+++ b/pallets/subtensor/src/staking/increase_take.rs
@@ -3,7 +3,7 @@ use super::*;
 impl<T: Config> Pallet<T> {
     /// The implementation for the extrinsic increase_take
     ///
-    /// # Args:
+    /// # Arguments
     /// * 'origin': (<T as frame_system::Config>::RuntimeOrigin):
     ///     - The signature of the caller's coldkey.
     ///
@@ -13,11 +13,11 @@ impl<T: Config> Pallet<T> {
     /// * 'take' (u16):
     ///     - The stake proportion that this hotkey takes from delegations for subnet ID.
     ///
-    /// # Event:
+    /// # Events
     /// * TakeIncreased;
     ///     - On successfully setting a increased take for this hotkey.
     ///
-    /// # Raises:
+    /// # Errors
     /// * 'NotRegistered':
     ///     - The hotkey we are delegating is not registered on the network.
     ///

--- a/pallets/subtensor/src/staking/move_stake.rs
+++ b/pallets/subtensor/src/staking/move_stake.rs
@@ -19,11 +19,14 @@ impl<T: Config> Pallet<T> {
     /// * `DispatchResult` - Indicates the success or failure of the operation.
     ///
     /// # Errors
-    /// This function will return an error if:
-    /// * The origin is not signed by the `origin_hotkey`.
-    /// * Either the origin or destination subnet does not exist.
-    /// * The `origin_hotkey` or `destination_hotkey` does not exist.
-    /// * There are locked funds that cannot be moved across subnets.
+    /// * 'BadOrigin': The origin is not signed by the coldkey that owns `origin_hotkey`.
+    /// * 'SubnetNotExists': Either the origin or destination subnet does not exist.
+    /// * 'SubtokenDisabled': The subtoken on either subnet is disabled.
+    /// * 'HotKeyAccountNotExists': The origin or destination hotkey account does not exist.
+    /// * 'NotEnoughStakeToWithdraw': The `(coldkey, origin_hotkey, origin_netuid)` position does not have enough stake.
+    /// * 'AmountTooLow': The resulting TAO-equivalent amount is below `DefaultMinStake`.
+    /// * 'InsufficientLiquidity': The origin/destination swap simulation fails.
+    /// * 'StakingOperationRateLimitExceeded': The caller hit the per-account staking operation rate limit.
     ///
     /// # Events
     /// Emits a `StakeMoved` event upon successful completion of the stake movement.
@@ -108,13 +111,15 @@ impl<T: Config> Pallet<T> {
     /// * `DispatchResult` - Indicates success or failure.
     ///
     /// # Errors
-    /// This function will return an error if:
-    /// * The transaction is not signed by the `origin_coldkey`.
-    /// * The subnet (`origin_netuid` or `destination_netuid`) does not exist.
-    /// * The `hotkey` does not exist.
-    /// * The `(origin_coldkey, hotkey, origin_netuid)` does not have enough stake for `alpha_amount`.
-    /// * The amount to be transferred is below the minimum stake requirement.
-    /// * There is a failure in staking or unstaking logic.
+    /// * 'BadOrigin': The transaction is not signed by `origin_coldkey`.
+    /// * 'SubnetNotExists': Either `origin_netuid` or `destination_netuid` does not exist.
+    /// * 'SubtokenDisabled': The subtoken on either subnet is disabled.
+    /// * 'HotKeyAccountNotExists': The `hotkey` account does not exist.
+    /// * 'NotEnoughStakeToWithdraw': The `(origin_coldkey, hotkey, origin_netuid)` position has less stake than `alpha_amount`.
+    /// * 'AmountTooLow': The resulting TAO-equivalent amount is below `DefaultMinStake`.
+    /// * 'InsufficientLiquidity': Swap simulation or execution on the origin/destination subnet fails.
+    /// * 'TransferDisallowed': Transfers are currently disabled on the origin or destination subnet.
+    /// * 'StakingOperationRateLimitExceeded': The caller hit the per-account staking operation rate limit.
     ///
     /// # Events
     /// Emits a `StakeTransferred` event upon successful completion of the transfer.
@@ -175,12 +180,14 @@ impl<T: Config> Pallet<T> {
     /// * `DispatchResult` - Indicates success or failure.
     ///
     /// # Errors
-    /// This function returns an error if:
-    /// * The origin is not signed by the correct coldkey (i.e., not associated with `hotkey`).
-    /// * Either the `origin_netuid` or the `destination_netuid` does not exist.
-    /// * The specified `hotkey` does not exist.
-    /// * The `(coldkey, hotkey, origin_netuid)` does not have enough stake (`alpha_amount`).
-    /// * The unstaked amount is below `DefaultMinStake`.
+    /// * 'BadOrigin': The transaction is not signed by the coldkey that owns `hotkey`.
+    /// * 'SubnetNotExists': Either `origin_netuid` or `destination_netuid` does not exist.
+    /// * 'SubtokenDisabled': The subtoken on either subnet is disabled.
+    /// * 'HotKeyAccountNotExists': The specified `hotkey` does not exist.
+    /// * 'NotEnoughStakeToWithdraw': The `(coldkey, hotkey, origin_netuid)` position has less stake than `alpha_amount`.
+    /// * 'AmountTooLow': The resulting TAO-equivalent amount is below `DefaultMinStake`.
+    /// * 'InsufficientLiquidity': Swap simulation or execution fails on the origin/destination subnet.
+    /// * 'StakingOperationRateLimitExceeded': The caller hit the per-account staking operation rate limit.
     ///
     /// # Events
     /// Emits a `StakeSwapped` event upon successful completion.
@@ -241,12 +248,16 @@ impl<T: Config> Pallet<T> {
     /// * `DispatchResult` - Indicates success or failure.
     ///
     /// # Errors
-    /// This function returns an error if:
-    /// * The origin is not signed by the correct coldkey (i.e., not associated with `hotkey`).
-    /// * Either the `origin_netuid` or the `destination_netuid` does not exist.
-    /// * The specified `hotkey` does not exist.
-    /// * The `(coldkey, hotkey, origin_netuid)` does not have enough stake (`alpha_amount`).
-    /// * The unstaked amount is below `DefaultMinStake`.
+    /// * 'BadOrigin': The transaction is not signed by the coldkey that owns `hotkey`.
+    /// * 'SubnetNotExists': Either `origin_netuid` or `destination_netuid` does not exist.
+    /// * 'SubtokenDisabled': The subtoken on either subnet is disabled.
+    /// * 'HotKeyAccountNotExists': The specified `hotkey` does not exist.
+    /// * 'NotEnoughStakeToWithdraw': The `(coldkey, hotkey, origin_netuid)` position has less stake than `alpha_amount`.
+    /// * 'AmountTooLow': The resulting TAO-equivalent amount is below `DefaultMinStake`.
+    /// * 'InsufficientLiquidity': Swap simulation or execution fails on the origin/destination subnet.
+    /// * 'SlippageTooHigh': `allow_partial` is false and `alpha_amount` would exceed the `limit_price` slippage bound.
+    /// * 'ZeroMaxStakeAmount': `limit_price` forces a zero maximum executable amount.
+    /// * 'StakingOperationRateLimitExceeded': The caller hit the per-account staking operation rate limit.
     ///
     /// # Events
     /// Emits a `StakeSwapped` event upon successful completion.

--- a/pallets/subtensor/src/staking/move_stake.rs
+++ b/pallets/subtensor/src/staking/move_stake.rs
@@ -9,14 +9,14 @@ impl<T: Config> Pallet<T> {
     /// Moves stake from one hotkey to another across subnets.
     ///
     /// # Arguments
-    /// * `origin` - The origin of the transaction, which must be signed by the `origin_hotkey`.
-    /// * `origin_hotkey` - The account ID of the hotkey from which the stake is being moved.
-    /// * `destination_hotkey` - The account ID of the hotkey to which the stake is being moved.
-    /// * `origin_netuid` - The network ID of the origin subnet.
-    /// * `destination_netuid` - The network ID of the destination subnet.
+    /// * `origin`: The origin of the transaction, which must be signed by the `origin_hotkey`.
+    /// * `origin_hotkey`: The account ID of the hotkey from which the stake is being moved.
+    /// * `destination_hotkey`: The account ID of the hotkey to which the stake is being moved.
+    /// * `origin_netuid`: The network ID of the origin subnet.
+    /// * `destination_netuid`: The network ID of the destination subnet.
     ///
     /// # Returns
-    /// * 'DispatchResult': Indicates the success or failure of the operation.
+    /// * `DispatchResult`: Indicates the success or failure of the operation.
     ///
     /// # Errors
     /// * 'BadOrigin': The origin is not signed by the coldkey that owns `origin_hotkey`.
@@ -81,11 +81,11 @@ impl<T: Config> Pallet<T> {
     /// Toggles the atomic alpha transfers for a specific subnet.
     ///
     /// # Arguments
-    /// * `netuid` - The network ID (subnet) for which the transfer functionality is being toggled.
-    /// * `toggle` - A boolean value indicating whether to enable (true) or disable (false) transfers.
+    /// * `netuid`: The network ID (subnet) for which the transfer functionality is being toggled.
+    /// * `toggle`: A boolean value indicating whether to enable (true) or disable (false) transfers.
     ///
     /// # Returns
-    /// * 'DispatchResult': Indicates success or failure of the operation.
+    /// * `DispatchResult`: Indicates success or failure of the operation.
     ///
     /// # Events
     /// Emits a `TransferToggle` event upon successful completion.
@@ -100,15 +100,15 @@ impl<T: Config> Pallet<T> {
     /// while keeping the same hotkey.
     ///
     /// # Arguments
-    /// * `origin` - The origin of the transaction, which must be signed by the `origin_coldkey`.
-    /// * `destination_coldkey` - The account ID of the coldkey to which the stake is being transferred.
-    /// * `hotkey` - The account ID of the hotkey associated with this stake.
-    /// * `origin_netuid` - The network ID (subnet) from which the stake is being transferred.
-    /// * `destination_netuid` - The network ID (subnet) to which the stake is being transferred.
-    /// * `alpha_amount` - The amount of stake to transfer.
+    /// * `origin`: The origin of the transaction, which must be signed by the `origin_coldkey`.
+    /// * `destination_coldkey`: The account ID of the coldkey to which the stake is being transferred.
+    /// * `hotkey`: The account ID of the hotkey associated with this stake.
+    /// * `origin_netuid`: The network ID (subnet) from which the stake is being transferred.
+    /// * `destination_netuid`: The network ID (subnet) to which the stake is being transferred.
+    /// * `alpha_amount`: The amount of stake to transfer.
     ///
     /// # Returns
-    /// * 'DispatchResult': Indicates success or failure.
+    /// * `DispatchResult`: Indicates success or failure.
     ///
     /// # Errors
     /// * 'BadOrigin': The transaction is not signed by `origin_coldkey`.
@@ -170,14 +170,14 @@ impl<T: Config> Pallet<T> {
     /// (`origin_netuid`) to another (`destination_netuid`).
     ///
     /// # Arguments
-    /// * `origin` - The origin of the transaction, which must be signed by the coldkey that owns the hotkey.
-    /// * `hotkey` - The hotkey whose stake is being swapped.
-    /// * `origin_netuid` - The subnet ID from which stake is removed.
-    /// * `destination_netuid` - The subnet ID to which stake is added.
-    /// * `alpha_amount` - The amount of stake to swap.
+    /// * `origin`: The origin of the transaction, which must be signed by the coldkey that owns the hotkey.
+    /// * `hotkey`: The hotkey whose stake is being swapped.
+    /// * `origin_netuid`: The subnet ID from which stake is removed.
+    /// * `destination_netuid`: The subnet ID to which stake is added.
+    /// * `alpha_amount`: The amount of stake to swap.
     ///
     /// # Returns
-    /// * 'DispatchResult': Indicates success or failure.
+    /// * `DispatchResult`: Indicates success or failure.
     ///
     /// # Errors
     /// * 'BadOrigin': The transaction is not signed by the coldkey that owns `hotkey`.
@@ -236,16 +236,16 @@ impl<T: Config> Pallet<T> {
     /// (`origin_netuid`) to another (`destination_netuid`).
     ///
     /// # Arguments
-    /// * `origin` - The origin of the transaction, which must be signed by the coldkey that owns the hotkey.
-    /// * `hotkey` - The hotkey whose stake is being swapped.
-    /// * `origin_netuid` - The subnet ID from which stake is removed.
-    /// * `destination_netuid` - The subnet ID to which stake is added.
-    /// * `alpha_amount` - The amount of stake to swap.
-    /// * `limit_price` - The limit price.
-    /// * `allow_partial` - Allow partial execution
+    /// * `origin`: The origin of the transaction, which must be signed by the coldkey that owns the hotkey.
+    /// * `hotkey`: The hotkey whose stake is being swapped.
+    /// * `origin_netuid`: The subnet ID from which stake is removed.
+    /// * `destination_netuid`: The subnet ID to which stake is added.
+    /// * `alpha_amount`: The amount of stake to swap.
+    /// * `limit_price`: The limit price.
+    /// * `allow_partial`: Allow partial execution.
     ///
     /// # Returns
-    /// * 'DispatchResult': Indicates success or failure.
+    /// * `DispatchResult`: Indicates success or failure.
     ///
     /// # Errors
     /// * 'BadOrigin': The transaction is not signed by the coldkey that owns `hotkey`.

--- a/pallets/subtensor/src/staking/move_stake.rs
+++ b/pallets/subtensor/src/staking/move_stake.rs
@@ -428,9 +428,7 @@ impl<T: Config> Pallet<T> {
     /// ```
     ///
     /// In the corner case when SubnetTAO(2) == SubnetTAO(1), no slippage is going to occur.
-    ///
-    /// TODO: This formula only works for a single swap step, so it is not 100% correct for swap v3. We need an updated one.
-    ///
+    // TODO: This formula only works for a single swap step, so it is not 100% correct for swap v3. We need an updated one.
     pub fn get_max_amount_move(
         origin_netuid: NetUid,
         destination_netuid: NetUid,

--- a/pallets/subtensor/src/staking/move_stake.rs
+++ b/pallets/subtensor/src/staking/move_stake.rs
@@ -16,7 +16,7 @@ impl<T: Config> Pallet<T> {
     /// * `destination_netuid` - The network ID of the destination subnet.
     ///
     /// # Returns
-    /// * `DispatchResult` - Indicates the success or failure of the operation.
+    /// * 'DispatchResult': Indicates the success or failure of the operation.
     ///
     /// # Errors
     /// * 'BadOrigin': The origin is not signed by the coldkey that owns `origin_hotkey`.
@@ -85,7 +85,7 @@ impl<T: Config> Pallet<T> {
     /// * `toggle` - A boolean value indicating whether to enable (true) or disable (false) transfers.
     ///
     /// # Returns
-    /// * `DispatchResult` - Indicates success or failure of the operation.
+    /// * 'DispatchResult': Indicates success or failure of the operation.
     ///
     /// # Events
     /// Emits a `TransferToggle` event upon successful completion.
@@ -108,7 +108,7 @@ impl<T: Config> Pallet<T> {
     /// * `alpha_amount` - The amount of stake to transfer.
     ///
     /// # Returns
-    /// * `DispatchResult` - Indicates success or failure.
+    /// * 'DispatchResult': Indicates success or failure.
     ///
     /// # Errors
     /// * 'BadOrigin': The transaction is not signed by `origin_coldkey`.
@@ -177,7 +177,7 @@ impl<T: Config> Pallet<T> {
     /// * `alpha_amount` - The amount of stake to swap.
     ///
     /// # Returns
-    /// * `DispatchResult` - Indicates success or failure.
+    /// * 'DispatchResult': Indicates success or failure.
     ///
     /// # Errors
     /// * 'BadOrigin': The transaction is not signed by the coldkey that owns `hotkey`.
@@ -245,7 +245,7 @@ impl<T: Config> Pallet<T> {
     /// * `allow_partial` - Allow partial execution
     ///
     /// # Returns
-    /// * `DispatchResult` - Indicates success or failure.
+    /// * 'DispatchResult': Indicates success or failure.
     ///
     /// # Errors
     /// * 'BadOrigin': The transaction is not signed by the coldkey that owns `hotkey`.

--- a/pallets/subtensor/src/staking/recycle_alpha.rs
+++ b/pallets/subtensor/src/staking/recycle_alpha.rs
@@ -7,14 +7,14 @@ impl<T: Config> Pallet<T> {
     ///
     /// # Arguments
     ///
-    /// * `origin` - The origin of the call (must be signed by the coldkey)
-    /// * `hotkey` - The hotkey account
-    /// * `amount` - The amount of alpha to recycle
-    /// * `netuid` - The subnet ID from which to reduce AlphaOut
+    /// * `origin`: The origin of the call (must be signed by the coldkey).
+    /// * `hotkey`: The hotkey account.
+    /// * `amount`: The amount of alpha to recycle.
+    /// * `netuid`: The subnet ID from which to reduce AlphaOut.
     ///
     /// # Returns
     ///
-    /// * 'DispatchResult': Success or error.
+    /// * `DispatchResult`: Success or error.
     pub(crate) fn do_recycle_alpha(
         origin: OriginFor<T>,
         hotkey: T::AccountId,
@@ -65,14 +65,14 @@ impl<T: Config> Pallet<T> {
     ///
     /// # Arguments
     ///
-    /// * `origin` - The origin of the call (must be signed by the coldkey)
-    /// * `hotkey` - The hotkey account
-    /// * `amount` - The "up to" amount of alpha to burn
-    /// * `netuid` - The subnet ID
+    /// * `origin`: The origin of the call (must be signed by the coldkey).
+    /// * `hotkey`: The hotkey account.
+    /// * `amount`: The "up to" amount of alpha to burn.
+    /// * `netuid`: The subnet ID.
     ///
     /// # Returns
     ///
-    /// * 'DispatchResult': Success or error.
+    /// * `DispatchResult`: Success or error.
     pub(crate) fn do_burn_alpha(
         origin: OriginFor<T>,
         hotkey: T::AccountId,

--- a/pallets/subtensor/src/staking/recycle_alpha.rs
+++ b/pallets/subtensor/src/staking/recycle_alpha.rs
@@ -14,7 +14,7 @@ impl<T: Config> Pallet<T> {
     ///
     /// # Returns
     ///
-    /// * `DispatchResult` - Success or error
+    /// * 'DispatchResult': Success or error.
     pub(crate) fn do_recycle_alpha(
         origin: OriginFor<T>,
         hotkey: T::AccountId,
@@ -72,7 +72,7 @@ impl<T: Config> Pallet<T> {
     ///
     /// # Returns
     ///
-    /// * `DispatchResult` - Success or error
+    /// * 'DispatchResult': Success or error.
     pub(crate) fn do_burn_alpha(
         origin: OriginFor<T>,
         hotkey: T::AccountId,

--- a/pallets/subtensor/src/staking/remove_stake.rs
+++ b/pallets/subtensor/src/staking/remove_stake.rs
@@ -4,7 +4,7 @@ use subtensor_runtime_common::{AlphaBalance, NetUid, TaoBalance, Token};
 use subtensor_swap_interface::{Order, SwapHandler};
 
 impl<T: Config> Pallet<T> {
-    /// ---- The implementation for the extrinsic remove_stake: Removes stake from a hotkey account and adds it onto a coldkey.
+    /// The implementation for the extrinsic remove_stake: Removes stake from a hotkey account and adds it onto a coldkey.
     ///
     /// # Args:
     /// * 'origin': (<T as frame_system::Config>RuntimeOrigin):
@@ -93,7 +93,7 @@ impl<T: Config> Pallet<T> {
         Ok(())
     }
 
-    /// ---- The implementation for the extrinsic unstake_all: Removes all stake from a hotkey account across all subnets and adds it onto a coldkey.
+    /// The implementation for the extrinsic unstake_all: Removes all stake from a hotkey account across all subnets and adds it onto a coldkey.
     ///
     /// # Args:
     /// * 'origin': (<T as frame_system::Config>RuntimeOrigin):
@@ -180,7 +180,7 @@ impl<T: Config> Pallet<T> {
         Ok(())
     }
 
-    /// ---- The implementation for the extrinsic unstake_all: Removes all stake from a hotkey account across all subnets and adds it onto a coldkey.
+    /// The implementation for the extrinsic unstake_all: Removes all stake from a hotkey account across all subnets and adds it onto a coldkey.
     ///
     /// # Args:
     /// * 'origin': (<T as frame_system::Config>RuntimeOrigin):
@@ -285,7 +285,7 @@ impl<T: Config> Pallet<T> {
         Ok(())
     }
 
-    /// ---- The implementation for the extrinsic remove_stake_limit: Removes stake from
+    /// The implementation for the extrinsic remove_stake_limit: Removes stake from
     /// a hotkey on a subnet with a price limit.
     ///
     /// In case if slippage occurs and the price shall move beyond the limit

--- a/pallets/subtensor/src/staking/remove_stake.rs
+++ b/pallets/subtensor/src/staking/remove_stake.rs
@@ -6,7 +6,7 @@ use subtensor_swap_interface::{Order, SwapHandler};
 impl<T: Config> Pallet<T> {
     /// The implementation for the extrinsic remove_stake: Removes stake from a hotkey account and adds it onto a coldkey.
     ///
-    /// # Args:
+    /// # Arguments
     /// * 'origin': (<T as frame_system::Config>RuntimeOrigin):
     ///     -  The signature of the caller's coldkey.
     ///
@@ -19,11 +19,11 @@ impl<T: Config> Pallet<T> {
     /// * 'alpha_unstaked' (Alpha):
     ///     -  The amount of stake to be removed from the staking account.
     ///
-    /// # Event:
+    /// # Events
     /// * StakeRemoved;
     ///     -  On the successfully removing stake from the hotkey account.
     ///
-    /// # Raises:
+    /// # Errors
     /// * 'NotRegistered':
     ///     -  Thrown if the account we are attempting to unstake from is non existent.
     ///
@@ -95,18 +95,18 @@ impl<T: Config> Pallet<T> {
 
     /// The implementation for the extrinsic unstake_all: Removes all stake from a hotkey account across all subnets and adds it onto a coldkey.
     ///
-    /// # Args:
+    /// # Arguments
     /// * 'origin': (<T as frame_system::Config>RuntimeOrigin):
     ///     -  The signature of the caller's coldkey.
     ///
     /// * 'hotkey' (T::AccountId):
     ///     -  The associated hotkey account.
     ///
-    /// # Event:
+    /// # Events
     /// * StakeRemoved;
     ///     -  On the successfully removing stake from the hotkey account.
     ///
-    /// # Raises:
+    /// # Errors
     /// * 'NotRegistered':
     ///     -  Thrown if the account we are attempting to unstake from is non existent.
     ///
@@ -182,18 +182,18 @@ impl<T: Config> Pallet<T> {
 
     /// The implementation for the extrinsic unstake_all: Removes all stake from a hotkey account across all subnets and adds it onto a coldkey.
     ///
-    /// # Args:
+    /// # Arguments
     /// * 'origin': (<T as frame_system::Config>RuntimeOrigin):
     ///     -  The signature of the caller's coldkey.
     ///
     /// * 'hotkey' (T::AccountId):
     ///     -  The associated hotkey account.
     ///
-    /// # Event:
+    /// # Events
     /// * StakeRemoved;
     ///     -  On the successfully removing stake from the hotkey account.
     ///
-    /// # Raises:
+    /// # Errors
     /// * 'NotRegistered':
     ///     -  Thrown if the account we are attempting to unstake from is non existent.
     ///
@@ -292,7 +292,7 @@ impl<T: Config> Pallet<T> {
     /// price, the staking order may execute only partially or not execute
     /// at all.
     ///
-    /// # Args:
+    /// # Arguments
     /// * 'origin': (<T as frame_system::Config>Origin):
     ///     - The signature of the caller's coldkey.
     ///
@@ -312,11 +312,11 @@ impl<T: Config> Pallet<T> {
     ///     - Allows partial execution of the amount. If set to false, this becomes
     ///       fill or kill type or order.
     ///
-    /// # Event:
+    /// # Events
     /// * StakeRemoved;
     ///     - On the successfully removing stake from the hotkey account.
     ///
-    /// # Raises:
+    /// # Errors
     /// * 'NotRegistered':
     ///     - Thrown if the account we are attempting to unstake from is non existent.
     ///

--- a/pallets/subtensor/src/staking/remove_stake.rs
+++ b/pallets/subtensor/src/staking/remove_stake.rs
@@ -7,17 +7,13 @@ impl<T: Config> Pallet<T> {
     /// The implementation for the extrinsic remove_stake: Removes stake from a hotkey account and adds it onto a coldkey.
     ///
     /// # Arguments
-    /// * 'origin': (<T as frame_system::Config>RuntimeOrigin):
-    ///     -  The signature of the caller's coldkey.
+    /// * `origin`: The signature of the caller's coldkey.
     ///
-    /// * 'hotkey' (T::AccountId):
-    ///     -  The associated hotkey account.
+    /// * `hotkey`: The associated hotkey account.
     ///
-    /// * 'netuid' (u16):
-    ///     - Subnetwork UID
+    /// * `netuid`: Subnetwork UID.
     ///
-    /// * 'alpha_unstaked' (Alpha):
-    ///     -  The amount of stake to be removed from the staking account.
+    /// * `alpha_unstaked`: The amount of stake to be removed from the staking account.
     ///
     /// # Events
     /// * 'StakeRemoved': On the successfully removing stake from the hotkey account.
@@ -91,11 +87,9 @@ impl<T: Config> Pallet<T> {
     /// The implementation for the extrinsic unstake_all: Removes all stake from a hotkey account across all subnets and adds it onto a coldkey.
     ///
     /// # Arguments
-    /// * 'origin': (<T as frame_system::Config>RuntimeOrigin):
-    ///     -  The signature of the caller's coldkey.
+    /// * `origin`: The signature of the caller's coldkey.
     ///
-    /// * 'hotkey' (T::AccountId):
-    ///     -  The associated hotkey account.
+    /// * `hotkey`: The associated hotkey account.
     ///
     /// # Events
     /// * 'StakeRemoved': On the successfully removing stake from the hotkey account.
@@ -173,11 +167,9 @@ impl<T: Config> Pallet<T> {
     /// The implementation for the extrinsic unstake_all: Removes all stake from a hotkey account across all subnets and adds it onto a coldkey.
     ///
     /// # Arguments
-    /// * 'origin': (<T as frame_system::Config>RuntimeOrigin):
-    ///     -  The signature of the caller's coldkey.
+    /// * `origin`: The signature of the caller's coldkey.
     ///
-    /// * 'hotkey' (T::AccountId):
-    ///     -  The associated hotkey account.
+    /// * `hotkey`: The associated hotkey account.
     ///
     /// # Events
     /// * 'StakeRemoved': On the successfully removing stake from the hotkey account.
@@ -278,24 +270,17 @@ impl<T: Config> Pallet<T> {
     /// at all.
     ///
     /// # Arguments
-    /// * 'origin': (<T as frame_system::Config>Origin):
-    ///     - The signature of the caller's coldkey.
+    /// * `origin`: The signature of the caller's coldkey.
     ///
-    /// * 'hotkey' (T::AccountId):
-    ///     - The associated hotkey account.
+    /// * `hotkey`: The associated hotkey account.
     ///
-    /// * 'netuid' (u16):
-    ///     - Subnetwork UID
+    /// * `netuid`: Subnetwork UID.
     ///
-    /// * 'amount_unstaked' (u64):
-    ///     - The amount of stake to be added to the hotkey staking account.
+    /// * `amount_unstaked`: The amount of stake to be added to the hotkey staking account.
     ///
-    ///  * 'limit_price' (u64):
-    ///     - The limit price expressed in units of RAO per one Alpha.
+    /// * `limit_price`: The limit price expressed in units of RAO per one Alpha.
     ///
-    ///  * 'allow_partial' (bool):
-    ///     - Allows partial execution of the amount. If set to false, this becomes
-    ///       fill or kill type or order.
+    /// * `allow_partial`: Allows partial execution of the amount. If set to false, this becomes a fill-or-kill order.
     ///
     /// # Events
     /// * 'StakeRemoved': On the successfully removing stake from the hotkey account.

--- a/pallets/subtensor/src/staking/remove_stake.rs
+++ b/pallets/subtensor/src/staking/remove_stake.rs
@@ -20,21 +20,16 @@ impl<T: Config> Pallet<T> {
     ///     -  The amount of stake to be removed from the staking account.
     ///
     /// # Events
-    /// * StakeRemoved;
-    ///     -  On the successfully removing stake from the hotkey account.
+    /// * 'StakeRemoved': On the successfully removing stake from the hotkey account.
     ///
     /// # Errors
-    /// * 'NotRegistered':
-    ///     -  Thrown if the account we are attempting to unstake from is non existent.
+    /// * 'NotRegistered': Thrown if the account we are attempting to unstake from is non existent.
     ///
-    /// * 'NonAssociatedColdKey':
-    ///     -  Thrown if the coldkey does not own the hotkey we are unstaking from.
+    /// * 'NonAssociatedColdKey': Thrown if the coldkey does not own the hotkey we are unstaking from.
     ///
-    /// * 'NotEnoughStakeToWithdraw':
-    ///     -  Thrown if there is not enough stake on the hotkey to withdwraw this amount.
+    /// * 'NotEnoughStakeToWithdraw': Thrown if there is not enough stake on the hotkey to withdwraw this amount.
     ///
-    /// * 'TxRateLimitExceeded':
-    ///     -  Thrown if key has hit transaction rate limit
+    /// * 'TxRateLimitExceeded': Thrown if key has hit transaction rate limit.
     ///
     pub fn do_remove_stake(
         origin: OriginFor<T>,
@@ -103,21 +98,16 @@ impl<T: Config> Pallet<T> {
     ///     -  The associated hotkey account.
     ///
     /// # Events
-    /// * StakeRemoved;
-    ///     -  On the successfully removing stake from the hotkey account.
+    /// * 'StakeRemoved': On the successfully removing stake from the hotkey account.
     ///
     /// # Errors
-    /// * 'NotRegistered':
-    ///     -  Thrown if the account we are attempting to unstake from is non existent.
+    /// * 'NotRegistered': Thrown if the account we are attempting to unstake from is non existent.
     ///
-    /// * 'NonAssociatedColdKey':
-    ///     -  Thrown if the coldkey does not own the hotkey we are unstaking from.
+    /// * 'NonAssociatedColdKey': Thrown if the coldkey does not own the hotkey we are unstaking from.
     ///
-    /// * 'NotEnoughStakeToWithdraw':
-    ///     -  Thrown if there is not enough stake on the hotkey to withdraw this amount.
+    /// * 'NotEnoughStakeToWithdraw': Thrown if there is not enough stake on the hotkey to withdraw this amount.
     ///
-    /// * 'TxRateLimitExceeded':
-    ///     -  Thrown if key has hit transaction rate limit
+    /// * 'TxRateLimitExceeded': Thrown if key has hit transaction rate limit.
     ///
     pub fn do_unstake_all(origin: OriginFor<T>, hotkey: T::AccountId) -> dispatch::DispatchResult {
         // 1. We check the transaction is signed by the caller and retrieve the T::AccountId coldkey information.
@@ -190,21 +180,16 @@ impl<T: Config> Pallet<T> {
     ///     -  The associated hotkey account.
     ///
     /// # Events
-    /// * StakeRemoved;
-    ///     -  On the successfully removing stake from the hotkey account.
+    /// * 'StakeRemoved': On the successfully removing stake from the hotkey account.
     ///
     /// # Errors
-    /// * 'NotRegistered':
-    ///     -  Thrown if the account we are attempting to unstake from is non existent.
+    /// * 'NotRegistered': Thrown if the account we are attempting to unstake from is non existent.
     ///
-    /// * 'NonAssociatedColdKey':
-    ///     -  Thrown if the coldkey does not own the hotkey we are unstaking from.
+    /// * 'NonAssociatedColdKey': Thrown if the coldkey does not own the hotkey we are unstaking from.
     ///
-    /// * 'NotEnoughStakeToWithdraw':
-    ///     -  Thrown if there is not enough stake on the hotkey to withdraw this amount.
+    /// * 'NotEnoughStakeToWithdraw': Thrown if there is not enough stake on the hotkey to withdraw this amount.
     ///
-    /// * 'TxRateLimitExceeded':
-    ///     -  Thrown if key has hit transaction rate limit
+    /// * 'TxRateLimitExceeded': Thrown if key has hit transaction rate limit.
     ///
     pub fn do_unstake_all_alpha(
         origin: OriginFor<T>,
@@ -313,18 +298,14 @@ impl<T: Config> Pallet<T> {
     ///       fill or kill type or order.
     ///
     /// # Events
-    /// * StakeRemoved;
-    ///     - On the successfully removing stake from the hotkey account.
+    /// * 'StakeRemoved': On the successfully removing stake from the hotkey account.
     ///
     /// # Errors
-    /// * 'NotRegistered':
-    ///     - Thrown if the account we are attempting to unstake from is non existent.
+    /// * 'NotRegistered': Thrown if the account we are attempting to unstake from is non existent.
     ///
-    /// * 'NonAssociatedColdKey':
-    ///     - Thrown if the coldkey does not own the hotkey we are unstaking from.
+    /// * 'NonAssociatedColdKey': Thrown if the coldkey does not own the hotkey we are unstaking from.
     ///
-    /// * 'NotEnoughStakeToWithdraw':
-    ///     - Thrown if there is not enough stake on the hotkey to withdwraw this amount.
+    /// * 'NotEnoughStakeToWithdraw': Thrown if there is not enough stake on the hotkey to withdwraw this amount.
     ///
     pub fn do_remove_stake_limit(
         origin: OriginFor<T>,

--- a/pallets/subtensor/src/staking/set_children.rs
+++ b/pallets/subtensor/src/staking/set_children.rs
@@ -712,7 +712,7 @@ impl<T: Config> Pallet<T> {
     ///       where 10000 represents 100%.
     ///
     /// # Returns
-    /// * `DispatchResult` - The result of the operation.
+    /// * 'DispatchResult': The result of the operation.
     ///
     /// # Errors
     /// * `NonAssociatedColdKey`:
@@ -811,7 +811,7 @@ impl<T: Config> Pallet<T> {
     /// * `netuid` - The subnet on which to establish relationships.
     ///
     /// # Returns
-    /// * `DispatchResult` - Ok if at least the setup completes; individual
+    /// * 'DispatchResult': Ok if at least the setup completes; individual.
     ///   scheduling failures per validator are logged but do not abort the loop.
     pub fn do_set_root_validators_for_subnet(netuid: NetUid) -> DispatchResult {
         // Cannot set children on root network itself.

--- a/pallets/subtensor/src/staking/set_children.rs
+++ b/pallets/subtensor/src/staking/set_children.rs
@@ -461,11 +461,11 @@ impl<T: Config> Pallet<T> {
     ///    **Proportion check**: Ensure that the sum of the proportions does not exceed u64::MAX.
     ///    **Duplicate check**: Ensure there are no duplicates in the list of children.
     ///
-    /// # Events:
+    /// # Events
     /// * `SetChildrenScheduled`:
     ///     - If all checks pass and setting the childkeys is scheduled.
     ///
-    /// # Errors:
+    /// # Errors
     /// * `MechanismDoesNotExist`:
     ///     - Attempting to register to a non-existent network.
     /// * `RegistrationNotPermittedOnRootSubnet`:
@@ -594,11 +594,11 @@ impl<T: Config> Pallet<T> {
     /// * `netuid` (u16):
     ///     - The u16 network identifier where the child keys will exist.
     ///
-    /// # Events:
+    /// # Events
     /// * `SetChildren`:
     ///     - On successfully registering children to a hotkey.
     ///
-    /// # Errors:
+    /// # Errors
     /// * `MechanismDoesNotExist`:
     ///     - Attempting to register to a non-existent network.
     /// * `RegistrationNotPermittedOnRootSubnet`:
@@ -608,7 +608,7 @@ impl<T: Config> Pallet<T> {
     /// * `HotKeyAccountNotExists`:
     ///     - The hotkey account does not exist.
     ///
-    /// # Detailed Explanation of actions:
+    /// # Note
     /// 1. **Old Children Cleanup**: Removes the hotkey from the parent list of its old children.
     /// 2. **New Children Assignment**: Assigns the new child to the hotkey and updates the parent list for the new child.
     ///
@@ -669,7 +669,7 @@ impl<T: Config> Pallet<T> {
     /// # Returns
     /// * `Vec<(u64, T::AccountId)>` - A vector of tuples containing the proportion and child account ID.
     ///
-    /// # Example
+    /// # Note
     /// ```
     /// let children = SubtensorModule::get_children(&hotkey, netuid);
      */
@@ -686,7 +686,7 @@ impl<T: Config> Pallet<T> {
     /// # Returns
     /// * `Vec<(u64, T::AccountId)>` - A vector of tuples containing the proportion and parent account ID.
     ///
-    /// # Example
+    /// # Note
     /// ```
     /// let parents = SubtensorModule::get_parents(&child, netuid);
      */
@@ -700,7 +700,7 @@ impl<T: Config> Pallet<T> {
     /// The childkey take determines the proportion of stake that the hotkey keeps for itself
     /// when distributing stake to its children.
     ///
-    /// # Arguments:
+    /// # Arguments
     /// * `coldkey` (T::AccountId):
     ///     - The coldkey that owns the hotkey.
     ///
@@ -711,10 +711,10 @@ impl<T: Config> Pallet<T> {
     ///     - The new childkey take value. This is a percentage represented as a value between 0 and 10000,
     ///       where 10000 represents 100%.
     ///
-    /// # Returns:
+    /// # Returns
     /// * `DispatchResult` - The result of the operation.
     ///
-    /// # Errors:
+    /// # Errors
     /// * `NonAssociatedColdKey`:
     ///     - The coldkey does not own the hotkey.
     /// * `InvalidChildkeyTake`:
@@ -781,10 +781,10 @@ impl<T: Config> Pallet<T> {
     /// This function retrieves the current childkey take value for a specified hotkey.
     /// If no specific take value has been set, it returns the default childkey take.
     ///
-    /// # Arguments:
+    /// # Arguments
     /// * `hotkey` (&T::AccountId): The hotkey for which to retrieve the childkey take.
     ///
-    /// # Returns:
+    /// # Returns
     /// * `u16`
     ///     - The childkey take value. This is a percentage represented as a value between 0
     ///       and 10000, where 10000 represents 100%.

--- a/pallets/subtensor/src/staking/set_children.rs
+++ b/pallets/subtensor/src/staking/set_children.rs
@@ -462,20 +462,14 @@ impl<T: Config> Pallet<T> {
     ///    **Duplicate check**: Ensure there are no duplicates in the list of children.
     ///
     /// # Events
-    /// * `SetChildrenScheduled`:
-    ///     - If all checks pass and setting the childkeys is scheduled.
+    /// * 'SetChildrenScheduled': If all checks pass and setting the childkeys is scheduled.
     ///
     /// # Errors
-    /// * `MechanismDoesNotExist`:
-    ///     - Attempting to register to a non-existent network.
-    /// * `RegistrationNotPermittedOnRootSubnet`:
-    ///     - Attempting to register a child on the root network.
-    /// * `NonAssociatedColdKey`:
-    ///     - The coldkey does not own the hotkey or the child is the same as the hotkey.
-    /// * `HotKeyAccountNotExists`:
-    ///     - The hotkey account does not exist.
-    /// * `TooManyChildren`:
-    ///     - Too many children in request
+    /// * 'MechanismDoesNotExist': Attempting to register to a non-existent network.
+    /// * 'RegistrationNotPermittedOnRootSubnet': Attempting to register a child on the root network.
+    /// * 'NonAssociatedColdKey': The coldkey does not own the hotkey or the child is the same as the hotkey.
+    /// * 'HotKeyAccountNotExists': The hotkey account does not exist.
+    /// * 'TooManyChildren': Too many children in request.
     ///
     pub fn do_schedule_children(
         origin: OriginFor<T>,
@@ -591,22 +585,17 @@ impl<T: Config> Pallet<T> {
 
     /// This function executes setting children keys when called during hotkey draining.
     ///
-    /// * `netuid` (u16):
-    ///     - The u16 network identifier where the child keys will exist.
+    /// # Arguments
+    /// * `netuid`: The u16 network identifier where the child keys will exist.
     ///
     /// # Events
-    /// * `SetChildren`:
-    ///     - On successfully registering children to a hotkey.
+    /// * 'SetChildren': On successfully registering children to a hotkey.
     ///
     /// # Errors
-    /// * `MechanismDoesNotExist`:
-    ///     - Attempting to register to a non-existent network.
-    /// * `RegistrationNotPermittedOnRootSubnet`:
-    ///     - Attempting to register a child on the root network.
-    /// * `NonAssociatedColdKey`:
-    ///     - The coldkey does not own the hotkey or the child is the same as the hotkey.
-    /// * `HotKeyAccountNotExists`:
-    ///     - The hotkey account does not exist.
+    /// * 'MechanismDoesNotExist': Attempting to register to a non-existent network.
+    /// * 'RegistrationNotPermittedOnRootSubnet': Attempting to register a child on the root network.
+    /// * 'NonAssociatedColdKey': The coldkey does not own the hotkey or the child is the same as the hotkey.
+    /// * 'HotKeyAccountNotExists': The hotkey account does not exist.
     ///
     /// # Note
     /// 1. **Old Children Cleanup**: Removes the hotkey from the parent list of its old children.
@@ -663,8 +652,8 @@ impl<T: Config> Pallet<T> {
     /* Retrieves the list of children for a given hotkey and network.
     ///
     /// # Arguments
-    /// * `hotkey` - The hotkey whose children are to be retrieved.
-    /// * `netuid` - The network identifier.
+    /// * `hotkey`: The hotkey whose children are to be retrieved.
+    /// * `netuid`: The network identifier.
     ///
     /// # Returns
     /// * `Vec<(u64, T::AccountId)>` - A vector of tuples containing the proportion and child account ID.
@@ -680,8 +669,8 @@ impl<T: Config> Pallet<T> {
     /* Retrieves the list of parents for a given child and network.
     ///
     /// # Arguments
-    /// * `child` - The child whose parents are to be retrieved.
-    /// * `netuid` - The network identifier.
+    /// * `child`: The child whose parents are to be retrieved.
+    /// * `netuid`: The network identifier.
     ///
     /// # Returns
     /// * `Vec<(u64, T::AccountId)>` - A vector of tuples containing the proportion and parent account ID.
@@ -701,26 +690,19 @@ impl<T: Config> Pallet<T> {
     /// when distributing stake to its children.
     ///
     /// # Arguments
-    /// * `coldkey` (T::AccountId):
-    ///     - The coldkey that owns the hotkey.
+    /// * `coldkey`: The coldkey that owns the hotkey.
     ///
-    /// * `hotkey` (T::AccountId):
-    ///     - The hotkey for which the childkey take will be set.
+    /// * `hotkey`: The hotkey for which the childkey take will be set.
     ///
-    /// * `take` (u16):
-    ///     - The new childkey take value. This is a percentage represented as a value between 0 and 10000,
-    ///       where 10000 represents 100%.
+    /// * `take`: The new childkey take value. This is a percentage represented as a value between 0 and 10000, where 10000 represents 100%.
     ///
     /// # Returns
-    /// * 'DispatchResult': The result of the operation.
+    /// * `DispatchResult`: The result of the operation.
     ///
     /// # Errors
-    /// * `NonAssociatedColdKey`:
-    ///     - The coldkey does not own the hotkey.
-    /// * `InvalidChildkeyTake`:
-    ///     - The provided take value is invalid (greater than the maximum allowed take).
-    /// * `TxChildkeyTakeRateLimitExceeded`:
-    ///     - The rate limit for changing childkey take has been exceeded.
+    /// * 'NonAssociatedColdKey': The coldkey does not own the hotkey.
+    /// * 'InvalidChildkeyTake': The provided take value is invalid (greater than the maximum allowed take).
+    /// * 'TxChildkeyTakeRateLimitExceeded': The rate limit for changing childkey take has been exceeded.
     pub fn do_set_childkey_take(
         coldkey: T::AccountId,
         hotkey: T::AccountId,
@@ -782,12 +764,10 @@ impl<T: Config> Pallet<T> {
     /// If no specific take value has been set, it returns the default childkey take.
     ///
     /// # Arguments
-    /// * `hotkey` (&T::AccountId): The hotkey for which to retrieve the childkey take.
+    /// * `hotkey`: The hotkey for which to retrieve the childkey take.
     ///
     /// # Returns
-    /// * `u16`
-    ///     - The childkey take value. This is a percentage represented as a value between 0
-    ///       and 10000, where 10000 represents 100%.
+    /// * `u16`: The childkey take value. This is a percentage represented as a value between 0 and 10000, where 10000 represents 100%.
     pub fn get_childkey_take(hotkey: &T::AccountId, netuid: NetUid) -> u16 {
         ChildkeyTake::<T>::get(hotkey, netuid)
     }
@@ -808,10 +788,10 @@ impl<T: Config> Pallet<T> {
     /// of that root validator on the given subnet, with full proportion (u64::MAX).
     ///
     /// # Arguments
-    /// * `netuid` - The subnet on which to establish relationships.
+    /// * `netuid`: The subnet on which to establish relationships.
     ///
     /// # Returns
-    /// * 'DispatchResult': Ok if at least the setup completes; individual.
+    /// * `DispatchResult`: Ok if at least the setup completes; individual.
     ///   scheduling failures per validator are logged but do not abort the loop.
     pub fn do_set_root_validators_for_subnet(netuid: NetUid) -> DispatchResult {
         // Cannot set children on root network itself.

--- a/pallets/subtensor/src/staking/set_children.rs
+++ b/pallets/subtensor/src/staking/set_children.rs
@@ -446,7 +446,7 @@ impl<T: Config> Pallet<T> {
         Self::persist_child_parent_relations(relations, netuid, weight)
     }
 
-    /// ---- The implementation for the extrinsic do_set_child_singular: Sets a single child.
+    /// The implementation for the extrinsic do_set_child_singular: Sets a single child.
     /// This function allows a coldkey to set children keys.
     ///
     /// Adds a childkey vector to the PendingChildKeys map and performs a few checks:

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -152,7 +152,7 @@ impl<T: Config> Pallet<T> {
     /// regardless of the actual stored weight value.
     ///
     /// # Returns
-    /// * `U96F32` - The normalized global global weight as a fixed-point number between 0 and 1.
+    /// * 'U96F32': The normalized global global weight as a fixed-point number between 0 and 1.
     ///
     /// # Note
     /// This function uses saturating division to prevent potential overflow errors.

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -180,13 +180,14 @@ impl<T: Config> Pallet<T> {
     /// 2. Updates the TaoWeight storage item with the new value.
     ///
     /// # Arguments
-    /// * `weight` - The new global weight value to be set, as a u64.
+    ///
+    /// * `weight`: The new global weight value to be set, as a u64.
     ///
     /// # Note
+    ///
     /// This function modifies the following storage item:
-    /// - `TaoWeight`: Updates it with the new weight value.
+    /// * `TaoWeight`: Updates it with the new weight value.
     ///
-    /// # Note
     /// The weight is stored as a raw u64 value. To get the normalized weight between 0 and 1,
     /// use the `get_tao_weight()` function.
     pub fn set_tao_weight(weight: u64) {

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -182,7 +182,7 @@ impl<T: Config> Pallet<T> {
     /// # Arguments
     /// * `weight` - The new global weight value to be set, as a u64.
     ///
-    /// # Effects
+    /// # Note
     /// This function modifies the following storage item:
     /// - `TaoWeight`: Updates it with the new weight value.
     ///

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -13,10 +13,10 @@ impl<T: Config> Pallet<T> {
     /// values from `SubnetAlphaIn` and `SubnetAlphaOut` for the specified subnet.
     ///
     /// # Arguments
-    /// * `netuid` - The unique identifier of the subnet.
+    /// * `netuid`: The unique identifier of the subnet.
     ///
     /// # Returns
-    /// * `u64` - The total alpha issuance for the specified subnet.
+    /// * `u64`: The total alpha issuance for the specified subnet.
     pub fn get_alpha_issuance(netuid: NetUid) -> AlphaBalance {
         SubnetAlphaIn::<T>::get(netuid).saturating_add(SubnetAlphaOut::<T>::get(netuid))
     }
@@ -152,7 +152,7 @@ impl<T: Config> Pallet<T> {
     /// regardless of the actual stored weight value.
     ///
     /// # Returns
-    /// * 'U96F32': The normalized global global weight as a fixed-point number between 0 and 1.
+    /// * `U96F32`: The normalized global global weight as a fixed-point number between 0 and 1.
     ///
     /// # Note
     /// This function uses saturating division to prevent potential overflow errors.
@@ -301,11 +301,11 @@ impl<T: Config> Pallet<T> {
     /// 6. Returns the final inherited alpha value.
     ///
     /// # Arguments
-    /// * `hotkey` - AccountId of the hotkey whose total inherited stake is to be calculated.
-    /// * `netuid` - Network unique identifier specifying the subnet context.
+    /// * `hotkey`: AccountId of the hotkey whose total inherited stake is to be calculated.
+    /// * `netuid`: Network unique identifier specifying the subnet context.
     ///
     /// # Returns
-    /// * `u64`: The total inherited alpha for the hotkey on the subnet after considering the
+    /// * `u64`: The total inherited alpha for the hotkey on the subnet after considering the.
     ///   stakes allocated to children and inherited from parents.
     ///
     /// # Note
@@ -458,13 +458,13 @@ impl<T: Config> Pallet<T> {
     /// 2. Compares this stake with the requested decrement amount.
     ///
     /// # Arguments
-    /// * `hotkey` - The account ID of the hotkey.
-    /// * `coldkey` - The account ID of the coldkey.
-    /// * `netuid` - The unique identifier of the subnet.
-    /// * `decrement` - The amount of stake to be potentially decremented.
+    /// * `hotkey`: The account ID of the hotkey.
+    /// * `coldkey`: The account ID of the coldkey.
+    /// * `netuid`: The unique identifier of the subnet.
+    /// * `decrement`: The amount of stake to be potentially decremented.
     ///
     /// # Returns
-    /// * `bool` - True if the account has enough stake to fulfill the decrement, false otherwise.
+    /// * `bool`: True if the account has enough stake to fulfill the decrement, false otherwise.
     ///
     /// # Note
     /// This function only checks the stake for the specific hotkey-coldkey pair, not the total stake of the hotkey or coldkey individually.
@@ -495,12 +495,12 @@ impl<T: Config> Pallet<T> {
     /// 3. Returns the retrieved stake value as a u64.
     ///
     /// # Arguments
-    /// * `hotkey` - The account ID of the hotkey (neuron).
-    /// * `coldkey` - The account ID of the coldkey (owner).
-    /// * `netuid` - The unique identifier of the subnet.
+    /// * `hotkey`: The account ID of the hotkey (neuron).
+    /// * `coldkey`: The account ID of the coldkey (owner).
+    /// * `netuid`: The unique identifier of the subnet.
     ///
     /// # Returns
-    /// * `u64` - The alpha (stake) value for the specified hotkey-coldkey pair on the given subnet.
+    /// * `u64`: The alpha (stake) value for the specified hotkey-coldkey pair on the given subnet.
     ///
     /// # Note
     /// This function retrieves the stake specific to the hotkey-coldkey pair, not the total stake of the hotkey or coldkey individually.
@@ -519,11 +519,11 @@ impl<T: Config> Pallet<T> {
     /// 1. Retrieves and returns the total alpha value associated with the hotkey on the specified subnet.
     ///
     /// # Arguments
-    /// * `hotkey` - The account ID of the hotkey.
-    /// * `netuid` - The unique identifier of the subnet.
+    /// * `hotkey`: The account ID of the hotkey.
+    /// * `netuid`: The unique identifier of the subnet.
     ///
     /// # Returns
-    /// * `u64` - The total alpha value for the hotkey on the specified subnet.
+    /// * `u64`: The total alpha value for the hotkey on the specified subnet.
     ///
     /// # Note
     /// This function returns the cumulative stake across all coldkeys associated with this hotkey on the subnet.
@@ -538,9 +538,9 @@ impl<T: Config> Pallet<T> {
     /// The function updates share totals given current prices.
     ///
     /// # Arguments
-    /// * `hotkey` - The account ID of the hotkey.
-    /// * `netuid` - The unique identifier of the subnet.
-    /// * `amount` - The amount of alpha to be added.
+    /// * `hotkey`: The account ID of the hotkey.
+    /// * `netuid`: The unique identifier of the subnet.
+    /// * `amount`: The amount of alpha to be added.
     ///
     pub fn increase_stake_for_hotkey_on_subnet(
         hotkey: &T::AccountId,
@@ -556,9 +556,9 @@ impl<T: Config> Pallet<T> {
     /// The function updates share totals given current prices.
     ///
     /// # Arguments
-    /// * `hotkey` - The account ID of the hotkey.
-    /// * `netuid` - The unique identifier of the subnet.
-    /// * `amount` - The amount of alpha to be added.
+    /// * `hotkey`: The account ID of the hotkey.
+    /// * `netuid`: The unique identifier of the subnet.
+    /// * `amount`: The amount of alpha to be added.
     ///
     pub fn decrease_stake_for_hotkey_on_subnet(hotkey: &T::AccountId, netuid: NetUid, amount: u64) {
         let mut alpha_share_pool = Self::get_alpha_share_pool(hotkey.clone(), netuid);
@@ -570,10 +570,10 @@ impl<T: Config> Pallet<T> {
     /// The function updates share totals given current prices.
     ///
     /// # Arguments
-    /// * `hotkey` - The account ID of the hotkey.
-    /// * `coldkey` - The account ID of the coldkey (owner).
-    /// * `netuid` - The unique identifier of the subnet.
-    /// * `amount` - The amount of alpha to be added.
+    /// * `hotkey`: The account ID of the hotkey.
+    /// * `coldkey`: The account ID of the coldkey (owner).
+    /// * `netuid`: The unique identifier of the subnet.
+    /// * `amount`: The amount of alpha to be added.
     ///
     pub fn increase_stake_for_hotkey_and_coldkey_on_subnet(
         hotkey: &T::AccountId,
@@ -610,10 +610,10 @@ impl<T: Config> Pallet<T> {
     /// The function updates share totals given current prices.
     ///
     /// # Arguments
-    /// * `hotkey` - The account ID of the hotkey.
-    /// * `coldkey` - The account ID of the coldkey (owner).
-    /// * `netuid` - The unique identifier of the subnet.
-    /// * `amount` - The amount of alpha to be added.
+    /// * `hotkey`: The account ID of the hotkey.
+    /// * `coldkey`: The account ID of the coldkey (owner).
+    /// * `netuid`: The unique identifier of the subnet.
+    /// * `amount`: The amount of alpha to be added.
     ///
     pub fn decrease_stake_for_hotkey_and_coldkey_on_subnet(
         hotkey: &T::AccountId,

--- a/pallets/subtensor/src/subnets/serving.rs
+++ b/pallets/subtensor/src/subnets/serving.rs
@@ -5,35 +5,25 @@ impl<T: Config> Pallet<T> {
     /// The implementation for the extrinsic serve_axon which sets the ip endpoint information for a uid on a network.
     ///
     /// # Arguments
-    /// * 'origin': (<T as frame_system::Config>RuntimeOrigin):
-    ///     - The signature of the caller.
+    /// * `origin`: The signature of the caller.
     ///
-    /// * 'netuid' (u16):
-    ///     - The u16 network identifier.
+    /// * `netuid`: The u16 network identifier.
     ///
-    /// * 'version' (u64):
-    ///     - The bittensor version identifier.
+    /// * `version`: The bittensor version identifier.
     ///
-    /// * 'ip' (u64):
-    ///     - The endpoint ip information as a u128 encoded integer.
+    /// * `ip`: The endpoint ip information as a u128 encoded integer.
     ///
-    /// * 'port' (u16):
-    ///     - The endpoint port information as a u16 encoded integer.
+    /// * `port`: The endpoint port information as a u16 encoded integer.
     ///
-    /// * 'ip_type' (u8):
-    ///     - The endpoint ip version as a u8, 4 or 6.
+    /// * `ip_type`: The endpoint ip version as a u8, 4 or 6.
     ///
-    /// * 'protocol' (u8):
-    ///     - UDP:1 or TCP:0
+    /// * `protocol`: UDP:1 or TCP:0.
     ///
-    /// * 'placeholder1' (u8):
-    ///     - Placeholder for further extra params.
+    /// * `placeholder1`: Placeholder for further extra params.
     ///
-    /// * 'placeholder2' (u8):
-    ///     - Placeholder for further extra params.
+    /// * `placeholder2`: Placeholder for further extra params.
     ///
-    /// * 'certificate' (Option<Vec<u8>>):
-    ///     - Certificate for mutual Tls connection between neurons
+    /// * `certificate`: Certificate for mutual Tls connection between neurons.
     ///
     /// # Events
     /// * 'AxonServed': On successfully serving the axon info.
@@ -115,23 +105,17 @@ impl<T: Config> Pallet<T> {
     /// The implementation for the extrinsic serve_prometheus.
     ///
     /// # Arguments
-    /// * 'origin': (<T as frame_system::Config>RuntimeOrigin):
-    ///     - The signature of the caller.
+    /// * `origin`: The signature of the caller.
     ///
-    /// * 'netuid' (u16):
-    ///     - The u16 network identifier.
+    /// * `netuid`: The u16 network identifier.
     ///
-    /// * 'version' (u64):
-    ///     - The bittensor version identifier.
+    /// * `version`: The bittensor version identifier.
     ///
-    /// * 'ip' (u64):
-    ///     - The prometheus ip information as a u128 encoded integer.
+    /// * `ip`: The prometheus ip information as a u128 encoded integer.
     ///
-    /// * 'port' (u16):
-    ///     - The prometheus port information as a u16 encoded integer.
+    /// * `port`: The prometheus port information as a u16 encoded integer.
     ///
-    /// * 'ip_type' (u8):
-    ///     - The prometheus ip version as a u8, 4 or 6.
+    /// * `ip_type`: The prometheus ip version as a u8, 4 or 6.
     ///
     /// # Events
     /// * 'PrometheusServed': On successfully serving the axon info.

--- a/pallets/subtensor/src/subnets/serving.rs
+++ b/pallets/subtensor/src/subnets/serving.rs
@@ -2,7 +2,7 @@ use super::*;
 use subtensor_runtime_common::NetUid;
 
 impl<T: Config> Pallet<T> {
-    /// ---- The implementation for the extrinsic serve_axon which sets the ip endpoint information for a uid on a network.
+    /// The implementation for the extrinsic serve_axon which sets the ip endpoint information for a uid on a network.
     ///
     /// # Args:
     /// * 'origin': (<T as frame_system::Config>RuntimeOrigin):
@@ -118,7 +118,7 @@ impl<T: Config> Pallet<T> {
         Ok(())
     }
 
-    /// ---- The implementation for the extrinsic serve_prometheus.
+    /// The implementation for the extrinsic serve_prometheus.
     ///
     /// # Args:
     /// * 'origin': (<T as frame_system::Config>RuntimeOrigin):

--- a/pallets/subtensor/src/subnets/serving.rs
+++ b/pallets/subtensor/src/subnets/serving.rs
@@ -36,24 +36,18 @@ impl<T: Config> Pallet<T> {
     ///     - Certificate for mutual Tls connection between neurons
     ///
     /// # Events
-    /// * AxonServed;
-    ///     - On successfully serving the axon info.
+    /// * 'AxonServed': On successfully serving the axon info.
     ///
     /// # Errors
-    /// * 'MechanismDoesNotExist':
-    ///     - Attempting to set weights on a non-existent network.
+    /// * 'MechanismDoesNotExist': Attempting to set weights on a non-existent network.
     ///
-    /// * 'NotRegistered':
-    ///     - Attempting to set weights from a non registered account.
+    /// * 'NotRegistered': Attempting to set weights from a non registered account.
     ///
-    /// * 'InvalidIpType':
-    ///     - The ip type is not 4 or 6.
+    /// * 'InvalidIpType': The ip type is not 4 or 6.
     ///
-    /// * 'InvalidIpAddress':
-    ///     - The numerically encoded ip address does not resolve to a proper ip.
+    /// * 'InvalidIpAddress': The numerically encoded ip address does not resolve to a proper ip.
     ///
-    /// * 'ServingRateLimitExceeded':
-    ///     - Attempting to set prometheus information withing the rate limit min.
+    /// * 'ServingRateLimitExceeded': Attempting to set prometheus information withing the rate limit min.
     ///
     pub fn do_serve_axon(
         origin: OriginFor<T>,
@@ -140,24 +134,18 @@ impl<T: Config> Pallet<T> {
     ///     - The prometheus ip version as a u8, 4 or 6.
     ///
     /// # Events
-    /// * PrometheusServed;
-    ///     - On successfully serving the axon info.
+    /// * 'PrometheusServed': On successfully serving the axon info.
     ///
     /// # Errors
-    /// * 'MechanismDoesNotExist':
-    ///     - Attempting to set weights on a non-existent network.
+    /// * 'MechanismDoesNotExist': Attempting to set weights on a non-existent network.
     ///
-    /// * 'NotRegistered':
-    ///     - Attempting to set weights from a non registered account.
+    /// * 'NotRegistered': Attempting to set weights from a non registered account.
     ///
-    /// * 'InvalidIpType':
-    ///     - The ip type is not 4 or 6.
+    /// * 'InvalidIpType': The ip type is not 4 or 6.
     ///
-    /// * 'InvalidIpAddress':
-    ///     - The numerically encoded ip address does not resolve to a proper ip.
+    /// * 'InvalidIpAddress': The numerically encoded ip address does not resolve to a proper ip.
     ///
-    /// * 'ServingRateLimitExceeded':
-    ///     - Attempting to set prometheus information withing the rate limit min.
+    /// * 'ServingRateLimitExceeded': Attempting to set prometheus information withing the rate limit min.
     ///
     pub fn do_serve_prometheus(
         origin: OriginFor<T>,

--- a/pallets/subtensor/src/subnets/serving.rs
+++ b/pallets/subtensor/src/subnets/serving.rs
@@ -4,7 +4,7 @@ use subtensor_runtime_common::NetUid;
 impl<T: Config> Pallet<T> {
     /// The implementation for the extrinsic serve_axon which sets the ip endpoint information for a uid on a network.
     ///
-    /// # Args:
+    /// # Arguments
     /// * 'origin': (<T as frame_system::Config>RuntimeOrigin):
     ///     - The signature of the caller.
     ///
@@ -35,11 +35,11 @@ impl<T: Config> Pallet<T> {
     /// * 'certificate' (Option<Vec<u8>>):
     ///     - Certificate for mutual Tls connection between neurons
     ///
-    /// # Event:
+    /// # Events
     /// * AxonServed;
     ///     - On successfully serving the axon info.
     ///
-    /// # Raises:
+    /// # Errors
     /// * 'MechanismDoesNotExist':
     ///     - Attempting to set weights on a non-existent network.
     ///
@@ -120,7 +120,7 @@ impl<T: Config> Pallet<T> {
 
     /// The implementation for the extrinsic serve_prometheus.
     ///
-    /// # Args:
+    /// # Arguments
     /// * 'origin': (<T as frame_system::Config>RuntimeOrigin):
     ///     - The signature of the caller.
     ///
@@ -139,11 +139,11 @@ impl<T: Config> Pallet<T> {
     /// * 'ip_type' (u8):
     ///     - The prometheus ip version as a u8, 4 or 6.
     ///
-    /// # Event:
+    /// # Events
     /// * PrometheusServed;
     ///     - On successfully serving the axon info.
     ///
-    /// # Raises:
+    /// # Errors
     /// * 'MechanismDoesNotExist':
     ///     - Attempting to set weights on a non-existent network.
     ///

--- a/pallets/subtensor/src/subnets/subnet.rs
+++ b/pallets/subtensor/src/subnets/subnet.rs
@@ -401,26 +401,26 @@ impl<T: Config> Pallet<T> {
     /// rate-limited to once per configured interval (default: one week) per subnet.
     ///
     /// # Arguments
-    /// - `origin`: The dispatch origin of the call. Must be either root or the current owner of the subnet.
-    /// - `netuid`: The unique identifier of the subnet whose owner hotkey is being set.
-    /// - `hotkey`: The new hotkey account to associate with the subnet owner.
+    ///
+    /// * `origin`: The dispatch origin of the call. Must be either root or the current owner of the subnet.
+    /// * `netuid`: The unique identifier of the subnet whose owner hotkey is being set.
+    /// * `hotkey`: The new hotkey account to associate with the subnet owner.
     ///
     /// # Returns
-    /// - `DispatchResult`: Returns `Ok(())` if the hotkey was successfully set, or an appropriate error otherwise.
+    ///
+    /// * `DispatchResult`: Returns `Ok(())` if the hotkey was successfully set, or an appropriate error otherwise.
     ///
     /// # Errors
-    /// - `Error::SubnetNotExists`: If the specified subnet does not exist.
-    /// - `Error::TxRateLimitExceeded`: If the function is called more frequently than the allowed rate limit.
+    ///
+    /// * `Error::SubnetNotExists`: If the specified subnet does not exist.
+    /// * `Error::TxRateLimitExceeded`: If the function is called more frequently than the allowed rate limit.
     ///
     /// # Note
-    /// Only callable by:
-    /// - Root origin, or
-    /// - The coldkey account that owns the subnet.
     ///
-    /// # Note
-    /// - Updates [`SubnetOwnerHotkey`] for the given `netuid`.
-    /// - Reads and updates [`LastRateLimitedBlock`] for rate-limiting.
-    /// - Reads [`DefaultSetSNOwnerHotkeyRateLimit`] to determine the interval between allowed updates.
+    /// Only callable by the root origin or the coldkey account that owns the subnet.
+    /// Updates [`SubnetOwnerHotkey`] for the given `netuid`. Reads and updates
+    /// [`LastRateLimitedBlock`] for rate-limiting, and reads
+    /// [`DefaultSetSNOwnerHotkeyRateLimit`] to determine the interval between allowed updates.
     ///
     /// # Note
     /// This function is rate-limited to one call per subnet per interval (e.g., one week).

--- a/pallets/subtensor/src/subnets/subnet.rs
+++ b/pallets/subtensor/src/subnets/subnet.rs
@@ -8,7 +8,7 @@ impl<T: Config> Pallet<T> {
     ///
     /// This function checks if a subnetwork with the given UID exists.
     ///
-    /// # Returns:
+    /// # Returns
     /// * 'bool': Whether the subnet exists.
     ///
     pub fn if_subnet_exist(netuid: NetUid) -> bool {
@@ -20,7 +20,7 @@ impl<T: Config> Pallet<T> {
     ///
     /// This iterates through all the networks and returns a list of netuids.
     ///
-    /// # Returns:
+    /// # Returns
     /// * 'Vec<u16>': Netuids of all subnets.
     ///
     pub fn get_all_subnet_netuids() -> Vec<NetUid> {
@@ -34,10 +34,10 @@ impl<T: Config> Pallet<T> {
     ///
     /// This checks the Mechanism map for the value, defaults to 0.
     ///
-    /// # Args:
+    /// # Arguments
     /// * 'u16': The subnet netuid
     ///
-    /// # Returns:
+    /// # Returns
     /// * 'u16': The subnet mechanism
     ///
     pub fn get_subnet_mechanism(netuid: NetUid) -> u16 {
@@ -90,7 +90,7 @@ impl<T: Config> Pallet<T> {
 
     /// Facilitates user registration of a new subnetwork.
     ///
-    /// # Args
+    /// # Arguments
     /// * **`origin`** – `T::RuntimeOrigin` &nbsp;Must be **signed** by the coldkey.
     /// * **`hotkey`** – `&T::AccountId` &nbsp;First neuron of the new subnet.
     /// * **`mechid`** – `u16` &nbsp;Only the dynamic mechanism (`1`) is currently supported.
@@ -353,12 +353,12 @@ impl<T: Config> Pallet<T> {
     /// and the last emission block number has not been set yet.
     /// It then sets the last emission block number to the current block number.
     ///
-    /// # Parameters
+    /// # Arguments
     ///
     /// * `origin`: The origin of the call, which is used to ensure the caller is the subnet owner.
     /// * `netuid`: The unique identifier of the subnet for which the start call process is being initiated.
     ///
-    /// # Raises
+    /// # Errors
     ///
     /// * `Error::<T>::SubnetNotExists`: If the subnet does not exist.
     /// * `DispatchError::BadOrigin`: If the caller is not the subnet owner.
@@ -400,7 +400,7 @@ impl<T: Config> Pallet<T> {
     /// the hotkey for a given subnet. The subnet must already exist. To prevent abuse, the call is
     /// rate-limited to once per configured interval (default: one week) per subnet.
     ///
-    /// # Parameters
+    /// # Arguments
     /// - `origin`: The dispatch origin of the call. Must be either root or the current owner of the subnet.
     /// - `netuid`: The unique identifier of the subnet whose owner hotkey is being set.
     /// - `hotkey`: The new hotkey account to associate with the subnet owner.
@@ -412,17 +412,17 @@ impl<T: Config> Pallet<T> {
     /// - `Error::SubnetNotExists`: If the specified subnet does not exist.
     /// - `Error::TxRateLimitExceeded`: If the function is called more frequently than the allowed rate limit.
     ///
-    /// # Access Control
+    /// # Note
     /// Only callable by:
     /// - Root origin, or
     /// - The coldkey account that owns the subnet.
     ///
-    /// # Storage
+    /// # Note
     /// - Updates [`SubnetOwnerHotkey`] for the given `netuid`.
     /// - Reads and updates [`LastRateLimitedBlock`] for rate-limiting.
     /// - Reads [`DefaultSetSNOwnerHotkeyRateLimit`] to determine the interval between allowed updates.
     ///
-    /// # Rate Limiting
+    /// # Note
     /// This function is rate-limited to one call per subnet per interval (e.g., one week).
     pub fn do_set_sn_owner_hotkey(
         origin: OriginFor<T>,

--- a/pallets/subtensor/src/subnets/subnet.rs
+++ b/pallets/subtensor/src/subnets/subnet.rs
@@ -97,18 +97,18 @@ impl<T: Config> Pallet<T> {
     /// * **`identity`** – `Option<SubnetIdentityOfV3>` &nbsp;Optional metadata for the subnet.
     ///
     /// # Events
-    /// * `NetworkAdded(netuid, mechid)` – always.
-    /// * `SubnetIdentitySet(netuid)`   – when a custom identity is supplied.
-    /// * `NetworkRemoved(netuid)`      – when a subnet is pruned to make room.
+    /// * 'NetworkAdded': always.
+    /// * 'SubnetIdentitySet': when a custom identity is supplied.
+    /// * 'NetworkRemoved': when a subnet is pruned to make room.
     ///
     /// # Errors
-    /// * `NonAssociatedColdKey`            – `hotkey` already belongs to another coldkey.
-    /// * `MechanismDoesNotExist`           – unsupported `mechid`.
-    /// * `NetworkTxRateLimitExceeded`      – caller hit the register-network rate limit.
-    /// * `SubnetLimitReached`              – limit hit **and** no eligible subnet to prune.
-    /// * `CannotAffordLockCost`            – caller lacks the lock cost.
-    /// * `BalanceWithdrawalError`          – failed to lock balance.
-    /// * `InvalidIdentity`                 – supplied `identity` failed validation.
+    /// * 'NonAssociatedColdKey': `hotkey` already belongs to another coldkey.
+    /// * 'MechanismDoesNotExist': unsupported `mechid`.
+    /// * 'NetworkTxRateLimitExceeded': caller hit the register-network rate limit.
+    /// * 'SubnetLimitReached': limit hit **and** no eligible subnet to prune.
+    /// * 'CannotAffordLockCost': caller lacks the lock cost.
+    /// * 'BalanceWithdrawalError': failed to lock balance.
+    /// * 'InvalidIdentity': supplied `identity` failed validation.
     ///
     pub fn do_register_network(
         origin: OriginFor<T>,

--- a/pallets/subtensor/src/subnets/subnet.rs
+++ b/pallets/subtensor/src/subnets/subnet.rs
@@ -9,7 +9,7 @@ impl<T: Config> Pallet<T> {
     /// This function checks if a subnetwork with the given UID exists.
     ///
     /// # Returns
-    /// * 'bool': Whether the subnet exists.
+    /// * `bool`: Whether the subnet exists.
     ///
     pub fn if_subnet_exist(netuid: NetUid) -> bool {
         NetworksAdded::<T>::get(netuid)
@@ -35,10 +35,10 @@ impl<T: Config> Pallet<T> {
     /// This checks the Mechanism map for the value, defaults to 0.
     ///
     /// # Arguments
-    /// * 'u16': The subnet netuid
+    /// * `u16`: The subnet netuid.
     ///
     /// # Returns
-    /// * 'u16': The subnet mechanism
+    /// * `u16`: The subnet mechanism.
     ///
     pub fn get_subnet_mechanism(netuid: NetUid) -> u16 {
         SubnetMechanism::<T>::get(netuid)
@@ -50,7 +50,7 @@ impl<T: Config> Pallet<T> {
     /// until it finds an ID that is not currently in use.
     ///
     /// # Returns
-    /// * `u16` - The next available mechanism ID.
+    /// * `u16`: The next available mechanism ID.
     pub fn get_next_netuid() -> NetUid {
         let mut next_netuid = NetUid::from(1); // do not allow creation of root
         let netuids = Self::get_all_subnet_netuids();
@@ -77,11 +77,11 @@ impl<T: Config> Pallet<T> {
     ///
     /// # Arguments
     ///
-    /// * `netuid` - The unique identifier of the subnet.
+    /// * `netuid`: The unique identifier of the subnet.
     ///
     /// # Returns
     ///
-    /// * `bool` - `true` if registrations are allowed for the subnet, `false` otherwise.
+    /// * `bool`: `true` if registrations are allowed for the subnet, `false` otherwise.
     pub fn is_registration_allowed(netuid: NetUid) -> bool {
         Self::get_subnet_hyperparams(netuid)
             .map(|params| params.registration_allowed)
@@ -421,9 +421,7 @@ impl<T: Config> Pallet<T> {
     /// Updates [`SubnetOwnerHotkey`] for the given `netuid`. Reads and updates
     /// [`LastRateLimitedBlock`] for rate-limiting, and reads
     /// [`DefaultSetSNOwnerHotkeyRateLimit`] to determine the interval between allowed updates.
-    ///
-    /// # Note
-    /// This function is rate-limited to one call per subnet per interval (e.g., one week).
+    /// Rate-limited to one call per subnet per interval (e.g., one week).
     pub fn do_set_sn_owner_hotkey(
         origin: OriginFor<T>,
         netuid: NetUid,

--- a/pallets/subtensor/src/subnets/subnet.rs
+++ b/pallets/subtensor/src/subnets/subnet.rs
@@ -90,18 +90,18 @@ impl<T: Config> Pallet<T> {
 
     /// Facilitates user registration of a new subnetwork.
     ///
-    /// ### Args
+    /// # Args
     /// * **`origin`** – `T::RuntimeOrigin` &nbsp;Must be **signed** by the coldkey.
     /// * **`hotkey`** – `&T::AccountId` &nbsp;First neuron of the new subnet.
     /// * **`mechid`** – `u16` &nbsp;Only the dynamic mechanism (`1`) is currently supported.
     /// * **`identity`** – `Option<SubnetIdentityOfV3>` &nbsp;Optional metadata for the subnet.
     ///
-    /// ### Events
+    /// # Events
     /// * `NetworkAdded(netuid, mechid)` – always.
     /// * `SubnetIdentitySet(netuid)`   – when a custom identity is supplied.
     /// * `NetworkRemoved(netuid)`      – when a subnet is pruned to make room.
     ///
-    /// ### Errors
+    /// # Errors
     /// * `NonAssociatedColdKey`            – `hotkey` already belongs to another coldkey.
     /// * `MechanismDoesNotExist`           – unsupported `mechid`.
     /// * `NetworkTxRateLimitExceeded`      – caller hit the register-network rate limit.

--- a/pallets/subtensor/src/subnets/weights.rs
+++ b/pallets/subtensor/src/subnets/weights.rs
@@ -157,16 +157,11 @@ impl<T: Config> Pallet<T> {
     ///    - The commit hashes to be committed, one hash for each netuid in the batch.
     ///
     /// # Events
-    ///  * WeightsCommitted;
-    ///    - On successfully storing the weight hashes.
-    ///  * BatchCompletedWithErrors;
-    ///    - Emitted when at least on of the weight commits has an error.
-    ///  * BatchWeightItemFailed;
-    ///    - Emitted for each error within the batch.
-    ///  * BatchWeightsCompleted
-    ///    - Emitted when the batch of weights is completed.
-    ///  * InputLengthsUnequal;
-    ///    - Emitted when the lengths of the input vectors are not equal.
+    /// * 'WeightsCommitted': On successfully storing the weight hashes.
+    /// * 'BatchCompletedWithErrors': Emitted when at least on of the weight commits has an error.
+    /// * 'BatchWeightItemFailed': Emitted for each error within the batch.
+    /// * 'BatchWeightsCompleted': Emitted when the batch of weights is completed.
+    /// * 'InputLengthsUnequal': Emitted when the lengths of the input vectors are not equal.
     ///
     pub fn do_batch_commit_weights(
         origin: OriginFor<T>,
@@ -249,14 +244,14 @@ impl<T: Config> Pallet<T> {
     ///    commit.
     ///
     /// # Errors
-    /// * `CommitRevealDisabled` – Commit-reveal is disabled on `netuid`.  
-    /// * `IncorrectCommitRevealVersion` – Provided version ≠ runtime version.  
-    /// * `HotKeyNotRegisteredInSubNet` – Caller’s hotkey is not registered.  
-    /// * `CommittingWeightsTooFast` – Caller exceeds commit-rate limit.  
-    /// * `TooManyUnrevealedCommits` – Caller already has 10 unrevealed commits.
+    /// * 'CommitRevealDisabled': Commit-reveal is disabled on `netuid`.
+    /// * 'IncorrectCommitRevealVersion': Provided version ≠ runtime version.
+    /// * 'HotKeyNotRegisteredInSubNet': Caller’s hotkey is not registered.
+    /// * 'CommittingWeightsTooFast': Caller exceeds commit-rate limit.
+    /// * 'TooManyUnrevealedCommits': Caller already has 10 unrevealed commits.
     ///
     /// # Events
-    /// * `TimelockedWeightsCommitted(hotkey, netuid, commit_hash, reveal_round)` – Fired after the commit is successfully stored.
+    /// * 'TimelockedWeightsCommitted': Fired after the commit is successfully stored.
     pub fn do_commit_timelocked_weights(
         origin: OriginFor<T>,
         netuid: NetUid,
@@ -879,42 +874,30 @@ impl<T: Config> Pallet<T> {
     ///    - The network version key.
     ///
     /// # Events
-    ///  * WeightsSet;
-    ///    - On successfully setting the weights on chain.
+    /// * 'WeightsSet': On successfully setting the weights on chain.
     ///
     /// # Errors
-    ///  * 'MechanismDoesNotExist':
-    ///    - Attempting to set weights on a non-existent network.
+    /// * 'MechanismDoesNotExist': Attempting to set weights on a non-existent network.
     ///
-    ///  * 'NotRegistered':
-    ///    - Attempting to set weights from a non registered account.
+    /// * 'NotRegistered': Attempting to set weights from a non registered account.
     ///
-    ///  * 'IncorrectWeightVersionKey':
-    ///    - Attempting to set weights without having an up-to-date version_key.
+    /// * 'IncorrectWeightVersionKey': Attempting to set weights without having an up-to-date version_key.
     ///
-    ///  * 'SettingWeightsTooFast':
-    ///    - Attempting to set weights faster than the weights_set_rate_limit.
+    /// * 'SettingWeightsTooFast': Attempting to set weights faster than the weights_set_rate_limit.
     ///
-    ///  * 'NeuronNoValidatorPermit':
-    ///    - Attempting to set non-self weights without a validator permit.
+    /// * 'NeuronNoValidatorPermit': Attempting to set non-self weights without a validator permit.
     ///
-    ///  * 'WeightVecNotEqualSize':
-    ///    - Attempting to set weights with uids not of same length.
+    /// * 'WeightVecNotEqualSize': Attempting to set weights with uids not of same length.
     ///
-    ///  * 'DuplicateUids':
-    ///    - Attempting to set weights with duplicate uids.
+    /// * 'DuplicateUids': Attempting to set weights with duplicate uids.
     ///
-    /// * 'UidsLengthExceedUidsInSubNet':
-    ///    - Attempting to set weights above the max allowed uids.
+    /// * 'UidsLengthExceedUidsInSubNet': Attempting to set weights above the max allowed uids.
     ///
-    /// * 'UidVecContainInvalidOne':
-    ///    - Attempting to set weights with invalid uids.
+    /// * 'UidVecContainInvalidOne': Attempting to set weights with invalid uids.
     ///
-    /// * 'WeightVecLengthIsLow':
-    ///    - Attempting to set weights with fewer weights than min.
+    /// * 'WeightVecLengthIsLow': Attempting to set weights with fewer weights than min.
     ///
-    /// * 'MaxWeightExceeded':
-    ///    - Attempting to set weights with max value exceeding limit.
+    /// * 'MaxWeightExceeded': Attempting to set weights with max value exceeding limit.
     ///
     pub fn do_set_weights(
         origin: OriginFor<T>,
@@ -948,42 +931,30 @@ impl<T: Config> Pallet<T> {
     ///    - The network version key.
     ///
     /// # Events
-    ///  * WeightsSet;
-    ///    - On successfully setting the weights on chain.
+    /// * 'WeightsSet': On successfully setting the weights on chain.
     ///
     /// # Errors
-    ///  * 'MechanismDoesNotExist':
-    ///    - Attempting to set weights on a non-existent network.
+    /// * 'MechanismDoesNotExist': Attempting to set weights on a non-existent network.
     ///
-    ///  * 'NotRegistered':
-    ///    - Attempting to set weights from a non registered account.
+    /// * 'NotRegistered': Attempting to set weights from a non registered account.
     ///
-    ///  * 'IncorrectWeightVersionKey':
-    ///    - Attempting to set weights without having an up-to-date version_key.
+    /// * 'IncorrectWeightVersionKey': Attempting to set weights without having an up-to-date version_key.
     ///
-    ///  * 'SettingWeightsTooFast':
-    ///    - Attempting to set weights faster than the weights_set_rate_limit.
+    /// * 'SettingWeightsTooFast': Attempting to set weights faster than the weights_set_rate_limit.
     ///
-    ///  * 'NeuronNoValidatorPermit':
-    ///    - Attempting to set non-self weights without a validator permit.
+    /// * 'NeuronNoValidatorPermit': Attempting to set non-self weights without a validator permit.
     ///
-    ///  * 'WeightVecNotEqualSize':
-    ///    - Attempting to set weights with uids not of same length.
+    /// * 'WeightVecNotEqualSize': Attempting to set weights with uids not of same length.
     ///
-    ///  * 'DuplicateUids':
-    ///    - Attempting to set weights with duplicate uids.
+    /// * 'DuplicateUids': Attempting to set weights with duplicate uids.
     ///
-    /// * 'UidsLengthExceedUidsInSubNet':
-    ///    - Attempting to set weights above the max allowed uids.
+    /// * 'UidsLengthExceedUidsInSubNet': Attempting to set weights above the max allowed uids.
     ///
-    /// * 'UidVecContainInvalidOne':
-    ///    - Attempting to set weights with invalid uids.
+    /// * 'UidVecContainInvalidOne': Attempting to set weights with invalid uids.
     ///
-    /// * 'WeightVecLengthIsLow':
-    ///    - Attempting to set weights with fewer weights than min.
+    /// * 'WeightVecLengthIsLow': Attempting to set weights with fewer weights than min.
     ///
-    /// * 'MaxWeightExceeded':
-    ///    - Attempting to set weights with max value exceeding limit.
+    /// * 'MaxWeightExceeded': Attempting to set weights with max value exceeding limit.
     ///
     pub fn do_set_mechanism_weights(
         origin: OriginFor<T>,
@@ -1015,16 +986,11 @@ impl<T: Config> Pallet<T> {
     ///    - The network version key, one u64 for each netuid in the batch.
     ///
     /// # Events
-    ///  * WeightsSet;
-    ///    - On successfully setting the weights on chain.
-    ///  * BatchCompletedWithErrors;
-    ///    - Emitted when at least on of the weight sets has an error.
-    ///  * BatchWeightItemFailed;
-    ///    - Emitted for each error within the batch.
-    ///  * BatchWeightsCompleted;
-    ///    - Emitted when the batch of weights is completed.
-    ///  * InputLengthsUnequal;
-    ///    - Emitted when the lengths of the input vectors are not equal.
+    /// * 'WeightsSet': On successfully setting the weights on chain.
+    /// * 'BatchCompletedWithErrors': Emitted when at least on of the weight sets has an error.
+    /// * 'BatchWeightItemFailed': Emitted for each error within the batch.
+    /// * 'BatchWeightsCompleted': Emitted when the batch of weights is completed.
+    /// * 'InputLengthsUnequal': Emitted when the lengths of the input vectors are not equal.
     ///
     pub fn do_batch_set_weights(
         origin: OriginFor<T>,

--- a/pallets/subtensor/src/subnets/weights.rs
+++ b/pallets/subtensor/src/subnets/weights.rs
@@ -13,7 +13,7 @@ use sp_std::{collections::vec_deque::VecDeque, vec};
 use subtensor_runtime_common::{MechId, NetUid, NetUidStorageIndex};
 
 impl<T: Config> Pallet<T> {
-    /// ---- The implementation for committing weight hashes.
+    /// The implementation for committing weight hashes.
     ///
     /// # Args:
     /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
@@ -142,7 +142,7 @@ impl<T: Config> Pallet<T> {
         })
     }
 
-    /// ---- The implementation for the extrinsic batch_commit_weights.
+    /// The implementation for the extrinsic batch_commit_weights.
     ///
     /// This call runs a batch of commit weights calls, continuing on errors.
     ///
@@ -213,7 +213,7 @@ impl<T: Config> Pallet<T> {
         Ok(())
     }
 
-    /// ---- Commits a timelocked, encrypted weight payload (Commit-Reveal v3).
+    /// Commits a timelocked, encrypted weight payload (Commit-Reveal v3).
     ///
     /// # Args
     /// * `origin` (`<T as frame_system::Config>::RuntimeOrigin`):  
@@ -381,7 +381,7 @@ impl<T: Config> Pallet<T> {
         )
     }
 
-    /// ---- The implementation for revealing committed weights.
+    /// The implementation for revealing committed weights.
     ///
     /// # Args:
     /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
@@ -563,7 +563,7 @@ impl<T: Config> Pallet<T> {
         )
     }
 
-    /// ---- The implementation for batch revealing committed weights.
+    /// The implementation for batch revealing committed weights.
     ///
     /// # Args:
     /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
@@ -860,7 +860,7 @@ impl<T: Config> Pallet<T> {
         Ok(())
     }
 
-    /// ---- The implementation for the extrinsic set_weights.
+    /// The implementation for the extrinsic set_weights.
     ///
     /// # Args:
     ///  * 'origin': (<T as frame_system::Config>RuntimeOrigin):
@@ -926,7 +926,7 @@ impl<T: Config> Pallet<T> {
         Self::internal_set_weights(origin, netuid, MechId::MAIN, uids, values, version_key)
     }
 
-    /// ---- The implementation for the extrinsic set_weights.
+    /// The implementation for the extrinsic set_weights.
     ///
     /// # Args:
     ///  * 'origin': (<T as frame_system::Config>RuntimeOrigin):
@@ -996,7 +996,7 @@ impl<T: Config> Pallet<T> {
         Self::internal_set_weights(origin, netuid, mecid, uids, values, version_key)
     }
 
-    /// ---- The implementation for the extrinsic batch_set_weights.
+    /// The implementation for the extrinsic batch_set_weights.
     ///
     /// This call runs a batch of set weights calls, continuing on errors.
     ///

--- a/pallets/subtensor/src/subnets/weights.rs
+++ b/pallets/subtensor/src/subnets/weights.rs
@@ -16,31 +16,23 @@ impl<T: Config> Pallet<T> {
     /// The implementation for committing weight hashes.
     ///
     /// # Arguments
-    /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
-    ///   - The signature of the committing hotkey.
+    /// * `origin`: The signature of the committing hotkey.
     ///
-    /// * `netuid` (`u16`):
-    ///   - The u16 network identifier.
+    /// * `netuid`: The u16 network identifier.
     ///
-    /// * `commit_hash` (`H256`):
-    ///   - The hash representing the committed weights.
+    /// * `commit_hash`: The hash representing the committed weights.
     ///
     /// # Errors
-    /// * `CommitRevealDisabled`:
-    ///   - Raised if commit-reveal is disabled for the specified network.
+    /// * 'CommitRevealDisabled': Raised if commit-reveal is disabled for the specified network.
     ///
-    /// * `HotKeyNotRegisteredInSubNet`:
-    ///   - Raised if the hotkey is not registered on the specified network.
+    /// * 'HotKeyNotRegisteredInSubNet': Raised if the hotkey is not registered on the specified network.
     ///
-    /// * `CommittingWeightsTooFast`:
-    ///   - Raised if the hotkey's commit rate exceeds the permitted limit.
+    /// * 'CommittingWeightsTooFast': Raised if the hotkey's commit rate exceeds the permitted limit.
     ///
-    /// * `TooManyUnrevealedCommits`:
-    ///   - Raised if the hotkey has reached the maximum number of unrevealed commits.
+    /// * 'TooManyUnrevealedCommits': Raised if the hotkey has reached the maximum number of unrevealed commits.
     ///
     /// # Events
-    /// * `WeightsCommitted`:
-    ///   - Emitted upon successfully storing the weight hash.
+    /// * 'WeightsCommitted': Emitted upon successfully storing the weight hash.
     pub fn do_commit_weights(
         origin: OriginFor<T>,
         netuid: NetUid,
@@ -147,14 +139,11 @@ impl<T: Config> Pallet<T> {
     /// This call runs a batch of commit weights calls, continuing on errors.
     ///
     /// # Arguments
-    ///  * 'origin': (<T as frame_system::Config>RuntimeOrigin):
-    ///    - The signature of the calling hotkey.
+    /// * `origin`: The signature of the calling hotkey.
     ///
-    ///  * 'netuids' ( Vec<Compact<u16>> ):
-    ///    - The u16 network identifiers.
+    /// * `netuids`: The u16 network identifiers.
     ///
-    ///  * 'commit_hashes' ( Vec<H256> ):
-    ///    - The commit hashes to be committed, one hash for each netuid in the batch.
+    /// * `commit_hashes`: The commit hashes to be committed, one hash for each netuid in the batch.
     ///
     /// # Events
     /// * 'WeightsCommitted': On successfully storing the weight hashes.
@@ -211,23 +200,18 @@ impl<T: Config> Pallet<T> {
     /// Commits a timelocked, encrypted weight payload (Commit-Reveal v3).
     ///
     /// # Arguments
-    /// * `origin` (`<T as frame_system::Config>::RuntimeOrigin`):  
-    ///   The signed origin of the committing hotkey.
-    /// * `netuid` (`NetUid` = `u16`):  
-    ///   Unique identifier for the subnet on which the commit is made.
-    /// * `commit` (`BoundedVec<u8, ConstU32<MAX_CRV3_COMMIT_SIZE_BYTES>>`):  
-    ///   The encrypted weight payload, produced as follows:  
-    ///   1. Build a [`WeightsPayload`] structure.  
-    ///   2. SCALE-encode it (`parity_scale_codec::Encode`).  
-    ///   3. Encrypt it following the steps  
-    ///      [here](https://github.com/ideal-lab5/tle/blob/f8e6019f0fb02c380ebfa6b30efb61786dede07b/timelock/src/tlock.rs#L283-L336) to  
-    ///      produce a [`TLECiphertext<TinyBLS381>`].  
+    /// * `origin`: The signed origin of the committing hotkey.
+    /// * `netuid`: Unique identifier for the subnet on which the commit is made.
+    /// * `commit`: The encrypted weight payload, produced as follows:
+    ///   1. Build a [`WeightsPayload`] structure.
+    ///   2. SCALE-encode it (`parity_scale_codec::Encode`).
+    ///   3. Encrypt it following the steps
+    ///      [here](https://github.com/ideal-lab5/tle/blob/f8e6019f0fb02c380ebfa6b30efb61786dede07b/timelock/src/tlock.rs#L283-L336) to
+    ///      produce a [`TLECiphertext<TinyBLS381>`].
     ///   4. Compress & serialise.
-    /// * `reveal_round` (`u64`):  
-    ///   DRAND round whose output becomes known during epoch `n + 1`; the payload  
+    /// * `reveal_round`: DRAND round whose output becomes known during epoch `n + 1`; the payload
     ///   must be revealed in that epoch.
-    /// * `commit_reveal_version` (`u16`):  
-    ///   Version tag that **must** match [`get_commit_reveal_weights_version`] for  
+    /// * `commit_reveal_version`: Version tag that **must** match [`get_commit_reveal_weights_version`] for
     ///   the call to succeed. Used to gate runtime upgrades.
     ///
     /// # Note
@@ -379,39 +363,28 @@ impl<T: Config> Pallet<T> {
     /// The implementation for revealing committed weights.
     ///
     /// # Arguments
-    /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
-    ///   - The signature of the revealing hotkey.
+    /// * `origin`: The signature of the revealing hotkey.
     ///
-    /// * `netuid` (`u16`):
-    ///   - The u16 network identifier.
+    /// * `netuid`: The u16 network identifier.
     ///
-    /// * `uids` (`Vec<u16>`):
-    ///   - The uids for the weights being revealed.
+    /// * `uids`: The uids for the weights being revealed.
     ///
-    /// * `values` (`Vec<u16>`):
-    ///   - The values of the weights being revealed.
+    /// * `values`: The values of the weights being revealed.
     ///
-    /// * `salt` (`Vec<u16>`):
-    ///   - The salt used to generate the commit hash.
+    /// * `salt`: The salt used to generate the commit hash.
     ///
-    /// * `version_key` (`u64`):
-    ///   - The network version key.
+    /// * `version_key`: The network version key.
     ///
     /// # Errors
-    /// * `CommitRevealDisabled`:
-    ///   - Attempting to reveal weights when the commit-reveal mechanism is disabled.
+    /// * 'CommitRevealDisabled': Attempting to reveal weights when the commit-reveal mechanism is disabled.
     ///
-    /// * `NoWeightsCommitFound`:
-    ///   - Attempting to reveal weights without an existing commit.
+    /// * 'NoWeightsCommitFound': Attempting to reveal weights without an existing commit.
     ///
-    /// * `ExpiredWeightCommit`:
-    ///   - Attempting to reveal a weight commit that has expired.
+    /// * 'ExpiredWeightCommit': Attempting to reveal a weight commit that has expired.
     ///
-    /// * `RevealTooEarly`:
-    ///   - Attempting to reveal weights outside the valid reveal period.
+    /// * 'RevealTooEarly': Attempting to reveal weights outside the valid reveal period.
     ///
-    /// * `InvalidRevealCommitHashNotMatch`:
-    ///   - The revealed hash does not match any committed hash.
+    /// * 'InvalidRevealCommitHashNotMatch': The revealed hash does not match any committed hash.
     pub fn do_reveal_weights(
         origin: OriginFor<T>,
         netuid: NetUid,
@@ -561,42 +534,30 @@ impl<T: Config> Pallet<T> {
     /// The implementation for batch revealing committed weights.
     ///
     /// # Arguments
-    /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
-    ///   - The signature of the revealing hotkey.
+    /// * `origin`: The signature of the revealing hotkey.
     ///
-    /// * `netuid` (`u16`):
-    ///   - The u16 network identifier.
+    /// * `netuid`: The u16 network identifier.
     ///
-    /// * `uids_list` (`Vec<Vec<u16>>`):
-    ///   - A list of uids for each set of weights being revealed.
+    /// * `uids_list`: A list of uids for each set of weights being revealed.
     ///
-    /// * `values_list` (`Vec<Vec<u16>>`):
-    ///   - A list of values for each set of weights being revealed.
+    /// * `values_list`: A list of values for each set of weights being revealed.
     ///
-    /// * `salts_list` (`Vec<Vec<u16>>`):
-    ///   - A list of salts used to generate the commit hashes.
+    /// * `salts_list`: A list of salts used to generate the commit hashes.
     ///
-    /// * `version_keys` (`Vec<u64>`):
-    ///   - A list of network version keys.
+    /// * `version_keys`: A list of network version keys.
     ///
     /// # Errors
-    /// * `CommitRevealDisabled`:
-    ///   - Attempting to reveal weights when the commit-reveal mechanism is disabled.
+    /// * 'CommitRevealDisabled': Attempting to reveal weights when the commit-reveal mechanism is disabled.
     ///
-    /// * `NoWeightsCommitFound`:
-    ///   - Attempting to reveal weights without an existing commit.
+    /// * 'NoWeightsCommitFound': Attempting to reveal weights without an existing commit.
     ///
-    /// * `ExpiredWeightCommit`:
-    ///   - Attempting to reveal a weight commit that has expired.
+    /// * 'ExpiredWeightCommit': Attempting to reveal a weight commit that has expired.
     ///
-    /// * `RevealTooEarly`:
-    ///   - Attempting to reveal weights outside the valid reveal period.
+    /// * 'RevealTooEarly': Attempting to reveal weights outside the valid reveal period.
     ///
-    /// * `InvalidRevealCommitHashNotMatch`:
-    ///   - The revealed hash does not match any committed hash.
+    /// * 'InvalidRevealCommitHashNotMatch': The revealed hash does not match any committed hash.
     ///
-    /// * `InputLengthsUnequal`:
-    ///   - The input vectors are of mismatched lengths.
+    /// * 'InputLengthsUnequal': The input vectors are of mismatched lengths.
     pub fn do_batch_reveal_weights(
         origin: OriginFor<T>,
         netuid: NetUid,
@@ -858,20 +819,15 @@ impl<T: Config> Pallet<T> {
     /// The implementation for the extrinsic set_weights.
     ///
     /// # Arguments
-    ///  * 'origin': (<T as frame_system::Config>RuntimeOrigin):
-    ///    - The signature of the calling hotkey.
+    /// * `origin`: The signature of the calling hotkey.
     ///
-    ///  * 'netuid' (u16):
-    ///    - The u16 network identifier.
+    /// * `netuid`: The u16 network identifier.
     ///
-    ///  * 'uids' ( Vec<u16> ):
-    ///    - The uids of the weights to be set on the chain.
+    /// * `uids`: The uids of the weights to be set on the chain.
     ///
-    ///  * 'values' ( Vec<u16> ):
-    ///    - The values of the weights to set on the chain.
+    /// * `values`: The values of the weights to set on the chain.
     ///
-    ///  * 'version_key' ( u64 ):
-    ///    - The network version key.
+    /// * `version_key`: The network version key.
     ///
     /// # Events
     /// * 'WeightsSet': On successfully setting the weights on chain.
@@ -912,23 +868,17 @@ impl<T: Config> Pallet<T> {
     /// The implementation for the extrinsic set_weights.
     ///
     /// # Arguments
-    ///  * 'origin': (<T as frame_system::Config>RuntimeOrigin):
-    ///    - The signature of the calling hotkey.
+    /// * `origin`: The signature of the calling hotkey.
     ///
-    ///  * 'netuid' (u16):
-    ///    - The u16 network identifier.
+    /// * `netuid`: The u16 network identifier.
     ///
-    ///  * 'mecid' (u8):
-    ///    - The u8 identifier of sub-subnet.
+    /// * `mecid`: The u8 identifier of sub-subnet.
     ///
-    ///  * 'uids' ( Vec<u16> ):
-    ///    - The uids of the weights to be set on the chain.
+    /// * `uids`: The uids of the weights to be set on the chain.
     ///
-    ///  * 'values' ( Vec<u16> ):
-    ///    - The values of the weights to set on the chain.
+    /// * `values`: The values of the weights to set on the chain.
     ///
-    ///  * 'version_key' ( u64 ):
-    ///    - The network version key.
+    /// * `version_key`: The network version key.
     ///
     /// # Events
     /// * 'WeightsSet': On successfully setting the weights on chain.
@@ -972,18 +922,13 @@ impl<T: Config> Pallet<T> {
     /// This call runs a batch of set weights calls, continuing on errors.
     ///
     /// # Arguments
-    ///  * 'origin': (<T as frame_system::Config>RuntimeOrigin):
-    ///    - The signature of the calling hotkey.
+    /// * `origin`: The signature of the calling hotkey.
     ///
-    ///  * 'netuids' ( Vec<Compact<u16>> ):
-    ///    - The u16 network identifiers.
+    /// * `netuids`: The u16 network identifiers.
     ///
-    ///  * 'weights' ( Vec<Vec<(Compact<u16>, Compact<u16>)>> ):
-    ///    - Tuples of (uid, value) of the weights to be set on the chain,
-    ///      one Vec for each netuid in the batch.
+    /// * `weights`: Tuples of (uid, value) of the weights to be set on the chain, one Vec for each netuid in the batch.
     ///
-    ///  * 'version_keys' ( Vec<Compact<u64>> ):
-    ///    - The network version key, one u64 for each netuid in the batch.
+    /// * `version_keys`: The network version key, one u64 for each netuid in the batch.
     ///
     /// # Events
     /// * 'WeightsSet': On successfully setting the weights on chain.

--- a/pallets/subtensor/src/subnets/weights.rs
+++ b/pallets/subtensor/src/subnets/weights.rs
@@ -15,7 +15,7 @@ use subtensor_runtime_common::{MechId, NetUid, NetUidStorageIndex};
 impl<T: Config> Pallet<T> {
     /// The implementation for committing weight hashes.
     ///
-    /// # Args:
+    /// # Arguments
     /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
     ///   - The signature of the committing hotkey.
     ///
@@ -25,7 +25,7 @@ impl<T: Config> Pallet<T> {
     /// * `commit_hash` (`H256`):
     ///   - The hash representing the committed weights.
     ///
-    /// # Raises:
+    /// # Errors
     /// * `CommitRevealDisabled`:
     ///   - Raised if commit-reveal is disabled for the specified network.
     ///
@@ -38,7 +38,7 @@ impl<T: Config> Pallet<T> {
     /// * `TooManyUnrevealedCommits`:
     ///   - Raised if the hotkey has reached the maximum number of unrevealed commits.
     ///
-    /// # Events:
+    /// # Events
     /// * `WeightsCommitted`:
     ///   - Emitted upon successfully storing the weight hash.
     pub fn do_commit_weights(
@@ -146,7 +146,7 @@ impl<T: Config> Pallet<T> {
     ///
     /// This call runs a batch of commit weights calls, continuing on errors.
     ///
-    /// # Args:
+    /// # Arguments
     ///  * 'origin': (<T as frame_system::Config>RuntimeOrigin):
     ///    - The signature of the calling hotkey.
     ///
@@ -156,7 +156,7 @@ impl<T: Config> Pallet<T> {
     ///  * 'commit_hashes' ( Vec<H256> ):
     ///    - The commit hashes to be committed, one hash for each netuid in the batch.
     ///
-    /// # Event:
+    /// # Events
     ///  * WeightsCommitted;
     ///    - On successfully storing the weight hashes.
     ///  * BatchCompletedWithErrors;
@@ -215,7 +215,7 @@ impl<T: Config> Pallet<T> {
 
     /// Commits a timelocked, encrypted weight payload (Commit-Reveal v3).
     ///
-    /// # Args
+    /// # Arguments
     /// * `origin` (`<T as frame_system::Config>::RuntimeOrigin`):  
     ///   The signed origin of the committing hotkey.
     /// * `netuid` (`NetUid` = `u16`):  
@@ -235,7 +235,7 @@ impl<T: Config> Pallet<T> {
     ///   Version tag that **must** match [`get_commit_reveal_weights_version`] for  
     ///   the call to succeed. Used to gate runtime upgrades.
     ///
-    /// # Behaviour
+    /// # Note
     /// 1. Verifies the caller’s signature and registration on `netuid`.  
     /// 2. Ensures commit-reveal is enabled **and** the supplied
     ///    `commit_reveal_version` is current.  
@@ -248,7 +248,7 @@ impl<T: Config> Pallet<T> {
     /// 7. Updates `LastUpdateForUid` so subsequent rate-limit checks include this
     ///    commit.
     ///
-    /// # Raises
+    /// # Errors
     /// * `CommitRevealDisabled` – Commit-reveal is disabled on `netuid`.  
     /// * `IncorrectCommitRevealVersion` – Provided version ≠ runtime version.  
     /// * `HotKeyNotRegisteredInSubNet` – Caller’s hotkey is not registered.  
@@ -383,7 +383,7 @@ impl<T: Config> Pallet<T> {
 
     /// The implementation for revealing committed weights.
     ///
-    /// # Args:
+    /// # Arguments
     /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
     ///   - The signature of the revealing hotkey.
     ///
@@ -402,7 +402,7 @@ impl<T: Config> Pallet<T> {
     /// * `version_key` (`u64`):
     ///   - The network version key.
     ///
-    /// # Raises:
+    /// # Errors
     /// * `CommitRevealDisabled`:
     ///   - Attempting to reveal weights when the commit-reveal mechanism is disabled.
     ///
@@ -565,7 +565,7 @@ impl<T: Config> Pallet<T> {
 
     /// The implementation for batch revealing committed weights.
     ///
-    /// # Args:
+    /// # Arguments
     /// * `origin`: (`<T as frame_system::Config>::RuntimeOrigin`):
     ///   - The signature of the revealing hotkey.
     ///
@@ -584,7 +584,7 @@ impl<T: Config> Pallet<T> {
     /// * `version_keys` (`Vec<u64>`):
     ///   - A list of network version keys.
     ///
-    /// # Raises:
+    /// # Errors
     /// * `CommitRevealDisabled`:
     ///   - Attempting to reveal weights when the commit-reveal mechanism is disabled.
     ///
@@ -862,7 +862,7 @@ impl<T: Config> Pallet<T> {
 
     /// The implementation for the extrinsic set_weights.
     ///
-    /// # Args:
+    /// # Arguments
     ///  * 'origin': (<T as frame_system::Config>RuntimeOrigin):
     ///    - The signature of the calling hotkey.
     ///
@@ -878,11 +878,11 @@ impl<T: Config> Pallet<T> {
     ///  * 'version_key' ( u64 ):
     ///    - The network version key.
     ///
-    /// # Event:
+    /// # Events
     ///  * WeightsSet;
     ///    - On successfully setting the weights on chain.
     ///
-    /// # Raises:
+    /// # Errors
     ///  * 'MechanismDoesNotExist':
     ///    - Attempting to set weights on a non-existent network.
     ///
@@ -928,7 +928,7 @@ impl<T: Config> Pallet<T> {
 
     /// The implementation for the extrinsic set_weights.
     ///
-    /// # Args:
+    /// # Arguments
     ///  * 'origin': (<T as frame_system::Config>RuntimeOrigin):
     ///    - The signature of the calling hotkey.
     ///
@@ -947,11 +947,11 @@ impl<T: Config> Pallet<T> {
     ///  * 'version_key' ( u64 ):
     ///    - The network version key.
     ///
-    /// # Event:
+    /// # Events
     ///  * WeightsSet;
     ///    - On successfully setting the weights on chain.
     ///
-    /// # Raises:
+    /// # Errors
     ///  * 'MechanismDoesNotExist':
     ///    - Attempting to set weights on a non-existent network.
     ///
@@ -1000,7 +1000,7 @@ impl<T: Config> Pallet<T> {
     ///
     /// This call runs a batch of set weights calls, continuing on errors.
     ///
-    /// # Args:
+    /// # Arguments
     ///  * 'origin': (<T as frame_system::Config>RuntimeOrigin):
     ///    - The signature of the calling hotkey.
     ///
@@ -1014,7 +1014,7 @@ impl<T: Config> Pallet<T> {
     ///  * 'version_keys' ( Vec<Compact<u64>> ):
     ///    - The network version key, one u64 for each netuid in the batch.
     ///
-    /// # Event:
+    /// # Events
     ///  * WeightsSet;
     ///    - On successfully setting the weights on chain.
     ///  * BatchCompletedWithErrors;

--- a/pallets/subtensor/src/swap/swap_hotkey.rs
+++ b/pallets/subtensor/src/swap/swap_hotkey.rs
@@ -19,17 +19,17 @@ impl<T: Config> Pallet<T> {
     ///
     /// # Returns
     ///
-    /// * `DispatchResultWithPostInfo` - The result of the dispatch.
+    /// * 'DispatchResultWithPostInfo': The result of the dispatch.
     ///
     /// # Errors
     ///
-    /// * `NonAssociatedColdKey` - If the coldkey does not own the old hotkey.
-    /// * `HotKeySetTxRateLimitExceeded` - If the transaction rate limit is exceeded.
-    /// * `NewHotKeyIsSameWithOld` - If the new hotkey is the same as the old hotkey.
-    /// * `HotKeyAlreadyRegisteredInSubNet` - If the new hotkey is already registered in the subnet.
-    /// * `NewHotKeyNotCleanForRootSwap` - If the swap touches root and the new hotkey
+    /// * 'NonAssociatedColdKey': If the coldkey does not own the old hotkey.
+    /// * 'HotKeySetTxRateLimitExceeded': If the transaction rate limit is exceeded.
+    /// * 'NewHotKeyIsSameWithOld': If the new hotkey is the same as the old hotkey.
+    /// * 'HotKeyAlreadyRegisteredInSubNet': If the new hotkey is already registered in the subnet.
+    /// * 'NewHotKeyNotCleanForRootSwap': If the swap touches root and the new hotkey.
     ///   has outstanding `RootClaimable` entries or non-zero root stake.
-    /// * `NotEnoughBalanceToPaySwapHotKey` - If there is not enough balance to pay for the swap.
+    /// * 'NotEnoughBalanceToPaySwapHotKey': If there is not enough balance to pay for the swap.
     pub fn do_swap_hotkey(
         origin: OriginFor<T>,
         old_hotkey: &T::AccountId,
@@ -191,7 +191,7 @@ impl<T: Config> Pallet<T> {
     /// * `weight` - A mutable reference to the Weight, updated as operations are performed.
     ///
     /// # Returns
-    /// * `DispatchResult` - Ok(()) if the swap was successful, or an error if any operation failed.
+    /// * 'DispatchResult': Ok(()) if the swap was successful, or an error if any operation failed.
     ///
     /// # Note
     /// This function performs extensive storage reads and writes, which can be computationally expensive.

--- a/pallets/subtensor/src/swap/swap_hotkey.rs
+++ b/pallets/subtensor/src/swap/swap_hotkey.rs
@@ -11,15 +11,15 @@ impl<T: Config> Pallet<T> {
     ///
     /// # Arguments
     ///
-    /// * `origin` - The origin of the transaction, and also the coldkey account.
-    /// * `old_hotkey` - The old hotkey to be swapped.
-    /// * `new_hotkey` - The new hotkey to replace the old one.
-    /// * `netuid` - The hotkey swap in a subnet or all subnets.
-    /// * `keep_stake` - If `true`, stake remains on the old hotkey and the rest metadata
+    /// * `origin`: The origin of the transaction, and also the coldkey account.
+    /// * `old_hotkey`: The old hotkey to be swapped.
+    /// * `new_hotkey`: The new hotkey to replace the old one.
+    /// * `netuid`: The hotkey swap in a subnet or all subnets.
+    /// * `keep_stake`: If `true`, stake remains on the old hotkey and the rest metadata.
     ///
     /// # Returns
     ///
-    /// * 'DispatchResultWithPostInfo': The result of the dispatch.
+    /// * `DispatchResultWithPostInfo`: The result of the dispatch.
     ///
     /// # Errors
     ///
@@ -185,13 +185,13 @@ impl<T: Config> Pallet<T> {
     /// Throughout the process, the function accumulates the computational weight of operations performed.
     ///
     /// # Arguments
-    /// * `old_hotkey` - The AccountId of the current hotkey to be replaced.
-    /// * `new_hotkey` - The AccountId of the new hotkey to replace the old one.
-    /// * `coldkey` - The AccountId of the coldkey that owns both hotkeys.
-    /// * `weight` - A mutable reference to the Weight, updated as operations are performed.
+    /// * `old_hotkey`: The AccountId of the current hotkey to be replaced.
+    /// * `new_hotkey`: The AccountId of the new hotkey to replace the old one.
+    /// * `coldkey`: The AccountId of the coldkey that owns both hotkeys.
+    /// * `weight`: A mutable reference to the Weight, updated as operations are performed.
     ///
     /// # Returns
-    /// * 'DispatchResult': Ok(()) if the swap was successful, or an error if any operation failed.
+    /// * `DispatchResult`: Ok(()) if the swap was successful, or an error if any operation failed.
     ///
     /// # Note
     /// This function performs extensive storage reads and writes, which can be computationally expensive.

--- a/pallets/subtensor/src/utils/evm.rs
+++ b/pallets/subtensor/src/utils/evm.rs
@@ -36,11 +36,11 @@ impl<T: Config> Pallet<T> {
     ///
     /// # Arguments
     ///
-    /// * `origin` - The origin of the call, which should be the hotkey.
-    /// * `netuid` - The unique identifier for the subnet that the hotkey belongs to.
-    /// * `evm_key` - The EVM address to associate with the `hotkey`.
-    /// * `block_number` - The block number used in the `signature`.
-    /// * `signature` - A signed message by the `evm_key` containing the `hotkey` and the hashed
+    /// * `origin`: The origin of the call, which should be the hotkey.
+    /// * `netuid`: The unique identifier for the subnet that the hotkey belongs to.
+    /// * `evm_key`: The EVM address to associate with the `hotkey`.
+    /// * `block_number`: The block number used in the `signature`.
+    /// * `signature`: A signed message by the `evm_key` containing the `hotkey` and the hashed.
     ///   `block_number`.
     pub fn do_associate_evm_key(
         origin: OriginFor<T>,

--- a/pallets/subtensor/src/utils/identity.rs
+++ b/pallets/subtensor/src/utils/identity.rs
@@ -13,13 +13,13 @@ impl<T: Config> Pallet<T> {
     ///
     /// # Arguments
     ///
-    /// * `origin` - The origin of the call, which should be a signed extrinsic.
-    /// * `name` - The name to be associated with the identity.
-    /// * `url` - A URL associated with the identity.
-    /// * `image` - An image URL or identifier for the identity.
-    /// * `discord` - Discord information for the identity.
-    /// * `description` - A description of the identity.
-    /// * `additional` - Any additional information for the identity.
+    /// * `origin`: The origin of the call, which should be a signed extrinsic.
+    /// * `name`: The name to be associated with the identity.
+    /// * `url`: A URL associated with the identity.
+    /// * `image`: An image URL or identifier for the identity.
+    /// * `discord`: Discord information for the identity.
+    /// * `description`: A description of the identity.
+    /// * `additional`: Any additional information for the identity.
     ///
     /// # Returns
     ///
@@ -86,11 +86,11 @@ impl<T: Config> Pallet<T> {
     ///
     /// # Arguments
     ///
-    /// * `origin` - The origin of the call, which should be a signed extrinsic.
-    /// * `netuid` - The unique identifier for the subnet.
-    /// * `subnet_name` - The name of the subnet to be associated with the identity.
-    /// * `github_repo` - The GitHub repository URL associated with the subnet identity.
-    /// * `subnet_contact` - Contact information for the subnet.
+    /// * `origin`: The origin of the call, which should be a signed extrinsic.
+    /// * `netuid`: The unique identifier for the subnet.
+    /// * `subnet_name`: The name of the subnet to be associated with the identity.
+    /// * `github_repo`: The GitHub repository URL associated with the subnet identity.
+    /// * `subnet_contact`: Contact information for the subnet.
     ///
     /// # Returns
     ///
@@ -155,11 +155,11 @@ impl<T: Config> Pallet<T> {
     ///
     /// # Arguments
     ///
-    /// * `identity` - A reference to the ChainIdentityOf struct to be validated.
+    /// * `identity`: A reference to the ChainIdentityOf struct to be validated.
     ///
     /// # Returns
     ///
-    /// * `bool` - Returns true if the Identity is valid, false otherwise.
+    /// * `bool`: Returns true if the Identity is valid, false otherwise.
     pub fn is_valid_identity(identity: &ChainIdentityOfV2) -> bool {
         let total_length = identity
             .name
@@ -196,11 +196,11 @@ impl<T: Config> Pallet<T> {
     ///
     /// # Arguments
     ///
-    /// * `identity` - A reference to the SubnetIdentityOfV3 struct to be validated.
+    /// * `identity`: A reference to the SubnetIdentityOfV3 struct to be validated.
     ///
     /// # Returns
     ///
-    /// * `bool` - Returns true if the SubnetIdentityV3 is valid, false otherwise.
+    /// * `bool`: Returns true if the SubnetIdentityV3 is valid, false otherwise.
     pub fn is_valid_subnet_identity(identity: &SubnetIdentityOfV3) -> bool {
         let total_length = identity
             .subnet_name

--- a/pallets/subtensor/src/utils/misc.rs
+++ b/pallets/subtensor/src/utils/misc.rs
@@ -827,7 +827,7 @@ impl<T: Config> Pallet<T> {
     ///
     /// * `duration` - The blocks for dissolve network execution.
     ///
-    /// # Effects
+    /// # Note
     ///
     /// * Update the DissolveNetworkScheduleDuration storage.
     /// * Emits a DissolveNetworkScheduleDurationSet evnet.
@@ -843,7 +843,7 @@ impl<T: Config> Pallet<T> {
     /// * `netuid` - The unique identifier for the subnet.
     /// * `hotkey` - The new hotkey for the subnet owner.
     ///
-    /// # Effects
+    /// # Note
     ///
     /// * Update the SubnetOwnerHotkey storage.
     /// * Emits a SubnetOwnerHotkeySet event.
@@ -867,7 +867,7 @@ impl<T: Config> Pallet<T> {
     /// and [`MaxImmuneOwnerUidsLimit`]. If the bound check fails, this returns
     /// [`Error::<T>::InvalidValue`] and leaves storage unchanged.
     ///
-    /// # Parameters
+    /// # Arguments
     /// - `netuid`: Identifier of the subnet to update.
     /// - `limit`: New inclusive upper bound for the count of owner-immune UIDs on this subnet.
     ///
@@ -887,7 +887,7 @@ impl<T: Config> Pallet<T> {
 
     /// Fetches the max number of subnet
     ///
-    /// # Returns:
+    /// # Returns
     /// * 'u16': The max number of subnet
     ///
     pub fn get_max_subnets() -> u16 {

--- a/pallets/subtensor/src/utils/misc.rs
+++ b/pallets/subtensor/src/utils/misc.rs
@@ -868,12 +868,14 @@ impl<T: Config> Pallet<T> {
     /// [`Error::<T>::InvalidValue`] and leaves storage unchanged.
     ///
     /// # Arguments
-    /// - `netuid`: Identifier of the subnet to update.
-    /// - `limit`: New inclusive upper bound for the count of owner-immune UIDs on this subnet.
+    ///
+    /// * `netuid`: Identifier of the subnet to update.
+    /// * `limit`: New inclusive upper bound for the count of owner-immune UIDs on this subnet.
     ///
     /// # Returns
-    /// - `Ok(())` on success (value written to storage).
-    /// - `Err(Error::<T>::InvalidValue)` if `limit` is outside `[MinImmuneOwnerUidsLimit, MaxImmuneOwnerUidsLimit]`.
+    ///
+    /// * `Ok(())` on success (value written to storage).
+    /// * `Err(Error::<T>::InvalidValue)` if `limit` is outside `[MinImmuneOwnerUidsLimit, MaxImmuneOwnerUidsLimit]`.
     pub fn set_owner_immune_neuron_limit(netuid: NetUid, limit: u16) -> DispatchResult {
         ensure!(
             limit >= MinImmuneOwnerUidsLimit::<T>::get()

--- a/pallets/subtensor/src/utils/misc.rs
+++ b/pallets/subtensor/src/utils/misc.rs
@@ -825,7 +825,7 @@ impl<T: Config> Pallet<T> {
     ///
     /// # Arguments
     ///
-    /// * `duration` - The blocks for dissolve network execution.
+    /// * `duration`: The blocks for dissolve network execution.
     ///
     /// # Note
     ///
@@ -840,8 +840,8 @@ impl<T: Config> Pallet<T> {
     ///
     /// # Arguments
     ///
-    /// * `netuid` - The unique identifier for the subnet.
-    /// * `hotkey` - The new hotkey for the subnet owner.
+    /// * `netuid`: The unique identifier for the subnet.
+    /// * `hotkey`: The new hotkey for the subnet owner.
     ///
     /// # Note
     ///
@@ -890,7 +890,7 @@ impl<T: Config> Pallet<T> {
     /// Fetches the max number of subnet
     ///
     /// # Returns
-    /// * 'u16': The max number of subnet
+    /// * `u16`: The max number of subnet.
     ///
     pub fn get_max_subnets() -> u16 {
         SubnetLimit::<T>::get()


### PR DESCRIPTION
## Description

Standardizes rustdoc comments across `pallets/subtensor/src/` on one canonical convention.

Split into 7 commits:

1. `e7ec631`: strip decorative `/// ---` / `/// ===` / banner lines
2. `82f7793`: normalize section headings (`# Args` -> `# Arguments`, etc.)
3. `77ce515`: replace `Returns an error if:` prose with named `# Errors` bullets
4. `3917853`: normalize event / error bullets to `* 'Name': desc.`
5. `b1d136d`: convert `/// NOTE:` / `WARNING:` / `TODO:` admonitions to headings or `//`
6. `c35f571`: move inline arg bullets under a proper `# Arguments` section
7. `e3abf8f`: normalize argument / return bullets to `` * `name`: desc. ``

Verified locally: `cargo clippy -p pallet-subtensor --all-targets -- -D warnings` and `cargo fmt --check`.


## Related Issue(s)

N/A

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Other (please describe):

## Breaking Change

None. This change is confined to `///` rustdoc comments and a small number of `//` developer comments inside `pallets/subtensor/src/`.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

N/A - documentation-only change, no UI surface.

## Additional Notes

Commit `77ce515` is the only one that adds new information (error-name enumerations in 5 extrinsics). Every name was cross-checked against the real `Error::<T>::*` call sites. All other commits are just reformatting.