### PR TITLE
docs(readme): use node-subtensor bin name and -p flag for cargo run

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,12 @@ First, complete the [basic Rust setup instructions](./docs/rust-setup.md).
 Use Rust's native `cargo` command to build and launch the template node:
 
 ```sh
-cargo run --release -- --dev
+cargo run --release -p node-subtensor -- --dev
 ```
+
+The workspace root is not itself a binary, so `cargo run` must target
+`node-subtensor` explicitly (otherwise cargo errors with
+`a bin target must be available for cargo run`).
 
 **Build only**
 
@@ -113,19 +117,19 @@ node.
 This command will start the single-node development chain with non-persistent state:
 
 ```bash
-./target/release/subtensor --dev
+./target/release/node-subtensor --dev
 ```
 
 Purge the development chain's state:
 
 ```bash
-./target/release/subtensor purge-chain --dev
+./target/release/node-subtensor purge-chain --dev
 ```
 
 Start the development chain with detailed logging:
 
 ```bash
-RUST_BACKTRACE=1 ./target/release/subtensor-ldebug --dev
+RUST_BACKTRACE=1 ./target/release/node-subtensor -ldebug --dev
 ```
 
 Running debug with logs.


### PR DESCRIPTION
Fixes #1807.

- The workspace root Cargo.toml has no [[bin]] target and the workspace contains multiple bin crates, so `cargo run --release -- --dev` fails with `error: a bin target must be available for cargo run`. Change the example to `cargo run --release -p node-subtensor -- --dev` and add a one-sentence explainer.
- The "Other ways to launch the node" section referenced the binary as `./target/release/subtensor` (x3); the produced binary is `node-subtensor` per node/Cargo.toml.
- One of those lines read `./target/release/subtensor-ldebug --dev` where the `-ldebug` log-filter flag had fused into the binary name. Restore the space.

## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.