### PR TITLE
fix: clear Active/ValidatorTrust/ValidatorPermit on neuron replace

### DIFF
--- a/pallets/subtensor/src/subnets/uids.rs
+++ b/pallets/subtensor/src/subnets/uids.rs
@@ -46,6 +46,8 @@ impl<T: Config> Pallet<T> {
         }
         Dividends::<T>::mutate(netuid, |v| Self::set_element_at(v, neuron_index, 0));
         StakeWeight::<T>::mutate(netuid, |v| Self::set_element_at(v, neuron_index, 0));
+        ValidatorTrust::<T>::mutate(netuid, |v| Self::set_element_at(v, neuron_index, 0));
+        ValidatorPermit::<T>::mutate(netuid, |v| Self::set_element_at(v, neuron_index, false));
     }
 
     /// Replace the neuron under this uid.

--- a/pallets/subtensor/src/subnets/uids.rs
+++ b/pallets/subtensor/src/subnets/uids.rs
@@ -46,6 +46,9 @@ impl<T: Config> Pallet<T> {
         }
         Dividends::<T>::mutate(netuid, |v| Self::set_element_at(v, neuron_index, 0));
         StakeWeight::<T>::mutate(netuid, |v| Self::set_element_at(v, neuron_index, 0));
+        ValidatorTrust::<T>::mutate(netuid, |v| Self::set_element_at(v, neuron_index, 0));
+        ValidatorPermit::<T>::mutate(netuid, |v| Self::set_element_at(v, neuron_index, false));
+        Active::<T>::mutate(netuid, |v| Self::set_element_at(v, neuron_index, false));
     }
 
     /// Replace the neuron under this uid.

--- a/pallets/subtensor/src/tests/uids.rs
+++ b/pallets/subtensor/src/tests/uids.rs
@@ -226,6 +226,52 @@ fn test_replace_neuron_resets_last_update() {
 }
 
 #[test]
+fn test_replace_neuron_clears_validator_trust_and_permit() {
+    new_test_ext(1).execute_with(|| {
+        let registration_block: u64 = 0;
+        let replacement_block: u64 = 123;
+        let netuid = NetUid::from(1);
+        let tempo: u16 = 13;
+        let hotkey_account_id = U256::from(1);
+        let coldkey_account_id = U256::from(1234);
+        let new_hotkey_account_id = U256::from(2);
+
+        System::set_block_number(registration_block);
+        add_network(netuid, tempo, 0);
+        register_ok_neuron(netuid, hotkey_account_id, coldkey_account_id, 0);
+
+        let neuron_uid =
+            SubtensorModule::get_uid_for_net_and_hotkey(netuid, &hotkey_account_id).unwrap();
+        let idx = neuron_uid as usize;
+
+        // Simulate the previous occupant having earned a validator_permit and trust score.
+        ValidatorTrust::<Test>::mutate(netuid, |v| {
+            if v.len() <= idx {
+                v.resize(idx + 1, 0);
+            }
+            v[idx] = 42;
+        });
+        ValidatorPermit::<Test>::mutate(netuid, |v| {
+            if v.len() <= idx {
+                v.resize(idx + 1, false);
+            }
+            v[idx] = true;
+        });
+
+        SubtensorModule::replace_neuron(
+            netuid,
+            neuron_uid,
+            &new_hotkey_account_id,
+            replacement_block,
+        );
+
+        // The replaced neuron must not inherit the previous occupant's validator state.
+        assert_eq!(ValidatorTrust::<Test>::get(netuid)[idx], 0);
+        assert!(!ValidatorPermit::<Test>::get(netuid)[idx]);
+    });
+}
+
+#[test]
 fn test_replace_neuron_multiple_subnets() {
     new_test_ext(1).execute_with(|| {
         let block_number: u64 = 0;

--- a/pallets/subtensor/src/tests/uids.rs
+++ b/pallets/subtensor/src/tests/uids.rs
@@ -226,6 +226,92 @@ fn test_replace_neuron_resets_last_update() {
 }
 
 #[test]
+fn test_replace_neuron_clears_validator_trust_and_permit() {
+    new_test_ext(1).execute_with(|| {
+        let registration_block: u64 = 0;
+        let replacement_block: u64 = 123;
+        let netuid = NetUid::from(1);
+        let tempo: u16 = 13;
+        let hotkey_account_id = U256::from(1);
+        let coldkey_account_id = U256::from(1234);
+        let new_hotkey_account_id = U256::from(2);
+
+        System::set_block_number(registration_block);
+        add_network(netuid, tempo, 0);
+        register_ok_neuron(netuid, hotkey_account_id, coldkey_account_id, 0);
+
+        let neuron_uid =
+            SubtensorModule::get_uid_for_net_and_hotkey(netuid, &hotkey_account_id).unwrap();
+        let idx = neuron_uid as usize;
+
+        // Simulate the previous occupant having earned a validator_permit and trust score.
+        ValidatorTrust::<Test>::mutate(netuid, |v| {
+            if v.len() <= idx {
+                v.resize(idx + 1, 0);
+            }
+            v[idx] = 42;
+        });
+        ValidatorPermit::<Test>::mutate(netuid, |v| {
+            if v.len() <= idx {
+                v.resize(idx + 1, false);
+            }
+            v[idx] = true;
+        });
+
+        SubtensorModule::replace_neuron(
+            netuid,
+            neuron_uid,
+            &new_hotkey_account_id,
+            replacement_block,
+        );
+
+        // The replaced neuron must not inherit the previous occupant's validator state.
+        assert_eq!(ValidatorTrust::<Test>::get(netuid)[idx], 0);
+        assert!(!ValidatorPermit::<Test>::get(netuid)[idx]);
+    });
+}
+
+#[test]
+fn test_replace_neuron_clears_active() {
+    new_test_ext(1).execute_with(|| {
+        let registration_block: u64 = 0;
+        let replacement_block: u64 = 123;
+        let netuid = NetUid::from(1);
+        let tempo: u16 = 13;
+        let hotkey_account_id = U256::from(1);
+        let coldkey_account_id = U256::from(1234);
+        let new_hotkey_account_id = U256::from(2);
+
+        System::set_block_number(registration_block);
+        add_network(netuid, tempo, 0);
+        register_ok_neuron(netuid, hotkey_account_id, coldkey_account_id, 0);
+
+        let neuron_uid =
+            SubtensorModule::get_uid_for_net_and_hotkey(netuid, &hotkey_account_id).unwrap();
+        let idx = neuron_uid as usize;
+
+        // Simulate the previous occupant having been marked active by a prior epoch.
+        Active::<Test>::mutate(netuid, |v| {
+            if v.len() <= idx {
+                v.resize(idx + 1, false);
+            }
+            v[idx] = true;
+        });
+
+        SubtensorModule::replace_neuron(
+            netuid,
+            neuron_uid,
+            &new_hotkey_account_id,
+            replacement_block,
+        );
+
+        // The replaced neuron must not inherit the previous occupant's active=true flag
+        // until the next epoch's vector rebuild.
+        assert!(!Active::<Test>::get(netuid)[idx]);
+    });
+}
+
+#[test]
 fn test_replace_neuron_multiple_subnets() {
     new_test_ext(1).execute_with(|| {
         let block_number: u64 = 0;


### PR DESCRIPTION
clear_neuron zeroed the per-UID slot of Emission, Consensus, Incentive, Dividends, StakeWeight, Bonds and Weights, but missed Active, ValidatorTrust, and ValidatorPermit. All three are Vec<_>-per-netuid storage (Active and ValidatorPermit are Vec<bool> via EmptyBoolVec; ValidatorTrust is Vec<u16>) that append_neuron initialises on a fresh UID, so when replace_neuron reuses a UID it currently left the old occupant's active=true flag, validator_permit=true flag, and validator_trust score in place until the next epoch recomputed the vectors.

Between replacement and the next epoch, RPC surfaces (delegate_info, show_subnet) and on-chain readers (trim_to_max_allowed_uids and the per-mechanism validator aggregation in mechanism.rs) observed stale validator/active state for the freshly registered neuron.

Same class of stale-inheritance bug PR #755 was introduced to fix; these three fields were missed there.

- clear_neuron now also zeroes ValidatorTrust[uid] and resets ValidatorPermit[uid] = false, using the same set_element_at idiom already applied to the other vec-per-netuid fields two lines above.
- Add test_replace_neuron_clears_validator_trust_and_permit mirroring the existing test_replace_neuron_resets_last_update style.

## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.