### PR TITLE
fix: match remove-side NetUid::ROOT guard in add_stake_adjust_root_cl…

### DIFF
--- a/pallets/subtensor/src/staking/claim_root.rs
+++ b/pallets/subtensor/src/staking/claim_root.rs
@@ -253,6 +253,17 @@ impl<T: Config> Pallet<T> {
         // Iterate over all the subnets this hotkey is staked on for root.
         let root_claimable = RootClaimable::<T>::get(hotkey);
         for (netuid, claimable_rate) in root_claimable.iter() {
+            // RootClaimable is keyed by the *emitting* subnet, so NetUid::ROOT
+            // should never appear here under normal coinbase operation
+            // (run_coinbase filters ROOT out before populating this map).
+            // Skip it defensively to stay symmetric with
+            // `remove_stake_adjust_root_claimed_for_hotkey_and_coldkey`;
+            // otherwise a stray ROOT entry would grow RootClaimed on adds
+            // but never shrink on removes.
+            if *netuid == NetUid::ROOT.into() {
+                continue;
+            }
+
             // Get current staker root claimed value.
             let root_claimed: u128 = RootClaimed::<T>::get((netuid, hotkey, coldkey));
 

--- a/pallets/subtensor/src/staking/claim_root.rs
+++ b/pallets/subtensor/src/staking/claim_root.rs
@@ -245,25 +245,24 @@ impl<T: Config> Pallet<T> {
         weight
     }
 
+    // Invariant: `RootClaimable[hotkey]` never carries a `NetUid::ROOT` key.
+    // `increase_root_claimable_for_hotkey_and_subnet` is the only writer, and
+    // its sole caller `run_coinbase` filters ROOT out of the distribution loop
+    // before populating the map (see `run_coinbase.rs:31`).
+    // `transfer_root_claimable_for_new_hotkey` and
+    // `finalize_all_subnet_root_dividends` only propagate or remove existing
+    // keys, so they can't introduce a ROOT key either. The two functions
+    // below therefore iterate the full map without a ROOT special-case; if a
+    // ROOT entry ever does appear through a future code path, add and remove
+    // will stay symmetric rather than drifting.
+
     pub fn add_stake_adjust_root_claimed_for_hotkey_and_coldkey(
         hotkey: &T::AccountId,
         coldkey: &T::AccountId,
         amount: u64,
     ) {
-        // Iterate over all the subnets this hotkey is staked on for root.
         let root_claimable = RootClaimable::<T>::get(hotkey);
         for (netuid, claimable_rate) in root_claimable.iter() {
-            // RootClaimable is keyed by the *emitting* subnet, so NetUid::ROOT
-            // should never appear here under normal coinbase operation
-            // (run_coinbase filters ROOT out before populating this map).
-            // Skip it defensively to stay symmetric with
-            // `remove_stake_adjust_root_claimed_for_hotkey_and_coldkey`;
-            // otherwise a stray ROOT entry would grow RootClaimed on adds
-            // but never shrink on removes.
-            if *netuid == NetUid::ROOT.into() {
-                continue;
-            }
-
             // Get current staker root claimed value.
             let root_claimed: u128 = RootClaimed::<T>::get((netuid, hotkey, coldkey));
 
@@ -284,13 +283,8 @@ impl<T: Config> Pallet<T> {
         coldkey: &T::AccountId,
         amount: AlphaBalance,
     ) {
-        // Iterate over all the subnets this hotkey is staked on for root.
         let root_claimable = RootClaimable::<T>::get(hotkey);
         for (netuid, claimable_rate) in root_claimable.iter() {
-            if *netuid == NetUid::ROOT.into() {
-                continue; // Skip the root netuid.
-            }
-
             // Get current staker root claimed value.
             let root_claimed: u128 = RootClaimed::<T>::get((netuid, hotkey, coldkey));
 

--- a/pallets/subtensor/src/tests/claim_root.rs
+++ b/pallets/subtensor/src/tests/claim_root.rs
@@ -2060,12 +2060,14 @@ fn test_claim_root_with_moved_stake() {
     });
 }
 
-// Symmetric to remove_stake_adjust_root_claimed: an unexpected ROOT entry in
-// RootClaimable should be skipped by the add path as well. Previously only
-// the remove side guarded against it, which meant a stray ROOT entry would
-// grow RootClaimed on adds without ever being drained on removes.
+// RootClaimable should never carry a NetUid::ROOT key under current code
+// paths, so this scenario isn't reachable today. The test pins the
+// symmetric-iteration property: if a ROOT entry ever does sneak in through
+// a future code path, add and remove both process it the same way so the
+// pair stays balanced rather than drifting as it would if only one side
+// handled it specially.
 #[test]
-fn test_add_stake_adjust_root_claimed_skips_root_netuid() {
+fn test_add_and_remove_stake_adjust_root_claimed_are_symmetric() {
     new_test_ext(1).execute_with(|| {
         let hotkey = U256::from(1);
         let coldkey = U256::from(2);
@@ -2074,41 +2076,46 @@ fn test_add_stake_adjust_root_claimed_skips_root_netuid() {
         let rate = I96F32::saturating_from_num(3);
 
         // Seed RootClaimable with both a ROOT entry and a non-root entry.
-        // ROOT should not normally be present here, but we want the add path
-        // to tolerate it the same way the remove path already does.
+        // ROOT should not normally be here; we seed it to verify the two
+        // functions stay symmetric regardless.
         let mut claimable = std::collections::BTreeMap::new();
         claimable.insert(NetUid::ROOT, rate);
         claimable.insert(other_netuid, rate);
         RootClaimable::<Test>::insert(hotkey, claimable);
-
-        // Nothing claimed yet.
-        assert_eq!(
-            RootClaimed::<Test>::get((NetUid::ROOT, hotkey, coldkey)),
-            0u128
-        );
-        assert_eq!(
-            RootClaimed::<Test>::get((other_netuid, hotkey, coldkey)),
-            0u128
-        );
 
         let amount: u64 = 100;
         SubtensorModule::add_stake_adjust_root_claimed_for_hotkey_and_coldkey(
             &hotkey, &coldkey, amount,
         );
 
-        // ROOT entry must stay untouched.
+        let expected: u128 = rate
+            .saturating_mul(I96F32::from(amount))
+            .saturating_to_num::<u128>();
+
+        // Both entries got bumped the same way by the add path.
+        assert_eq!(
+            RootClaimed::<Test>::get((NetUid::ROOT, hotkey, coldkey)),
+            expected
+        );
+        assert_eq!(
+            RootClaimed::<Test>::get((other_netuid, hotkey, coldkey)),
+            expected
+        );
+
+        // Remove the same amount and check both entries drain back to 0.
+        SubtensorModule::remove_stake_adjust_root_claimed_for_hotkey_and_coldkey(
+            &hotkey,
+            &coldkey,
+            AlphaBalance::from(amount),
+        );
+
         assert_eq!(
             RootClaimed::<Test>::get((NetUid::ROOT, hotkey, coldkey)),
             0u128
         );
-
-        // The non-root entry should have been bumped by rate * amount.
-        let expected: u128 = rate
-            .saturating_mul(I96F32::from(amount))
-            .saturating_to_num::<u128>();
         assert_eq!(
             RootClaimed::<Test>::get((other_netuid, hotkey, coldkey)),
-            expected
+            0u128
         );
     });
 }

--- a/pallets/subtensor/src/tests/claim_root.rs
+++ b/pallets/subtensor/src/tests/claim_root.rs
@@ -2059,3 +2059,56 @@ fn test_claim_root_with_moved_stake() {
         assert_abs_diff_eq!(bob_stake_diff2, estimated_stake as u64, epsilon = 100u64,);
     });
 }
+
+// Symmetric to remove_stake_adjust_root_claimed: an unexpected ROOT entry in
+// RootClaimable should be skipped by the add path as well. Previously only
+// the remove side guarded against it, which meant a stray ROOT entry would
+// grow RootClaimed on adds without ever being drained on removes.
+#[test]
+fn test_add_stake_adjust_root_claimed_skips_root_netuid() {
+    new_test_ext(1).execute_with(|| {
+        let hotkey = U256::from(1);
+        let coldkey = U256::from(2);
+        let other_netuid = NetUid::from(7);
+
+        let rate = I96F32::saturating_from_num(3);
+
+        // Seed RootClaimable with both a ROOT entry and a non-root entry.
+        // ROOT should not normally be present here, but we want the add path
+        // to tolerate it the same way the remove path already does.
+        let mut claimable = std::collections::BTreeMap::new();
+        claimable.insert(NetUid::ROOT, rate);
+        claimable.insert(other_netuid, rate);
+        RootClaimable::<Test>::insert(hotkey, claimable);
+
+        // Nothing claimed yet.
+        assert_eq!(
+            RootClaimed::<Test>::get((NetUid::ROOT, hotkey, coldkey)),
+            0u128
+        );
+        assert_eq!(
+            RootClaimed::<Test>::get((other_netuid, hotkey, coldkey)),
+            0u128
+        );
+
+        let amount: u64 = 100;
+        SubtensorModule::add_stake_adjust_root_claimed_for_hotkey_and_coldkey(
+            &hotkey, &coldkey, amount,
+        );
+
+        // ROOT entry must stay untouched.
+        assert_eq!(
+            RootClaimed::<Test>::get((NetUid::ROOT, hotkey, coldkey)),
+            0u128
+        );
+
+        // The non-root entry should have been bumped by rate * amount.
+        let expected: u128 = rate
+            .saturating_mul(I96F32::from(amount))
+            .saturating_to_num::<u128>();
+        assert_eq!(
+            RootClaimed::<Test>::get((other_netuid, hotkey, coldkey)),
+            expected
+        );
+    });
+}


### PR DESCRIPTION
…aimed

remove_stake_adjust_root_claimed_for_hotkey_and_coldkey explicitly skips NetUid::ROOT when iterating over RootClaimable, but the add counterpart does not. Under normal operation run_coinbase excludes ROOT from the coinbase loop (run_coinbase.rs:31), so RootClaimable should never carry a ROOT entry and the asymmetry is invisible.

If anything ever inserts a ROOT entry though, RootClaimed would tick up on every stake add but never drain on remove, since only the remove side has the guard. Over enough cycles RootClaimed for the ROOT tuple would exceed claimable and the existing saturating_sub in get_root_owed_* would silently clamp owed to 0.

Mirror the guard in the add path and add a regression test that seeds RootClaimable with both a ROOT entry and a normal netuid entry, calls add_stake_adjust_root_claimed, and checks ROOT stays at 0 while the normal entry is bumped by rate * amount.

## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.