### PR TITLE
Use Address type instead of H256 for destination_address in the precompile

### DIFF
--- a/contract-tests/src/contracts/staking.ts
+++ b/contract-tests/src/contracts/staking.ts
@@ -561,9 +561,9 @@ export const IStakingV2ABI = [
                 "type": "address"
             },
             {
-                "internalType": "bytes32",
-                "name": "destination_coldkey",
-                "type": "bytes32"
+                "internalType": "address",
+                "name": "destination_address",
+                "type": "address"
             },
             {
                 "internalType": "bytes32",

--- a/contract-tests/src/contracts/staking.ts
+++ b/contract-tests/src/contracts/staking.ts
@@ -557,12 +557,12 @@ export const IStakingV2ABI = [
         "inputs": [
             {
                 "internalType": "address",
-                "name": "source_address",
+                "name": "sourceAddress",
                 "type": "address"
             },
             {
                 "internalType": "address",
-                "name": "destination_address",
+                "name": "destinationAddress",
                 "type": "address"
             },
             {
@@ -572,12 +572,12 @@ export const IStakingV2ABI = [
             },
             {
                 "internalType": "uint256",
-                "name": "origin_netuid",
+                "name": "originNetuid",
                 "type": "uint256"
             },
             {
                 "internalType": "uint256",
-                "name": "destination_netuid",
+                "name": "destinationNetuid",
                 "type": "uint256"
             },
             {

--- a/contract-tests/test/staking.precompile.approval.test.ts
+++ b/contract-tests/test/staking.precompile.approval.test.ts
@@ -79,7 +79,7 @@ describe("Test approval in staking precompile", () => {
             const contract = new ethers.Contract(ISTAKING_V2_ADDRESS, IStakingV2ABI, wallet2);
             const tx = await contract.transferStakeFrom(
                 wallet1.address, // source
-                convertH160ToPublicKey(wallet2.address), // distination
+                wallet2.address, // destination
                 hotkey.publicKey,
                 stakeNetuid,
                 stakeNetuid,
@@ -134,7 +134,7 @@ describe("Test approval in staking precompile", () => {
         // wallet2 transfer from wallet1
         const tx = await contract.transferStakeFrom(
             wallet1.address, // source
-            convertH160ToPublicKey(wallet2.address), // destination
+            wallet2.address, // destination
             hotkey.publicKey,
             stakeNetuid,
             stakeNetuid,
@@ -162,7 +162,7 @@ describe("Test approval in staking precompile", () => {
             const contract = new ethers.Contract(ISTAKING_V2_ADDRESS, IStakingV2ABI, wallet2);
             const tx = await contract.transferStakeFrom(
                 wallet1.address, // source
-                convertH160ToPublicKey(wallet2.address), // distination
+                wallet2.address, // destination
                 hotkey.publicKey,
                 stakeNetuid,
                 stakeNetuid,

--- a/precompiles/src/solidity/stakingV2.abi
+++ b/precompiles/src/solidity/stakingV2.abi
@@ -501,9 +501,9 @@
         "type": "address"
       },
       {
-        "internalType": "bytes32",
-        "name": "destination_coldkey",
-        "type": "bytes32"
+        "internalType": "address",
+        "name": "destination_address",
+        "type": "address"
       },
       {
         "internalType": "bytes32",

--- a/precompiles/src/solidity/stakingV2.abi
+++ b/precompiles/src/solidity/stakingV2.abi
@@ -497,12 +497,12 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "source_address",
+        "name": "sourceAddress",
         "type": "address"
       },
       {
         "internalType": "address",
-        "name": "destination_address",
+        "name": "destinationAddress",
         "type": "address"
       },
       {
@@ -512,12 +512,12 @@
       },
       {
         "internalType": "uint256",
-        "name": "origin_netuid",
+        "name": "originNetuid",
         "type": "uint256"
       },
       {
         "internalType": "uint256",
-        "name": "destination_netuid",
+        "name": "destinationNetuid",
         "type": "uint256"
       },
       {

--- a/precompiles/src/solidity/stakingV2.sol
+++ b/precompiles/src/solidity/stakingV2.sol
@@ -387,14 +387,14 @@ interface IStaking {
      * (spender) to spend at least the `amount` (allowance). The allowance towards that spender will be
      * decreased by this amount.
      *
-     * This function allows external accounts and contracts to transfer staked TAO to another coldkey,
-     * which effectively calls `transfer_stake` on the subtensor pallet with specified destination
-     * coldkey as a parameter being the hashed address mapping of H160 sender address to Substrate ss58
-     * address as implemented in Frontier HashedAddressMapping:
+     * This function allows external accounts and contracts to transfer staked TAO to another EVM
+     * address, which effectively calls `transfer_stake` on the subtensor pallet. Both the source and
+     * destination EVM addresses are converted to their Substrate ss58 representation using Frontier
+     * HashedAddressMapping:
      * https://github.com/polkadot-evm/frontier/blob/2e219e17a526125da003e64ef22ec037917083fa/frame/evm/src/lib.rs#L739
      *
      * @param source_address The source address (20 bytes).
-     * @param destination_coldkey The destination coldkey public key (32 bytes).
+     * @param destination_address The destination EVM address (20 bytes).
      * @param hotkey The hotkey public key (32 bytes).
      * @param origin_netuid The subnet to move stake from (uint256).
      * @param destination_netuid The subnet to move stake to (uint256).
@@ -406,7 +406,7 @@ interface IStaking {
      */
     function transferStakeFrom(
         address source_address,
-        bytes32 destination_coldkey,
+        address destination_address,
         bytes32 hotkey,
         uint256 origin_netuid,
         uint256 destination_netuid,

--- a/precompiles/src/solidity/stakingV2.sol
+++ b/precompiles/src/solidity/stakingV2.sol
@@ -382,8 +382,8 @@ interface IStaking {
     ) external;
 
     /**
-     * @dev Transfer a subtensor stake `amount` associated with the `source_address` to a different coldkey
-     * `destination_coldkey`. The `source_address` must have approved beforehand the transaction signer
+     * @dev Transfer a subtensor stake `amount` associated with the `sourceAddress` to a different
+     * destination address. The `sourceAddress` must have approved beforehand the transaction signer
      * (spender) to spend at least the `amount` (allowance). The allowance towards that spender will be
      * decreased by this amount.
      *
@@ -393,11 +393,11 @@ interface IStaking {
      * HashedAddressMapping:
      * https://github.com/polkadot-evm/frontier/blob/2e219e17a526125da003e64ef22ec037917083fa/frame/evm/src/lib.rs#L739
      *
-     * @param source_address The source address (20 bytes).
-     * @param destination_address The destination EVM address (20 bytes).
+     * @param sourceAddress The source address (20 bytes).
+     * @param destinationAddress The destination EVM address (20 bytes).
      * @param hotkey The hotkey public key (32 bytes).
-     * @param origin_netuid The subnet to move stake from (uint256).
-     * @param destination_netuid The subnet to move stake to (uint256).
+     * @param originNetuid The subnet to move stake from (uint256).
+     * @param destinationNetuid The subnet to move stake to (uint256).
      * @param amount The amount to move in rao.
      *
      * Requirements:
@@ -405,11 +405,11 @@ interface IStaking {
      * that the stake is correctly attributed.
      */
     function transferStakeFrom(
-        address source_address,
-        address destination_address,
+        address sourceAddress,
+        address destinationAddress,
         bytes32 hotkey,
-        uint256 origin_netuid,
-        uint256 destination_netuid,
+        uint256 originNetuid,
+        uint256 destinationNetuid,
         uint256 amount
     ) external;
 }

--- a/precompiles/src/staking.rs
+++ b/precompiles/src/staking.rs
@@ -634,11 +634,11 @@ where
         Ok(())
     }
 
-    #[precompile::public("transferStakeFrom(address,bytes32,bytes32,uint256,uint256,uint256)")]
+    #[precompile::public("transferStakeFrom(address,address,bytes32,uint256,uint256,uint256)")]
     fn transfer_stake_from(
         handle: &mut impl PrecompileHandle,
         source_address: Address,
-        destination_coldkey: H256,
+        destination_address: Address,
         hotkey: H256,
         origin_netuid: U256,
         destination_netuid: U256,
@@ -646,7 +646,8 @@ where
     ) -> EvmResult<()> {
         let spender = handle.context().caller;
         let source_address = source_address.0;
-        let destination_coldkey = R::AccountId::from(destination_coldkey.0);
+        let destination_coldkey =
+            <R as pallet_evm::Config>::AddressMapping::into_account_id(destination_address.0);
         let hotkey = R::AccountId::from(hotkey.0);
         let origin_netuid = try_u16_from_u256(origin_netuid)?;
         let destination_netuid = try_u16_from_u256(destination_netuid)?;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -272,7 +272,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 399,
+    spec_version: 400,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description
This PR fixes the PR comment from [here](https://github.com/opentensor/subtensor/pull/2478/changes/b3b21482b580ffc358014a4d65012e5d7957501c#r3125410071). 

Rebased https://github.com/opentensor/subtensor/pull/2612 to devnet-ready.

## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.