### PR TITLE
fix(docker): skip gosu when running as non-root

### DIFF
--- a/scripts/docker_entrypoint.sh
+++ b/scripts/docker_entrypoint.sh
@@ -36,21 +36,33 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-echo "entrypoint: ensuring permissions for base path: ${base_path}"
-mkdir -p "$base_path"
-chown -R subtensor:subtensor "$base_path"
+# If the container is already running as a non-root user (e.g. a hardened
+# Kubernetes securityContext with runAsUser != 0), `chown` and `gosu` will
+# both fail with "operation not permitted". In that case the operator has
+# already arranged correct UID/GID + filesystem permissions out-of-band, so
+# we skip the privilege-changing path entirely and exec node-subtensor
+# directly. Closes opentensor/subtensor#2475.
+if [ "$(id -u)" = "0" ]; then
+    echo "entrypoint: ensuring permissions for base path: ${base_path}"
+    mkdir -p "$base_path"
+    chown -R subtensor:subtensor "$base_path"
 
-# Check if a chain spec was provided and if it's an existing file
-if [ -n "$chain_spec" ] && [ -f "$chain_spec" ]; then
-    echo "entrypoint: ensuring permissions for chain spec: ${chain_spec}"
-    chown subtensor:subtensor "$chain_spec"
+    # Check if a chain spec was provided and if it's an existing file
+    if [ -n "$chain_spec" ] && [ -f "$chain_spec" ]; then
+        echo "entrypoint: ensuring permissions for chain spec: ${chain_spec}"
+        chown subtensor:subtensor "$chain_spec"
+    fi
+
+    # Also check for the hardcoded /tmp/blockchain directory
+    if [ -d "/tmp/blockchain" ]; then
+        chown -R subtensor:subtensor /tmp/blockchain
+    fi
+
+    # Execute node-subtensor with the original, unmodified arguments
+    echo "executing: gosu subtensor node-subtensor $original_args"
+    exec gosu subtensor node-subtensor $original_args
+else
+    echo "entrypoint: running as non-root UID $(id -u); skipping chown + gosu"
+    echo "executing: node-subtensor $original_args"
+    exec node-subtensor $original_args
 fi
-
-# Also check for the hardcoded /tmp/blockchain directory
-if [ -d "/tmp/blockchain" ]; then
-    chown -R subtensor:subtensor /tmp/blockchain
-fi
-
-# Execute node-subtensor with the original, unmodified arguments
-echo "executing: gosu subtensor node-subtensor $original_args"
-exec gosu subtensor node-subtensor $original_args


### PR DESCRIPTION
## Summary

`scripts/docker_entrypoint.sh` unconditionally runs `chown -R` and `exec gosu subtensor ...`, which fails when the container itself is already running as a non-root user (e.g. a Kubernetes pod with `securityContext.runAsUser: 10001` and externally-managed filesystem permissions). The container exits with `operation not permitted` before `node-subtensor` ever starts.

This PR wraps the privilege-changing branch in an `id -u` check:

- **As root (existing behavior, unchanged)**: `chown` the data dir + chain spec + `/tmp/blockchain`, then `exec gosu subtensor node-subtensor "$@"`.
- **As non-root (new path)**: log the detected UID and `exec node-subtensor "$@"` directly.

This makes `gosu` effectively optional via auto-detection — no new flag or env var, no API surface change. Existing deployments that mount `/data` as root keep working bit-for-bit.

Closes #2475.

## Diff size

`scripts/docker_entrypoint.sh` only — `+27 / -15`. No code changes anywhere else, no Cargo/runtime impact, no spec_version bump.

## Test plan

- [x] `sh -n scripts/docker_entrypoint.sh` — clean.
- [x] Simulated root path: still echoes "ensuring permissions for base path" + "executing: gosu subtensor node-subtensor ...".
- [x] Simulated non-root path (UID 10001): echoes "running as non-root UID 10001; skipping chown + gosu" then "executing: node-subtensor ...".
- [ ] Reviewer build of the Docker image and run with `--user 10001` to confirm behavior end-to-end.