### PR TITLE
fix the admin window not set in e2e

### DIFF
--- a/contract-tests/test/runtime.call.precompile.test.ts
+++ b/contract-tests/test/runtime.call.precompile.test.ts
@@ -6,7 +6,7 @@ import { devnet, MultiAddress } from "@polkadot-api/descriptors"
 import { PublicClient } from "viem";
 import { PolkadotSigner, TypedApi, getTypedCodecs } from "polkadot-api";
 import { convertPublicKeyToSs58 } from "../src/address-utils"
-import { forceSetBalanceToEthAddress, setMaxChildkeyTake, burnedRegister, forceSetBalanceToSs58Address, addStake, setTxRateLimit, addNewSubnetwork, startCall, setTempo } from "../src/subtensor";
+import { forceSetBalanceToEthAddress, setMaxChildkeyTake, burnedRegister, forceSetBalanceToSs58Address, addStake, setTxRateLimit, addNewSubnetwork, startCall, setTempo, disableAdminFreezeWindowAndOwnerHyperparamRateLimit } from "../src/subtensor";
 import { xxhashAsHex } from "@polkadot/util-crypto";
 
 describe("Test the dispatch precompile", () => {
@@ -27,6 +27,7 @@ describe("Test the dispatch precompile", () => {
         await forceSetBalanceToSs58Address(api, convertPublicKeyToSs58(hotkey.publicKey))
         await forceSetBalanceToSs58Address(api, convertPublicKeyToSs58(coldkey.publicKey))
 
+        await disableAdminFreezeWindowAndOwnerHyperparamRateLimit(api)
 
         netuid = await addNewSubnetwork(api, hotkey, coldkey)
         // set tempo big enough to avoid stake value updated with fast block feature
@@ -76,7 +77,7 @@ describe("Test the dispatch precompile", () => {
             await api.query.Multisig.Multisigs.getKey(),
             await api.query.Timestamp.Now.getKey(),
         ];
-        
+
         for (const key of authorizedKeys) {
             await assert.doesNotReject(
                 publicClient.call({
@@ -89,7 +90,7 @@ describe("Test the dispatch precompile", () => {
         const unauthorizedKeys = [
             await api.query.System.Events.getKey(),
             await api.query.Grandpa.CurrentSetId.getKey(),
-            xxhashAsHex(":code" , 128),
+            xxhashAsHex(":code", 128),
         ];
 
         for (const key of unauthorizedKeys) {


### PR DESCRIPTION
## Description
One e2e test is failed because the admin frozen window not set, cause the rate limit.

## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.