### PR TITLE
fix multiplier event type

### DIFF
--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -562,7 +562,7 @@ mod events {
             /// The subnet identifier.
             netuid: NetUid,
             /// The burn increase multiplier value for neuron registration.
-            burn_increase_mult: u64,
+            burn_increase_mult: U64F64,
         },
 
         /// A root validator toggled the "auto parent delegation" flag.


### PR DESCRIPTION
## Description
The `BurnIncreaseMultSet` event incorrectly defined the `burn_increase_mult` type as `u64`. This PR changes it to the correct type `U64F64`. 