### PR TITLE
Count burned registration in tao inflow

### DIFF
--- a/pallets/subtensor/src/subnets/registration.rs
+++ b/pallets/subtensor/src/subnets/registration.rs
@@ -120,6 +120,7 @@ impl<T: Config> Pallet<T> {
         // 11) counters
         RegistrationsThisBlock::<T>::mutate(netuid, |val| val.saturating_inc());
         Self::increase_rao_recycled(netuid, registration_cost.into());
+        Self::record_tao_inflow(netuid, actual_burn_amount);
 
         // 12) event
         log::debug!("NeuronRegistered( netuid:{netuid:?} uid:{neuron_uid:?} hotkey:{hotkey:?} )");

--- a/pallets/subtensor/src/tests/subnet.rs
+++ b/pallets/subtensor/src/tests/subnet.rs
@@ -976,3 +976,35 @@ fn test_cannot_register_system_hotkey() {
         }
     });
 }
+
+#[test]
+fn test_burned_register_increases_subnet_tao_flow() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let coldkey = U256::from(77);
+        let hotkey = U256::from(88);
+
+        add_network(netuid, 13, 0);
+        mock::setup_reserves(netuid, DEFAULT_RESERVE.into(), DEFAULT_RESERVE.into());
+
+        let burn = 1_000u64;
+        SubtensorModule::set_burn(netuid, burn.into());
+        let flow_before = SubnetTaoFlow::<Test>::get(netuid);
+
+        add_balance_to_coldkey_account(
+            &coldkey,
+            ExistentialDeposit::get() + burn.into() + 10u64.into(),
+        );
+
+        assert_ok!(SubtensorModule::burned_register(
+            <<Test as Config>::RuntimeOrigin>::signed(coldkey),
+            netuid,
+            hotkey
+        ));
+
+        assert_eq!(
+            SubnetTaoFlow::<Test>::get(netuid),
+            flow_before + burn as i64
+        );
+    });
+}


### PR DESCRIPTION
## Description

Burned registration (buy with TAO and burn Alpha) is now counted as TAO inflow.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
