### PR TITLE
fix(weights): include netuid in BatchWeightItemFailed event

### DIFF
--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -279,8 +279,9 @@ mod events {
 
         /// A weight set among a batch of weights failed.
         ///
+        /// - **netuid**: The netuid of the batch item that failed.
         /// - **error**: The dispatch error emitted by the failed item.
-        BatchWeightItemFailed(sp_runtime::DispatchError),
+        BatchWeightItemFailed(NetUid, sp_runtime::DispatchError),
 
         /// Stake has been transferred from one coldkey to another on the same subnet.
         /// Parameters:

--- a/pallets/subtensor/src/subnets/weights.rs
+++ b/pallets/subtensor/src/subnets/weights.rs
@@ -184,24 +184,27 @@ impl<T: Config> Pallet<T> {
             Error::<T>::InputLengthsUnequal
         );
 
-        let results: Vec<dispatch::DispatchResult> = netuids
+        let results: Vec<(NetUid, dispatch::DispatchResult)> = netuids
             .iter()
             .zip(commit_hashes.iter())
             .map(|(&netuid, &commit_hash)| {
                 let origin_cloned = origin.clone();
-
-                Self::do_commit_weights(origin_cloned, netuid.into(), commit_hash)
+                let netuid: NetUid = netuid.into();
+                (
+                    netuid,
+                    Self::do_commit_weights(origin_cloned, netuid, commit_hash),
+                )
             })
             .collect();
 
         let mut completed_with_errors: bool = false;
-        for result in results {
+        for (netuid, result) in results {
             if let Some(err) = result.err() {
                 if !completed_with_errors {
                     Self::deposit_event(Event::BatchCompletedWithErrors());
                     completed_with_errors = true;
                 }
-                Self::deposit_event(Event::BatchWeightItemFailed(err));
+                Self::deposit_event(Event::BatchWeightItemFailed(netuid, err));
             }
         }
 
@@ -1043,39 +1046,37 @@ impl<T: Config> Pallet<T> {
             Error::<T>::InputLengthsUnequal
         );
 
-        let results: Vec<dispatch::DispatchResult> = netuids
+        let results: Vec<(NetUid, dispatch::DispatchResult)> = netuids
             .iter()
             .zip(weights.iter())
             .zip(version_keys.iter())
             .map(|((&netuid, w), &version_key)| {
                 let origin_cloned = origin.clone();
+                let netuid: NetUid = netuid.into();
 
-                if Self::get_commit_reveal_weights_enabled(netuid.into()) {
-                    return Err(Error::<T>::CommitRevealEnabled.into());
+                if Self::get_commit_reveal_weights_enabled(netuid) {
+                    return (netuid, Err(Error::<T>::CommitRevealEnabled.into()));
                 }
 
                 let uids = w.iter().map(|(u, _)| (*u).into()).collect::<Vec<u16>>();
 
                 let values = w.iter().map(|(_, v)| (*v).into()).collect::<Vec<u16>>();
 
-                Self::do_set_weights(
-                    origin_cloned,
-                    netuid.into(),
-                    uids,
-                    values,
-                    version_key.into(),
+                (
+                    netuid,
+                    Self::do_set_weights(origin_cloned, netuid, uids, values, version_key.into()),
                 )
             })
             .collect();
 
         let mut completed_with_errors: bool = false;
-        for result in results {
+        for (netuid, result) in results {
             if let Some(err) = result.err() {
                 if !completed_with_errors {
                     Self::deposit_event(Event::BatchCompletedWithErrors());
                     completed_with_errors = true;
                 }
-                Self::deposit_event(Event::BatchWeightItemFailed(err));
+                Self::deposit_event(Event::BatchWeightItemFailed(netuid, err));
             }
         }
 

--- a/pallets/subtensor/src/tests/weights.rs
+++ b/pallets/subtensor/src/tests/weights.rs
@@ -2,6 +2,7 @@
 
 use ark_serialize::CanonicalDeserialize;
 use ark_serialize::CanonicalSerialize;
+use codec::Compact;
 use frame_support::dispatch::DispatchInfo;
 use frame_support::{
     assert_err, assert_ok,
@@ -6963,5 +6964,95 @@ fn test_subnet_owner_can_validate_without_stake_or_manual_permit() {
         assert!(SubtensorModule::get_validator_permit_for_uid(
             netuid, other_uid
         ));
+    });
+}
+
+// Regression: when a batch of weight commits has per-item failures, each
+// emitted BatchWeightItemFailed event must carry the netuid of the failing
+// item so downstream consumers (indexers, validator monitors) can correlate
+// failure → subnet without re-deriving from iteration order.
+//
+// Both netuids in this test fail (commit-reveal disabled on both) — what we
+// assert is the *positional propagation*: the per-item events carry the
+// distinct netuids that produced them, in iteration order.
+#[test]
+fn test_batch_commit_weights_item_failure_event_includes_netuid() {
+    new_test_ext(1).execute_with(|| {
+        let netuid_a = NetUid::from(1);
+        let netuid_b = NetUid::from(2);
+        add_network(netuid_a, 1, 0);
+        add_network(netuid_b, 1, 0);
+        SubtensorModule::set_commit_reveal_weights_enabled(netuid_a, false);
+        SubtensorModule::set_commit_reveal_weights_enabled(netuid_b, false);
+
+        let hotkey = U256::from(1);
+        let netuids: Vec<Compact<NetUid>> = vec![netuid_a.into(), netuid_b.into()];
+        let hashes: Vec<H256> = vec![H256::repeat_byte(0xAA), H256::repeat_byte(0xBB)];
+
+        assert_ok!(SubtensorModule::do_batch_commit_weights(
+            RuntimeOrigin::signed(hotkey),
+            netuids,
+            hashes,
+        ));
+
+        let failures: Vec<NetUid> = System::events()
+            .iter()
+            .filter_map(|e| match &e.event {
+                RuntimeEvent::SubtensorModule(Event::BatchWeightItemFailed(netuid, _err)) => {
+                    Some(*netuid)
+                }
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(
+            failures,
+            vec![netuid_a, netuid_b],
+            "BatchWeightItemFailed events should carry each failing netuid in batch order"
+        );
+    });
+}
+
+// Regression: same shape as the commit-path test, but for the set-path
+// (`do_batch_set_weights`). Each failing item must emit a
+// BatchWeightItemFailed carrying its netuid.
+#[test]
+fn test_batch_set_weights_item_failure_event_includes_netuid() {
+    new_test_ext(1).execute_with(|| {
+        let netuid_a = NetUid::from(3);
+        let netuid_b = NetUid::from(4);
+        add_network(netuid_a, 1, 0);
+        add_network(netuid_b, 1, 0);
+        // do_set_weights fails iff commit-reveal is ENABLED on the netuid.
+        SubtensorModule::set_commit_reveal_weights_enabled(netuid_a, true);
+        SubtensorModule::set_commit_reveal_weights_enabled(netuid_b, true);
+
+        let hotkey = U256::from(11);
+        let netuids: Vec<Compact<NetUid>> = vec![netuid_a.into(), netuid_b.into()];
+        let weights: Vec<Vec<(Compact<u16>, Compact<u16>)>> = vec![vec![], vec![]];
+        let version_keys: Vec<Compact<u64>> = vec![0u64.into(), 0u64.into()];
+
+        assert_ok!(SubtensorModule::do_batch_set_weights(
+            RuntimeOrigin::signed(hotkey),
+            netuids,
+            weights,
+            version_keys,
+        ));
+
+        let failures: Vec<NetUid> = System::events()
+            .iter()
+            .filter_map(|e| match &e.event {
+                RuntimeEvent::SubtensorModule(Event::BatchWeightItemFailed(netuid, _err)) => {
+                    Some(*netuid)
+                }
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(
+            failures,
+            vec![netuid_a, netuid_b],
+            "BatchWeightItemFailed events should carry each failing netuid in batch order"
+        );
     });
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -272,7 +272,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 406,
+    spec_version: 407,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description

`do_batch_commit_weights` and `do_batch_set_weights` accept a list of `(netuid, payload)` pairs and forward each one to the per-item dispatch. When an item fails, the chain emits

```rust
Self::deposit_event(Event::BatchWeightItemFailed(err));
```

which carries the `DispatchError` but **not the netuid** that produced it. Downstream consumers (block explorers, validator monitors, indexers) watching a batch see *that* an item failed and *what* error variant fired, but cannot tell *which subnet* without re-deriving from iteration order — fragile across runtime upgrades and not available to event-only subscribers.

The call site already has `netuid` in scope at the time of emission, so plumbing it through is mechanical.

## Fix

1. Change event signature:
   ```rust
   BatchWeightItemFailed(NetUid, sp_runtime::DispatchError)
   ```
2. Both emission sites in `subnets/weights.rs` now collect `Vec<(NetUid, DispatchResult)>` from the per-item map and emit `BatchWeightItemFailed(netuid, err)` for each failing item.
3. Bumps `spec_version` 406 → 407.

Shape mirrors [#2614](https://github.com/opentensor/subtensor/pull/2614) (\"Add netuid to TransactionFeePaidWithAlpha event\") which made the same observability improvement on a different event.

## Tests

Adds two regression tests in `pallets/subtensor/src/tests/weights.rs`. The batch-event layer had no prior coverage (`grep` on the test tree for either event returned no hits).

- `test_batch_commit_weights_item_failure_event_includes_netuid` — submits a 2-item batch where both items hit `CommitRevealDisabled`, asserts the emitted `BatchWeightItemFailed` events carry `[netuid_a, netuid_b]` in iteration order.
- `test_batch_set_weights_item_failure_event_includes_netuid` — same shape for the set-path, using `CommitRevealEnabled` as the failure trigger.

Both pass locally:
```
SKIP_WASM_BUILD=1 cargo test -p pallet-subtensor --lib -- \
  tests::weights::test_batch_commit_weights_item_failure_event_includes_netuid \
  tests::weights::test_batch_set_weights_item_failure_event_includes_netuid
running 2 tests
test tests::weights::test_batch_commit_weights_item_failure_event_includes_netuid ... ok
test tests::weights::test_batch_set_weights_item_failure_event_includes_netuid ... ok
test result: ok. 2 passed; 0 failed
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

The event signature is extended by one positional argument. Consumers that decode events by position (Polkadot.js Apps, indexer libraries, off-chain workers) will need to update their parsers — same compatibility surface as #2614. No on-chain storage change; no migration required.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix

## Related

- Companion observability fix to PR #2614 (\"Add netuid to TransactionFeePaidWithAlpha event\")
- Open PR #2652 (RUNECTZ33) — different bug class (orphan storage on dissolve); independent of this change