### PR TITLE
fix(staking): include netuid in ChildKeyTakeSet event

### DIFF
--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -123,8 +123,8 @@ mod events {
         MinChildKeyTakeSet(u16),
         /// maximum childkey take set
         MaxChildKeyTakeSet(u16),
-        /// childkey take set
-        ChildKeyTakeSet(T::AccountId, u16),
+        /// childkey take set for a specific (hotkey, netuid) pair
+        ChildKeyTakeSet(T::AccountId, NetUid, u16),
         /// a sudo call is done.
         Sudid(DispatchResult),
         /// registration is allowed/disallowed for a subnet.

--- a/pallets/subtensor/src/staking/set_children.rs
+++ b/pallets/subtensor/src/staking/set_children.rs
@@ -771,8 +771,8 @@ impl<T: Config> Pallet<T> {
         );
 
         // Emit the event
-        Self::deposit_event(Event::ChildKeyTakeSet(hotkey.clone(), take));
-        log::debug!("Childkey take set for hotkey: {hotkey:?} and take: {take:?}");
+        Self::deposit_event(Event::ChildKeyTakeSet(hotkey.clone(), netuid, take));
+        log::debug!("Childkey take set for hotkey: {hotkey:?} netuid: {netuid:?} take: {take:?}");
         Ok(())
     }
 

--- a/pallets/subtensor/src/tests/children.rs
+++ b/pallets/subtensor/src/tests/children.rs
@@ -4635,3 +4635,45 @@ fn test_register_network_schedules_root_validators_auto_parent_delegation_flag()
         ));
     });
 }
+
+// Regression: ChildkeyTake is stored per-(hotkey, netuid), and the
+// `set_childkey_take` dispatch accepts a netuid argument. The
+// ChildKeyTakeSet event historically carried only (hotkey, take), giving
+// off-chain consumers no way to correlate the take change to its subnet
+// without re-deriving from extrinsic args. The event must include netuid.
+#[test]
+fn test_set_childkey_take_event_includes_netuid() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(101);
+        let hotkey = U256::from(102);
+        let netuid = NetUid::from(7);
+
+        add_network(netuid, 13, 0);
+        register_ok_neuron(netuid, hotkey, coldkey, 0);
+
+        let new_take: u16 = SubtensorModule::get_max_childkey_take() / 2;
+
+        assert_ok!(SubtensorModule::set_childkey_take(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            new_take,
+        ));
+
+        let matches: Vec<(U256, NetUid, u16)> = System::events()
+            .iter()
+            .filter_map(|e| match &e.event {
+                RuntimeEvent::SubtensorModule(Event::ChildKeyTakeSet(hk, net, take)) => {
+                    Some((*hk, *net, *take))
+                }
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(
+            matches,
+            vec![(hotkey, netuid, new_take)],
+            "ChildKeyTakeSet event should carry (hotkey, netuid, take)"
+        );
+    });
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -272,7 +272,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 406,
+    spec_version: 407,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description

`ChildkeyTake` is a `StorageDoubleMap<_, hotkey, _, netuid, u16>` — per-(hotkey, netuid). The `set_childkey_take` dispatch accepts a `netuid` parameter:

```rust
pub fn do_set_childkey_take(
    coldkey: T::AccountId,
    hotkey: T::AccountId,
    netuid: NetUid,
    take: u16,
) -> DispatchResult { ... }
```

and the storage write at [`set_children.rs:764`](https://github.com/opentensor/subtensor/blob/devnet-ready/pallets/subtensor/src/staking/set_children.rs#L764) uses that netuid:

```rust
ChildkeyTake::<T>::insert(hotkey.clone(), netuid, take);
```

But the emitted event at [`set_children.rs:774`](https://github.com/opentensor/subtensor/blob/devnet-ready/pallets/subtensor/src/staking/set_children.rs#L774) carries only `(hotkey, take)`:

```rust
Self::deposit_event(Event::ChildKeyTakeSet(hotkey.clone(), take));
```

Off-chain consumers (block explorers, validator monitors, takes-rate trackers) watching `ChildKeyTakeSet` have no way to correlate a take change to its subnet without re-deriving from the extrinsic args — fragile across runtime upgrades and not available to event-only subscribers.

The dispatch already has `netuid` in scope, so threading it through is mechanical.

## Fix

Change the event signature to `ChildKeyTakeSet(T::AccountId, NetUid, u16)` and pass `netuid` at the single emission site in `do_set_childkey_take`.

Shape mirrors [#2614](https://github.com/opentensor/subtensor/pull/2614) (\"Add netuid to TransactionFeePaidWithAlpha event\") which made the same observability fix on a different event.

Bumps `spec_version` 406 → 407.

## Tests

Adds `test_set_childkey_take_event_includes_netuid` in `pallets/subtensor/src/tests/children.rs`. The event had no prior coverage (`grep` on the test tree returned no hits for `ChildKeyTakeSet`).

```
SKIP_WASM_BUILD=1 cargo test -p pallet-subtensor --lib -- \
  tests::children::test_set_childkey_take_event_includes_netuid
running 1 test
test tests::children::test_set_childkey_take_event_includes_netuid ... ok
test result: ok. 1 passed; 0 failed
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

The event signature is extended by one positional argument. Consumers that decode events by position (Polkadot.js Apps, indexer libraries, off-chain workers) will need to update their parsers — same compatibility surface as #2614. No on-chain storage change; no migration required.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix

## Related

- Companion observability fix to #2614 (\"Add netuid to TransactionFeePaidWithAlpha event\")
- Same author's adjacent PRs in flight: #2652 (orphan storage cleanup on dissolve) and #2654 (`BatchWeightItemFailed` event netuid). Each is independent in scope.