### PR TITLE
Allow subnet owners to set minimum childkey take per subnet

### DIFF
--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -1149,6 +1149,45 @@ pub mod pallet {
             Ok(())
         }
 
+        /// The extrinsic sets the minimum childkey take for a subnet.
+        /// It is callable by root or the subnet owner.
+        /// The subnet minimum can only make the global minimum stricter.
+        #[pallet::call_index(93)]
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::sudo_set_min_childkey_take_per_subnet())]
+        pub fn sudo_set_min_childkey_take_per_subnet(
+            origin: OriginFor<T>,
+            netuid: NetUid,
+            take: u16,
+        ) -> DispatchResult {
+            let maybe_owner = pallet_subtensor::Pallet::<T>::ensure_sn_owner_or_root_with_limits(
+                origin,
+                netuid,
+                &[Hyperparameter::MinChildkeyTake.into()],
+            )?;
+            pallet_subtensor::Pallet::<T>::ensure_admin_window_open(netuid)?;
+
+            ensure!(
+                pallet_subtensor::Pallet::<T>::if_subnet_exist(netuid),
+                Error::<T>::SubnetDoesNotExist
+            );
+            ensure!(
+                take >= pallet_subtensor::Pallet::<T>::get_min_childkey_take()
+                    && take <= pallet_subtensor::Pallet::<T>::get_max_childkey_take(),
+                Error::<T>::InvalidValue
+            );
+
+            pallet_subtensor::Pallet::<T>::set_min_childkey_take_for_subnet(netuid, take);
+            pallet_subtensor::Pallet::<T>::record_owner_rl(
+                maybe_owner,
+                netuid,
+                &[Hyperparameter::MinChildkeyTake.into()],
+            );
+            log::debug!(
+                "MinChildkeyTakePerSubnetSet( netuid: {netuid:?}, min_childkey_take: {take:?} ) "
+            );
+            Ok(())
+        }
+
         /// The extrinsic enabled/disables commit/reaveal for a given subnet.
         /// It is only callable by the root account or subnet owner.
         /// The extrinsic will call the Subtensor pallet to set the value.

--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -1108,6 +1108,67 @@ fn test_sudo_set_min_delegate_take() {
 }
 
 #[test]
+fn test_sudo_set_min_childkey_take_per_subnet() {
+    new_test_ext().execute_with(|| {
+        let netuid = NetUid::from(1);
+        let owner = U256::from(10);
+        let non_owner = U256::from(11);
+        let take = SubtensorModule::get_max_childkey_take() / 2;
+
+        add_network(netuid, 10);
+        SubnetOwner::<Test>::insert(netuid, owner);
+
+        assert_eq!(
+            AdminUtils::sudo_set_min_childkey_take_per_subnet(
+                <<Test as Config>::RuntimeOrigin>::signed(non_owner),
+                netuid,
+                take
+            ),
+            Err(DispatchError::BadOrigin)
+        );
+
+        assert_ok!(AdminUtils::sudo_set_min_childkey_take_per_subnet(
+            <<Test as Config>::RuntimeOrigin>::signed(owner),
+            netuid,
+            take
+        ));
+        assert_eq!(
+            SubtensorModule::get_min_childkey_take_for_subnet(netuid),
+            take
+        );
+        assert_eq!(
+            SubtensorModule::get_effective_min_childkey_take(netuid),
+            take
+        );
+    });
+}
+
+#[test]
+fn test_sudo_set_min_childkey_take_per_subnet_rejects_below_global() {
+    new_test_ext().execute_with(|| {
+        let netuid = NetUid::from(1);
+        let global_min = 100;
+
+        add_network(netuid, 10);
+        SubtensorModule::set_min_childkey_take(global_min);
+
+        assert_noop!(
+            AdminUtils::sudo_set_min_childkey_take_per_subnet(
+                <<Test as Config>::RuntimeOrigin>::root(),
+                netuid,
+                global_min - 1
+            ),
+            Error::<Test>::InvalidValue
+        );
+        assert_ok!(AdminUtils::sudo_set_min_childkey_take_per_subnet(
+            <<Test as Config>::RuntimeOrigin>::root(),
+            netuid,
+            global_min
+        ));
+    });
+}
+
+#[test]
 fn test_sudo_set_commit_reveal_weights_enabled() {
     new_test_ext().execute_with(|| {
         let netuid = NetUid::from(1);

--- a/pallets/admin-utils/src/weights.rs
+++ b/pallets/admin-utils/src/weights.rs
@@ -72,6 +72,7 @@ pub trait WeightInfo {
 	fn sudo_set_nominator_min_required_stake() -> Weight;
 	fn sudo_set_tx_delegate_take_rate_limit() -> Weight;
 	fn sudo_set_min_delegate_take() -> Weight;
+	fn sudo_set_min_childkey_take_per_subnet() -> Weight;
 	fn sudo_set_liquid_alpha_enabled() -> Weight;
 	fn sudo_set_alpha_values() -> Weight;
 	fn sudo_set_coldkey_swap_announcement_delay() -> Weight;
@@ -639,6 +640,15 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		//  Estimated: `0`
 		// Minimum execution time: 5_079_000 picoseconds.
 		Weight::from_parts(5_410_000, 0)
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
+	/// Storage: `SubtensorModule::MinChildkeyTake` (r:1 w:0)
+	/// Proof: `SubtensorModule::MinChildkeyTake` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::MinChildkeyTakePerSubnet` (r:0 w:1)
+	/// Proof: `SubtensorModule::MinChildkeyTakePerSubnet` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	fn sudo_set_min_childkey_take_per_subnet() -> Weight {
+		Weight::from_parts(6_000_000, 0)
+			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
@@ -1454,6 +1464,15 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 5_079_000 picoseconds.
 		Weight::from_parts(5_410_000, 0)
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+	/// Storage: `SubtensorModule::MinChildkeyTake` (r:1 w:0)
+	/// Proof: `SubtensorModule::MinChildkeyTake` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::MinChildkeyTakePerSubnet` (r:0 w:1)
+	/// Proof: `SubtensorModule::MinChildkeyTakePerSubnet` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	fn sudo_set_min_childkey_take_per_subnet() -> Weight {
+		Weight::from_parts(6_000_000, 0)
+			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1170,6 +1170,10 @@ pub mod pallet {
     #[pallet::storage]
     pub type MinChildkeyTake<T> = StorageValue<_, u16, ValueQuery, DefaultMinChildKeyTake<T>>;
 
+    /// MAP ( netuid ) --> take | Returns the subnet-specific minimum childkey take.
+    #[pallet::storage]
+    pub type MinChildkeyTakePerSubnet<T: Config> = StorageMap<_, Identity, NetUid, u16, ValueQuery>;
+
     /// MAP ( hot ) --> cold | Returns the controlling coldkey for a hotkey
     #[pallet::storage]
     pub type Owner<T: Config> =

--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -121,6 +121,8 @@ mod events {
         OwnerHyperparamRateLimitSet(u16),
         /// minimum childkey take set
         MinChildKeyTakeSet(u16),
+        /// subnet-specific minimum childkey take set
+        MinChildKeyTakePerSubnetSet(NetUid, u16),
         /// maximum childkey take set
         MaxChildKeyTakeSet(u16),
         /// childkey take set

--- a/pallets/subtensor/src/staking/set_children.rs
+++ b/pallets/subtensor/src/staking/set_children.rs
@@ -735,7 +735,8 @@ impl<T: Config> Pallet<T> {
 
         // Ensure the take value is valid
         ensure!(
-            take <= Self::get_max_childkey_take(),
+            take >= Self::get_effective_min_childkey_take(netuid)
+                && take <= Self::get_max_childkey_take(),
             Error::<T>::InvalidChildkeyTake
         );
 
@@ -789,7 +790,7 @@ impl<T: Config> Pallet<T> {
     ///     - The childkey take value. This is a percentage represented as a value between 0
     ///       and 10000, where 10000 represents 100%.
     pub fn get_childkey_take(hotkey: &T::AccountId, netuid: NetUid) -> u16 {
-        ChildkeyTake::<T>::get(hotkey, netuid)
+        ChildkeyTake::<T>::get(hotkey, netuid).max(Self::get_effective_min_childkey_take(netuid))
     }
 
     pub fn get_auto_parent_delegation_enabled(root_validator_hotkey: &T::AccountId) -> bool {

--- a/pallets/subtensor/src/tests/children.rs
+++ b/pallets/subtensor/src/tests/children.rs
@@ -924,6 +924,52 @@ fn test_childkey_take_functionality() {
     });
 }
 
+#[test]
+fn test_childkey_take_respects_effective_subnet_minimum() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let netuid = NetUid::from(1);
+        let subnet_min = SubtensorModule::get_max_childkey_take() / 2;
+
+        add_network(netuid, 13, 0);
+        register_ok_neuron(netuid, hotkey, coldkey, 0);
+        SubtensorModule::set_min_childkey_take_for_subnet(netuid, subnet_min);
+
+        assert_eq!(
+            SubtensorModule::get_effective_min_childkey_take(netuid),
+            subnet_min
+        );
+        assert_eq!(
+            SubtensorModule::get_childkey_take(&hotkey, netuid),
+            subnet_min
+        );
+
+        assert_noop!(
+            SubtensorModule::set_childkey_take(
+                RuntimeOrigin::signed(coldkey),
+                hotkey,
+                netuid,
+                subnet_min - 1
+            ),
+            Error::<Test>::InvalidChildkeyTake
+        );
+
+        assert_ok!(SubtensorModule::set_childkey_take(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            subnet_min
+        ));
+
+        ChildkeyTake::<Test>::insert(hotkey, netuid, subnet_min - 1);
+        assert_eq!(
+            SubtensorModule::get_childkey_take(&hotkey, netuid),
+            subnet_min
+        );
+    });
+}
+
 // 25: Test childkey take rate limiting
 // This test verifies the rate limiting functionality for setting childkey take:
 // - Sets up a network and registers a hotkey

--- a/pallets/subtensor/src/utils/misc.rs
+++ b/pallets/subtensor/src/utils/misc.rs
@@ -408,12 +408,22 @@ impl<T: Config> Pallet<T> {
         MinChildkeyTake::<T>::put(take);
         Self::deposit_event(Event::MinChildKeyTakeSet(take));
     }
+    pub fn set_min_childkey_take_for_subnet(netuid: NetUid, take: u16) {
+        MinChildkeyTakePerSubnet::<T>::insert(netuid, take);
+        Self::deposit_event(Event::MinChildKeyTakePerSubnetSet(netuid, take));
+    }
     pub fn set_max_childkey_take(take: u16) {
         MaxChildkeyTake::<T>::put(take);
         Self::deposit_event(Event::MaxChildKeyTakeSet(take));
     }
     pub fn get_min_childkey_take() -> u16 {
         MinChildkeyTake::<T>::get()
+    }
+    pub fn get_min_childkey_take_for_subnet(netuid: NetUid) -> u16 {
+        MinChildkeyTakePerSubnet::<T>::get(netuid)
+    }
+    pub fn get_effective_min_childkey_take(netuid: NetUid) -> u16 {
+        Self::get_min_childkey_take().max(Self::get_min_childkey_take_for_subnet(netuid))
     }
 
     pub fn get_max_childkey_take() -> u16 {

--- a/pallets/subtensor/src/utils/rate_limiting.rs
+++ b/pallets/subtensor/src/utils/rate_limiting.rs
@@ -205,6 +205,7 @@ pub enum Hyperparameter {
     BurnHalfLife = 26,
     BurnIncreaseMult = 27,
     SubnetEmissionEnabled = 28,
+    MinChildkeyTake = 29,
 }
 
 impl<T: Config> Pallet<T> {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -815,6 +815,9 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
                     | RuntimeCall::AdminUtils(
                         pallet_admin_utils::Call::sudo_set_subnet_emission_enabled { .. }
                     )
+                    | RuntimeCall::AdminUtils(
+                        pallet_admin_utils::Call::sudo_set_min_childkey_take_per_subnet { .. }
+                    )
             ),
             ProxyType::RootClaim => matches!(
                 c,


### PR DESCRIPTION
## Description

This change adds subnet-specific minimum childkey take support.

A new `MinChildkeyTakePerSubnet` storage map allows each subnet to define its own minimum childkey take. The effective minimum childkey take for a subnet is now:

```text
max(global MinChildkeyTake, MinChildkeyTakePerSubnet[netuid])
```

This preserves the global protocol floor while allowing subnet owners to make their subnet stricter.

### Behavior

- The global MinChildkeyTake remains the protocol-wide lower bound.
- A subnet owner can set a higher minimum childkey take for their subnet.
- A subnet owner cannot set the subnet minimum below the global minimum.
- set_childkey_take now validates against the effective subnet minimum.
- get_childkey_take(hotkey, netuid) clamps stored values upward to the effective minimum, so existing low stored values cannot bypass a newly raised subnet floor.

### New Storage

```rust
MinChildkeyTakePerSubnet<T: Config>: StorageMap<_, Identity, NetUid, u16, ValueQuery>
```

### New Helpers

```rust
set_min_childkey_take_for_subnet(netuid, take)
get_min_childkey_take_for_subnet(netuid)
get_effective_min_childkey_take(netuid)
```

### New Admin Call

```rust
sudo_set_min_childkey_take_per_subnet(origin, netuid, take)
```

Callable by root or the subnet owner through pallet-admin-utils.

### Rationale

This gives subnet owners an economic lever to discourage low-take childkey strategies on their subnet, while preserving root governance’s global minimum as an invariant floor.

The global minimum is not replaced. Instead, the subnet-specific value can only make the effective minimum stricter.

### Tests

Added tests covering:

- subnet minimum enforcement in set_childkey_take
- clamping of existing stored childkey take values through get_childkey_take
- subnet owner authorization
- rejection of subnet minimum values below the global minimum

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

