### PR TITLE
Drain protocol ema when net_flow disabled

### DIFF
--- a/pallets/subtensor/src/coinbase/subnet_emissions.rs
+++ b/pallets/subtensor/src/coinbase/subnet_emissions.rs
@@ -249,8 +249,8 @@ impl<T: Config> Pallet<T> {
             .iter()
             .map(|netuid| {
                 let user_ema = Self::get_ema_flow(*netuid);
+                let protocol_ema = Self::update_ema_protocol_flow(*netuid);
                 let net = if net_flow_enabled {
-                    let protocol_ema = Self::update_ema_protocol_flow(*netuid);
                     user_ema.saturating_sub(protocol_ema)
                 } else {
                     user_ema

--- a/pallets/subtensor/src/tests/coinbase.rs
+++ b/pallets/subtensor/src/tests/coinbase.rs
@@ -249,6 +249,43 @@ fn test_coinbase_disabled_subnet_emission_redistributes_tao_to_enabled_subnets()
 }
 
 #[test]
+fn test_net_tao_flow_disabled_still_drains_protocol_flow_into_ema() {
+    new_test_ext(1).execute_with(|| {
+        let netuid1 = NetUid::from(1);
+        let netuid2 = NetUid::from(2);
+
+        add_network(netuid1, 1, 0);
+        add_network(netuid2, 1, 0);
+
+        NetTaoFlowEnabled::<Test>::set(false);
+        FlowEmaSmoothingFactor::<Test>::set(i64::MAX as u64);
+
+        SubnetTaoFlow::<Test>::insert(netuid1, 1_000_i64);
+        SubnetTaoFlow::<Test>::insert(netuid2, 1_000_i64);
+        SubtensorModule::record_protocol_inflow(netuid1, 700.into());
+        SubtensorModule::record_protocol_outflow(netuid2, 300.into());
+
+        System::set_block_number(1);
+
+        SubtensorModule::get_subnet_block_emissions(
+            &[netuid1, netuid2],
+            U96F32::saturating_from_num(1_000_000u64),
+        );
+
+        assert_eq!(SubnetProtocolFlow::<Test>::get(netuid1), 0);
+        assert_eq!(SubnetProtocolFlow::<Test>::get(netuid2), 0);
+        assert_eq!(
+            SubnetEmaProtocolFlow::<Test>::get(netuid1),
+            Some((1, I64F64::from_num(700)))
+        );
+        assert_eq!(
+            SubnetEmaProtocolFlow::<Test>::get(netuid2),
+            Some((1, I64F64::from_num(-300)))
+        );
+    });
+}
+
+#[test]
 fn test_sudo_set_subnet_emission_enabled_multiple_subnets_multiple_toggles() {
     new_test_ext(1).execute_with(|| {
         let netuid1 = NetUid::from(1);


### PR DESCRIPTION
## Description

While net_flow_enabled is disabled, protocol flow accumulates indefinitely without EMA updates, causing a massive one-time emission distribution shock across subnets when the flag is re-enabled.

## Related Issue(s)

- Closes #2667 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

