### PR TITLE
Disable TI checks in try-runtime

### DIFF
--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -182,7 +182,6 @@ mod hooks {
 
         #[cfg(feature = "try-runtime")]
         fn try_state(_n: BlockNumberFor<T>) -> Result<(), sp_runtime::TryRuntimeError> {
-            Self::check_total_issuance()?;
             // Disabled: https://github.com/opentensor/subtensor/pull/1166
             // Self::check_total_stake()?;
             Ok(())

--- a/pallets/subtensor/src/migrations/migrate_init_total_issuance.rs
+++ b/pallets/subtensor/src/migrations/migrate_init_total_issuance.rs
@@ -155,8 +155,6 @@ pub mod initialise_total_issuance {
         /// This function is only compiled when the "try-runtime" feature is enabled.
         #[cfg(feature = "try-runtime")]
         fn post_upgrade(_state: Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
-            // Verify that all accounting invariants are satisfied after the migration
-            crate::Pallet::<T>::check_total_issuance()?;
             Ok(())
         }
     }

--- a/pallets/subtensor/src/utils/try_state.rs
+++ b/pallets/subtensor/src/utils/try_state.rs
@@ -1,63 +1,6 @@
-use frame_support::traits::fungible::Inspect;
-use frame_system::pallet_prelude::BlockNumberFor;
-
 use super::*;
 
 impl<T: Config> Pallet<T> {
-    /// Checks [`TotalIssuance`] equals the sum of currency issuance, total stake, and total subnet
-    /// locked.
-    #[allow(clippy::arithmetic_side_effects, clippy::expect_used)]
-    pub(crate) fn check_total_issuance() -> Result<(), sp_runtime::TryRuntimeError> {
-        // Get the total currency issuance
-        let currency_issuance = <T as Config>::Currency::total_issuance();
-        let total_issuance = TotalIssuance::<T>::get();
-
-        log::info!("=== Try runtime check_total_issuance ===");
-        log::info!("  currency_issuance: {}", currency_issuance);
-        log::info!("  total_issuance: {}", total_issuance);
-
-        // If balances total issuance is greater than 21M, we're on devnet or testnet, ignore
-        // this check, TI is off for multiple reasons.
-        if currency_issuance > 21_000_000_000_000_000_u64.into() {
-            return Ok(());
-        }
-
-        // If there's an exact match, it means we are past imbalances upgrade
-        if currency_issuance == total_issuance {
-            return Ok(());
-        }
-
-        // Calculate the expected total issuance
-        let expected_total_issuance =
-            currency_issuance.saturating_add(TotalStake::<T>::get().into());
-
-        // Verify the diff between calculated TI and actual TI is less than delta
-        // Allow greater tolerance for non-mainnet
-        let genesis_hash = frame_system::Pallet::<T>::block_hash(BlockNumberFor::<T>::zero());
-        let genesis_bytes = genesis_hash.as_ref();
-        let mainnet_genesis =
-            hex_literal::hex!("2f0555cc76fc2840a25a6ea3b9637146806f1f44b090c175ffde2a7e5ab36c03");
-        let delta = if genesis_bytes == mainnet_genesis {
-            TaoBalance::from(1000)
-        } else {
-            TaoBalance::from(1_000_000_000_000_u64)
-        };
-
-        let diff = if total_issuance > expected_total_issuance {
-            total_issuance.checked_sub(&expected_total_issuance)
-        } else {
-            expected_total_issuance.checked_sub(&total_issuance)
-        }
-        .expect("LHS > RHS");
-
-        ensure!(
-            diff <= delta,
-            "TotalIssuance diff greater than allowable delta",
-        );
-
-        Ok(())
-    }
-
     /// Checks the sum of all stakes matches the [`TotalStake`].
     #[allow(dead_code)]
     pub(crate) fn check_total_stake() -> Result<(), sp_runtime::TryRuntimeError> {


### PR DESCRIPTION
## Description

The total issuance check is not needed anymore because we can compare two TIs at any time in the state and they are supposed to exactly match.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please describe): Cleanup

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

