### PR TITLE
Remove deprecated conviction maps

### DIFF
--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -176,7 +176,9 @@ mod hooks {
                 // Mint missing SubnetTAO and SubnetLocked into subnet accounts to make TotalIssuance match in balances and subtensor
                 .saturating_add(migrations::migrate_subnet_balances::migrate_subnet_balances::<T>())
                 // Fix testnet Subtensor TotalIssuance after the EVM fees issue.
-                .saturating_add(migrations::migrate_fix_total_issuance_evm_fees::migrate_fix_total_issuance_evm_fees::<T>());
+                .saturating_add(migrations::migrate_fix_total_issuance_evm_fees::migrate_fix_total_issuance_evm_fees::<T>())
+                // Remove deprecated conviction lock storage.
+                .saturating_add(migrations::migrate_remove_deprecated_conviction_maps::migrate_remove_deprecated_conviction_maps::<T>());
             weight
         }
 

--- a/pallets/subtensor/src/migrations/migrate_remove_deprecated_conviction_maps.rs
+++ b/pallets/subtensor/src/migrations/migrate_remove_deprecated_conviction_maps.rs
@@ -1,0 +1,105 @@
+use super::*;
+use codec::{Decode, DecodeWithMemTracking, Encode};
+use frame_support::{
+    pallet_prelude::{Blake2_128Concat, Identity, NMapKey, OptionQuery, ValueQuery},
+    storage_alias,
+    traits::Get,
+    weights::Weight,
+};
+use scale_info::{TypeInfo, prelude::string::String};
+use substrate_fixed::types::U64F64;
+
+pub mod deprecated {
+    use super::*;
+
+    /// Deprecated lock state for a coldkey on a subnet.
+    #[crate::freeze_struct("13703236126f1b2b")]
+    #[derive(Encode, Decode, DecodeWithMemTracking, Clone, PartialEq, Eq, Debug, TypeInfo)]
+    pub struct LockState {
+        /// Locked amount, stays constant unless user makes changes.
+        pub locked_mass: AlphaBalance,
+        /// Unlocked amount, gradually decays over time.
+        pub unlocked_mass: AlphaBalance,
+        /// Matured decaying score.
+        pub conviction: U64F64,
+        /// Block number of last roll-forward.
+        pub last_update: u64,
+    }
+
+    #[storage_alias]
+    pub type Lock<T: Config> = StorageNMap<
+        Pallet<T>,
+        (
+            NMapKey<Blake2_128Concat, AccountIdOf<T>>,
+            NMapKey<Identity, NetUid>,
+            NMapKey<Blake2_128Concat, AccountIdOf<T>>,
+        ),
+        LockState,
+        OptionQuery,
+    >;
+
+    #[storage_alias]
+    pub type HotkeyLock<T: Config> = StorageDoubleMap<
+        Pallet<T>,
+        Identity,
+        NetUid,
+        Blake2_128Concat,
+        AccountIdOf<T>,
+        LockState,
+        OptionQuery,
+    >;
+
+    #[storage_alias]
+    pub type MaturityRate<T: Config> = StorageValue<Pallet<T>, u64, ValueQuery>;
+
+    #[storage_alias]
+    pub type UnlockRate<T: Config> = StorageValue<Pallet<T>, u64, ValueQuery>;
+}
+
+/// This migration removes the conviction v1 maps that were deprecated before they were
+/// deployed on mainnet. They existed briefly on testnet and contain some values that need
+/// to be cleaned before deploying conviction v2.
+pub fn migrate_remove_deprecated_conviction_maps<T: Config>() -> Weight {
+    let migration_name = b"migrate_remove_deprecated_conviction_maps".to_vec();
+    let mut weight = T::DbWeight::get().reads(1);
+
+    if HasMigrationRun::<T>::get(&migration_name) {
+        log::info!(
+            "Migration '{:?}' has already run. Skipping.",
+            String::from_utf8_lossy(&migration_name)
+        );
+        return weight;
+    }
+
+    log::info!(
+        "Running migration '{}'",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    let lock_removal = deprecated::Lock::<T>::clear(u32::MAX, None);
+    weight = weight.saturating_add(
+        T::DbWeight::get().reads_writes(lock_removal.loops as u64, lock_removal.backend as u64),
+    );
+
+    let hotkey_lock_removal = deprecated::HotkeyLock::<T>::clear(u32::MAX, None);
+    weight = weight.saturating_add(T::DbWeight::get().reads_writes(
+        hotkey_lock_removal.loops as u64,
+        hotkey_lock_removal.backend as u64,
+    ));
+
+    deprecated::MaturityRate::<T>::kill();
+    deprecated::UnlockRate::<T>::kill();
+    weight = weight.saturating_add(T::DbWeight::get().writes(2));
+
+    HasMigrationRun::<T>::insert(&migration_name, true);
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+    log::info!(
+        "Migration '{:?}' completed successfully. Removed Lock entries: {:?}, HotkeyLock entries: {:?}.",
+        String::from_utf8_lossy(&migration_name),
+        lock_removal.backend,
+        hotkey_lock_removal.backend,
+    );
+
+    weight
+}

--- a/pallets/subtensor/src/migrations/mod.rs
+++ b/pallets/subtensor/src/migrations/mod.rs
@@ -38,6 +38,7 @@ pub mod migrate_rate_limit_keys;
 pub mod migrate_rate_limiting_last_blocks;
 pub mod migrate_remove_add_stake_burn_rate_limit;
 pub mod migrate_remove_commitments_rate_limit;
+pub mod migrate_remove_deprecated_conviction_maps;
 pub mod migrate_remove_network_modality;
 pub mod migrate_remove_old_identity_maps;
 pub mod migrate_remove_stake_map;


### PR DESCRIPTION
## Description

This PR adds a migration that removes the conviction v1 maps that were deprecated before they were deployed on mainnet. They existed briefly on testnet and contain some values that need to be cleaned before deploying conviction v2.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please describe): State cleanup

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
