### PR TITLE
Use frontier-stable2506-otf-patches clean branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4447,7 +4447,7 @@ dependencies = [
 [[package]]
 name = "fc-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "async-trait",
  "fp-storage",
@@ -4459,7 +4459,7 @@ dependencies = [
 [[package]]
 name = "fc-aura"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "fc-rpc",
  "fp-storage",
@@ -4475,7 +4475,7 @@ dependencies = [
 [[package]]
 name = "fc-babe"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "fc-rpc",
  "sc-client-api",
@@ -4491,7 +4491,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "async-trait",
  "fp-consensus",
@@ -4507,7 +4507,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "async-trait",
  "ethereum",
@@ -4537,7 +4537,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "fc-db",
  "fc-storage",
@@ -4560,7 +4560,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4611,7 +4611,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4626,7 +4626,7 @@ dependencies = [
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4818,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "hex",
  "impl-serde",
@@ -4836,7 +4836,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -4847,7 +4847,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4859,7 +4859,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "environmental",
  "evm",
@@ -4875,7 +4875,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4891,7 +4891,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4903,7 +4903,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -9166,7 +9166,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -9744,7 +9744,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -9767,7 +9767,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "environmental",
@@ -9792,7 +9792,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9803,7 +9803,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -9813,7 +9813,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -9825,7 +9825,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "fp-evm",
  "num",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -9843,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "fp-evm",
  "ripemd",
@@ -9911,7 +9911,7 @@ dependencies = [
 [[package]]
 name = "pallet-hotfix-sufficients"
 version = "1.0.0"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -13183,7 +13183,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils"
 version = "0.1.0"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "derive_more 1.0.0",
  "environmental",
@@ -13212,7 +13212,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/opentensor/frontier?rev=d553a11551333c2457d9e64d6d912e2210a4ca26#d553a11551333c2457d9e64d6d912e2210a4ca26"
+source = "git+https://github.com/opentensor/frontier?rev=d460ccd223c6d0a454473c706c449094a76bc78b#d460ccd223c6d0a454473c706c449094a76bc78b"
 dependencies = [
  "case",
  "num_enum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -248,35 +248,35 @@ runtime-common = { package = "polkadot-runtime-common", git = "https://github.co
 
 # Frontier
 # current frontier branch is polkadot-stable2506-2-otf-get-call-indices-metadata
-fp-evm = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
-fp-rpc = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
-fp-self-contained = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
-fp-account = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
-fc-storage = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
-fc-db = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
-fc-consensus = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
-fp-consensus = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
-fp-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
-fc-api = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
-fc-rpc = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
-fc-rpc-core = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
-fc-aura = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
-fc-babe = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
-fc-mapping-sync = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
-precompile-utils = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
+fp-evm = { git = "https://github.com/opentensor/frontier", rev = "d460ccd223c6d0a454473c706c449094a76bc78b", default-features = false }
+fp-rpc = { git = "https://github.com/opentensor/frontier", rev = "d460ccd223c6d0a454473c706c449094a76bc78b", default-features = false }
+fp-self-contained = { git = "https://github.com/opentensor/frontier", rev = "d460ccd223c6d0a454473c706c449094a76bc78b", default-features = false }
+fp-account = { git = "https://github.com/opentensor/frontier", rev = "d460ccd223c6d0a454473c706c449094a76bc78b", default-features = false }
+fc-storage = { git = "https://github.com/opentensor/frontier", rev = "d460ccd223c6d0a454473c706c449094a76bc78b", default-features = false }
+fc-db = { git = "https://github.com/opentensor/frontier", rev = "d460ccd223c6d0a454473c706c449094a76bc78b", default-features = false }
+fc-consensus = { git = "https://github.com/opentensor/frontier", rev = "d460ccd223c6d0a454473c706c449094a76bc78b", default-features = false }
+fp-consensus = { git = "https://github.com/opentensor/frontier", rev = "d460ccd223c6d0a454473c706c449094a76bc78b", default-features = false }
+fp-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "d460ccd223c6d0a454473c706c449094a76bc78b", default-features = false }
+fc-api = { git = "https://github.com/opentensor/frontier", rev = "d460ccd223c6d0a454473c706c449094a76bc78b", default-features = false }
+fc-rpc = { git = "https://github.com/opentensor/frontier", rev = "d460ccd223c6d0a454473c706c449094a76bc78b", default-features = false }
+fc-rpc-core = { git = "https://github.com/opentensor/frontier", rev = "d460ccd223c6d0a454473c706c449094a76bc78b", default-features = false }
+fc-aura = { git = "https://github.com/opentensor/frontier", rev = "d460ccd223c6d0a454473c706c449094a76bc78b", default-features = false }
+fc-babe = { git = "https://github.com/opentensor/frontier", rev = "d460ccd223c6d0a454473c706c449094a76bc78b", default-features = false }
+fc-mapping-sync = { git = "https://github.com/opentensor/frontier", rev = "d460ccd223c6d0a454473c706c449094a76bc78b", default-features = false }
+precompile-utils = { git = "https://github.com/opentensor/frontier", rev = "d460ccd223c6d0a454473c706c449094a76bc78b", default-features = false }
 
 # Frontier FRAME
-pallet-base-fee = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
-pallet-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
-pallet-ethereum = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
-pallet-evm = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
-pallet-evm-precompile-dispatch = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
-pallet-evm-chain-id = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
-pallet-evm-precompile-modexp = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
-pallet-evm-precompile-sha3fips = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
-pallet-evm-precompile-simple = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
-pallet-evm-precompile-bn128 = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
-pallet-hotfix-sufficients = { git = "https://github.com/opentensor/frontier", rev = "d553a11551333c2457d9e64d6d912e2210a4ca26", default-features = false }
+pallet-base-fee = { git = "https://github.com/opentensor/frontier", rev = "d460ccd223c6d0a454473c706c449094a76bc78b", default-features = false }
+pallet-dynamic-fee = { git = "https://github.com/opentensor/frontier", rev = "d460ccd223c6d0a454473c706c449094a76bc78b", default-features = false }
+pallet-ethereum = { git = "https://github.com/opentensor/frontier", rev = "d460ccd223c6d0a454473c706c449094a76bc78b", default-features = false }
+pallet-evm = { git = "https://github.com/opentensor/frontier", rev = "d460ccd223c6d0a454473c706c449094a76bc78b", default-features = false }
+pallet-evm-precompile-dispatch = { git = "https://github.com/opentensor/frontier", rev = "d460ccd223c6d0a454473c706c449094a76bc78b", default-features = false }
+pallet-evm-chain-id = { git = "https://github.com/opentensor/frontier", rev = "d460ccd223c6d0a454473c706c449094a76bc78b", default-features = false }
+pallet-evm-precompile-modexp = { git = "https://github.com/opentensor/frontier", rev = "d460ccd223c6d0a454473c706c449094a76bc78b", default-features = false }
+pallet-evm-precompile-sha3fips = { git = "https://github.com/opentensor/frontier", rev = "d460ccd223c6d0a454473c706c449094a76bc78b", default-features = false }
+pallet-evm-precompile-simple = { git = "https://github.com/opentensor/frontier", rev = "d460ccd223c6d0a454473c706c449094a76bc78b", default-features = false }
+pallet-evm-precompile-bn128 = { git = "https://github.com/opentensor/frontier", rev = "d460ccd223c6d0a454473c706c449094a76bc78b", default-features = false }
+pallet-hotfix-sufficients = { git = "https://github.com/opentensor/frontier", rev = "d460ccd223c6d0a454473c706c449094a76bc78b", default-features = false }
 
 #DRAND
 pallet-drand = { path = "pallets/drand", default-features = false }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2197,9 +2197,6 @@ impl_runtime_apis! {
                     }
                     _ => (None, None),
                 };
-
-            let whitelist = pallet_evm::WhitelistedCreators::<Runtime>::get();
-            let whitelist_disabled = pallet_evm::DisableWhitelistCheck::<Runtime>::get();
             <Runtime as pallet_evm::Config>::Runner::create(
                 from,
                 data,
@@ -2209,8 +2206,6 @@ impl_runtime_apis! {
                 max_priority_fee_per_gas,
                 nonce,
                 access_list.unwrap_or_default(),
-                whitelist,
-                whitelist_disabled,
                 authorization_list.unwrap_or_default(),
                 false,
                 true,


### PR DESCRIPTION
## Summary

- Update Subtensor's EVM runtime API implementation for the reorganized Frontier runner API.
- Stop forwarding EVM contract-creation whitelist storage into `Runner::create`; Frontier now reads and enforces that storage during runner validation.
- Bump Frontier dependencies to the `frontier-stable2506-otf-patches` revision.