### PR TITLE
Restrict sudo_set_subnet_emission_enabled to root origin

### DIFF
--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -2232,11 +2232,7 @@ pub mod pallet {
             netuid: NetUid,
             enabled: bool,
         ) -> DispatchResult {
-            let maybe_owner = pallet_subtensor::Pallet::<T>::ensure_sn_owner_or_root_with_limits(
-                origin,
-                netuid,
-                &[Hyperparameter::SubnetEmissionEnabled.into()],
-            )?;
+            ensure_root(origin)?;
             pallet_subtensor::Pallet::<T>::ensure_admin_window_open(netuid)?;
 
             ensure!(
@@ -2248,12 +2244,6 @@ pub mod pallet {
             pallet_subtensor::SubnetEmissionEnabled::<T>::insert(netuid, enabled);
             Self::deposit_event(Event::SubnetEmissionEnabledSet { netuid, enabled });
             log::debug!("SubnetEmissionEnabledSet( netuid: {netuid:?}, enabled: {enabled:?} )");
-
-            pallet_subtensor::Pallet::<T>::record_owner_rl(
-                maybe_owner,
-                netuid,
-                &[Hyperparameter::SubnetEmissionEnabled.into()],
-            );
 
             Ok(())
         }

--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -3104,3 +3104,45 @@ fn test_sudo_set_start_call_delay_permissions_and_zero_delay() {
         );
     });
 }
+
+#[test]
+fn test_sudo_set_subnet_emission_enabled_root_only() {
+    new_test_ext().execute_with(|| {
+        let netuid = NetUid::from(1);
+        let sn_owner = U256::from(42);
+
+        add_network(netuid, 10);
+        SubnetOwner::<Test>::insert(netuid, sn_owner);
+
+        // Disable the admin freeze window so neither path is blocked by it.
+        SubtensorModule::set_admin_freeze_window(0);
+
+        let initial = pallet_subtensor::SubnetEmissionEnabled::<Test>::get(netuid);
+
+        // Signed subnet owner must be rejected with BadOrigin and storage unchanged.
+        assert_eq!(
+            AdminUtils::sudo_set_subnet_emission_enabled(
+                <<Test as Config>::RuntimeOrigin>::signed(sn_owner),
+                netuid,
+                !initial,
+            ),
+            Err(DispatchError::BadOrigin)
+        );
+        assert_eq!(
+            pallet_subtensor::SubnetEmissionEnabled::<Test>::get(netuid),
+            initial,
+            "signed owner origin must not mutate SubnetEmissionEnabled"
+        );
+
+        // Root can still toggle the flag.
+        assert_ok!(AdminUtils::sudo_set_subnet_emission_enabled(
+            <<Test as Config>::RuntimeOrigin>::root(),
+            netuid,
+            !initial,
+        ));
+        assert_eq!(
+            pallet_subtensor::SubnetEmissionEnabled::<Test>::get(netuid),
+            !initial
+        );
+    });
+}


### PR DESCRIPTION
## Summary

- Switch the `sudo_set_subnet_emission_enabled` dispatch from `ensure_sn_owner_or_root_with_limits` to `ensure_root`, so only the Triumvirate (root) can toggle pool-side emission for a subnet.
- Drop the trailing `record_owner_rl(...)` call — no subnet owner can take this path anymore, so there is no owner rate-limit window to record.

Behavior preserved on the root path: `ensure_admin_window_open`, `if_subnet_exist`, the `NotPermittedOnRootSubnet` check, the storage write, the `SubnetEmissionEnabledSet` event, and the debug log are all unchanged.

## Test plan

- [ ] `cargo check -p pallet-admin-utils --tests` — clean
- [ ] `cargo check -p pallet-subtensor --tests` — clean
- [ ] `cargo check -p node-subtensor-runtime` — clean
- [ ] `cargo test -p pallet-subtensor --lib tests::coinbase::test_sudo_set_subnet_emission_enabled_multiple_subnets_multiple_toggles` — passes (storage-level test, unaffected by the origin change)


Made with [Cursor](https://cursor.com)