### PR TITLE
Record miner burn as TAO outflow in coinbase

### DIFF
--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -621,8 +621,7 @@ impl<T: Config> Pallet<T> {
                 // Record the miner burn as a TAO outflow. The incentive is
                 // denominated in alpha, so convert to its TAO equivalent at
                 // the current spot price (no slippage, since no swap occurs).
-                let current_price: U96F32 =
-                    T::SwapInterface::current_alpha_price(netuid.into());
+                let current_price: U96F32 = T::SwapInterface::current_alpha_price(netuid.into());
                 let tao_equivalent: TaoBalance = current_price
                     .saturating_mul(asfloat!(incentive))
                     .saturating_to_num::<u64>()

--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -627,6 +627,7 @@ impl<T: Config> Pallet<T> {
                     .saturating_to_num::<u64>()
                     .min(i64::MAX as u64)
                     .into();
+                Self::record_tao_outflow(netuid, tao_equivalent);
                 // Check if we should recycle or burn the incentive
                 match RecycleOrBurn::<T>::try_get(netuid) {
                     Ok(RecycleOrBurnEnum::Recycle) => {

--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -626,8 +626,8 @@ impl<T: Config> Pallet<T> {
                 let tao_equivalent: TaoBalance = current_price
                     .saturating_mul(asfloat!(incentive))
                     .saturating_to_num::<u64>()
+                    .min(i64::MAX as u64)
                     .into();
-                Self::record_tao_outflow(netuid, tao_equivalent);
                 // Check if we should recycle or burn the incentive
                 match RecycleOrBurn::<T>::try_get(netuid) {
                     Ok(RecycleOrBurnEnum::Recycle) => {

--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -617,6 +617,17 @@ impl<T: Config> Pallet<T> {
                 log::debug!(
                     "incentives: hotkey: {hotkey:?} is SN owner hotkey or associated hotkey, skipping {incentive:?}"
                 );
+
+                // Record the miner burn as a TAO outflow. The incentive is
+                // denominated in alpha, so convert to its TAO equivalent at
+                // the current spot price (no slippage, since no swap occurs).
+                let current_price: U96F32 =
+                    T::SwapInterface::current_alpha_price(netuid.into());
+                let tao_equivalent: TaoBalance = current_price
+                    .saturating_mul(asfloat!(incentive))
+                    .saturating_to_num::<u64>()
+                    .into();
+                Self::record_tao_outflow(netuid, tao_equivalent);
                 // Check if we should recycle or burn the incentive
                 match RecycleOrBurn::<T>::try_get(netuid) {
                     Ok(RecycleOrBurnEnum::Recycle) => {


### PR DESCRIPTION
## Summary

- When the coinbase incentive loop encounters an SN-owner-associated hotkey, it skips the payout and recycles or burns the incentive. The corresponding TAO leaving the pool was not being recorded.
- This PR converts the skipped alpha incentive to its TAO equivalent at the current spot price (no slippage, since no swap occurs) and calls `record_tao_outflow(netuid, tao_equivalent)` so the subnet's TAO flow accounting stays in sync with what actually leaves circulation on this path.

Code path touched: `pallets/subtensor/src/coinbase/run_coinbase.rs`, inside the `owner_hotkeys.contains(&hotkey)` branch of the incentives loop, just before the `RecycleOrBurn` match.

## Test plan

- [ ] `cargo check -p pallet-subtensor` — clean
- [ ] Existing coinbase tests still pass: `cargo test -p pallet-subtensor --lib tests::coinbase`
- [ ] Spot-check that `SubnetTaoFlow` decreases by the expected TAO-equivalent on a subnet where an owner hotkey appears in the `incentives` list


Made with [Cursor](https://cursor.com)