### PR TITLE
No default auto-lock

### DIFF
--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -2479,7 +2479,7 @@ fn test_sudo_set_owner_cut_auto_lock_enabled() {
         let dispatch_info = call.get_dispatch_info();
         assert_eq!(dispatch_info.pays_fee, Pays::Yes);
 
-        assert!(SubtensorModule::get_owner_cut_auto_lock_enabled(netuid));
+        assert!(!SubtensorModule::get_owner_cut_auto_lock_enabled(netuid));
         assert_noop!(
             AdminUtils::sudo_set_owner_cut_auto_lock_enabled(
                 <<Test as Config>::RuntimeOrigin>::signed(non_owner),

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1573,7 +1573,7 @@ pub mod pallet {
     /// Default value for owner cut auto-locking.
     #[pallet::type_value]
     pub fn DefaultOwnerCutAutoLockEnabled<T: Config>() -> bool {
-        true
+        false
     }
 
     /// --- MAP ( netuid ) --> bool | Whether subnet owner cut should be auto-locked.

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2580,11 +2580,9 @@ mod dispatches {
 
         /// Sets or clears the caller's perpetual lock flag for a subnet.
         ///
-        /// Locks are perpetual by default. Internally, only decaying overrides
-        /// are stored.
-        /// When enabled, the caller's individual lock does not unlock through
-        /// locked-mass decay. Passing `false` removes the flag, returning the
-        /// caller's lock to normal decay.
+        /// Locks decay by default. When enabled, the caller's individual lock
+        /// does not unlock through locked-mass decay. Passing `false` returns
+        /// the caller's lock to normal decay.
         #[pallet::call_index(138)]
         #[pallet::weight(<T as frame_system::Config>::DbWeight::get().reads_writes(4, 3))]
         pub fn set_perpetual_lock(

--- a/pallets/subtensor/src/tests/locks.rs
+++ b/pallets/subtensor/src/tests/locks.rs
@@ -3510,7 +3510,7 @@ fn test_epoch_distribution_auto_locks_owner_cut() {
 }
 
 #[test]
-fn test_auto_lock_owner_cut_is_enabled_by_default_and_can_be_disabled() {
+fn test_auto_lock_owner_cut_is_disabled_by_default_and_can_be_enabled() {
     new_test_ext(1).execute_with(|| {
         let subnet_owner_coldkey = U256::from(1001);
         let subnet_owner_hotkey = U256::from(1002);
@@ -3518,15 +3518,6 @@ fn test_auto_lock_owner_cut_is_enabled_by_default_and_can_be_disabled() {
             setup_subnet_with_stake(subnet_owner_coldkey, subnet_owner_hotkey, 100_000_000_000);
         let owner_cut: AlphaBalance = 10_000_000u64.into();
 
-        assert!(SubtensorModule::get_owner_cut_auto_lock_enabled(netuid));
-        SubtensorModule::auto_lock_owner_cut(netuid, owner_cut);
-
-        let owner_lock = Lock::<Test>::get((subnet_owner_coldkey, netuid, subnet_owner_hotkey))
-            .expect("owner cut should be auto-locked by default");
-        assert_eq!(owner_lock.locked_mass, owner_cut);
-
-        Lock::<Test>::remove((subnet_owner_coldkey, netuid, subnet_owner_hotkey));
-        OwnerCutAutoLockEnabled::<Test>::insert(netuid, false);
         assert!(!SubtensorModule::get_owner_cut_auto_lock_enabled(netuid));
         SubtensorModule::auto_lock_owner_cut(netuid, owner_cut);
 
@@ -3535,6 +3526,14 @@ fn test_auto_lock_owner_cut_is_enabled_by_default_and_can_be_disabled() {
                 .next()
                 .is_none()
         );
+
+        OwnerCutAutoLockEnabled::<Test>::insert(netuid, true);
+        assert!(SubtensorModule::get_owner_cut_auto_lock_enabled(netuid));
+        SubtensorModule::auto_lock_owner_cut(netuid, owner_cut);
+
+        let owner_lock = Lock::<Test>::get((subnet_owner_coldkey, netuid, subnet_owner_hotkey))
+            .expect("owner cut should be auto-locked when enabled");
+        assert_eq!(owner_lock.locked_mass, owner_cut);
     });
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -274,7 +274,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 409,
+    spec_version: 410,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description

Owner-cut auto-locking is no longer enabled by default. Missing `OwnerCutAutoLockEnabled` storage entries now resolve to `false`, so owner cut is only auto-locked after the subnet owner or root explicitly enables the flag.

## What Changed

- Changed `DefaultOwnerCutAutoLockEnabled` from `true` to `false` in `pallets/subtensor`.
- Updated lock tests to assert that owner cut is not auto-locked by default and is auto-locked after explicit opt-in.
- Updated the admin-utils test expectation for the new default.
- Adjusted related lock rustdoc to describe the current default decay behavior.
- Bumped `runtime` `spec_version` from 409 to 410 because this is a runtime behavior change.

## Behavioral Impact

Subnets without an explicit `OwnerCutAutoLockEnabled` value will no longer auto-lock owner cut. Owners can still opt in using the existing owner/root-controlled setting path.

## Testing

- Updated unit coverage for default-disabled owner-cut auto-locking and explicit opt-in behavior.
- Author checklist reports `./scripts/fix_rust.sh` and unit tests were run locally.