### PR TITLE
60 day unlock and maturity rate

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1582,16 +1582,16 @@ pub mod pallet {
     pub type OwnerCutAutoLockEnabled<T: Config> =
         StorageMap<_, Identity, NetUid, bool, ValueQuery, DefaultOwnerCutAutoLockEnabled<T>>;
 
-    /// Default unlock timescale: 50% lock back in 1 month.
+    /// Default unlock timescale: 50% lock back in ~60 days.
     #[pallet::type_value]
     pub fn DefaultUnlockRate<T: Config>() -> u64 {
-        311_622
+        648_000
     }
 
-    /// Default maturity timescale: 50% conviction in 1 month
+    /// Default maturity timescale: 50% conviction in ~60 days.
     #[pallet::type_value]
     pub fn DefaultMaturityRate<T: Config>() -> u64 {
-        311_622
+        648_000
     }
 
     /// --- ITEM( maturity_rate ) | Decay timescale in blocks for lock conviction.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -274,7 +274,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 409,
+    spec_version: 410,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description

Updates the default stake-lock unlock rate and conviction maturity rate so the existing exponential decay model reaches roughly 50% unlock / 50% conviction maturity after about 60 days.

## What Changed

- `pallets/subtensor/src/lib.rs`
  - Changed `DefaultUnlockRate` from `311_622` to `648_000` blocks.
  - Changed `DefaultMaturityRate` from `311_622` to `648_000` blocks.
  - Updated comments to describe the new approximately 60-day behavior.
- `runtime/src/lib.rs`
  - Bumped `spec_version` from `409` to `410` for the runtime-affecting change.

## Behavioral Impact

The default lock decay and conviction maturity windows are lengthened from the previous roughly 30-day half-life to roughly 60 days. This affects the default values returned by `UnlockRate` and `MaturityRate` when those storage values are not explicitly set.

## Migration / Spec Version

No storage migration is introduced. The runtime `spec_version` is bumped to `410`.

## Testing

The PR checklist indicates `./scripts/fix_rust.sh` and existing unit tests were run locally. The auditor review did not run additional tests because the implementation is limited to constant changes and the spec-version bump.