### PR TITLE
Set unlock and maturity rates to 90 days half life

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1582,16 +1582,16 @@ pub mod pallet {
     pub type OwnerCutAutoLockEnabled<T: Config> =
         StorageMap<_, Identity, NetUid, bool, ValueQuery, DefaultOwnerCutAutoLockEnabled<T>>;
 
-    /// Default unlock timescale: 50% lock back in ~60 days.
+    /// Default unlock timescale: 50% lock back in ~90 days.
     #[pallet::type_value]
     pub fn DefaultUnlockRate<T: Config>() -> u64 {
-        648_000
+        934_866
     }
 
-    /// Default maturity timescale: 50% conviction in ~60 days.
+    /// Default maturity timescale: 50% conviction in ~90 days.
     #[pallet::type_value]
     pub fn DefaultMaturityRate<T: Config>() -> u64 {
-        648_000
+        934_866
     }
 
     /// --- ITEM( maturity_rate ) | Decay timescale in blocks for lock conviction.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -274,7 +274,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 410,
+    spec_version: 411,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description

This PR updates the default stake lock unlock and conviction maturity time constants so their exponential half-life is approximately 90 days at 12-second block time.

## What Changed

- Updated `DefaultUnlockRate` in `pallets/subtensor/src/lib.rs` from `648_000` to `934_866`.
- Updated `DefaultMaturityRate` in `pallets/subtensor/src/lib.rs` from `648_000` to `934_866`.
- Bumped `runtime/src/lib.rs` `spec_version` from 410 to 411 for the runtime behavior change.

## Behavioral Impact

Existing storage values are not migrated. This changes the default values used when `UnlockRate` or `MaturityRate` are absent, making 50% lock unlock and 50% conviction maturity occur in roughly 90 days rather than roughly 60 days.

## Migration / Spec Version

No storage migration is required. A runtime `spec_version` bump is included.

## Testing

Author checklist indicates `./scripts/fix_rust.sh` and existing unit tests were run locally. No new tests were added because this PR only changes default constants.