### PR TITLE
Bump actions versions + correctly handle labels

### DIFF
--- a/.github/workflows/apply-benchmark-patch.yml
+++ b/.github/workflows/apply-benchmark-patch.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Check out PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -10,38 +10,87 @@ concurrency:
   group: cargo-audit-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   cargo-audit:
     name: cargo audit
     runs-on: [self-hosted, type-ccx13]
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-cargo-audit') }}
     steps:
+      - name: Decide whether to run, skip, or mirror previous result
+        id: gate
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const labels = context.payload.pull_request?.labels?.map(l => l.name) ?? [];
+            if (labels.includes('skip-cargo-audit')) {
+              core.info('skip-cargo-audit label present on PR; skipping audit work.');
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+            const action = context.payload.action;
+            const labelName = context.payload.label?.name;
+            const isLabelEvent = action === 'labeled' || action === 'unlabeled';
+            if (isLabelEvent && labelName !== 'skip-cargo-audit') {
+              const sha = context.payload.pull_request.head.sha;
+              const runs = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'cargo-audit.yml',
+                head_sha: sha,
+                status: 'completed',
+                per_page: 20,
+              });
+              const prev = runs.data.workflow_runs.find(r => r.id !== context.runId);
+              core.info(`Previous completed run for ${sha}: ${prev?.conclusion ?? 'none'}`);
+              if (prev?.conclusion === 'success') {
+                core.setOutput('skip', 'true');
+                return;
+              }
+              if (prev?.conclusion === 'failure') {
+                core.setFailed('Mirroring previous failed run for this commit.');
+                return;
+              }
+            }
+
+            core.setOutput('skip', 'false');
+
       - name: Check-out repositoroy under $GITHUB_WORKSPACE
+        if: steps.gate.outputs.skip != 'true'
         uses: actions/checkout@v6
 
       - name: Install dependencies
+        if: steps.gate.outputs.skip != 'true'
         run: |
           sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update
           sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" build-essential clang curl libssl-dev llvm libudev-dev protobuf-compiler pkg-config
 
       - name: Install Rust
+        if: steps.gate.outputs.skip != 'true'
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
 
       - name: Utilize Shared Rust Cache
+        if: steps.gate.outputs.skip != 'true'
         uses: Swatinem/rust-cache@v2
         with:
           key: cargo-audit
           cache-on-failure: true
 
       - name: Install cargo-audit
+        if: steps.gate.outputs.skip != 'true'
         run: cargo install --force cargo-audit
 
       - name: Display cargo-audit --version
+        if: steps.gate.outputs.skip != 'true'
         run: cargo audit --version
 
       - name: cargo audit
+        if: steps.gate.outputs.skip != 'true'
         run: |
           cargo audit --ignore RUSTSEC-2023-0091 \
                       --ignore RUSTSEC-2024-0438 \

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -14,10 +14,7 @@ jobs:
   cargo-audit:
     name: cargo audit
     runs-on: [self-hosted, type-ccx13]
-    if: |
-      ((github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
-       github.event.label.name == 'skip-cargo-audit') &&
-      !contains(github.event.pull_request.labels.*.name, 'skip-cargo-audit')
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-cargo-audit') }}
     steps:
       - name: Check-out repositoroy under $GITHUB_WORKSPACE
         uses: actions/checkout@v6

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -14,10 +14,13 @@ jobs:
   cargo-audit:
     name: cargo audit
     runs-on: [self-hosted, type-ccx13]
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-cargo-audit') }}
+    if: |
+      ((github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+       github.event.label.name == 'skip-cargo-audit') &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-cargo-audit')
     steps:
       - name: Check-out repositoroy under $GITHUB_WORKSPACE
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/check-bittensor-e2e-tests.yml
+++ b/.github/workflows/check-bittensor-e2e-tests.yml
@@ -27,6 +27,10 @@ env:
 jobs:
   check-label:
     runs-on: ubuntu-latest
+    if: |
+      github.event_name != 'pull_request' ||
+      (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+      github.event.label.name == 'skip-bittensor-e2e-tests'
     outputs:
       skip-bittensor-e2e-tests: ${{ steps.get-labels.outputs.skip-bittensor-e2e-tests || steps.set-default.outputs.skip-bittensor-e2e-tests }}
     steps:
@@ -36,7 +40,7 @@ jobs:
           sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" gh jq
 
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
@@ -82,7 +86,7 @@ jobs:
         run: git checkout staging
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 
@@ -142,7 +146,7 @@ jobs:
         run: git checkout staging
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 
@@ -199,7 +203,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
@@ -259,7 +263,7 @@ jobs:
             build/ci_target/${RUNTIME}/${TRIPLE}/release/wbuild/node-subtensor-runtime/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: binaries-${{ matrix.platform.triple }}-${{ matrix.runtime }}
           path: build/
@@ -272,13 +276,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
 
       - name: Download all binary artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: binaries-*
           path: build/
@@ -301,7 +305,7 @@ jobs:
         run: docker save -o /mnt/data/subtensor-localnet.tar localnet
 
       - name: Upload Docker Image as Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: subtensor-localnet
           path: /mnt/data/subtensor-localnet.tar
@@ -324,7 +328,7 @@ jobs:
     name: "cli: ${{ matrix.label }}"
     steps:
       - name: Check-out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
@@ -353,7 +357,7 @@ jobs:
           uv run --active pip install pytest
 
       - name: Download Cached Docker Image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: subtensor-localnet
 
@@ -405,7 +409,7 @@ jobs:
     name: "sdk: ${{ matrix.label }}"
     steps:
       - name: Check-out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
@@ -434,7 +438,7 @@ jobs:
           uv run --active pip install pytest
 
       - name: Download Cached Docker Image
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: subtensor-localnet
 

--- a/.github/workflows/check-bittensor-e2e-tests.yml
+++ b/.github/workflows/check-bittensor-e2e-tests.yml
@@ -3,6 +3,7 @@ name: Bittensor Bittensor E2E Test
 permissions:
   pull-requests: write
   contents: read
+  actions: read
 
 concurrency:
   group: e2e-cli-${{ github.ref }}
@@ -28,38 +29,51 @@ jobs:
   check-label:
     runs-on: ubuntu-latest
     outputs:
-      skip-bittensor-e2e-tests: ${{ steps.get-labels.outputs.skip-bittensor-e2e-tests || steps.set-default.outputs.skip-bittensor-e2e-tests }}
+      skip-bittensor-e2e-tests: ${{ steps.decide.outputs.skip-bittensor-e2e-tests }}
+      mirror-skip: ${{ steps.decide.outputs.mirror-skip }}
+      mirror-fail: ${{ steps.decide.outputs.mirror-fail }}
     steps:
-      - name: Install dependencies
-        run: |
-          sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update
-          sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" gh jq
-
-      - name: Check out repository
-        uses: actions/checkout@v6
+      - name: Decide skip / mirror state
+        id: decide
+        uses: actions/github-script@v9
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          script: |
+            const eventName = context.eventName;
+            const action = context.payload.action;
+            const labelName = context.payload.label?.name;
+            const isLabelEvent = action === 'labeled' || action === 'unlabeled';
 
-      - name: Get labels from PR
-        id: get-labels
-        if: github.event_name == 'pull_request'
-        run: |
-          LABELS=$(gh pr -R ${{ github.repository }} view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
-          echo "Current labels: $LABELS"
-          if echo "$LABELS" | grep -q "skip-bittensor-e2e-tests"; then
-            echo "skip-bittensor-e2e-tests=true" >> $GITHUB_OUTPUT
-          else
-            echo "skip-bittensor-e2e-tests=false" >> $GITHUB_OUTPUT
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            core.setOutput('skip-bittensor-e2e-tests', 'false');
+            core.setOutput('mirror-skip', 'false');
+            core.setOutput('mirror-fail', 'false');
 
-      - name: Set default skip value for workflow_dispatch
-        id: set-default
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          echo "skip-bittensor-e2e-tests=false" >> $GITHUB_OUTPUT
+            if (eventName === 'pull_request') {
+              const labels = context.payload.pull_request?.labels?.map(l => l.name) ?? [];
+              if (labels.includes('skip-bittensor-e2e-tests')) {
+                core.info('skip-bittensor-e2e-tests label present on PR.');
+                core.setOutput('skip-bittensor-e2e-tests', 'true');
+                return;
+              }
+
+              if (isLabelEvent && labelName !== 'skip-bittensor-e2e-tests') {
+                const sha = context.payload.pull_request.head.sha;
+                const runs = await github.rest.actions.listWorkflowRuns({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: 'check-bittensor-e2e-tests.yml',
+                  head_sha: sha,
+                  status: 'completed',
+                  per_page: 20,
+                });
+                const prev = runs.data.workflow_runs.find(r => r.id !== context.runId);
+                core.info(`Previous completed run for ${sha}: ${prev?.conclusion ?? 'none'}`);
+                if (prev?.conclusion === 'success') {
+                  core.setOutput('mirror-skip', 'true');
+                } else if (prev?.conclusion === 'failure') {
+                  core.setOutput('mirror-fail', 'true');
+                }
+              }
+            }
 
   find-btcli-e2e-tests:
     needs: check-label
@@ -198,28 +212,47 @@ jobs:
     runs-on: ${{ matrix.platform.runner }}
 
     steps:
+      - name: Mirror gate
+        id: gate
+        run: |
+          if [ "${{ needs.check-label.outputs.mirror-fail }}" = "true" ]; then
+            echo "Mirroring previous failed run for this commit."
+            exit 1
+          fi
+          if [ "${{ needs.check-label.outputs.mirror-skip }}" = "true" ]; then
+            echo "Mirroring previous successful run for this commit."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout code
+        if: steps.gate.outputs.skip != 'true'
         uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
 
       - name: Install Rust + dependencies
+        if: steps.gate.outputs.skip != 'true'
         run: |
           chmod +x ./scripts/install_build_env.sh
           ./scripts/install_build_env.sh
 
       - name: Add Rust target triple
+        if: steps.gate.outputs.skip != 'true'
         run: |
           source "$HOME/.cargo/env"
           rustup target add ${{ matrix.platform.triple }}
 
       - name: Patch limits for local run
+        if: steps.gate.outputs.skip != 'true'
         run: |
           chmod +x ./scripts/localnet_patch.sh
           ./scripts/localnet_patch.sh
 
       - name: Build binaries
+        if: steps.gate.outputs.skip != 'true'
         run: |
           export PATH="$HOME/.cargo/bin:$PATH"
           export CARGO_BUILD_TARGET="${{ matrix.platform.triple }}"
@@ -232,6 +265,7 @@ jobs:
 
       # use `ci_target` name bc .dockerignore excludes `target`
       - name: Prepare artifacts for upload
+        if: steps.gate.outputs.skip != 'true'
         run: |
           RUNTIME="${{ matrix.runtime }}"
           TRIPLE="${{ matrix.platform.triple }}"
@@ -259,6 +293,7 @@ jobs:
             build/ci_target/${RUNTIME}/${TRIPLE}/release/wbuild/node-subtensor-runtime/
 
       - name: Upload artifact
+        if: steps.gate.outputs.skip != 'true'
         uses: actions/upload-artifact@v7
         with:
           name: binaries-${{ matrix.platform.triple }}-${{ matrix.runtime }}
@@ -271,13 +306,29 @@ jobs:
     if: needs.check-label.outputs.skip-bittensor-e2e-tests == 'false'
     runs-on: ubuntu-latest
     steps:
+      - name: Mirror gate
+        id: gate
+        run: |
+          if [ "${{ needs.check-label.outputs.mirror-fail }}" = "true" ]; then
+            echo "Mirroring previous failed run for this commit."
+            exit 1
+          fi
+          if [ "${{ needs.check-label.outputs.mirror-skip }}" = "true" ]; then
+            echo "Mirroring previous successful run for this commit."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout code
+        if: steps.gate.outputs.skip != 'true'
         uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
 
       - name: Download all binary artifacts
+        if: steps.gate.outputs.skip != 'true'
         uses: actions/download-artifact@v8
         with:
           pattern: binaries-*
@@ -285,6 +336,7 @@ jobs:
           merge-multiple: true
 
       - name: Move Docker data-root to /mnt/data
+        if: steps.gate.outputs.skip != 'true'
         run: |
           sudo systemctl stop docker
           sudo mkdir -p /mnt/data/docker
@@ -295,12 +347,15 @@ jobs:
           docker info | grep "Docker Root Dir"
 
       - name: Build Docker Image
+        if: steps.gate.outputs.skip != 'true'
         run: docker build -f Dockerfile-localnet --build-arg BUILT_IN_CI="Boom shakalaka" -t localnet .
 
       - name: Save Docker Image as Tar
+        if: steps.gate.outputs.skip != 'true'
         run: docker save -o /mnt/data/subtensor-localnet.tar localnet
 
       - name: Upload Docker Image as Artifact
+        if: steps.gate.outputs.skip != 'true'
         uses: actions/upload-artifact@v7
         with:
           name: subtensor-localnet
@@ -323,26 +378,45 @@ jobs:
     timeout-minutes: 60
     name: "cli: ${{ matrix.label }}"
     steps:
+      - name: Mirror gate
+        id: gate
+        run: |
+          if [ "${{ needs.check-label.outputs.mirror-fail }}" = "true" ]; then
+            echo "Mirroring previous failed run for this commit."
+            exit 1
+          fi
+          if [ "${{ needs.check-label.outputs.mirror-skip }}" = "true" ]; then
+            echo "Mirroring previous successful run for this commit."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check-out repository
+        if: steps.gate.outputs.skip != 'true'
         uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
 
       - name: Install uv
+        if: steps.gate.outputs.skip != 'true'
         uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: "false"
 
       - name: Create Python virtual environment
+        if: steps.gate.outputs.skip != 'true'
         working-directory: ${{ github.workspace }}
         run: uv venv --seed ${{ github.workspace }}/venv
 
       - name: Clone Bittensor CLI repo
+        if: steps.gate.outputs.skip != 'true'
         working-directory: ${{ github.workspace }}
         run: git clone https://github.com/opentensor/btcli.git
 
       - name: Setup Bittensor-cli from cloned repo
+        if: steps.gate.outputs.skip != 'true'
         working-directory: ${{ github.workspace }}/btcli
         run: |
           source ${{ github.workspace }}/venv/bin/activate
@@ -353,17 +427,21 @@ jobs:
           uv run --active pip install pytest
 
       - name: Download Cached Docker Image
+        if: steps.gate.outputs.skip != 'true'
         uses: actions/download-artifact@v8
         with:
           name: subtensor-localnet
 
       - name: Load Docker Image
+        if: steps.gate.outputs.skip != 'true'
         run: docker load -i subtensor-localnet.tar
 
       - name: Retag Docker Image
+        if: steps.gate.outputs.skip != 'true'
         run: docker tag localnet ghcr.io/opentensor/subtensor-localnet:devnet-ready
 
       - name: Run with retry
+        if: steps.gate.outputs.skip != 'true'
         working-directory: ${{ github.workspace }}/btcli
         run: |
           source ${{ github.workspace }}/venv/bin/activate
@@ -404,26 +482,45 @@ jobs:
     timeout-minutes: 60
     name: "sdk: ${{ matrix.label }}"
     steps:
+      - name: Mirror gate
+        id: gate
+        run: |
+          if [ "${{ needs.check-label.outputs.mirror-fail }}" = "true" ]; then
+            echo "Mirroring previous failed run for this commit."
+            exit 1
+          fi
+          if [ "${{ needs.check-label.outputs.mirror-skip }}" = "true" ]; then
+            echo "Mirroring previous successful run for this commit."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check-out repository
+        if: steps.gate.outputs.skip != 'true'
         uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
 
       - name: Install uv
+        if: steps.gate.outputs.skip != 'true'
         uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: "false"
 
       - name: Create Python virtual environment
+        if: steps.gate.outputs.skip != 'true'
         working-directory: ${{ github.workspace }}
         run: uv venv --seed ${{ github.workspace }}/venv
 
       - name: Clone Bittensor SDK repo
+        if: steps.gate.outputs.skip != 'true'
         working-directory: ${{ github.workspace }}
         run: git clone https://github.com/opentensor/bittensor.git
 
       - name: Setup Bittensor SDK from cloned repo
+        if: steps.gate.outputs.skip != 'true'
         working-directory: ${{ github.workspace }}/bittensor
         run: |
           source ${{ github.workspace }}/venv/bin/activate
@@ -434,17 +531,21 @@ jobs:
           uv run --active pip install pytest
 
       - name: Download Cached Docker Image
+        if: steps.gate.outputs.skip != 'true'
         uses: actions/download-artifact@v8
         with:
           name: subtensor-localnet
 
       - name: Load Docker Image
+        if: steps.gate.outputs.skip != 'true'
         run: docker load -i subtensor-localnet.tar
 
       - name: Retag Docker Image
+        if: steps.gate.outputs.skip != 'true'
         run: docker tag localnet ghcr.io/opentensor/subtensor-localnet:devnet-ready
 
       - name: Run with retry
+        if: steps.gate.outputs.skip != 'true'
         working-directory: ${{ github.workspace }}/bittensor
         run: |
           source ${{ github.workspace }}/venv/bin/activate

--- a/.github/workflows/check-bittensor-e2e-tests.yml
+++ b/.github/workflows/check-bittensor-e2e-tests.yml
@@ -27,10 +27,6 @@ env:
 jobs:
   check-label:
     runs-on: ubuntu-latest
-    if: |
-      github.event_name != 'pull_request' ||
-      (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
-      github.event.label.name == 'skip-bittensor-e2e-tests'
     outputs:
       skip-bittensor-e2e-tests: ${{ steps.get-labels.outputs.skip-bittensor-e2e-tests || steps.set-default.outputs.skip-bittensor-e2e-tests }}
     steps:

--- a/.github/workflows/check-bittensor-e2e-tests.yml
+++ b/.github/workflows/check-bittensor-e2e-tests.yml
@@ -91,7 +91,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: "false"
 
@@ -151,7 +151,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: "false"
 
@@ -334,7 +334,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: "false"
 
@@ -415,7 +415,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: "false"
 

--- a/.github/workflows/check-devnet.yml
+++ b/.github/workflows/check-devnet.yml
@@ -16,7 +16,10 @@ jobs:
   check-spec-version:
     name: Check spec_version bump
     runs-on: [self-hosted, type-ccx33]
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-spec-version-bump') }}
+    if: |
+      ((github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+       github.event.label.name == 'no-spec-version-bump') &&
+      !contains(github.event.pull_request.labels.*.name, 'no-spec-version-bump')
     steps:
       - name: Dependencies
         run: |
@@ -29,7 +32,7 @@ jobs:
           toolchain: stable
 
       - name: Check-out repository under $GITHUB_WORKSPACE
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Utilize Shared Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/check-devnet.yml
+++ b/.github/workflows/check-devnet.yml
@@ -16,10 +16,7 @@ jobs:
   check-spec-version:
     name: Check spec_version bump
     runs-on: [self-hosted, type-ccx33]
-    if: |
-      ((github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
-       github.event.label.name == 'no-spec-version-bump') &&
-      !contains(github.event.pull_request.labels.*.name, 'no-spec-version-bump')
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-spec-version-bump') }}
     steps:
       - name: Dependencies
         run: |

--- a/.github/workflows/check-devnet.yml
+++ b/.github/workflows/check-devnet.yml
@@ -4,10 +4,14 @@ on:
   pull_request:
     branches: [devnet, devnet-ready]
     types: [labeled, unlabeled, synchronize, opened]
-    
+
 concurrency:
   group: check-devnet-${{ github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -16,22 +20,64 @@ jobs:
   check-spec-version:
     name: Check spec_version bump
     runs-on: [self-hosted, type-ccx33]
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-spec-version-bump') }}
     steps:
+      - name: Decide whether to run, skip, or mirror previous result
+        id: gate
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const labels = context.payload.pull_request?.labels?.map(l => l.name) ?? [];
+            if (labels.includes('no-spec-version-bump')) {
+              core.info('no-spec-version-bump label present on PR; skipping spec_version check.');
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+            const action = context.payload.action;
+            const labelName = context.payload.label?.name;
+            const isLabelEvent = action === 'labeled' || action === 'unlabeled';
+            if (isLabelEvent && labelName !== 'no-spec-version-bump') {
+              const sha = context.payload.pull_request.head.sha;
+              const runs = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'check-devnet.yml',
+                head_sha: sha,
+                status: 'completed',
+                per_page: 20,
+              });
+              const prev = runs.data.workflow_runs.find(r => r.id !== context.runId);
+              core.info(`Previous completed run for ${sha}: ${prev?.conclusion ?? 'none'}`);
+              if (prev?.conclusion === 'success') {
+                core.setOutput('skip', 'true');
+                return;
+              }
+              if (prev?.conclusion === 'failure') {
+                core.setFailed('Mirroring previous failed run for this commit.');
+                return;
+              }
+            }
+
+            core.setOutput('skip', 'false');
+
       - name: Dependencies
+        if: steps.gate.outputs.skip != 'true'
         run: |
           sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update
           sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" build-essential clang curl libssl-dev llvm libudev-dev protobuf-compiler pkg-config
 
       - name: Install Rust
+        if: steps.gate.outputs.skip != 'true'
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
 
       - name: Check-out repository under $GITHUB_WORKSPACE
+        if: steps.gate.outputs.skip != 'true'
         uses: actions/checkout@v6
 
       - name: Utilize Shared Rust Cache
+        if: steps.gate.outputs.skip != 'true'
         uses: Swatinem/rust-cache@v2
         with:
           key: try-runtime
@@ -39,9 +85,11 @@ jobs:
           save-if: true
 
       - name: Install substrate-spec-version
+        if: steps.gate.outputs.skip != 'true'
         run: cargo install substrate-spec-version
 
       - name: Check that spec_version has been bumped
+        if: steps.gate.outputs.skip != 'true'
         run: |
           spec_version=$(PATH=$PATH:$HOME/.cargo/.bin substrate-spec-version wss://dev.chain.opentensor.ai:443 | tr -d '\n')
           echo "network spec_version: $spec_version"

--- a/.github/workflows/check-docker.yml
+++ b/.github/workflows/check-docker.yml
@@ -13,13 +13,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v4.1.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4.1.0
 
       - name: Build Docker Image
         run: docker build .

--- a/.github/workflows/check-finney.yml
+++ b/.github/workflows/check-finney.yml
@@ -16,7 +16,10 @@ jobs:
   check-spec-version:
     name: Check spec_version bump
     runs-on: [self-hosted, type-ccx33]
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-spec-version-bump') }}
+    if: |
+      ((github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+       github.event.label.name == 'no-spec-version-bump') &&
+      !contains(github.event.pull_request.labels.*.name, 'no-spec-version-bump')
     steps:
       - name: Dependencies
         run: |
@@ -29,7 +32,7 @@ jobs:
           toolchain: stable
 
       - name: Check-out repository under $GITHUB_WORKSPACE
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Utilize Shared Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/check-finney.yml
+++ b/.github/workflows/check-finney.yml
@@ -16,10 +16,7 @@ jobs:
   check-spec-version:
     name: Check spec_version bump
     runs-on: [self-hosted, type-ccx33]
-    if: |
-      ((github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
-       github.event.label.name == 'no-spec-version-bump') &&
-      !contains(github.event.pull_request.labels.*.name, 'no-spec-version-bump')
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-spec-version-bump') }}
     steps:
       - name: Dependencies
         run: |

--- a/.github/workflows/check-finney.yml
+++ b/.github/workflows/check-finney.yml
@@ -4,10 +4,14 @@ on:
   pull_request:
     branches: [finney, main]
     types: [labeled, unlabeled, synchronize, opened]
-    
+
 concurrency:
   group: check-finney-${{ github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -16,30 +20,74 @@ jobs:
   check-spec-version:
     name: Check spec_version bump
     runs-on: [self-hosted, type-ccx33]
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-spec-version-bump') }}
     steps:
+      - name: Decide whether to run, skip, or mirror previous result
+        id: gate
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const labels = context.payload.pull_request?.labels?.map(l => l.name) ?? [];
+            if (labels.includes('no-spec-version-bump')) {
+              core.info('no-spec-version-bump label present on PR; skipping spec_version check.');
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+            const action = context.payload.action;
+            const labelName = context.payload.label?.name;
+            const isLabelEvent = action === 'labeled' || action === 'unlabeled';
+            if (isLabelEvent && labelName !== 'no-spec-version-bump') {
+              const sha = context.payload.pull_request.head.sha;
+              const runs = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'check-finney.yml',
+                head_sha: sha,
+                status: 'completed',
+                per_page: 20,
+              });
+              const prev = runs.data.workflow_runs.find(r => r.id !== context.runId);
+              core.info(`Previous completed run for ${sha}: ${prev?.conclusion ?? 'none'}`);
+              if (prev?.conclusion === 'success') {
+                core.setOutput('skip', 'true');
+                return;
+              }
+              if (prev?.conclusion === 'failure') {
+                core.setFailed('Mirroring previous failed run for this commit.');
+                return;
+              }
+            }
+
+            core.setOutput('skip', 'false');
+
       - name: Dependencies
+        if: steps.gate.outputs.skip != 'true'
         run: |
           sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update
           sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" build-essential clang curl libssl-dev llvm libudev-dev protobuf-compiler pkg-config
 
       - name: Install Rust
+        if: steps.gate.outputs.skip != 'true'
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
 
       - name: Check-out repository under $GITHUB_WORKSPACE
+        if: steps.gate.outputs.skip != 'true'
         uses: actions/checkout@v6
 
       - name: Utilize Shared Rust Cache
+        if: steps.gate.outputs.skip != 'true'
         uses: Swatinem/rust-cache@v2
         with:
           key: try-runtime
 
       - name: Install substrate-spec-version
+        if: steps.gate.outputs.skip != 'true'
         run: cargo install substrate-spec-version
 
       - name: Check that spec_version has been bumped
+        if: steps.gate.outputs.skip != 'true'
         run: |
           spec_version=$(PATH=$PATH:$HOME/.cargo/.bin substrate-spec-version wss://entrypoint-finney.opentensor.ai:443 | tr -d '\n')
           echo "network spec_version: $spec_version"

--- a/.github/workflows/check-node-compat.yml
+++ b/.github/workflows/check-node-compat.yml
@@ -22,8 +22,10 @@ jobs:
     strategy:
       matrix:
         version:
-          - { name: old, ref: devnet-ready }
-          - { name: new, ref: ${{ github.head_ref }} }
+          - name: old
+            ref: devnet-ready
+          - name: new
+            ref: ${{ github.head_ref }}
 
     steps:
       - name: Install dependencies

--- a/.github/workflows/check-node-compat.yml
+++ b/.github/workflows/check-node-compat.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     name: build ${{ matrix.version.name }}
     runs-on: [self-hosted, type-ccx33]
-    if: contains(github.event.pull_request.labels.*.name, 'check-node-compat')
+    if: github.event.label.name == 'check-node-compat'
     env:
         RUST_BACKTRACE: full
     strategy:
@@ -42,7 +42,7 @@ jobs:
           key: "check-node-compat-${{ matrix.version.name }}"
       
       - name: Checkout ${{ matrix.version.name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ matrix.version.ref }}
           path: ${{ matrix.version.name }}
@@ -52,7 +52,7 @@ jobs:
         run: cargo build --release --locked
         
       - name: Upload ${{ matrix.version.name }} node binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: node-subtensor-${{ matrix.version.name }}
           path: ${{ matrix.version.name }}/target/release/node-subtensor
@@ -63,19 +63,19 @@ jobs:
     runs-on: [self-hosted, type-ccx33]
     steps:
       - name: Download old node binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: node-subtensor-old
           path: /tmp/node-subtensor-old
           
       - name: Download new node binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: node-subtensor-new
           path: /tmp/node-subtensor-new
           
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
 

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -28,7 +28,7 @@ jobs:
       RUST_BACKTRACE: full
     steps:
       - name: Check-out repository under $GITHUB_WORKSPACE
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -73,7 +73,7 @@ jobs:
       SKIP_WASM_BUILD: 1
     steps:
       - name: Check-out repository under $GITHUB_WORKSPACE
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -104,7 +104,7 @@ jobs:
       SKIP_WASM_BUILD: 1
     steps:
       - name: Check-out repository under $GITHUB_WORKSPACE
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -136,7 +136,7 @@ jobs:
       SKIP_WASM_BUILD: 1
     steps:
       - name: Check-out repository under $GITHUB_WORKSPACE
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -167,7 +167,7 @@ jobs:
       SKIP_WASM_BUILD: 1
     steps:
       - name: Check-out repository under $GITHUB_WORKSPACE
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -197,7 +197,7 @@ jobs:
       SKIP_WASM_BUILD: 1
     steps:
       - name: Check-out repository under $GITHUB_WORKSPACE
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -234,7 +234,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Dont clone historic commits.
 

--- a/.github/workflows/check-testnet.yml
+++ b/.github/workflows/check-testnet.yml
@@ -16,7 +16,10 @@ jobs:
   check-spec-version:
     name: Check spec_version bump
     runs-on: [self-hosted, type-ccx33]
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-spec-version-bump') }}
+    if: |
+      ((github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+       github.event.label.name == 'no-spec-version-bump') &&
+      !contains(github.event.pull_request.labels.*.name, 'no-spec-version-bump')
     steps:
       - name: Dependencies
         run: |
@@ -29,7 +32,7 @@ jobs:
           toolchain: stable
 
       - name: Check-out repository under $GITHUB_WORKSPACE
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Utilize Shared Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/check-testnet.yml
+++ b/.github/workflows/check-testnet.yml
@@ -16,10 +16,7 @@ jobs:
   check-spec-version:
     name: Check spec_version bump
     runs-on: [self-hosted, type-ccx33]
-    if: |
-      ((github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
-       github.event.label.name == 'no-spec-version-bump') &&
-      !contains(github.event.pull_request.labels.*.name, 'no-spec-version-bump')
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-spec-version-bump') }}
     steps:
       - name: Dependencies
         run: |

--- a/.github/workflows/check-testnet.yml
+++ b/.github/workflows/check-testnet.yml
@@ -9,6 +9,10 @@ concurrency:
   group: check-testnet-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  actions: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -16,31 +20,75 @@ jobs:
   check-spec-version:
     name: Check spec_version bump
     runs-on: [self-hosted, type-ccx33]
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-spec-version-bump') }}
     steps:
+      - name: Decide whether to run, skip, or mirror previous result
+        id: gate
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const labels = context.payload.pull_request?.labels?.map(l => l.name) ?? [];
+            if (labels.includes('no-spec-version-bump')) {
+              core.info('no-spec-version-bump label present on PR; skipping spec_version check.');
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+            const action = context.payload.action;
+            const labelName = context.payload.label?.name;
+            const isLabelEvent = action === 'labeled' || action === 'unlabeled';
+            if (isLabelEvent && labelName !== 'no-spec-version-bump') {
+              const sha = context.payload.pull_request.head.sha;
+              const runs = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'check-testnet.yml',
+                head_sha: sha,
+                status: 'completed',
+                per_page: 20,
+              });
+              const prev = runs.data.workflow_runs.find(r => r.id !== context.runId);
+              core.info(`Previous completed run for ${sha}: ${prev?.conclusion ?? 'none'}`);
+              if (prev?.conclusion === 'success') {
+                core.setOutput('skip', 'true');
+                return;
+              }
+              if (prev?.conclusion === 'failure') {
+                core.setFailed('Mirroring previous failed run for this commit.');
+                return;
+              }
+            }
+
+            core.setOutput('skip', 'false');
+
       - name: Dependencies
+        if: steps.gate.outputs.skip != 'true'
         run: |
           sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update
           sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" build-essential clang curl libssl-dev llvm libudev-dev protobuf-compiler pkg-config
 
       - name: Install Rust
+        if: steps.gate.outputs.skip != 'true'
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
 
       - name: Check-out repository under $GITHUB_WORKSPACE
+        if: steps.gate.outputs.skip != 'true'
         uses: actions/checkout@v6
 
       - name: Utilize Shared Rust Cache
+        if: steps.gate.outputs.skip != 'true'
         uses: Swatinem/rust-cache@v2
         with:
           key: try-runtime
           cache-on-failure: true
 
       - name: Install substrate-spec-version
+        if: steps.gate.outputs.skip != 'true'
         run: cargo install substrate-spec-version
 
       - name: Check that spec_version has been bumped
+        if: steps.gate.outputs.skip != 'true'
         run: |
           spec_version=$(PATH=$PATH:$HOME/.cargo/.bin substrate-spec-version wss://test.finney.opentensor.ai:443 | tr -d '\n')
           echo "network spec_version: $spec_version"

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -29,9 +29,11 @@ jobs:
       RUST_BACKTRACE: full
     steps:
       - name: Check-out repository under $GITHUB_WORKSPACE
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
+        # This has been archived since Oct 2023, might be a good idea to eventually switch to
+        # https://github.com/marketplace/actions/rustup-toolchain-install
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -40,7 +42,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 

--- a/.github/workflows/docker-localnet.yml
+++ b/.github/workflows/docker-localnet.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Get PR branch (if pr-number is specified)
         id: pr-info
         if: ${{ github.event.inputs.pr-number != '' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const prNumber = '${{ github.event.inputs.pr-number }}';
@@ -108,7 +108,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.setup.outputs.ref }}
 
@@ -153,7 +153,7 @@ jobs:
             build/ci_target/${RUNTIME}/${TRIPLE}/release/wbuild/node-subtensor-runtime/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: binaries-${{ matrix.platform.triple }}-${{ matrix.runtime }}
           path: build/
@@ -169,12 +169,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.setup.outputs.ref }}
 
       - name: Download all binary artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: binaries-*
           path: build/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,7 +46,7 @@ jobs:
           fi
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ env.ref }}
 

--- a/.github/workflows/eco-tests.yml
+++ b/.github/workflows/eco-tests.yml
@@ -23,7 +23,7 @@ jobs:
       SKIP_WASM_BUILD: 1
     steps:
       - name: Check-out repository under $GITHUB_WORKSPACE
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/label-triggers.yml
+++ b/.github/workflows/label-triggers.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Check if 'breaking change' label is added
         if: github.event.label.name == 'breaking-change'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/require-clean-merges.yml
+++ b/.github/workflows/require-clean-merges.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: [self-hosted, type-ccx13]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Ensures we get all branches for merging
 

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Check out PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload patch artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bench-patch
           path: bench-patch.tgz

--- a/.github/workflows/rustdocs.yml
+++ b/.github/workflows/rustdocs.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -48,7 +48,7 @@ jobs:
         run: |
             echo "<meta http-equiv=refresh content=0;url=wasm_oidc_plugin/index.html>" > target/doc/index.html
       - name: Upload documentation
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
             path: ./target/doc
 
@@ -66,4 +66,4 @@ jobs:
         steps:
           - name: Deploy documentation
             id: pages
-            uses: actions/deploy-pages@v2
+            uses: actions/deploy-pages@v5

--- a/.github/workflows/scheduled-smoke-tests.yml
+++ b/.github/workflows/scheduled-smoke-tests.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Check-out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ts-tests/.nvmrc
 

--- a/.github/workflows/try-runtime.yml
+++ b/.github/workflows/try-runtime.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: [self-hosted, type-ccx33]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -48,7 +48,7 @@ jobs:
     runs-on: [self-hosted, type-ccx33]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -79,7 +79,7 @@ jobs:
     runs-on: [self-hosted, type-ccx33]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/typescript-e2e.yml
+++ b/.github/workflows/typescript-e2e.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check-out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -22,7 +22,7 @@ jobs:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ts-tests/.nvmrc
 
@@ -58,7 +58,7 @@ jobs:
       RUST_BACKTRACE: full
     steps:
       - name: Check-out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install system dependencies
         run: |
@@ -82,7 +82,7 @@ jobs:
         run: cargo build --profile release ${{ matrix.flags }} -p node-subtensor
 
       - name: Upload binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: node-subtensor-${{ matrix.variant }}
           path: target/release/node-subtensor
@@ -112,10 +112,10 @@ jobs:
 
     steps:
       - name: Check-out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: node-subtensor-${{ matrix.binary }}
           path: target/release
@@ -124,7 +124,7 @@ jobs:
         run: chmod +x target/release/node-subtensor
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ts-tests/.nvmrc
 

--- a/.github/workflows/typescript-e2e.yml
+++ b/.github/workflows/typescript-e2e.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6.0.8
         with:
           version: 10
 

--- a/.github/workflows/update-chainspec.yml
+++ b/.github/workflows/update-chainspec.yml
@@ -31,7 +31,7 @@ jobs:
       RUST_BACKTRACE: full
     steps:
       - name: Check-out repository under $GITHUB_WORKSPACE
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Description
This is a two-part PR. 
Part One:
Workflows run correctly depending on labeling now. Previously any label change would trigger the rerunning of a number of tests:
 - check-bittensor-e2e-tests.yml (should only not run on skip-bittensor-e2e-tests label)
 - check-devnet.yml (no-spec-version-bump label)
 - check-finney.yml (no-spec-version-bump label)
 - check-testnet.yml (no-spec-version-bump label)
 - cargo-audit.yml (skip-cargo-audit)
 - check-node-compat.yml (check-node-compat, switched from 'contains')

Part Two:
Basically every GitHub Action used in this PR was outdated and using deprecated Node versions, causing 200+ warnings on every run. This is annoying to look through annotations to find one that actually matters out of hundreds.

## Related Issue(s)

N/A

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please describe): better workflows

## Breaking Change

N/A

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

<img width="334" height="800" alt="Screenshot 2026-05-28 at 15 08 33" src="https://github.com/user-attachments/assets/cd620162-e38a-41e1-8030-75e31f4ee6e9" />
<img width="526" height="775" alt="Screenshot 2026-05-28 at 15 08 01" src="https://github.com/user-attachments/assets/c8335201-8a5f-4443-8daf-cb7f5a8eb716" />


## Additional Notes

I didn't touch the actions in ai-review.yml or ai-review-index-gittensor.yml because those use hash-specified actions versions, and I don't know why.