### PR TITLE
Fix chain buys accounting

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -694,6 +694,12 @@ pub mod pallet {
         0
     }
 
+    /// Default value for TAO-in refund deployment block.
+    #[pallet::type_value]
+    pub fn DefaultTaoInRefundDeploymentBlock() -> u64 {
+        0
+    }
+
     /// Default value for weights version key rate limit.
     /// In units of tempos.
     #[pallet::type_value]
@@ -2558,6 +2564,11 @@ pub mod pallet {
     #[pallet::storage]
     pub type NetworkRegistrationStartBlock<T> =
         StorageValue<_, u64, ValueQuery, DefaultNetworkRegistrationStartBlock<T>>;
+
+    /// ITEM( TaoInRefundDeploymentBlock )
+    #[pallet::storage]
+    pub type TaoInRefundDeploymentBlock<T> =
+        StorageValue<_, u64, ValueQuery, DefaultTaoInRefundDeploymentBlock>;
 
     /// --- MAP ( netuid ) --> minimum required number of non-immortal & non-immune UIDs
     #[pallet::storage]

--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -181,8 +181,8 @@ mod hooks {
                 .saturating_add(migrations::migrate_remove_deprecated_conviction_maps::migrate_remove_deprecated_conviction_maps::<T>())
                 // Reset testnet conviction lock storage before deploying the current design.
                 .saturating_add(migrations::migrate_reset_tnet_conviction_locks::migrate_reset_tnet_conviction_locks::<T>())
-            // Capture the runtime-upgrade block for TAO-in refund cutover.
-            .saturating_add(migrations::migrate_tao_in_refund_deployment_block::migrate_tao_in_refund_deployment_block::<T>());
+                // Capture the runtime-upgrade block for TAO-in refund cutover.
+                .saturating_add(migrations::migrate_tao_in_refund_deployment_block::migrate_tao_in_refund_deployment_block::<T>());
             weight
         }
 

--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -180,7 +180,9 @@ mod hooks {
                 // Remove deprecated conviction lock storage.
                 .saturating_add(migrations::migrate_remove_deprecated_conviction_maps::migrate_remove_deprecated_conviction_maps::<T>())
                 // Reset testnet conviction lock storage before deploying the current design.
-                .saturating_add(migrations::migrate_reset_tnet_conviction_locks::migrate_reset_tnet_conviction_locks::<T>());
+                .saturating_add(migrations::migrate_reset_tnet_conviction_locks::migrate_reset_tnet_conviction_locks::<T>())
+            // Capture the runtime-upgrade block for TAO-in refund cutover.
+            .saturating_add(migrations::migrate_tao_in_refund_deployment_block::migrate_tao_in_refund_deployment_block::<T>());
             weight
         }
 

--- a/pallets/subtensor/src/migrations/migrate_tao_in_refund_deployment_block.rs
+++ b/pallets/subtensor/src/migrations/migrate_tao_in_refund_deployment_block.rs
@@ -1,0 +1,40 @@
+use super::*;
+
+use frame_support::{traits::Get, weights::Weight};
+use scale_info::prelude::string::String;
+use sp_runtime::traits::SaturatedConversion;
+
+/// Captures the runtime-upgrade block used as the TAO-in refund behavior cutover.
+pub fn migrate_tao_in_refund_deployment_block<T: Config>() -> Weight {
+    let migration_name = b"migrate_tao_in_refund_deployment_block".to_vec();
+    let mut weight = T::DbWeight::get().reads(1);
+
+    if HasMigrationRun::<T>::get(&migration_name) {
+        log::info!(
+            "Migration '{:?}' has already run. Skipping.",
+            String::from_utf8_lossy(&migration_name)
+        );
+        return weight;
+    }
+
+    log::info!(
+        "Running migration '{:?}'",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    let deployment_block: u64 = frame_system::Pallet::<T>::block_number().saturated_into::<u64>();
+
+    TaoInRefundDeploymentBlock::<T>::put(deployment_block);
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+    HasMigrationRun::<T>::insert(&migration_name, true);
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+    log::info!(
+        "Migration '{:?}' completed successfully. TaoInRefundDeploymentBlock: {}.",
+        String::from_utf8_lossy(&migration_name),
+        deployment_block
+    );
+
+    weight
+}

--- a/pallets/subtensor/src/migrations/mod.rs
+++ b/pallets/subtensor/src/migrations/mod.rs
@@ -63,6 +63,7 @@ pub mod migrate_subnet_limit_to_default;
 pub mod migrate_subnet_locked;
 pub mod migrate_subnet_symbols;
 pub mod migrate_subnet_volume;
+pub mod migrate_tao_in_refund_deployment_block;
 pub mod migrate_to_v1_separate_emission;
 pub mod migrate_to_v2_fixed_total_stake;
 pub mod migrate_transfer_ownership_to_foundation;

--- a/pallets/subtensor/src/staking/remove_stake.rs
+++ b/pallets/subtensor/src/staking/remove_stake.rs
@@ -476,10 +476,8 @@ impl<T: Config> Pallet<T> {
 
         let tao_in_refund_deployment_block: u64 = TaoInRefundDeploymentBlock::<T>::get();
 
-        // For subnets registered after this runtime was deployed, the protocol-owned
-        // alpha bucket includes both the pool reserve and cached protocol alpha.
-        // Subnets registered before or at deployment keep the previous accounting:
-        // only cached protocol alpha participates in the dissolution settlement.
+        // Legacy subnets keep the old dereg behavior: ignore SubnetAlphaIn.
+        // New subnets include SubnetAlphaIn.
         let protocol_alpha_value_u128: u128 = if reg_at > tao_in_refund_deployment_block {
             SubnetAlphaIn::<T>::get(netuid)
                 .saturating_add(SubnetProtocolAlpha::<T>::get(netuid))

--- a/pallets/subtensor/src/staking/remove_stake.rs
+++ b/pallets/subtensor/src/staking/remove_stake.rs
@@ -479,7 +479,8 @@ impl<T: Config> Pallet<T> {
         // recycled back to the chain (see step 8/9 below). Note we deliberately do
         // NOT include `SubnetAlphaIn` (the AMM pool reserve) here: it is not held
         // alpha and must not dilute stakers' pro-rata shares.
-        let protocol_alpha_value_u128: u128 = SubnetProtocolAlpha::<T>::get(netuid).to_u64() as u128;
+        let protocol_alpha_value_u128: u128 =
+            SubnetProtocolAlpha::<T>::get(netuid).to_u64() as u128;
         let mut total_alpha_value_u128: u128 = protocol_alpha_value_u128;
         let mut protocol_tao_share = TaoBalance::ZERO;
 

--- a/pallets/subtensor/src/staking/remove_stake.rs
+++ b/pallets/subtensor/src/staking/remove_stake.rs
@@ -473,9 +473,13 @@ impl<T: Config> Pallet<T> {
         //    - track hotkeys to clear pool totals.
         let mut keys_to_remove: Vec<(T::AccountId, T::AccountId)> = Vec::new();
         let mut stakers: Vec<(T::AccountId, T::AccountId, u128)> = Vec::new();
-        let protocol_alpha_value_u128: u128 = SubnetAlphaIn::<T>::get(netuid)
-            .saturating_add(SubnetProtocolAlpha::<T>::get(netuid))
-            .to_u64() as u128;
+        // Alpha bought by the chain during protocol TAO buys is cached in
+        // `SubnetProtocolAlpha` (rather than burned). On dissolution it is converted
+        // to TAO pro-rata exactly like every staker's alpha, and that TAO is then
+        // recycled back to the chain (see step 8/9 below). Note we deliberately do
+        // NOT include `SubnetAlphaIn` (the AMM pool reserve) here: it is not held
+        // alpha and must not dilute stakers' pro-rata shares.
+        let protocol_alpha_value_u128: u128 = SubnetProtocolAlpha::<T>::get(netuid).to_u64() as u128;
         let mut total_alpha_value_u128: u128 = protocol_alpha_value_u128;
         let mut protocol_tao_share = TaoBalance::ZERO;
 

--- a/pallets/subtensor/src/staking/remove_stake.rs
+++ b/pallets/subtensor/src/staking/remove_stake.rs
@@ -473,14 +473,21 @@ impl<T: Config> Pallet<T> {
         //    - track hotkeys to clear pool totals.
         let mut keys_to_remove: Vec<(T::AccountId, T::AccountId)> = Vec::new();
         let mut stakers: Vec<(T::AccountId, T::AccountId, u128)> = Vec::new();
-        // Alpha bought by the chain during protocol TAO buys is cached in
-        // `SubnetProtocolAlpha` (rather than burned). On dissolution it is converted
-        // to TAO pro-rata exactly like every staker's alpha, and that TAO is then
-        // recycled back to the chain (see step 8/9 below). Note we deliberately do
-        // NOT include `SubnetAlphaIn` (the AMM pool reserve) here: it is not held
-        // alpha and must not dilute stakers' pro-rata shares.
-        let protocol_alpha_value_u128: u128 =
-            SubnetProtocolAlpha::<T>::get(netuid).to_u64() as u128;
+
+        let tao_in_refund_deployment_block: u64 = TaoInRefundDeploymentBlock::<T>::get();
+
+        // For subnets registered after this runtime was deployed, the protocol-owned
+        // alpha bucket includes both the pool reserve and cached protocol alpha.
+        // Subnets registered before or at deployment keep the previous accounting:
+        // only cached protocol alpha participates in the dissolution settlement.
+        let protocol_alpha_value_u128: u128 = if reg_at > tao_in_refund_deployment_block {
+            SubnetAlphaIn::<T>::get(netuid)
+                .saturating_add(SubnetProtocolAlpha::<T>::get(netuid))
+                .to_u64() as u128
+        } else {
+            SubnetProtocolAlpha::<T>::get(netuid).to_u64() as u128
+        };
+
         let mut total_alpha_value_u128: u128 = protocol_alpha_value_u128;
         let mut protocol_tao_share = TaoBalance::ZERO;
 

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -48,6 +48,27 @@ fn close(value: u64, target: u64, eps: u64) {
 }
 
 #[test]
+fn test_migrate_tao_in_refund_deployment_block() {
+    new_test_ext(1).execute_with(|| {
+        let deployment_block: u64 = 42;
+        let migration_name = b"migrate_tao_in_refund_deployment_block".to_vec();
+
+        TaoInRefundDeploymentBlock::<Test>::put(0);
+        HasMigrationRun::<Test>::remove(&migration_name);
+
+        run_to_block(deployment_block);
+        crate::migrations::migrate_tao_in_refund_deployment_block::migrate_tao_in_refund_deployment_block::<Test>();
+
+        assert_eq!(TaoInRefundDeploymentBlock::<Test>::get(), deployment_block);
+        assert!(HasMigrationRun::<Test>::get(&migration_name));
+
+        run_to_block(deployment_block.saturating_add(1));
+        crate::migrations::migrate_tao_in_refund_deployment_block::migrate_tao_in_refund_deployment_block::<Test>();
+
+        assert_eq!(TaoInRefundDeploymentBlock::<Test>::get(), deployment_block);
+    });
+}
+#[test]
 fn test_migration_transfer_nets_to_foundation() {
     new_test_ext(1).execute_with(|| {
         // Create subnet 1

--- a/pallets/subtensor/src/tests/networks.rs
+++ b/pallets/subtensor/src/tests/networks.rs
@@ -739,10 +739,15 @@ fn dissolve_protocol_alpha_share_is_not_paid_to_users() {
         let owner_hot = U256::from(620);
         let net = add_dynamic_network(&owner_hot, &owner_cold);
         remove_owner_registration_stake(net);
+
+        // Make this subnet pre-deploy for protocol-alpha accounting.
+        let reg_at = NetworkRegisteredAt::<Test>::get(net);
+        TaoInRefundDeploymentBlock::<Test>::put(reg_at.saturating_add(1));
         SubtensorModule::set_subnet_locked_balance(net, TaoBalance::ZERO);
 
         // Alpha-in is the AMM pool reserve and must NOT participate in the
-        // deregistration settlement. Only the chain-bought (cached protocol)
+        // deregistration settlement for pre-deploy subnets. Only the chain-bought
+        // cached protocol
         // alpha is converted to TAO pro-rata, exactly like every staker's alpha.
         SubnetAlphaIn::<Test>::insert(net, AlphaBalance::from(100u64));
         SubnetProtocolAlpha::<Test>::insert(net, AlphaBalance::from(50u64));
@@ -780,17 +785,68 @@ fn dissolve_protocol_alpha_share_is_not_paid_to_users() {
 }
 
 #[test]
+fn dissolve_protocol_alpha_post_deploy_includes_alpha_in() {
+    new_test_ext(0).execute_with(|| {
+        let owner_cold = U256::from(611);
+        let owner_hot = U256::from(621);
+
+        let net = add_dynamic_network(&owner_hot, &owner_cold);
+        remove_owner_registration_stake(net);
+
+        // Make this subnet post-deploy for protocol-alpha accounting.
+        TaoInRefundDeploymentBlock::<Test>::put(100);
+        NetworkRegisteredAt::<Test>::insert(net, 101);
+
+        SubtensorModule::set_subnet_locked_balance(net, TaoBalance::ZERO);
+
+        SubnetAlphaIn::<Test>::insert(net, AlphaBalance::from(100u64));
+        SubnetProtocolAlpha::<Test>::insert(net, AlphaBalance::from(50u64));
+
+        let staker_hot = U256::from(631);
+        let staker_cold = U256::from(641);
+
+        AlphaV2::<Test>::insert((staker_hot, staker_cold, net), sf_from_u64(50u64));
+        TotalHotkeyAlpha::<Test>::insert(staker_hot, net, AlphaBalance::from(50u64));
+
+        let pot: u64 = 200;
+        SubnetTAO::<Test>::insert(net, TaoBalance::from(pot));
+
+        let staker_before = SubtensorModule::get_coldkey_balance(&staker_cold);
+        let owner_before = SubtensorModule::get_coldkey_balance(&owner_cold);
+
+        assert_ok!(SubtensorModule::do_dissolve_network(net));
+
+        // Post-deploy denominator = 100 alpha-in + 50 cached protocol alpha
+        // + 50 user alpha = 200. The user gets 50/200 of the 200 TAO pot.
+        assert_eq!(
+            SubtensorModule::get_coldkey_balance(&staker_cold),
+            staker_before + 50.into()
+        );
+
+        assert_eq!(
+            SubtensorModule::get_coldkey_balance(&owner_cold),
+            owner_before
+        );
+
+        assert!(!SubnetProtocolAlpha::<Test>::contains_key(net));
+    });
+}
+#[test]
 fn dissolve_chain_bought_alpha_is_converted_to_tao_and_recycled() {
     new_test_ext(0).execute_with(|| {
         let owner_cold = U256::from(710);
         let owner_hot = U256::from(720);
         let net = add_dynamic_network(&owner_hot, &owner_cold);
         remove_owner_registration_stake(net);
+
+        // Make this subnet pre-deploy for protocol-alpha accounting.
+        let reg_at = NetworkRegisteredAt::<Test>::get(net);
+        TaoInRefundDeploymentBlock::<Test>::put(reg_at.saturating_add(1));
         // No owner refund path: any TAO left on the subnet account is recycled.
         SubtensorModule::set_subnet_locked_balance(net, TaoBalance::ZERO);
 
-        // Alpha-in (pool reserve) is present but must be ignored. The chain-bought
-        // alpha is the only claimant, so it is the sole settlement weight.
+        // Alpha-in is present but ignored on the pre-deploy branch. The cached
+        // protocol alpha is the only claimant, so the entire pot is recycled.
         SubnetAlphaIn::<Test>::insert(net, AlphaBalance::from(123u64));
         SubnetProtocolAlpha::<Test>::insert(net, AlphaBalance::from(100u64));
 

--- a/pallets/subtensor/src/tests/networks.rs
+++ b/pallets/subtensor/src/tests/networks.rs
@@ -741,7 +741,9 @@ fn dissolve_protocol_alpha_share_is_not_paid_to_users() {
         remove_owner_registration_stake(net);
         SubtensorModule::set_subnet_locked_balance(net, TaoBalance::ZERO);
 
-        // Protocol owns both alpha-in and cached chain-buy alpha on dereg.
+        // Alpha-in is the AMM pool reserve and must NOT participate in the
+        // deregistration settlement. Only the chain-bought (cached protocol)
+        // alpha is converted to TAO pro-rata, exactly like every staker's alpha.
         SubnetAlphaIn::<Test>::insert(net, AlphaBalance::from(100u64));
         SubnetProtocolAlpha::<Test>::insert(net, AlphaBalance::from(50u64));
 
@@ -754,13 +756,62 @@ fn dissolve_protocol_alpha_share_is_not_paid_to_users() {
         SubnetTAO::<Test>::insert(net, TaoBalance::from(pot));
 
         let staker_before = SubtensorModule::get_coldkey_balance(&staker_cold);
+        let owner_before = SubtensorModule::get_coldkey_balance(&owner_cold);
+
         assert_ok!(SubtensorModule::do_dissolve_network(net));
 
-        // User gets 50 / (100 alpha-in + 50 cached protocol alpha + 50 user alpha)
-        // of the TAO pot. The protocol share is withheld from user/owner payout.
+        // Settlement denominator = 50 cached protocol alpha + 50 user alpha = 100
+        // (alpha-in is excluded). The user therefore gets 50/100 of the 200 TAO pot,
+        // i.e. 100 TAO. The chain-bought alpha's 100 TAO share is withheld from the
+        // user/owner payout (it is recycled back to the chain, see the dedicated
+        // recycling test below).
         assert_eq!(
             SubtensorModule::get_coldkey_balance(&staker_cold),
-            staker_before + 50.into()
+            staker_before + 100.into()
+        );
+        // The owner is not paid the protocol share either (locked balance is zero, so
+        // there is no refund path that could leak it).
+        assert_eq!(
+            SubtensorModule::get_coldkey_balance(&owner_cold),
+            owner_before
+        );
+        assert!(!SubnetProtocolAlpha::<Test>::contains_key(net));
+    });
+}
+
+#[test]
+fn dissolve_chain_bought_alpha_is_converted_to_tao_and_recycled() {
+    new_test_ext(0).execute_with(|| {
+        let owner_cold = U256::from(710);
+        let owner_hot = U256::from(720);
+        let net = add_dynamic_network(&owner_hot, &owner_cold);
+        remove_owner_registration_stake(net);
+        // No owner refund path: any TAO left on the subnet account is recycled.
+        SubtensorModule::set_subnet_locked_balance(net, TaoBalance::ZERO);
+
+        // Alpha-in (pool reserve) is present but must be ignored. The chain-bought
+        // alpha is the only claimant, so it is the sole settlement weight.
+        SubnetAlphaIn::<Test>::insert(net, AlphaBalance::from(123u64));
+        SubnetProtocolAlpha::<Test>::insert(net, AlphaBalance::from(100u64));
+
+        let pot: u64 = 100;
+        SubnetTAO::<Test>::insert(net, TaoBalance::from(pot));
+
+        let issuance_before = TotalIssuance::<Test>::get();
+        let owner_before = SubtensorModule::get_coldkey_balance(&owner_cold);
+
+        assert_ok!(SubtensorModule::do_dissolve_network(net));
+
+        // There are no stakers, so the entire pot is the chain-bought alpha's TAO
+        // share. It is not paid to the owner; instead it is recycled back to the
+        // chain, which removes it from existence and reduces total issuance.
+        assert_eq!(
+            SubtensorModule::get_coldkey_balance(&owner_cold),
+            owner_before
+        );
+        assert!(
+            TotalIssuance::<Test>::get() < issuance_before,
+            "recycling the chain-bought alpha's TAO must reduce total issuance"
         );
         assert!(!SubnetProtocolAlpha::<Test>::contains_key(net));
     });

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -277,7 +277,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 414,
+    spec_version: 415,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description

Follow-up to #2645 (Subnet Protocol Alpha Accounting).

#2645 stopped burning alpha bought during protocol TAO buys and cached it in `SubnetProtocolAlpha`. This PR adds a deployment-block cutover so deregistration can handle legacy and post-upgrade subnets correctly.

Behavior on deregistration:

- Subnets registered **before or at** `TaoInRefundDeploymentBlock` settle using `SubnetProtocolAlpha` only.
- Subnets registered **after** `TaoInRefundDeploymentBlock` settle using `SubnetAlphaIn + SubnetProtocolAlpha`.