### PR TITLE
Use ParityDb weights by default

### DIFF
--- a/.maintain/frame-weight-template.hbs
+++ b/.maintain/frame-weight-template.hbs
@@ -18,7 +18,7 @@
 #![allow(missing_docs)]
 #![allow(dead_code)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame_support::{traits::Get, weights::{Weight, constants::ParityDbWeight}};
 use core::marker::PhantomData;
 
 /// Weight functions needed for `{{pallet}}`.
@@ -103,16 +103,16 @@ impl WeightInfo for () {
 			.saturating_add(Weight::from_parts({{underscore cw.slope}}, 0).saturating_mul({{cw.name}}.into()))
 			{{/each}}
 			{{#if (ne benchmark.base_reads "0")}}
-			.saturating_add(RocksDbWeight::get().reads({{benchmark.base_reads}}_u64))
+			.saturating_add(ParityDbWeight::get().reads({{benchmark.base_reads}}_u64))
 			{{/if}}
 			{{#each benchmark.component_reads as |cr|}}
-			.saturating_add(RocksDbWeight::get().reads(({{cr.slope}}_u64).saturating_mul({{cr.name}}.into())))
+			.saturating_add(ParityDbWeight::get().reads(({{cr.slope}}_u64).saturating_mul({{cr.name}}.into())))
 			{{/each}}
 			{{#if (ne benchmark.base_writes "0")}}
-			.saturating_add(RocksDbWeight::get().writes({{benchmark.base_writes}}_u64))
+			.saturating_add(ParityDbWeight::get().writes({{benchmark.base_writes}}_u64))
 			{{/if}}
 			{{#each benchmark.component_writes as |cw|}}
-			.saturating_add(RocksDbWeight::get().writes(({{cw.slope}}_u64).saturating_mul({{cw.name}}.into())))
+			.saturating_add(ParityDbWeight::get().writes(({{cw.slope}}_u64).saturating_mul({{cw.name}}.into())))
 			{{/each}}
 			{{#each benchmark.component_calculated_proof_size as |cp|}}
 			.saturating_add(Weight::from_parts(0, {{cp.slope}}).saturating_mul({{cp.name}}.into()))

--- a/pallets/admin-utils/src/weights.rs
+++ b/pallets/admin-utils/src/weights.rs
@@ -31,7 +31,7 @@
 #![allow(missing_docs)]
 #![allow(dead_code)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame_support::{traits::Get, weights::{Weight, constants::ParityDbWeight}};
 use core::marker::PhantomData;
 
 /// Weight functions needed for `pallet_admin_utils`.
@@ -941,7 +941,7 @@ impl WeightInfo for () {
 		Weight::from_parts(4_538_772, 0)
 			// Standard Error: 736
 			.saturating_add(Weight::from_parts(25_351, 0).saturating_mul(a.into()))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `Grandpa::PendingChange` (r:1 w:1)
 	/// Proof: `Grandpa::PendingChange` (`max_values`: Some(1), `max_size`: Some(1294), added: 1789, mode: `MaxEncodedLen`)
@@ -954,8 +954,8 @@ impl WeightInfo for () {
 		Weight::from_parts(7_890_823, 2779)
 			// Standard Error: 864
 			.saturating_add(Weight::from_parts(17_669, 0).saturating_mul(a.into()))
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::MaxDelegateTake` (r:0 w:1)
 	/// Proof: `SubtensorModule::MaxDelegateTake` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -965,7 +965,7 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 5_250_000 picoseconds.
 		Weight::from_parts(5_640_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -979,8 +979,8 @@ impl WeightInfo for () {
 		//  Estimated: `4092`
 		// Minimum execution time: 20_679_000 picoseconds.
 		Weight::from_parts(21_500_000, 4092)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -996,8 +996,8 @@ impl WeightInfo for () {
 		//  Estimated: `4235`
 		// Minimum execution time: 26_119_000 picoseconds.
 		Weight::from_parts(26_870_000, 4235)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1013,8 +1013,8 @@ impl WeightInfo for () {
 		//  Estimated: `4235`
 		// Minimum execution time: 25_999_000 picoseconds.
 		Weight::from_parts(26_890_000, 4235)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::NetworksAdded` (r:1 w:0)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1026,8 +1026,8 @@ impl WeightInfo for () {
 		//  Estimated: `4084`
 		// Minimum execution time: 15_890_000 picoseconds.
 		Weight::from_parts(16_571_000, 4084)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1043,8 +1043,8 @@ impl WeightInfo for () {
 		//  Estimated: `4235`
 		// Minimum execution time: 26_109_000 picoseconds.
 		Weight::from_parts(26_960_000, 4235)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1060,8 +1060,8 @@ impl WeightInfo for () {
 		//  Estimated: `4235`
 		// Minimum execution time: 26_049_000 picoseconds.
 		Weight::from_parts(27_130_000, 4235)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1077,8 +1077,8 @@ impl WeightInfo for () {
 		//  Estimated: `4235`
 		// Minimum execution time: 26_179_000 picoseconds.
 		Weight::from_parts(27_021_000, 4235)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1096,8 +1096,8 @@ impl WeightInfo for () {
 		//  Estimated: `4235`
 		// Minimum execution time: 27_652_000 picoseconds.
 		Weight::from_parts(28_463_000, 4235)
-			.saturating_add(RocksDbWeight::get().reads(4_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(4_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1113,8 +1113,8 @@ impl WeightInfo for () {
 		//  Estimated: `4235`
 		// Minimum execution time: 26_359_000 picoseconds.
 		Weight::from_parts(27_091_000, 4235)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::NetworksAdded` (r:1 w:0)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1126,8 +1126,8 @@ impl WeightInfo for () {
 		//  Estimated: `4084`
 		// Minimum execution time: 15_729_000 picoseconds.
 		Weight::from_parts(16_811_000, 4084)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1143,8 +1143,8 @@ impl WeightInfo for () {
 		//  Estimated: `4235`
 		// Minimum execution time: 26_169_000 picoseconds.
 		Weight::from_parts(26_990_000, 4235)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1162,8 +1162,8 @@ impl WeightInfo for () {
 		//  Estimated: `4297`
 		// Minimum execution time: 28_202_000 picoseconds.
 		Weight::from_parts(29_676_000, 4297)
-			.saturating_add(RocksDbWeight::get().reads(4_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(4_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1179,8 +1179,8 @@ impl WeightInfo for () {
 		//  Estimated: `4235`
 		// Minimum execution time: 23_193_000 picoseconds.
 		Weight::from_parts(23_735_000, 4235)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::NetworksAdded` (r:1 w:0)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1192,8 +1192,8 @@ impl WeightInfo for () {
 		//  Estimated: `4084`
 		// Minimum execution time: 16_009_000 picoseconds.
 		Weight::from_parts(16_501_000, 4084)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1213,8 +1213,8 @@ impl WeightInfo for () {
 		//  Estimated: `4235`
 		// Minimum execution time: 29_495_000 picoseconds.
 		Weight::from_parts(30_577_000, 4235)
-			.saturating_add(RocksDbWeight::get().reads(5_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(5_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1236,8 +1236,8 @@ impl WeightInfo for () {
 		//  Estimated: `4285`
 		// Minimum execution time: 34_475_000 picoseconds.
 		Weight::from_parts(35_696_000, 4285)
-			.saturating_add(RocksDbWeight::get().reads(6_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(6_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1253,8 +1253,8 @@ impl WeightInfo for () {
 		//  Estimated: `4235`
 		// Minimum execution time: 26_209_000 picoseconds.
 		Weight::from_parts(27_151_000, 4235)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1270,8 +1270,8 @@ impl WeightInfo for () {
 		//  Estimated: `4235`
 		// Minimum execution time: 26_239_000 picoseconds.
 		Weight::from_parts(26_920_000, 4235)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1287,8 +1287,8 @@ impl WeightInfo for () {
 		//  Estimated: `4235`
 		// Minimum execution time: 25_969_000 picoseconds.
 		Weight::from_parts(26_951_000, 4235)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1306,8 +1306,8 @@ impl WeightInfo for () {
 		//  Estimated: `4262`
 		// Minimum execution time: 28_954_000 picoseconds.
 		Weight::from_parts(29_765_000, 4262)
-			.saturating_add(RocksDbWeight::get().reads(4_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(4_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1325,8 +1325,8 @@ impl WeightInfo for () {
 		//  Estimated: `4237`
 		// Minimum execution time: 29_265_000 picoseconds.
 		Weight::from_parts(30_005_000, 4237)
-			.saturating_add(RocksDbWeight::get().reads(4_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(4_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::NetworkRegistrationAllowed` (r:0 w:1)
 	/// Proof: `SubtensorModule::NetworkRegistrationAllowed` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1336,7 +1336,7 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 6_683_000 picoseconds.
 		Weight::from_parts(7_124_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:1)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1350,8 +1350,8 @@ impl WeightInfo for () {
 		//  Estimated: `4235`
 		// Minimum execution time: 25_758_000 picoseconds.
 		Weight::from_parts(26_580_000, 4235)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1367,8 +1367,8 @@ impl WeightInfo for () {
 		//  Estimated: `4235`
 		// Minimum execution time: 26_099_000 picoseconds.
 		Weight::from_parts(27_551_000, 4235)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1384,8 +1384,8 @@ impl WeightInfo for () {
 		//  Estimated: `4235`
 		// Minimum execution time: 26_319_000 picoseconds.
 		Weight::from_parts(26_940_000, 4235)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::CommitRevealWeightsVersion` (r:0 w:1)
 	/// Proof: `SubtensorModule::CommitRevealWeightsVersion` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -1395,7 +1395,7 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 5_871_000 picoseconds.
 		Weight::from_parts(6_292_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::TxRateLimit` (r:0 w:1)
 	/// Proof: `SubtensorModule::TxRateLimit` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -1405,7 +1405,7 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 5_130_000 picoseconds.
 		Weight::from_parts(5_500_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	fn sudo_set_total_issuance() -> Weight {
 		// Proof Size summary in bytes:
@@ -1424,8 +1424,8 @@ impl WeightInfo for () {
 		//  Estimated: `4084`
 		// Minimum execution time: 15_890_000 picoseconds.
 		Weight::from_parts(16_380_000, 4084)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::StakeThreshold` (r:0 w:1)
 	/// Proof: `SubtensorModule::StakeThreshold` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -1435,7 +1435,7 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 5_259_000 picoseconds.
 		Weight::from_parts(5_510_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::NominatorMinRequiredStake` (r:1 w:1)
 	/// Proof: `SubtensorModule::NominatorMinRequiredStake` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -1451,8 +1451,8 @@ impl WeightInfo for () {
 		//  Estimated: `6852`
 		// Minimum execution time: 28_783_000 picoseconds.
 		Weight::from_parts(29_535_000, 6852)
-			.saturating_add(RocksDbWeight::get().reads(5_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(5_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::TxDelegateTakeRateLimit` (r:0 w:1)
 	/// Proof: `SubtensorModule::TxDelegateTakeRateLimit` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -1462,7 +1462,7 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 5_190_000 picoseconds.
 		Weight::from_parts(5_390_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::MinDelegateTake` (r:0 w:1)
 	/// Proof: `SubtensorModule::MinDelegateTake` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -1472,7 +1472,7 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 5_179_000 picoseconds.
 		Weight::from_parts(5_471_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1492,8 +1492,8 @@ impl WeightInfo for () {
 		//  Estimated: `4271`
 		// Minimum execution time: 29_535_000 picoseconds.
 		Weight::from_parts(30_327_000, 4271)
-			.saturating_add(RocksDbWeight::get().reads(5_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(5_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1507,8 +1507,8 @@ impl WeightInfo for () {
 		//  Estimated: `4132`
 		// Minimum execution time: 17_453_000 picoseconds.
 		Weight::from_parts(18_084_000, 4132)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1524,8 +1524,8 @@ impl WeightInfo for () {
 		//  Estimated: `4279`
 		// Minimum execution time: 25_918_000 picoseconds.
 		Weight::from_parts(26_509_000, 4279)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::ColdkeySwapAnnouncementDelay` (r:0 w:1)
 	/// Proof: `SubtensorModule::ColdkeySwapAnnouncementDelay` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -1535,7 +1535,7 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 5_190_000 picoseconds.
 		Weight::from_parts(5_511_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::ColdkeySwapReannouncementDelay` (r:0 w:1)
 	/// Proof: `SubtensorModule::ColdkeySwapReannouncementDelay` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -1545,7 +1545,7 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 5_270_000 picoseconds.
 		Weight::from_parts(5_500_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::DissolveNetworkScheduleDuration` (r:0 w:1)
 	/// Proof: `SubtensorModule::DissolveNetworkScheduleDuration` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -1555,7 +1555,7 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 5_139_000 picoseconds.
 		Weight::from_parts(5_440_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1569,8 +1569,8 @@ impl WeightInfo for () {
 		//  Estimated: `4132`
 		// Minimum execution time: 19_987_000 picoseconds.
 		Weight::from_parts(20_628_000, 4132)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `AdminUtils::PrecompileEnable` (r:1 w:0)
 	/// Proof: `AdminUtils::PrecompileEnable` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1580,7 +1580,7 @@ impl WeightInfo for () {
 		//  Estimated: `3507`
 		// Minimum execution time: 6_161_000 picoseconds.
 		Weight::from_parts(6_382_000, 3507)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
 	}
 	/// Storage: `SubtensorModule::SubnetMovingAlpha` (r:0 w:1)
 	/// Proof: `SubtensorModule::SubnetMovingAlpha` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -1590,7 +1590,7 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 2_665_000 picoseconds.
 		Weight::from_parts(2_945_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::EMAPriceHalvingBlocks` (r:0 w:1)
 	/// Proof: `SubtensorModule::EMAPriceHalvingBlocks` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1600,7 +1600,7 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 3_857_000 picoseconds.
 		Weight::from_parts(4_158_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1616,8 +1616,8 @@ impl WeightInfo for () {
 		//  Estimated: `4235`
 		// Minimum execution time: 23_253_000 picoseconds.
 		Weight::from_parts(23_824_000, 4235)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1631,8 +1631,8 @@ impl WeightInfo for () {
 		//  Estimated: `4132`
 		// Minimum execution time: 20_408_000 picoseconds.
 		Weight::from_parts(20_928_000, 4132)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1646,8 +1646,8 @@ impl WeightInfo for () {
 		//  Estimated: `4132`
 		// Minimum execution time: 22_281_000 picoseconds.
 		Weight::from_parts(23_013_000, 4132)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::NetworksAdded` (r:1 w:0)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1659,8 +1659,8 @@ impl WeightInfo for () {
 		//  Estimated: `4084`
 		// Minimum execution time: 15_729_000 picoseconds.
 		Weight::from_parts(16_490_000, 4084)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::NetworksAdded` (r:1 w:0)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1674,8 +1674,8 @@ impl WeightInfo for () {
 		//  Estimated: `4177`
 		// Minimum execution time: 24_325_000 picoseconds.
 		Weight::from_parts(25_427_000, 4177)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1689,8 +1689,8 @@ impl WeightInfo for () {
 		//  Estimated: `4132`
 		// Minimum execution time: 16_661_000 picoseconds.
 		Weight::from_parts(17_342_000, 4132)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::AdminFreezeWindow` (r:0 w:1)
 	/// Proof: `SubtensorModule::AdminFreezeWindow` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -1700,7 +1700,7 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 5_279_000 picoseconds.
 		Weight::from_parts(5_540_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::OwnerHyperparamRateLimit` (r:0 w:1)
 	/// Proof: `SubtensorModule::OwnerHyperparamRateLimit` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -1710,7 +1710,7 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 5_260_000 picoseconds.
 		Weight::from_parts(5_620_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1724,8 +1724,8 @@ impl WeightInfo for () {
 		//  Estimated: `4132`
 		// Minimum execution time: 16_961_000 picoseconds.
 		Weight::from_parts(17_663_000, 4132)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Tempo` (r:1 w:0)
 	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1745,8 +1745,8 @@ impl WeightInfo for () {
 		//  Estimated: `4250`
 		// Minimum execution time: 29_645_000 picoseconds.
 		Weight::from_parts(30_477_000, 4250)
-			.saturating_add(RocksDbWeight::get().reads(6_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(6_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::MinNonImmuneUids` (r:0 w:1)
 	/// Proof: `SubtensorModule::MinNonImmuneUids` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -1756,6 +1756,6 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 6_953_000 picoseconds.
 		Weight::from_parts(7_134_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 }

--- a/pallets/commitments/src/weights.rs
+++ b/pallets/commitments/src/weights.rs
@@ -24,7 +24,7 @@
 #![allow(unused_imports)]
 #![allow(missing_docs)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame_support::{traits::Get, weights::{Weight, constants::ParityDbWeight}};
 use core::marker::PhantomData;
 
 /// Weight functions needed for `pallet_commitments`.
@@ -51,11 +51,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 impl WeightInfo for () {
 	fn set_commitment() -> Weight {
 		Weight::from_parts(33_480_000, 0)
-			.saturating_add(RocksDbWeight::get().reads(5_u64))
-			.saturating_add(RocksDbWeight::get().writes(4_u64))
+			.saturating_add(ParityDbWeight::get().reads(5_u64))
+			.saturating_add(ParityDbWeight::get().writes(4_u64))
 	}
 	fn set_max_space() -> Weight {
 		Weight::from_parts(2_856_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 }

--- a/pallets/crowdloan/src/weights.rs
+++ b/pallets/crowdloan/src/weights.rs
@@ -31,7 +31,7 @@
 #![allow(missing_docs)]
 #![allow(dead_code)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame_support::{traits::Get, weights::{Weight, constants::ParityDbWeight}};
 use core::marker::PhantomData;
 
 /// Weight functions needed for `pallet_crowdloan`.
@@ -224,8 +224,8 @@ impl WeightInfo for () {
 		//  Estimated: `6148`
 		// Minimum execution time: 58_307_000 picoseconds.
 		Weight::from_parts(59_829_000, 6148)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(5_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(5_u64))
 	}
 	/// Storage: `Crowdloan::Crowdloans` (r:1 w:1)
 	/// Proof: `Crowdloan::Crowdloans` (`max_values`: None, `max_size`: Some(282), added: 2757, mode: `MaxEncodedLen`)
@@ -241,8 +241,8 @@ impl WeightInfo for () {
 		//  Estimated: `6148`
 		// Minimum execution time: 65_557_000 picoseconds.
 		Weight::from_parts(66_609_000, 6148)
-			.saturating_add(RocksDbWeight::get().reads(5_u64))
-			.saturating_add(RocksDbWeight::get().writes(4_u64))
+			.saturating_add(ParityDbWeight::get().reads(5_u64))
+			.saturating_add(ParityDbWeight::get().writes(4_u64))
 	}
 	/// Storage: `Crowdloan::Crowdloans` (r:1 w:1)
 	/// Proof: `Crowdloan::Crowdloans` (`max_values`: None, `max_size`: Some(282), added: 2757, mode: `MaxEncodedLen`)
@@ -256,8 +256,8 @@ impl WeightInfo for () {
 		//  Estimated: `6148`
 		// Minimum execution time: 59_438_000 picoseconds.
 		Weight::from_parts(60_259_000, 6148)
-			.saturating_add(RocksDbWeight::get().reads(4_u64))
-			.saturating_add(RocksDbWeight::get().writes(4_u64))
+			.saturating_add(ParityDbWeight::get().reads(4_u64))
+			.saturating_add(ParityDbWeight::get().writes(4_u64))
 	}
 	/// Storage: `Crowdloan::Crowdloans` (r:1 w:1)
 	/// Proof: `Crowdloan::Crowdloans` (`max_values`: None, `max_size`: Some(282), added: 2757, mode: `MaxEncodedLen`)
@@ -275,8 +275,8 @@ impl WeightInfo for () {
 		//  Estimated: `4197809`
 		// Minimum execution time: 30_264_000 picoseconds.
 		Weight::from_parts(31_507_000, 4197809)
-			.saturating_add(RocksDbWeight::get().reads(4_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(4_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `Crowdloan::Crowdloans` (r:1 w:1)
 	/// Proof: `Crowdloan::Crowdloans` (`max_values`: None, `max_size`: Some(282), added: 2757, mode: `MaxEncodedLen`)
@@ -293,9 +293,9 @@ impl WeightInfo for () {
 		Weight::from_parts(110_703_000, 3747)
 			// Standard Error: 96_515
 			.saturating_add(Weight::from_parts(39_503_253, 0).saturating_mul(k.into()))
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().reads((2_u64).saturating_mul(k.into())))
-			.saturating_add(RocksDbWeight::get().writes((2_u64).saturating_mul(k.into())))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().reads((2_u64).saturating_mul(k.into())))
+			.saturating_add(ParityDbWeight::get().writes((2_u64).saturating_mul(k.into())))
 			.saturating_add(Weight::from_parts(0, 2579).saturating_mul(k.into()))
 	}
 	/// Storage: `Crowdloan::Crowdloans` (r:1 w:1)
@@ -312,8 +312,8 @@ impl WeightInfo for () {
 		//  Estimated: `6148`
 		// Minimum execution time: 66_138_000 picoseconds.
 		Weight::from_parts(66_939_000, 6148)
-			.saturating_add(RocksDbWeight::get().reads(4_u64))
-			.saturating_add(RocksDbWeight::get().writes(5_u64))
+			.saturating_add(ParityDbWeight::get().reads(4_u64))
+			.saturating_add(ParityDbWeight::get().writes(5_u64))
 	}
 	/// Storage: `Crowdloan::Crowdloans` (r:1 w:1)
 	/// Proof: `Crowdloan::Crowdloans` (`max_values`: None, `max_size`: Some(282), added: 2757, mode: `MaxEncodedLen`)
@@ -325,8 +325,8 @@ impl WeightInfo for () {
 		//  Estimated: `3747`
 		// Minimum execution time: 12_639_000 picoseconds.
 		Weight::from_parts(13_259_000, 3747)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `Crowdloan::Crowdloans` (r:1 w:1)
 	/// Proof: `Crowdloan::Crowdloans` (`max_values`: None, `max_size`: Some(282), added: 2757, mode: `MaxEncodedLen`)
@@ -336,8 +336,8 @@ impl WeightInfo for () {
 		//  Estimated: `3747`
 		// Minimum execution time: 11_637_000 picoseconds.
 		Weight::from_parts(12_048_000, 3747)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `Crowdloan::Crowdloans` (r:1 w:1)
 	/// Proof: `Crowdloan::Crowdloans` (`max_values`: None, `max_size`: Some(282), added: 2757, mode: `MaxEncodedLen`)
@@ -347,8 +347,8 @@ impl WeightInfo for () {
 		//  Estimated: `3747`
 		// Minimum execution time: 11_026_000 picoseconds.
 		Weight::from_parts(11_357_000, 3747)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `Crowdloan::Crowdloans` (r:1 w:0)
 	/// Proof: `Crowdloan::Crowdloans` (`max_values`: None, `max_size`: Some(282), added: 2757, mode: `MaxEncodedLen`)
@@ -362,7 +362,7 @@ impl WeightInfo for () {
 		//  Estimated: `3747`
 		// Minimum execution time: 15_263_000 picoseconds.
 		Weight::from_parts(16_024_000, 3747)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 }

--- a/pallets/drand/src/weights.rs
+++ b/pallets/drand/src/weights.rs
@@ -10,7 +10,7 @@
 #![allow(missing_docs)]
 #![allow(dead_code)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame_support::{traits::Get, weights::{Weight, constants::ParityDbWeight}};
 use core::marker::PhantomData;
 
 /// Weight functions needed for `pallet_drand`.
@@ -42,15 +42,15 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 impl WeightInfo for () {
 	fn set_beacon_config() -> Weight {
 		Weight::from_parts(8_766_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 	fn write_pulse() -> Weight {
 		Weight::from_parts(4_294_000_000, 0)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(4_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(4_u64))
 	}
 	fn set_oldest_stored_round() -> Weight {
 		Weight::from_parts(5_370_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 }

--- a/pallets/proxy/src/weights.rs
+++ b/pallets/proxy/src/weights.rs
@@ -31,7 +31,7 @@
 #![allow(missing_docs)]
 #![allow(dead_code)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame_support::{traits::Get, weights::{Weight, constants::ParityDbWeight}};
 use core::marker::PhantomData;
 
 /// Weight functions needed for `pallet_subtensor_proxy`.
@@ -286,8 +286,8 @@ impl WeightInfo for () {
 		Weight::from_parts(24_151_161, 4254)
 			// Standard Error: 3_337
 			.saturating_add(Weight::from_parts(96_756, 0).saturating_mul(p.into()))
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 			.saturating_add(Weight::from_parts(0, 37).saturating_mul(p.into()))
 	}
 	/// Storage: `Proxy::Proxies` (r:1 w:0)
@@ -314,8 +314,8 @@ impl WeightInfo for () {
 			.saturating_add(Weight::from_parts(261_812, 0).saturating_mul(a.into()))
 			// Standard Error: 5_727
 			.saturating_add(Weight::from_parts(54_276, 0).saturating_mul(p.into()))
-			.saturating_add(RocksDbWeight::get().reads(5_u64))
-			.saturating_add(RocksDbWeight::get().writes(3_u64))
+			.saturating_add(ParityDbWeight::get().reads(5_u64))
+			.saturating_add(ParityDbWeight::get().writes(3_u64))
 			.saturating_add(Weight::from_parts(0, 68).saturating_mul(a.into()))
 			.saturating_add(Weight::from_parts(0, 37).saturating_mul(p.into()))
 	}
@@ -335,8 +335,8 @@ impl WeightInfo for () {
 			.saturating_add(Weight::from_parts(211_445, 0).saturating_mul(a.into()))
 			// Standard Error: 3_552
 			.saturating_add(Weight::from_parts(20_637, 0).saturating_mul(p.into()))
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `Proxy::Announcements` (r:1 w:1)
 	/// Proof: `Proxy::Announcements` (`max_values`: None, `max_size`: Some(5150), added: 7625, mode: `MaxEncodedLen`)
@@ -354,8 +354,8 @@ impl WeightInfo for () {
 			.saturating_add(Weight::from_parts(211_311, 0).saturating_mul(a.into()))
 			// Standard Error: 3_572
 			.saturating_add(Weight::from_parts(19_850, 0).saturating_mul(p.into()))
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `Proxy::Proxies` (r:1 w:0)
 	/// Proof: `Proxy::Proxies` (`max_values`: None, `max_size`: Some(789), added: 3264, mode: `MaxEncodedLen`)
@@ -375,8 +375,8 @@ impl WeightInfo for () {
 			.saturating_add(Weight::from_parts(245_681, 0).saturating_mul(a.into()))
 			// Standard Error: 10_638
 			.saturating_add(Weight::from_parts(108_442, 0).saturating_mul(p.into()))
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `Proxy::Proxies` (r:1 w:1)
 	/// Proof: `Proxy::Proxies` (`max_values`: None, `max_size`: Some(789), added: 3264, mode: `MaxEncodedLen`)
@@ -389,8 +389,8 @@ impl WeightInfo for () {
 		Weight::from_parts(23_099_598, 4254)
 			// Standard Error: 1_922
 			.saturating_add(Weight::from_parts(76_038, 0).saturating_mul(p.into()))
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `Proxy::Proxies` (r:1 w:1)
 	/// Proof: `Proxy::Proxies` (`max_values`: None, `max_size`: Some(789), added: 3264, mode: `MaxEncodedLen`)
@@ -405,8 +405,8 @@ impl WeightInfo for () {
 		Weight::from_parts(24_761_635, 4254)
 			// Standard Error: 2_310
 			.saturating_add(Weight::from_parts(58_413, 0).saturating_mul(p.into()))
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `Proxy::Proxies` (r:1 w:1)
 	/// Proof: `Proxy::Proxies` (`max_values`: None, `max_size`: Some(789), added: 3264, mode: `MaxEncodedLen`)
@@ -419,8 +419,8 @@ impl WeightInfo for () {
 		Weight::from_parts(24_632_652, 4254)
 			// Standard Error: 2_253
 			.saturating_add(Weight::from_parts(48_858, 0).saturating_mul(p.into()))
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `Proxy::Proxies` (r:1 w:1)
 	/// Proof: `Proxy::Proxies` (`max_values`: None, `max_size`: Some(789), added: 3264, mode: `MaxEncodedLen`)
@@ -433,8 +433,8 @@ impl WeightInfo for () {
 		Weight::from_parts(24_892_331, 4254)
 			// Standard Error: 2_007
 			.saturating_add(Weight::from_parts(21_649, 0).saturating_mul(p.into()))
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `Proxy::Proxies` (r:1 w:1)
 	/// Proof: `Proxy::Proxies` (`max_values`: None, `max_size`: Some(789), added: 3264, mode: `MaxEncodedLen`)
@@ -447,8 +447,8 @@ impl WeightInfo for () {
 		Weight::from_parts(23_802_763, 4254)
 			// Standard Error: 2_166
 			.saturating_add(Weight::from_parts(41_019, 0).saturating_mul(p.into()))
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `Proxy::Proxies` (r:1 w:1)
 	/// Proof: `Proxy::Proxies` (`max_values`: None, `max_size`: Some(789), added: 3264, mode: `MaxEncodedLen`)
@@ -462,8 +462,8 @@ impl WeightInfo for () {
 		//  Estimated: `8615`
 		// Minimum execution time: 42_413_000 picoseconds.
 		Weight::from_parts(43_264_000, 8615)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(3_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(3_u64))
 	}
 	/// Storage: `Proxy::Proxies` (r:1 w:0)
 	/// Proof: `Proxy::Proxies` (`max_values`: None, `max_size`: Some(789), added: 3264, mode: `MaxEncodedLen`)
@@ -478,7 +478,7 @@ impl WeightInfo for () {
 		Weight::from_parts(12_050_045, 4254)
 			// Standard Error: 1_620
 			.saturating_add(Weight::from_parts(45_828, 0).saturating_mul(p.into()))
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 }

--- a/pallets/registry/src/weights.rs
+++ b/pallets/registry/src/weights.rs
@@ -36,7 +36,7 @@
 #![allow(missing_docs)]
 #![allow(dead_code)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame_support::{traits::Get, weights::{Weight, constants::ParityDbWeight}};
 use core::marker::PhantomData;
 
 /// Weight functions needed for `pallet_registry`.
@@ -88,8 +88,8 @@ impl WeightInfo for () {
 		//  Estimated: `3564`
 		// Minimum execution time: 50_534_000 picoseconds.
 		Weight::from_parts(51_626_000, 3564)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `Registry::IdentityOf` (r:1 w:1)
 	/// Proof: `Registry::IdentityOf` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -101,7 +101,7 @@ impl WeightInfo for () {
 		//  Estimated: `3847`
 		// Minimum execution time: 42_379_000 picoseconds.
 		Weight::from_parts(43_501_000, 3847)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 }

--- a/pallets/shield/src/weights.rs
+++ b/pallets/shield/src/weights.rs
@@ -31,7 +31,7 @@
 #![allow(missing_docs)]
 #![allow(dead_code)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame_support::{traits::Get, weights::{Weight, constants::ParityDbWeight}};
 use core::marker::PhantomData;
 
 /// Weight functions needed for `pallet_shield`.
@@ -141,8 +141,8 @@ impl WeightInfo for () {
 		//  Estimated: `5555`
 		// Minimum execution time: 32_118_000 picoseconds.
 		Weight::from_parts(33_661_000, 5555)
-			.saturating_add(RocksDbWeight::get().reads(4_u64))
-			.saturating_add(RocksDbWeight::get().writes(6_u64))
+			.saturating_add(ParityDbWeight::get().reads(4_u64))
+			.saturating_add(ParityDbWeight::get().writes(6_u64))
 	}
 	fn submit_encrypted() -> Weight {
 		// Proof Size summary in bytes:
@@ -159,7 +159,7 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 3_865_000 picoseconds.
 		Weight::from_parts(4_206_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `MevShield::OnInitializeWeight` (r:0 w:1)
 	/// Proof: `MevShield::OnInitializeWeight` (`max_values`: Some(1), `max_size`: Some(8), added: 503, mode: `MaxEncodedLen`)
@@ -169,7 +169,7 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 4_066_000 picoseconds.
 		Weight::from_parts(4_327_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `MevShield::ExtrinsicLifetime` (r:0 w:1)
 	/// Proof: `MevShield::ExtrinsicLifetime` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
@@ -179,7 +179,7 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 3_906_000 picoseconds.
 		Weight::from_parts(4_116_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `MevShield::MaxExtrinsicWeight` (r:0 w:1)
 	/// Proof: `MevShield::MaxExtrinsicWeight` (`max_values`: Some(1), `max_size`: Some(8), added: 503, mode: `MaxEncodedLen`)
@@ -189,6 +189,6 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 4_037_000 picoseconds.
 		Weight::from_parts(4_227_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 }

--- a/pallets/subtensor/src/weights.rs
+++ b/pallets/subtensor/src/weights.rs
@@ -31,7 +31,7 @@
 #![allow(missing_docs)]
 #![allow(dead_code)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame_support::{traits::Get, weights::{Weight, constants::ParityDbWeight}};
 use core::marker::PhantomData;
 
 /// Weight functions needed for `pallet_subtensor`.
@@ -2577,8 +2577,8 @@ impl WeightInfo for () {
 		//  Estimated: `13600`
 		// Minimum execution time: 374_002_000 picoseconds.
 		Weight::from_parts(380_312_000, 13600)
-			.saturating_add(RocksDbWeight::get().reads(48_u64))
-			.saturating_add(RocksDbWeight::get().writes(40_u64))
+			.saturating_add(ParityDbWeight::get().reads(48_u64))
+			.saturating_add(ParityDbWeight::get().writes(40_u64))
 	}
 	/// Storage: `SubtensorModule::CommitRevealWeightsEnabled` (r:1 w:0)
 	/// Proof: `SubtensorModule::CommitRevealWeightsEnabled` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -2620,8 +2620,8 @@ impl WeightInfo for () {
 		//  Estimated: `10327382`
 		// Minimum execution time: 16_598_698_000 picoseconds.
 		Weight::from_parts(16_897_861_000, 10327382)
-			.saturating_add(RocksDbWeight::get().reads(4112_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(4112_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `SubtensorModule::NetworksAdded` (r:1 w:0)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -2699,8 +2699,8 @@ impl WeightInfo for () {
 		//  Estimated: `8727`
 		// Minimum execution time: 459_249_000 picoseconds.
 		Weight::from_parts(476_173_000, 8727)
-			.saturating_add(RocksDbWeight::get().reads(38_u64))
-			.saturating_add(RocksDbWeight::get().writes(18_u64))
+			.saturating_add(ParityDbWeight::get().reads(38_u64))
+			.saturating_add(ParityDbWeight::get().writes(18_u64))
 	}
 	/// Storage: `SubtensorModule::IsNetworkMember` (r:2 w:0)
 	/// Proof: `SubtensorModule::IsNetworkMember` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -2714,8 +2714,8 @@ impl WeightInfo for () {
 		//  Estimated: `6741`
 		// Minimum execution time: 32_538_000 picoseconds.
 		Weight::from_parts(33_289_000, 6741)
-			.saturating_add(RocksDbWeight::get().reads(4_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(4_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::IsNetworkMember` (r:2 w:0)
 	/// Proof: `SubtensorModule::IsNetworkMember` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -2729,8 +2729,8 @@ impl WeightInfo for () {
 		//  Estimated: `6714`
 		// Minimum execution time: 29_163_000 picoseconds.
 		Weight::from_parts(29_784_000, 6714)
-			.saturating_add(RocksDbWeight::get().reads(4_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(4_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::NetworksAdded` (r:1 w:0)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -2832,8 +2832,8 @@ impl WeightInfo for () {
 		//  Estimated: `13600`
 		// Minimum execution time: 362_295_000 picoseconds.
 		Weight::from_parts(368_123_000, 13600)
-			.saturating_add(RocksDbWeight::get().reads(48_u64))
-			.saturating_add(RocksDbWeight::get().writes(40_u64))
+			.saturating_add(ParityDbWeight::get().reads(48_u64))
+			.saturating_add(ParityDbWeight::get().writes(40_u64))
 	}
 	/// Storage: `SubtensorModule::NetworksAdded` (r:1 w:0)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -2885,8 +2885,8 @@ impl WeightInfo for () {
 		//  Estimated: `4910`
 		// Minimum execution time: 102_751_000 picoseconds.
 		Weight::from_parts(104_294_000, 4910)
-			.saturating_add(RocksDbWeight::get().reads(19_u64))
-			.saturating_add(RocksDbWeight::get().writes(16_u64))
+			.saturating_add(ParityDbWeight::get().reads(19_u64))
+			.saturating_add(ParityDbWeight::get().writes(16_u64))
 	}
 	/// Storage: `SubtensorModule::Owner` (r:1 w:1)
 	/// Proof: `SubtensorModule::Owner` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -3008,8 +3008,8 @@ impl WeightInfo for () {
 		//  Estimated: `9874`
 		// Minimum execution time: 277_470_000 picoseconds.
 		Weight::from_parts(282_297_000, 9874)
-			.saturating_add(RocksDbWeight::get().reads(42_u64))
-			.saturating_add(RocksDbWeight::get().writes(49_u64))
+			.saturating_add(ParityDbWeight::get().reads(42_u64))
+			.saturating_add(ParityDbWeight::get().writes(49_u64))
 	}
 	/// Storage: `SubtensorModule::NetworksAdded` (r:1 w:0)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -3037,8 +3037,8 @@ impl WeightInfo for () {
 		//  Estimated: `4536`
 		// Minimum execution time: 60_340_000 picoseconds.
 		Weight::from_parts(61_421_000, 4536)
-			.saturating_add(RocksDbWeight::get().reads(10_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(10_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `SubtensorModule::CommitRevealWeightsEnabled` (r:1 w:0)
 	/// Proof: `SubtensorModule::CommitRevealWeightsEnabled` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -3082,8 +3082,8 @@ impl WeightInfo for () {
 		//  Estimated: `7529`
 		// Minimum execution time: 108_541_000 picoseconds.
 		Weight::from_parts(110_183_000, 7529)
-			.saturating_add(RocksDbWeight::get().reads(18_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(18_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `SubtensorModule::TxChildkeyTakeRateLimit` (r:0 w:1)
 	/// Proof: `SubtensorModule::TxChildkeyTakeRateLimit` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -3093,7 +3093,7 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 4_076_000 picoseconds.
 		Weight::from_parts(4_647_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Owner` (r:1 w:0)
 	/// Proof: `SubtensorModule::Owner` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -3115,8 +3115,8 @@ impl WeightInfo for () {
 		//  Estimated: `4464`
 		// Minimum execution time: 52_278_000 picoseconds.
 		Weight::from_parts(53_209_000, 4464)
-			.saturating_add(RocksDbWeight::get().reads(7_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(7_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `SubtensorModule::ColdkeySwapAnnouncements` (r:1 w:1)
 	/// Proof: `SubtensorModule::ColdkeySwapAnnouncements` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -3132,8 +3132,8 @@ impl WeightInfo for () {
 		//  Estimated: `4159`
 		// Minimum execution time: 43_995_000 picoseconds.
 		Weight::from_parts(45_167_000, 4159)
-			.saturating_add(RocksDbWeight::get().reads(4_u64))
-			.saturating_add(RocksDbWeight::get().writes(3_u64))
+			.saturating_add(ParityDbWeight::get().reads(4_u64))
+			.saturating_add(ParityDbWeight::get().writes(3_u64))
 	}
 	/// Storage: `SubtensorModule::ColdkeySwapAnnouncements` (r:1 w:1)
 	/// Proof: `SubtensorModule::ColdkeySwapAnnouncements` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -3177,8 +3177,8 @@ impl WeightInfo for () {
 		//  Estimated: `13065`
 		// Minimum execution time: 286_653_000 picoseconds.
 		Weight::from_parts(294_536_000, 13065)
-			.saturating_add(RocksDbWeight::get().reads(35_u64))
-			.saturating_add(RocksDbWeight::get().writes(15_u64))
+			.saturating_add(ParityDbWeight::get().reads(35_u64))
+			.saturating_add(ParityDbWeight::get().writes(15_u64))
 	}
 	/// Storage: `System::Account` (r:2 w:2)
 	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(104), added: 2579, mode: `MaxEncodedLen`)
@@ -3226,8 +3226,8 @@ impl WeightInfo for () {
 		//  Estimated: `13121`
 		// Minimum execution time: 310_339_000 picoseconds.
 		Weight::from_parts(313_503_000, 13121)
-			.saturating_add(RocksDbWeight::get().reads(35_u64))
-			.saturating_add(RocksDbWeight::get().writes(19_u64))
+			.saturating_add(ParityDbWeight::get().reads(35_u64))
+			.saturating_add(ParityDbWeight::get().writes(19_u64))
 	}
 	/// Storage: `SubtensorModule::ColdkeySwapAnnouncements` (r:1 w:0)
 	/// Proof: `SubtensorModule::ColdkeySwapAnnouncements` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -3239,8 +3239,8 @@ impl WeightInfo for () {
 		//  Estimated: `4130`
 		// Minimum execution time: 20_290_000 picoseconds.
 		Weight::from_parts(21_452_000, 4130)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::ColdkeySwapAnnouncements` (r:1 w:1)
 	/// Proof: `SubtensorModule::ColdkeySwapAnnouncements` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -3252,8 +3252,8 @@ impl WeightInfo for () {
 		//  Estimated: `4078`
 		// Minimum execution time: 16_995_000 picoseconds.
 		Weight::from_parts(17_505_000, 4078)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::ColdkeySwapAnnouncements` (r:0 w:1)
 	/// Proof: `SubtensorModule::ColdkeySwapAnnouncements` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -3265,7 +3265,7 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 6_830_000 picoseconds.
 		Weight::from_parts(7_271_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `SubtensorModule::CommitRevealWeightsEnabled` (r:1 w:0)
 	/// Proof: `SubtensorModule::CommitRevealWeightsEnabled` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -3309,8 +3309,8 @@ impl WeightInfo for () {
 		//  Estimated: `8034`
 		// Minimum execution time: 429_484_000 picoseconds.
 		Weight::from_parts(443_415_000, 8034)
-			.saturating_add(RocksDbWeight::get().reads(18_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(18_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `SubtensorModule::NetworksAdded` (r:1 w:0)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -3344,8 +3344,8 @@ impl WeightInfo for () {
 		//  Estimated: `5338`
 		// Minimum execution time: 176_220_000 picoseconds.
 		Weight::from_parts(178_253_000, 5338)
-			.saturating_add(RocksDbWeight::get().reads(13_u64))
-			.saturating_add(RocksDbWeight::get().writes(6_u64))
+			.saturating_add(ParityDbWeight::get().reads(13_u64))
+			.saturating_add(ParityDbWeight::get().writes(6_u64))
 	}
 	/// Storage: `SubtensorModule::NetworksAdded` (r:1 w:0)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -3377,8 +3377,8 @@ impl WeightInfo for () {
 		//  Estimated: `5338`
 		// Minimum execution time: 172_335_000 picoseconds.
 		Weight::from_parts(174_197_000, 5338)
-			.saturating_add(RocksDbWeight::get().reads(12_u64))
-			.saturating_add(RocksDbWeight::get().writes(4_u64))
+			.saturating_add(ParityDbWeight::get().reads(12_u64))
+			.saturating_add(ParityDbWeight::get().writes(4_u64))
 	}
 	/// Storage: `SubtensorModule::NetworksAdded` (r:1 w:0)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -3398,8 +3398,8 @@ impl WeightInfo for () {
 		//  Estimated: `4583`
 		// Minimum execution time: 37_836_000 picoseconds.
 		Weight::from_parts(38_907_000, 4583)
-			.saturating_add(RocksDbWeight::get().reads(5_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(5_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `SubtensorModule::SubnetMechanism` (r:1 w:0)
 	/// Proof: `SubtensorModule::SubnetMechanism` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -3477,8 +3477,8 @@ impl WeightInfo for () {
 		//  Estimated: `8727`
 		// Minimum execution time: 499_258_000 picoseconds.
 		Weight::from_parts(516_242_000, 8727)
-			.saturating_add(RocksDbWeight::get().reads(38_u64))
-			.saturating_add(RocksDbWeight::get().writes(18_u64))
+			.saturating_add(ParityDbWeight::get().reads(38_u64))
+			.saturating_add(ParityDbWeight::get().writes(18_u64))
 	}
 	/// Storage: `SubtensorModule::Alpha` (r:2 w:0)
 	/// Proof: `SubtensorModule::Alpha` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -3514,8 +3514,8 @@ impl WeightInfo for () {
 		//  Estimated: `8000`
 		// Minimum execution time: 222_999_000 picoseconds.
 		Weight::from_parts(227_526_000, 8000)
-			.saturating_add(RocksDbWeight::get().reads(19_u64))
-			.saturating_add(RocksDbWeight::get().writes(7_u64))
+			.saturating_add(ParityDbWeight::get().reads(19_u64))
+			.saturating_add(ParityDbWeight::get().writes(7_u64))
 	}
 	/// Storage: `SubtensorModule::SubtokenEnabled` (r:1 w:0)
 	/// Proof: `SubtensorModule::SubtokenEnabled` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -3581,8 +3581,8 @@ impl WeightInfo for () {
 		//  Estimated: `10979`
 		// Minimum execution time: 435_183_000 picoseconds.
 		Weight::from_parts(444_777_000, 10979)
-			.saturating_add(RocksDbWeight::get().reads(35_u64))
-			.saturating_add(RocksDbWeight::get().writes(15_u64))
+			.saturating_add(ParityDbWeight::get().reads(35_u64))
+			.saturating_add(ParityDbWeight::get().writes(15_u64))
 	}
 	/// Storage: `SubtensorModule::SubnetMechanism` (r:2 w:0)
 	/// Proof: `SubtensorModule::SubnetMechanism` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -3646,8 +3646,8 @@ impl WeightInfo for () {
 		//  Estimated: `11013`
 		// Minimum execution time: 475_352_000 picoseconds.
 		Weight::from_parts(478_116_000, 11013)
-			.saturating_add(RocksDbWeight::get().reads(34_u64))
-			.saturating_add(RocksDbWeight::get().writes(15_u64))
+			.saturating_add(ParityDbWeight::get().reads(34_u64))
+			.saturating_add(ParityDbWeight::get().writes(15_u64))
 	}
 	/// Storage: `SubtensorModule::Alpha` (r:2 w:0)
 	/// Proof: `SubtensorModule::Alpha` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -3727,8 +3727,8 @@ impl WeightInfo for () {
 		//  Estimated: `11523`
 		// Minimum execution time: 688_567_000 picoseconds.
 		Weight::from_parts(707_234_000, 11523)
-			.saturating_add(RocksDbWeight::get().reads(54_u64))
-			.saturating_add(RocksDbWeight::get().writes(26_u64))
+			.saturating_add(ParityDbWeight::get().reads(54_u64))
+			.saturating_add(ParityDbWeight::get().writes(26_u64))
 	}
 	/// Storage: `SubtensorModule::Alpha` (r:2 w:0)
 	/// Proof: `SubtensorModule::Alpha` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -3768,8 +3768,8 @@ impl WeightInfo for () {
 		//  Estimated: `7994`
 		// Minimum execution time: 254_636_000 picoseconds.
 		Weight::from_parts(258_541_000, 7994)
-			.saturating_add(RocksDbWeight::get().reads(18_u64))
-			.saturating_add(RocksDbWeight::get().writes(6_u64))
+			.saturating_add(ParityDbWeight::get().reads(18_u64))
+			.saturating_add(ParityDbWeight::get().writes(6_u64))
 	}
 	/// Storage: `SubtensorModule::Alpha` (r:2 w:0)
 	/// Proof: `SubtensorModule::Alpha` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -3849,8 +3849,8 @@ impl WeightInfo for () {
 		//  Estimated: `11366`
 		// Minimum execution time: 633_996_000 picoseconds.
 		Weight::from_parts(655_699_000, 11366)
-			.saturating_add(RocksDbWeight::get().reads(54_u64))
-			.saturating_add(RocksDbWeight::get().writes(26_u64))
+			.saturating_add(ParityDbWeight::get().reads(54_u64))
+			.saturating_add(ParityDbWeight::get().writes(26_u64))
 	}
 	/// Storage: `SubtensorModule::NetworksAdded` (r:1 w:0)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -3880,8 +3880,8 @@ impl WeightInfo for () {
 		//  Estimated: `4587`
 		// Minimum execution time: 127_058_000 picoseconds.
 		Weight::from_parts(129_030_000, 4587)
-			.saturating_add(RocksDbWeight::get().reads(11_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(11_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `SubtensorModule::CommitRevealWeightsEnabled` (r:1 w:0)
 	/// Proof: `SubtensorModule::CommitRevealWeightsEnabled` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -3921,8 +3921,8 @@ impl WeightInfo for () {
 		//  Estimated: `7366`
 		// Minimum execution time: 101_319_000 picoseconds.
 		Weight::from_parts(102_992_000, 7366)
-			.saturating_add(RocksDbWeight::get().reads(16_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(16_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `SubtensorModule::Owner` (r:1 w:0)
 	/// Proof: `SubtensorModule::Owner` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -3938,8 +3938,8 @@ impl WeightInfo for () {
 		//  Estimated: `4258`
 		// Minimum execution time: 25_969_000 picoseconds.
 		Weight::from_parts(27_160_000, 4258)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `SubtensorModule::Owner` (r:1 w:0)
 	/// Proof: `SubtensorModule::Owner` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -3957,8 +3957,8 @@ impl WeightInfo for () {
 		//  Estimated: `4351`
 		// Minimum execution time: 33_360_000 picoseconds.
 		Weight::from_parts(34_381_000, 4351)
-			.saturating_add(RocksDbWeight::get().reads(5_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(5_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `SubtensorModule::Owner` (r:1 w:1)
 	/// Proof: `SubtensorModule::Owner` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -4080,8 +4080,8 @@ impl WeightInfo for () {
 		//  Estimated: `9758`
 		// Minimum execution time: 271_161_000 picoseconds.
 		Weight::from_parts(278_281_000, 9758)
-			.saturating_add(RocksDbWeight::get().reads(41_u64))
-			.saturating_add(RocksDbWeight::get().writes(48_u64))
+			.saturating_add(ParityDbWeight::get().reads(41_u64))
+			.saturating_add(ParityDbWeight::get().writes(48_u64))
 	}
 	/// Storage: `SubtensorModule::IsNetworkMember` (r:2 w:0)
 	/// Proof: `SubtensorModule::IsNetworkMember` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -4095,8 +4095,8 @@ impl WeightInfo for () {
 		//  Estimated: `6712`
 		// Minimum execution time: 31_877_000 picoseconds.
 		Weight::from_parts(32_949_000, 6712)
-			.saturating_add(RocksDbWeight::get().reads(4_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(4_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::OwnedHotkeys` (r:1 w:0)
 	/// Proof: `SubtensorModule::OwnedHotkeys` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -4110,8 +4110,8 @@ impl WeightInfo for () {
 		//  Estimated: `6792`
 		// Minimum execution time: 28_833_000 picoseconds.
 		Weight::from_parts(29_874_000, 6792)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::SubnetOwner` (r:1 w:0)
 	/// Proof: `SubtensorModule::SubnetOwner` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -4123,8 +4123,8 @@ impl WeightInfo for () {
 		//  Estimated: `4060`
 		// Minimum execution time: 15_502_000 picoseconds.
 		Weight::from_parts(16_184_000, 4060)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Owner` (r:1 w:2)
 	/// Proof: `SubtensorModule::Owner` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -4200,8 +4200,8 @@ impl WeightInfo for () {
 		//  Estimated: `28766`
 		// Minimum execution time: 1_201_334_000 picoseconds.
 		Weight::from_parts(1_208_365_000, 28766)
-			.saturating_add(RocksDbWeight::get().reads(171_u64))
-			.saturating_add(RocksDbWeight::get().writes(95_u64))
+			.saturating_add(ParityDbWeight::get().reads(171_u64))
+			.saturating_add(ParityDbWeight::get().writes(95_u64))
 	}
 	/// Storage: `SubtensorModule::Owner` (r:1 w:1)
 	/// Proof: `SubtensorModule::Owner` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -4215,8 +4215,8 @@ impl WeightInfo for () {
 		//  Estimated: `4210`
 		// Minimum execution time: 22_373_000 picoseconds.
 		Weight::from_parts(23_134_000, 4210)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(3_u64))
+			.saturating_add(ParityDbWeight::get().reads(3_u64))
+			.saturating_add(ParityDbWeight::get().writes(3_u64))
 	}
 	/// Storage: `SubtensorModule::Owner` (r:1 w:0)
 	/// Proof: `SubtensorModule::Owner` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -4230,7 +4230,7 @@ impl WeightInfo for () {
 		//  Estimated: `9155`
 		// Minimum execution time: 25_017_000 picoseconds.
 		Weight::from_parts(25_658_000, 9155)
-			.saturating_add(RocksDbWeight::get().reads(6_u64))
+			.saturating_add(ParityDbWeight::get().reads(6_u64))
 	}
 	/// Storage: `SubtensorModule::Owner` (r:1 w:0)
 	/// Proof: `SubtensorModule::Owner` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -4302,8 +4302,8 @@ impl WeightInfo for () {
 		//  Estimated: `11306`
 		// Minimum execution time: 583_803_000 picoseconds.
 		Weight::from_parts(599_485_000, 11306)
-			.saturating_add(RocksDbWeight::get().reads(50_u64))
-			.saturating_add(RocksDbWeight::get().writes(27_u64))
+			.saturating_add(ParityDbWeight::get().reads(50_u64))
+			.saturating_add(ParityDbWeight::get().writes(27_u64))
 	}
 	/// Storage: `SubtensorModule::Alpha` (r:1 w:0)
 	/// Proof: `SubtensorModule::Alpha` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -4367,8 +4367,8 @@ impl WeightInfo for () {
 		//  Estimated: `11013`
 		// Minimum execution time: 497_956_000 picoseconds.
 		Weight::from_parts(503_033_000, 11013)
-			.saturating_add(RocksDbWeight::get().reads(34_u64))
-			.saturating_add(RocksDbWeight::get().writes(15_u64))
+			.saturating_add(ParityDbWeight::get().reads(34_u64))
+			.saturating_add(ParityDbWeight::get().writes(15_u64))
 	}
 	/// Storage: `Crowdloan::CurrentCrowdloanId` (r:1 w:0)
 	/// Proof: `Crowdloan::CurrentCrowdloanId` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
@@ -4511,10 +4511,10 @@ impl WeightInfo for () {
 		Weight::from_parts(306_068_429, 10183)
 			// Standard Error: 24_263
 			.saturating_add(Weight::from_parts(48_393_644, 0).saturating_mul(k.into()))
-			.saturating_add(RocksDbWeight::get().reads(51_u64))
-			.saturating_add(RocksDbWeight::get().reads((2_u64).saturating_mul(k.into())))
-			.saturating_add(RocksDbWeight::get().writes(54_u64))
-			.saturating_add(RocksDbWeight::get().writes((2_u64).saturating_mul(k.into())))
+			.saturating_add(ParityDbWeight::get().reads(51_u64))
+			.saturating_add(ParityDbWeight::get().reads((2_u64).saturating_mul(k.into())))
+			.saturating_add(ParityDbWeight::get().writes(54_u64))
+			.saturating_add(ParityDbWeight::get().writes((2_u64).saturating_mul(k.into())))
 			.saturating_add(Weight::from_parts(0, 2579).saturating_mul(k.into()))
 	}
 	/// Storage: `SubtensorModule::SubnetLeases` (r:1 w:1)
@@ -4544,10 +4544,10 @@ impl WeightInfo for () {
 		Weight::from_parts(96_646_996, 6148)
 			// Standard Error: 5_309
 			.saturating_add(Weight::from_parts(1_570_386, 0).saturating_mul(k.into()))
-			.saturating_add(RocksDbWeight::get().reads(4_u64))
-			.saturating_add(RocksDbWeight::get().reads((1_u64).saturating_mul(k.into())))
-			.saturating_add(RocksDbWeight::get().writes(7_u64))
-			.saturating_add(RocksDbWeight::get().writes((1_u64).saturating_mul(k.into())))
+			.saturating_add(ParityDbWeight::get().reads(4_u64))
+			.saturating_add(ParityDbWeight::get().reads((1_u64).saturating_mul(k.into())))
+			.saturating_add(ParityDbWeight::get().writes(7_u64))
+			.saturating_add(ParityDbWeight::get().writes((1_u64).saturating_mul(k.into())))
 			.saturating_add(Weight::from_parts(0, 2514).saturating_mul(k.into()))
 	}
 	/// Storage: `SubtensorModule::SubnetOwner` (r:1 w:0)
@@ -4560,8 +4560,8 @@ impl WeightInfo for () {
 		//  Estimated: `9074`
 		// Minimum execution time: 24_486_000 picoseconds.
 		Weight::from_parts(25_798_000, 9074)
-			.saturating_add(RocksDbWeight::get().reads(4_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(4_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::NetworksAdded` (r:1 w:0)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -4589,8 +4589,8 @@ impl WeightInfo for () {
 		//  Estimated: `4535`
 		// Minimum execution time: 72_186_000 picoseconds.
 		Weight::from_parts(73_359_000, 4535)
-			.saturating_add(RocksDbWeight::get().reads(10_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(10_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `SubtensorModule::NetworksAdded` (r:1 w:0)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -4606,8 +4606,8 @@ impl WeightInfo for () {
 		//  Estimated: `4274`
 		// Minimum execution time: 31_566_000 picoseconds.
 		Weight::from_parts(32_979_000, 4274)
-			.saturating_add(RocksDbWeight::get().reads(4_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(4_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `SubtensorModule::StakingColdkeys` (r:1 w:1)
 	/// Proof: `SubtensorModule::StakingColdkeys` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -4623,8 +4623,8 @@ impl WeightInfo for () {
 		//  Estimated: `3941`
 		// Minimum execution time: 15_613_000 picoseconds.
 		Weight::from_parts(16_064_000, 3941)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(4_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().writes(4_u64))
 	}
 	/// Storage: `SubtensorModule::StakingColdkeys` (r:1 w:0)
 	/// Proof: `SubtensorModule::StakingColdkeys` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -4654,8 +4654,8 @@ impl WeightInfo for () {
 		//  Estimated: `7869`
 		// Minimum execution time: 140_608_000 picoseconds.
 		Weight::from_parts(142_310_000, 7869)
-			.saturating_add(RocksDbWeight::get().reads(16_u64))
-			.saturating_add(RocksDbWeight::get().writes(4_u64))
+			.saturating_add(ParityDbWeight::get().reads(16_u64))
+			.saturating_add(ParityDbWeight::get().writes(4_u64))
 	}
 	/// Storage: `SubtensorModule::NumRootClaim` (r:0 w:1)
 	/// Proof: `SubtensorModule::NumRootClaim` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -4665,7 +4665,7 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 1_883_000 picoseconds.
 		Weight::from_parts(2_083_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::RootClaimableThreshold` (r:0 w:1)
 	/// Proof: `SubtensorModule::RootClaimableThreshold` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -4675,7 +4675,7 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 4_136_000 picoseconds.
 		Weight::from_parts(4_747_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Owner` (r:1 w:0)
 	/// Proof: `SubtensorModule::Owner` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -4689,8 +4689,8 @@ impl WeightInfo for () {
 		//  Estimated: `4327`
 		// Minimum execution time: 23_675_000 picoseconds.
 		Weight::from_parts(25_277_000, 4327)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::SubnetMechanism` (r:1 w:0)
 	/// Proof: `SubtensorModule::SubnetMechanism` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -4770,8 +4770,8 @@ impl WeightInfo for () {
 		//  Estimated: `8727`
 		// Minimum execution time: 630_852_000 picoseconds.
 		Weight::from_parts(646_565_000, 8727)
-			.saturating_add(RocksDbWeight::get().reads(39_u64))
-			.saturating_add(RocksDbWeight::get().writes(19_u64))
+			.saturating_add(ParityDbWeight::get().reads(39_u64))
+			.saturating_add(ParityDbWeight::get().writes(19_u64))
 	}
 	/// Storage: `SubtensorModule::PendingChildKeyCooldown` (r:0 w:1)
 	/// Proof: `SubtensorModule::PendingChildKeyCooldown` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
@@ -4781,7 +4781,7 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 1_963_000 picoseconds.
 		Weight::from_parts(2_083_000, 0)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	/// Storage: `SubtensorModule::Owner` (r:1 w:0)
 	/// Proof: `SubtensorModule::Owner` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -4821,8 +4821,8 @@ impl WeightInfo for () {
 		//  Estimated: `7584`
 		// Minimum execution time: 111_775_000 picoseconds.
 		Weight::from_parts(114_028_000, 7584)
-			.saturating_add(RocksDbWeight::get().reads(17_u64))
-			.saturating_add(RocksDbWeight::get().writes(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(17_u64))
+			.saturating_add(ParityDbWeight::get().writes(2_u64))
 	}
 	/// Storage: `SubtensorModule::Owner` (r:2 w:0)
 	/// Proof: `SubtensorModule::Owner` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -4850,7 +4850,7 @@ impl WeightInfo for () {
 		//  Estimated: `7306`
 		// Minimum execution time: 146_897_000 picoseconds.
 		Weight::from_parts(148_699_000, 7306)
-			.saturating_add(RocksDbWeight::get().reads(14_u64))
-			.saturating_add(RocksDbWeight::get().writes(4_u64))
+			.saturating_add(ParityDbWeight::get().reads(14_u64))
+			.saturating_add(ParityDbWeight::get().writes(4_u64))
 	}
 }

--- a/pallets/swap/src/weights.rs
+++ b/pallets/swap/src/weights.rs
@@ -31,7 +31,7 @@
 #![allow(missing_docs)]
 #![allow(dead_code)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame_support::{traits::Get, weights::{Weight, constants::ParityDbWeight}};
 use core::marker::PhantomData;
 
 /// Weight functions needed for `pallet_subtensor_swap`.
@@ -212,8 +212,8 @@ impl WeightInfo for () {
 		//  Estimated: `3994`
 		// Minimum execution time: 15_950_000 picoseconds.
 		Weight::from_parts(16_481_000, 3994)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().writes(1_u64))
 	}
 	fn add_liquidity() -> Weight {
 		// Proof Size summary in bytes:
@@ -340,8 +340,8 @@ impl WeightInfo for () {
 		//  Estimated: `670430`
 		// Minimum execution time: 795_151_000 picoseconds.
 		Weight::from_parts(795_151_000, 670430)
-			.saturating_add(RocksDbWeight::get().reads(128_u64))
-			.saturating_add(RocksDbWeight::get().writes(128_u64))
+			.saturating_add(ParityDbWeight::get().reads(128_u64))
+			.saturating_add(ParityDbWeight::get().writes(128_u64))
 	}
 	/// Storage: `SubtensorModule::NetworksAdded` (r:1 w:0)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -351,6 +351,6 @@ impl WeightInfo for () {
 		//  Estimated: `4003`
 		// Minimum execution time: 13_054_000 picoseconds.
 		Weight::from_parts(13_335_000, 4003)
-			.saturating_add(RocksDbWeight::get().reads(1_u64))
+			.saturating_add(ParityDbWeight::get().reads(1_u64))
 	}
 }

--- a/pallets/utility/src/weights.rs
+++ b/pallets/utility/src/weights.rs
@@ -31,7 +31,7 @@
 #![allow(missing_docs)]
 #![allow(dead_code)]
 
-use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame_support::{traits::Get, weights::{Weight, constants::ParityDbWeight}};
 use core::marker::PhantomData;
 
 /// Weight functions needed for `pallet_subtensor_utility`.
@@ -148,7 +148,7 @@ impl WeightInfo for () {
 		Weight::from_parts(12_108_520, 3983)
 			// Standard Error: 3_458
 			.saturating_add(Weight::from_parts(5_277_918, 0).saturating_mul(c.into()))
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
 	}
 	/// Storage: `SafeMode::EnteredUntil` (r:1 w:0)
 	/// Proof: `SafeMode::EnteredUntil` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
@@ -160,7 +160,7 @@ impl WeightInfo for () {
 		//  Estimated: `3983`
 		// Minimum execution time: 13_480_000 picoseconds.
 		Weight::from_parts(13_830_000, 3983)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
 	}
 	/// Storage: `SafeMode::EnteredUntil` (r:1 w:0)
 	/// Proof: `SafeMode::EnteredUntil` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
@@ -175,7 +175,7 @@ impl WeightInfo for () {
 		Weight::from_parts(15_244_012, 3983)
 			// Standard Error: 2_052
 			.saturating_add(Weight::from_parts(5_505_817, 0).saturating_mul(c.into()))
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
 	}
 	fn dispatch_as() -> Weight {
 		// Proof Size summary in bytes:
@@ -197,7 +197,7 @@ impl WeightInfo for () {
 		Weight::from_parts(1_067_442, 3983)
 			// Standard Error: 4_142
 			.saturating_add(Weight::from_parts(5_312_644, 0).saturating_mul(c.into()))
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
 	}
 	fn dispatch_as_fallible() -> Weight {
 		// Proof Size summary in bytes:
@@ -216,6 +216,6 @@ impl WeightInfo for () {
 		//  Estimated: `3983`
 		// Minimum execution time: 18_757_000 picoseconds.
 		Weight::from_parts(19_459_000, 3983)
-			.saturating_add(RocksDbWeight::get().reads(2_u64))
+			.saturating_add(ParityDbWeight::get().reads(2_u64))
 	}
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -92,7 +92,7 @@ pub use frame_support::{
         IdentityFee, Weight, WeightToFeeCoefficient, WeightToFeeCoefficients,
         WeightToFeePolynomial,
         constants::{
-            BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_REF_TIME_PER_SECOND,
+            BlockExecutionWeight, ExtrinsicBaseWeight, ParityDbWeight, WEIGHT_REF_TIME_PER_SECOND,
         },
     },
 };
@@ -362,7 +362,7 @@ impl frame_system::Config for Runtime {
     // Maximum number of block number to block hash mappings to keep (oldest pruned first).
     type BlockHashCount = BlockHashCount;
     // The weight of database operations that the runtime can invoke.
-    type DbWeight = RocksDbWeight;
+    type DbWeight = ParityDbWeight;
     // Version of the runtime.
     type Version = Version;
     // Converts a module to the index of the module in `construct_runtime!`.


### PR DESCRIPTION
## Summary

- Switch the runtime `DbWeight` from `RocksDbWeight` to `ParityDbWeight`.
- Update the benchmark weight template to emit `ParityDbWeight` for fallback `WeightInfo for ()` implementations.
- Regenerate the existing pallet weight files so their fallback DB read/write costs match the ParityDB default.

## Rationale

The node now defaults to ParityDB, but the runtime still used RocksDB database weights when resolving pallet weights through `T::DbWeight`. This made runtime DB read/write accounting inconsistent with the configured backend.

Most production pallet weights already delegate DB read/write costs through `T::DbWeight`; updating the runtime fixes that path. The generated fallback implementations in `pallets/*/src/weights.rs` still hardcoded `RocksDbWeight`, so those were updated as well, along with the shared benchmark template to keep future generated weights aligned.