### PR TITLE
Get spec version directly from file

### DIFF
--- a/.github/workflows/check-devnet.yml
+++ b/.github/workflows/check-devnet.yml
@@ -46,8 +46,9 @@ jobs:
           spec_version=$(PATH=$PATH:$HOME/.cargo/.bin substrate-spec-version wss://dev.chain.opentensor.ai:443 | tr -d '\n')
           echo "network spec_version: $spec_version"
           : ${spec_version:?bad spec version}
-          local_spec_version=$(cargo run -p subtensor-tools --bin spec-version | tr -d '\n')
+          local_spec_version=$(sed -n 's/ *spec_version: \([0-9]*\),/\1/p' runtime/src/lib.rs | head -n 1 | tr -d '\n')
           echo "local spec_version: $local_spec_version"
           echo "network spec_version: $spec_version"
+          : ${local_spec_version:?bad local spec version}
           if (( $(echo "$local_spec_version <= $spec_version" | bc -l) )); then echo "$local_spec_version ≯ $spec_version ❌"; exit 1; fi
           echo "$local_spec_version > $spec_version ✅"

--- a/.github/workflows/check-finney.yml
+++ b/.github/workflows/check-finney.yml
@@ -44,8 +44,9 @@ jobs:
           spec_version=$(PATH=$PATH:$HOME/.cargo/.bin substrate-spec-version wss://entrypoint-finney.opentensor.ai:443 | tr -d '\n')
           echo "network spec_version: $spec_version"
           : ${spec_version:?bad spec version}
-          local_spec_version=$(cargo run -p subtensor-tools --bin spec-version | tr -d '\n')
+          local_spec_version=$(sed -n 's/ *spec_version: \([0-9]*\),/\1/p' runtime/src/lib.rs | head -n 1 | tr -d '\n')
           echo "local spec_version: $local_spec_version"
           echo "network spec_version: $spec_version"
+          : ${local_spec_version:?bad local spec version}
           if (( $(echo "$local_spec_version <= $spec_version" | bc -l) )); then echo "$local_spec_version ≯ $spec_version ❌"; exit 1; fi
           echo "$local_spec_version > $spec_version ✅"

--- a/.github/workflows/check-testnet.yml
+++ b/.github/workflows/check-testnet.yml
@@ -45,8 +45,9 @@ jobs:
           spec_version=$(PATH=$PATH:$HOME/.cargo/.bin substrate-spec-version wss://test.finney.opentensor.ai:443 | tr -d '\n')
           echo "network spec_version: $spec_version"
           : ${spec_version:?bad spec version}
-          local_spec_version=$(cargo run -p subtensor-tools --bin spec-version | tr -d '\n')
+          local_spec_version=$(sed -n 's/ *spec_version: \([0-9]*\),/\1/p' runtime/src/lib.rs | head -n 1 | tr -d '\n')
           echo "local spec_version: $local_spec_version"
           echo "network spec_version: $spec_version"
+          : ${local_spec_version:?bad local spec version}
           if (( $(echo "$local_spec_version <= $spec_version" | bc -l) )); then echo "$local_spec_version ≯ $spec_version ❌"; exit 1; fi
           echo "$local_spec_version > $spec_version ✅"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18321,7 +18321,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "node-subtensor-runtime",
  "semver 1.0.27",
  "toml_edit 0.22.27",
 ]

--- a/support/tools/Cargo.toml
+++ b/support/tools/Cargo.toml
@@ -12,13 +12,8 @@ homepage = "https://bittensor.com"
 name = "bump-version"
 path = "src/bump_version.rs"
 
-[[bin]]
-name = "spec-version"
-path = "src/spec_version.rs"
-
 [dependencies]
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }
 semver.workspace = true
 toml_edit.workspace = true
-node-subtensor-runtime = { workspace = true, default-features = true }

--- a/support/tools/src/spec_version.rs
+++ b/support/tools/src/spec_version.rs
@@ -1,5 +1,0 @@
-use node_subtensor_runtime::VERSION;
-
-fn main() {
-    println!("{}", VERSION.spec_version);
-}


### PR DESCRIPTION
## Summary

- Read the local runtime `spec_version` directly from `runtime/src/lib.rs` in deploy-check workflows.
- Remove the unused `spec-version` support binary and its runtime dependency.