### PR TITLE
Adapt rate limits after disabling in-block staking rate limit

### DIFF
--- a/pallets/subtensor/src/staking/order_swap.rs
+++ b/pallets/subtensor/src/staking/order_swap.rs
@@ -47,10 +47,8 @@ impl<T: Config> OrderSwapInterface<T::AccountId> for Pallet<T> {
             );
         }
         let alpha_out =
-            Self::stake_into_subnet(hotkey, coldkey, netuid, tao_amount, amm_limit, false, false)?;
-        if validate {
-            Self::set_stake_operation_limit(hotkey, coldkey, netuid);
-        }
+            Self::stake_into_subnet(hotkey, coldkey, netuid, tao_amount, amm_limit, false)?;
+
         Ok(alpha_out)
     }
 
@@ -136,7 +134,6 @@ impl<T: Config> OrderSwapInterface<T::AccountId> for Pallet<T> {
                 TaoBalance::from(tao_equiv) >= DefaultMinStake::<T>::get(),
                 Error::<T>::AmountTooLow
             );
-            Self::ensure_stake_operation_limit_not_exceeded(from_hotkey, from_coldkey, netuid)?;
             Self::ensure_available_to_unstake(from_coldkey, netuid, amount)?;
         }
 
@@ -145,7 +142,6 @@ impl<T: Config> OrderSwapInterface<T::AccountId> for Pallet<T> {
                 Self::hotkey_account_exists(to_hotkey),
                 Error::<T>::HotKeyAccountNotExists
             );
-            Self::set_stake_operation_limit(to_hotkey, to_coldkey, netuid);
         }
 
         let available =


### PR DESCRIPTION
## Description
Follow-up PR to adapt rate limits after merging: 
- https://github.com/opentensor/subtensor/pull/2712
- https://github.com/opentensor/subtensor/pull/2554


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.