### PR TITLE
fixes pallet limit orders

### DIFF
--- a/pallets/limit-orders/src/lib.rs
+++ b/pallets/limit-orders/src/lib.rs
@@ -199,9 +199,11 @@ pub mod pallet {
         PalletId,
         pallet_prelude::*,
         traits::{Get, UnixTime},
+        transactional,
     };
     use frame_system::pallet_prelude::*;
     use sp_runtime::traits::AccountIdConversion;
+    use sp_std::collections::btree_set::BTreeSet;
     use sp_std::vec::Vec;
 
     #[pallet::pallet]
@@ -348,6 +350,8 @@ pub mod pallet {
         PalletHotkeyNotRegistered,
         /// A TAO -> alpha conversion overflowed the fixed-point range.
         ArithmeticOverflow,
+        /// The same order appears more than once in a single batch.
+        DuplicateOrderInBatch,
     }
 
     // ── Hooks ─────────────────────────────────────────────────────────────────
@@ -693,6 +697,12 @@ pub mod pallet {
 
         /// Attempt to execute one signed order. Returns an error on any
         /// validation or execution failure without panicking.
+        ///
+        /// `#[transactional]` makes the whole body a single storage layer: the
+        /// swap (`buy_alpha`/`sell_alpha`, themselves transactional), the fee
+        /// transfer, and the `Orders::insert` either all commit together or all
+        /// roll back together.
+        #[transactional]
         fn try_execute_order(
             signed_order: SignedOrder<T::AccountId>,
             order_id: H256,
@@ -903,8 +913,20 @@ pub mod pallet {
             let mut buys = BoundedVec::new();
             let mut sells = BoundedVec::new();
 
+            // Track which order_ids we have already seen in this batch. A repeated
+            // order_id is never legitimate within a single batch.
+            let mut seen_order_ids: BTreeSet<H256> = BTreeSet::new();
+
             for signed_order in orders.iter() {
                 let order_id = Self::derive_order_id(&signed_order.order);
+
+                // Hard-fail on the first duplicate order_id in the batch (covers both
+                // buys and sells). BTreeSet::insert returns false if already present.
+                ensure!(
+                    seen_order_ids.insert(order_id),
+                    Error::<T>::DuplicateOrderInBatch
+                );
+
                 let order = signed_order.order.inner();
 
                 // Hard-fail if the order targets a different subnet than the batch netuid.

--- a/pallets/limit-orders/src/tests/extrinsics.rs
+++ b/pallets/limit-orders/src/tests/extrinsics.rs
@@ -2927,6 +2927,104 @@ fn execute_batched_orders_second_partial_fill_completes_order() {
     });
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// In-batch order_id deduplication — regression tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Regression: the same fully-signed `LimitBuy` order appearing twice in one
+/// batch must hard-fail with `DuplicateOrderInBatch` rather than debiting the
+/// signer twice. Pre-fix, `validate_and_classify` validated each entry against
+/// the same pre-batch `Orders::get(order_id)` snapshot with no in-batch tracking,
+/// so the signer was charged N× their signed amount.
+///
+/// `assert_noop!` also asserts the storage root is unchanged, proving the
+/// all-or-nothing batch rolled back. (The mock's TAO/alpha ledgers are
+/// thread-local RefCell maps, not substrate storage, so we do not assert on
+/// them here — see `mock.rs`.) We additionally assert `Orders::get` was never
+/// written.
+#[test]
+fn execute_batched_orders_full_fill_duplicate_rejected() {
+    new_test_ext().execute_with(|| {
+        MockTime::set(1_000_000);
+        MockSwap::set_price(1.0);
+        MockSwap::set_buy_alpha_return(500);
+        MockSwap::set_tao_balance(alice(), 1_000);
+
+        // Open-relay (relayer: None) fully-signed LimitBuy.
+        let order = make_signed_order(
+            AccountKeyring::Alice,
+            dave(),
+            netuid(),
+            OrderType::LimitBuy,
+            600,
+            u64::MAX,
+            FAR_FUTURE,
+            Perbill::zero(),
+            fee_recipient(),
+            None,
+        );
+        let id = order_id(&order.order);
+
+        // The same order twice in one batch.
+        assert_noop!(
+            LimitOrders::execute_batched_orders(
+                RuntimeOrigin::signed(charlie()),
+                netuid(),
+                bounded(vec![order.clone(), order]),
+            ),
+            Error::<Test>::DuplicateOrderInBatch
+        );
+
+        // The batch rolled back: no order status was recorded.
+        assert!(Orders::<Test>::get(id).is_none());
+    });
+}
+
+/// Regression: two `SignedOrder`s that share the same inner `VersionedOrder`
+/// (so the same `order_id`, since `order_id` excludes `partial_fill` and the
+/// signature) but carry *different* `partial_fill` values must still collide
+/// and be caught by the in-batch dedup. This exercises the partial-fill path
+/// (partial_fills_enabled = true, relayer set).
+#[test]
+fn execute_batched_orders_partial_fill_duplicate_rejected() {
+    new_test_ext().execute_with(|| {
+        MockTime::set(1_000_000);
+        MockSwap::set_price(1.0);
+        MockSwap::set_buy_alpha_return(400);
+        MockSwap::set_tao_balance(alice(), 1_000);
+
+        // Same inner VersionedOrder; only the envelope `partial_fill` differs.
+        let first = make_partial_fill_order(
+            AccountKeyring::Alice,
+            bob(),
+            netuid(),
+            OrderType::LimitBuy,
+            1_000,
+            u64::MAX,
+            FAR_FUTURE,
+            charlie(),
+            600,
+        );
+        let mut second = first.clone();
+        second.partial_fill = Some(400);
+
+        // Same inner order ⇒ same order_id ⇒ caught by the dedup set.
+        assert_eq!(order_id(&first.order), order_id(&second.order));
+        let id = order_id(&first.order);
+
+        assert_noop!(
+            LimitOrders::execute_batched_orders(
+                RuntimeOrigin::signed(charlie()),
+                netuid(),
+                bounded(vec![first, second]),
+            ),
+            Error::<Test>::DuplicateOrderInBatch
+        );
+
+        assert!(Orders::<Test>::get(id).is_none());
+    });
+}
+
 /// Non-root origin cannot disable the pallet
 #[test]
 fn non_root_cannot_disable_the_pallet() {

--- a/runtime/tests/limit_orders.rs
+++ b/runtime/tests/limit_orders.rs
@@ -681,9 +681,7 @@ fn batched_buy_dominant_executes_correctly() {
 /// appearing twice in one batch must hard-fail with `DuplicateOrderInBatch` and
 /// leave the signer's balances completely untouched.
 ///
-/// Pre-fix, `validate_and_classify` had no in-batch tracking, so the signer was
-/// debited once per occurrence — submitting `[order, order]` drained 2× the
-/// signed TAO amount. Here balances are real substrate storage, so the
+/// Balances are real substrate storage, so the
 /// all-or-nothing rollback is faithfully observable: free TAO and staked alpha
 /// must match their pre-call values exactly, and the order must never be
 /// recorded in `Orders`.
@@ -2535,14 +2533,10 @@ fn batched_sell_order_fails_when_alpha_is_conviction_locked() {
     });
 }
 
-/// Regression test for the missing `#[transactional]` on `try_execute_order`.
+/// Regression test for `#[transactional]` on `try_execute_order`.
 ///
 /// Invariant: a single buy order is **atomic** — either the TAO→alpha swap AND
 /// the fee transfer both commit (and the order is recorded), or neither does.
-/// There must never be an intermediate state where `buy_alpha` has committed
-/// (signer debited TAO, credited alpha) but the subsequent `forward_fee` failed,
-/// leaving the order un-recorded in `Orders` (and therefore replayable) while the
-/// fee recipient received nothing.
 ///
 /// ## Trigger (buy path)
 /// `buy_alpha` only checks the signer can remove `tao_after_fee`, NOT the full
@@ -2564,9 +2558,6 @@ fn batched_sell_order_fails_when_alpha_is_conviction_locked() {
 ///       `stake_into_subnet` debits the full `18_000_000` because
 ///       `B - ED = 18_999_500 ≥ 18_000_000` (no ED clamp).  Balance → 1_000_000.
 ///     * `forward_fee` of `fee_tao (2_000_000)` then fails: only 1_000_000 left.
-///
-/// This test FAILS before the fix (signer debited 18_000_000, alpha credited,
-/// order un-recorded) and PASSES after it (everything rolled back).
 #[test]
 fn fee_failure_after_buy_rolls_back_swap() {
     new_test_ext().execute_with(|| {

--- a/runtime/tests/limit_orders.rs
+++ b/runtime/tests/limit_orders.rs
@@ -10,8 +10,8 @@ use frame_support::{
     traits::{ConstU32, Hooks},
 };
 use node_subtensor_runtime::{
-    BuildStorage, LimitOrders, Runtime, RuntimeGenesisConfig, RuntimeOrigin, SubtensorModule,
-    System, pallet_subtensor,
+    BuildStorage, LimitOrders, Runtime, RuntimeEvent, RuntimeGenesisConfig, RuntimeOrigin,
+    SubtensorModule, System, pallet_subtensor,
 };
 use pallet_limit_orders::{
     HasMigrationRun, LimitOrdersEnabled, Order, OrderStatus, OrderType, Orders, SignedOrder,
@@ -673,6 +673,85 @@ fn batched_buy_dominant_executes_correctly() {
             bob_tao,
             TaoBalance::from(min_default_stake().to_u64()),
             "bob should hold exactly min_default_stake TAO after buy-dominant batch"
+        );
+    });
+}
+
+/// Regression (real-storage rollback): the same fully-signed `LimitBuy` order
+/// appearing twice in one batch must hard-fail with `DuplicateOrderInBatch` and
+/// leave the signer's balances completely untouched.
+///
+/// Pre-fix, `validate_and_classify` had no in-batch tracking, so the signer was
+/// debited once per occurrence — submitting `[order, order]` drained 2× the
+/// signed TAO amount. Here balances are real substrate storage, so the
+/// all-or-nothing rollback is faithfully observable: free TAO and staked alpha
+/// must match their pre-call values exactly, and the order must never be
+/// recorded in `Orders`.
+#[test]
+fn batched_full_fill_duplicate_rejected_and_rolled_back() {
+    new_test_ext().execute_with(|| {
+        let netuid = NetUid::from(1u16);
+        let alice = Sr25519Keyring::Alice;
+        let alice_id = alice.to_account_id();
+        let bob_id = Sr25519Keyring::Bob.to_account_id();
+        let charlie_id = Sr25519Keyring::Charlie.to_account_id();
+        let dave_id = Sr25519Keyring::Dave.to_account_id();
+
+        setup_subnet(netuid);
+        setup_buyer_seller(netuid, &alice_id, &charlie_id, &bob_id, &dave_id);
+
+        // Open-relay (relayer: None) fully-signed LimitBuy from Alice, staking
+        // to her hotkey (charlie).
+        let order = make_signed_order(
+            alice,
+            charlie_id.clone(),
+            netuid,
+            OrderType::LimitBuy,
+            min_default_stake().into(),
+            u64::MAX,
+            u64::MAX,
+            Perbill::zero(),
+            charlie_id.clone(),
+        );
+        let id = order_id(&order.order);
+
+        // Snapshot the signer's real balances before the call.
+        let alice_tao_before = SubtensorModule::get_coldkey_balance(&alice_id);
+        let alice_alpha_before = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+            &charlie_id,
+            &alice_id,
+            netuid,
+        );
+
+        // The same order twice in one batch — must hard-fail the whole batch.
+        let orders = make_order_batch(vec![order.clone(), order]);
+        assert_noop!(
+            LimitOrders::execute_batched_orders(
+                RuntimeOrigin::signed(charlie_id.clone()),
+                netuid,
+                orders,
+            ),
+            pallet_limit_orders::Error::<Runtime>::DuplicateOrderInBatch
+        );
+
+        // Full rollback: balances unchanged and no order status recorded.
+        assert_eq!(
+            SubtensorModule::get_coldkey_balance(&alice_id),
+            alice_tao_before,
+            "signer's free TAO must be unchanged after a duplicate-order batch rollback"
+        );
+        assert_eq!(
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+                &charlie_id,
+                &alice_id,
+                netuid,
+            ),
+            alice_alpha_before,
+            "signer's staked alpha must be unchanged after a duplicate-order batch rollback"
+        );
+        assert!(
+            Orders::<Runtime>::get(id).is_none(),
+            "no order status must be recorded when the batch is rolled back"
         );
     });
 }
@@ -2452,6 +2531,146 @@ fn batched_sell_order_fails_when_alpha_is_conviction_locked() {
                 make_order_batch(vec![sell]),
             ),
             pallet_subtensor::Error::<Runtime>::StakeUnavailable
+        );
+    });
+}
+
+/// Regression test for the missing `#[transactional]` on `try_execute_order`.
+///
+/// Invariant: a single buy order is **atomic** — either the TAO→alpha swap AND
+/// the fee transfer both commit (and the order is recorded), or neither does.
+/// There must never be an intermediate state where `buy_alpha` has committed
+/// (signer debited TAO, credited alpha) but the subsequent `forward_fee` failed,
+/// leaving the order un-recorded in `Orders` (and therefore replayable) while the
+/// fee recipient received nothing.
+///
+/// ## Trigger (buy path)
+/// `buy_alpha` only checks the signer can remove `tao_after_fee`, NOT the full
+/// `tao_in`.  So if the signer's free TAO sits in the window
+/// `[tao_after_fee, tao_in)`, `buy_alpha` succeeds but the subsequent
+/// `forward_fee` of `fee_tao` fails for insufficient funds.  In best-effort mode
+/// (`should_fail = false`) the caller catches that `Err`, emits `OrderSkipped`,
+/// and returns `Ok(())`.  Without `#[transactional]` the orphaned `buy_alpha`
+/// swap would be committed by the outer storage layer; with it, the whole order
+/// rolls back.
+///
+/// ## Arithmetic (ED = 500, min_default_stake = 2_000_000)
+/// - `amount = tao_in = min_default_stake * 10 = 20_000_000`
+/// - `fee_rate = 10%` → `fee_tao = 2_000_000`, `tao_after_fee = 18_000_000`
+///   (≥ min_default_stake, so it clears the `AmountTooLow` check).
+/// - Fund the signer with `B = 19_000_000`, which sits strictly inside the
+///   vulnerable window `[18_000_000, 20_000_000)`:
+///     * `buy_alpha` passes: `tao_after_fee (18_000_000) ≤ B`, and
+///       `stake_into_subnet` debits the full `18_000_000` because
+///       `B - ED = 18_999_500 ≥ 18_000_000` (no ED clamp).  Balance → 1_000_000.
+///     * `forward_fee` of `fee_tao (2_000_000)` then fails: only 1_000_000 left.
+///
+/// This test FAILS before the fix (signer debited 18_000_000, alpha credited,
+/// order un-recorded) and PASSES after it (everything rolled back).
+#[test]
+fn fee_failure_after_buy_rolls_back_swap() {
+    new_test_ext().execute_with(|| {
+        let netuid = NetUid::from(1u16);
+        let alice = Sr25519Keyring::Alice;
+        let alice_id = alice.to_account_id();
+        let bob_id = Sr25519Keyring::Bob.to_account_id();
+        // Fee recipient distinct from the signer (Alice) and the relayer.
+        let charlie_id = Sr25519Keyring::Charlie.to_account_id();
+        // Relayer that submits the batch — kept distinct so its balance is irrelevant.
+        let dave_id = Sr25519Keyring::Dave.to_account_id();
+
+        setup_subnet(netuid);
+
+        // Create the hotkey association so buy_alpha's validation passes.
+        let _ = SubtensorModule::create_account_if_non_existent(&alice_id, &bob_id);
+
+        // amount = tao_in = min_default_stake * 10; fee_rate = 10%.
+        //   fee_tao        = 2_000_000
+        //   tao_after_fee  = 18_000_000  (≥ min_default_stake, clears AmountTooLow)
+        let tao_in = min_default_stake().to_u64() * 10u64;
+
+        // Fund Alice's coldkey so her free TAO is inside the vulnerable window
+        // [tao_after_fee, tao_in) = [18_000_000, 20_000_000): 19_000_000.
+        //   buy_alpha passes (18_000_000 ≤ 19_000_000, and 19_000_000 - ED clears the
+        //   full debit), leaving 1_000_000 — which is < fee_tao (2_000_000), so
+        //   forward_fee fails for insufficient funds.
+        let signer_balance = TaoBalance::from(19_000_000u64);
+        add_balance_to_coldkey_account(&alice_id, signer_balance);
+
+        let signed = make_signed_order(
+            alice,
+            bob_id.clone(),
+            netuid,
+            OrderType::LimitBuy,
+            tao_in,
+            u64::MAX, // price ceiling — always satisfied
+            u64::MAX, // no expiry
+            Perbill::from_percent(10),
+            charlie_id.clone(),
+        );
+        let id = order_id(&signed.order);
+
+        // Snapshot the observable state before the call.
+        let alice_balance_before = SubtensorModule::get_coldkey_balance(&alice_id);
+        let alice_stake_before =
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&bob_id, &alice_id, netuid);
+        let charlie_balance_before = SubtensorModule::get_coldkey_balance(&charlie_id);
+
+        // Sanity: Alice really is funded to 19_000_000, inside the window.
+        assert_eq!(alice_balance_before, signer_balance);
+
+        let orders = make_order_batch(vec![signed]);
+
+        // Best-effort path: the per-order error is caught, OrderSkipped is emitted,
+        // and the extrinsic returns Ok(()).
+        assert_ok!(LimitOrders::execute_orders(
+            RuntimeOrigin::signed(dave_id),
+            orders,
+            false,
+        ));
+
+        // ── Atomic rollback assertions ───────────────────────────────────────────
+
+        // 1. The signer's free TAO is unchanged: the buy_alpha debit was rolled back.
+        assert_eq!(
+            SubtensorModule::get_coldkey_balance(&alice_id),
+            alice_balance_before,
+            "signer's TAO must be unchanged: the orphaned buy_alpha swap must roll back when forward_fee fails"
+        );
+
+        // 2. No alpha was credited to the signer: the swap was rolled back.
+        assert_eq!(
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&bob_id, &alice_id, netuid),
+            alice_stake_before,
+            "signer's staked alpha must be unchanged: no alpha may be credited from a rolled-back buy"
+        );
+
+        // 3. The order was NOT recorded — it must remain replayable-free, i.e. absent.
+        assert!(
+            Orders::<Runtime>::get(id).is_none(),
+            "order must not be recorded when its execution failed and rolled back"
+        );
+
+        // 4. The fee recipient received nothing.
+        assert_eq!(
+            SubtensorModule::get_coldkey_balance(&charlie_id),
+            charlie_balance_before,
+            "fee recipient's balance must be unchanged: the fee transfer failed and rolled back"
+        );
+
+        // 5. An OrderSkipped event was emitted for this order id.
+        let skipped = System::events().into_iter().any(|record| {
+            matches!(
+                record.event,
+                RuntimeEvent::LimitOrders(pallet_limit_orders::Event::OrderSkipped {
+                    order_id: skipped_id,
+                    ..
+                }) if skipped_id == id
+            )
+        });
+        assert!(
+            skipped,
+            "an OrderSkipped event must be emitted for the failed order"
         );
     });
 }


### PR DESCRIPTION
## Description
Closes a couple of bugs in the pallet-limit-orders:

1. before this PR, `try_execute_order` was not transactional, therefore one could have a erronous fee-forwarding logic (e.g., fee-forwarding when we dont have enough balance for paying the fee) and the order would still apply the storage changes relative to the order.  After this PR, try_execute_order is transactional, so upon any failure, all storage changes are discarded

2. `execute_batched_orders` allowed the same order to be injected twice in the batch, something that created spurious cases like being able to claim twice a fee. After this PR order ids are tracked within the same batch, preventing the injection of the same order twice in the same batch


## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
