### PR TITLE
Add `StakeInfoRuntimeApi.get_stake_availability_for_coldkeys` runtime API

### DIFF
--- a/pallets/subtensor/runtime-api/src/lib.rs
+++ b/pallets/subtensor/runtime-api/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 extern crate alloc;
+use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 use codec::Compact;
 use pallet_subtensor::rpc_info::{
@@ -8,7 +9,7 @@ use pallet_subtensor::rpc_info::{
     metagraph::{Metagraph, SelectiveMetagraph},
     neuron_info::{NeuronInfo, NeuronInfoLite},
     show_subnet::SubnetState,
-    stake_info::StakeInfo,
+    stake_info::{StakeAvailability, StakeInfo},
     subnet_info::{
         SubnetHyperparams, SubnetHyperparamsV2, SubnetHyperparamsV3, SubnetInfo, SubnetInfov2,
     },
@@ -65,6 +66,7 @@ sp_api::decl_runtime_apis! {
         fn get_stake_info_for_coldkey( coldkey_account: AccountId32 ) -> Vec<StakeInfo<AccountId32>>;
         fn get_stake_info_for_coldkeys( coldkey_accounts: Vec<AccountId32> ) -> Vec<(AccountId32, Vec<StakeInfo<AccountId32>>)>;
         fn get_stake_info_for_hotkey_coldkey_netuid( hotkey_account: AccountId32, coldkey_account: AccountId32, netuid: NetUid ) -> Option<StakeInfo<AccountId32>>;
+        fn get_stake_availability_for_coldkeys( coldkey_accounts: Vec<AccountId32>, netuids: Option<Vec<NetUid>> ) -> BTreeMap<AccountId32, BTreeMap<NetUid, StakeAvailability>>;
         fn get_stake_fee( origin: Option<(AccountId32, NetUid)>, origin_coldkey_account: AccountId32, destination: Option<(AccountId32, NetUid)>, destination_coldkey_account: AccountId32, amount: u64 ) -> u64;
         fn get_coldkey_lock(coldkey: AccountId32, netuid: NetUid) -> Option<LockState>;
         fn get_hotkey_conviction(hotkey: AccountId32, netuid: NetUid) -> U64F64;

--- a/pallets/subtensor/src/rpc_info/stake_info.rs
+++ b/pallets/subtensor/src/rpc_info/stake_info.rs
@@ -147,6 +147,9 @@ impl<T: Config> Pallet<T> {
     ///
     /// `netuids: None` scans every subnet; `Some(vec)` limits the scan.
     /// Subnets with zero stake and zero lock are left out of the response.
+    ///
+    /// Invalid `Some(vec)` requests (empty or longer than the number of subnets on chain)
+    /// return each coldkey with an empty inner map. Non-existent netuids are omitted.
     pub fn get_stake_availability_for_coldkeys(
         coldkey_accounts: Vec<T::AccountId>,
         netuids: Option<Vec<NetUid>>,
@@ -155,10 +158,24 @@ impl<T: Config> Pallet<T> {
             return BTreeMap::new();
         }
 
-        let mut netuids = netuids.unwrap_or_else(Self::get_all_subnet_netuids);
-        // Same netuid may appear more than once in the request — keep one row per subnet.
-        netuids.sort();
-        netuids.dedup();
+        let existing_netuids = Self::get_all_subnet_netuids();
+
+        let netuids = match netuids {
+            None => existing_netuids,
+            Some(mut requested) => {
+                // Same netuid may appear more than once in the request — keep one row per subnet.
+                requested.sort();
+                requested.dedup();
+                if requested.is_empty() || requested.len() > existing_netuids.len() {
+                    return coldkey_accounts
+                        .into_iter()
+                        .map(|coldkey| (coldkey, BTreeMap::new()))
+                        .collect();
+                }
+                requested.retain(|n| Self::if_subnet_exist(*n));
+                requested
+            }
+        };
 
         coldkey_accounts
             .into_iter()

--- a/pallets/subtensor/src/rpc_info/stake_info.rs
+++ b/pallets/subtensor/src/rpc_info/stake_info.rs
@@ -2,6 +2,7 @@ extern crate alloc;
 
 use codec::Compact;
 use frame_support::pallet_prelude::{Decode, Encode};
+use sp_std::collections::btree_map::BTreeMap;
 use subtensor_runtime_common::{AlphaBalance, NetUid, TaoBalance, Token};
 use subtensor_swap_interface::SwapHandler;
 
@@ -19,6 +20,29 @@ pub struct StakeInfo<AccountId: TypeInfo + Encode + Decode> {
     tao_emission: Compact<TaoBalance>,
     drain: Compact<u64>,
     is_registered: bool,
+}
+
+#[freeze_struct("2d52e2de04425fb6")]
+#[derive(Decode, Encode, PartialEq, Eq, Clone, Debug, TypeInfo)]
+pub struct StakeAvailability {
+    total: Compact<AlphaBalance>,
+    locked: Compact<AlphaBalance>,
+    available: Compact<AlphaBalance>,
+}
+
+// Per-subnet stake breakdown: total alpha, locked mass, and what is free to unstake.
+impl StakeAvailability {
+    pub fn total(&self) -> AlphaBalance {
+        self.total.into()
+    }
+
+    pub fn locked(&self) -> AlphaBalance {
+        self.locked.into()
+    }
+
+    pub fn available(&self) -> AlphaBalance {
+        self.available.into()
+    }
 }
 
 impl<T: Config> Pallet<T> {
@@ -117,6 +141,52 @@ impl<T: Config> Pallet<T> {
             drain: 0.into(),
             is_registered,
         })
+    }
+
+    /// Batch query of unstakable stake per coldkey and subnet.
+    ///
+    /// `netuids: None` scans every subnet; `Some(vec)` limits the scan.
+    /// Subnets with zero stake and zero lock are left out of the response.
+    pub fn get_stake_availability_for_coldkeys(
+        coldkey_accounts: Vec<T::AccountId>,
+        netuids: Option<Vec<NetUid>>,
+    ) -> BTreeMap<T::AccountId, BTreeMap<NetUid, StakeAvailability>> {
+        if coldkey_accounts.is_empty() {
+            return BTreeMap::new();
+        }
+
+        let mut netuids = netuids.unwrap_or_else(Self::get_all_subnet_netuids);
+        // Same netuid may appear more than once in the request — keep one row per subnet.
+        netuids.sort();
+        netuids.dedup();
+
+        coldkey_accounts
+            .into_iter()
+            .map(|coldkey| {
+                let availability: BTreeMap<NetUid, StakeAvailability> = netuids
+                    .iter()
+                    .filter_map(|netuid| {
+                        let (total, locked, available) =
+                            Self::stake_availability(&coldkey, *netuid);
+                        // Nothing staked and no active lock — skip this subnet.
+                        if total.is_zero() && locked.is_zero() {
+                            None
+                        } else {
+                            Some((
+                                *netuid,
+                                StakeAvailability {
+                                    total: total.into(),
+                                    locked: locked.into(),
+                                    available: available.into(),
+                                },
+                            ))
+                        }
+                    })
+                    .collect();
+
+                (coldkey, availability)
+            })
+            .collect()
     }
 
     pub fn get_stake_fee(

--- a/pallets/subtensor/src/staking/lock.rs
+++ b/pallets/subtensor/src/staking/lock.rs
@@ -669,15 +669,24 @@ impl<T: Config> Pallet<T> {
         })
     }
 
-    /// Returns the alpha amount available to unstake for a coldkey on a subnet.
-    pub fn available_to_unstake(coldkey: &T::AccountId, netuid: NetUid) -> AlphaBalance {
+    /// (total_stake, locked_mass, available_to_unstake) for a coldkey on one subnet.
+    ///
+    /// The lock is subnet-wide: it blocks unstaking from any hotkey on that subnet,
+    /// not from a single hotkey position.
+    pub(crate) fn stake_availability(
+        coldkey: &T::AccountId,
+        netuid: NetUid,
+    ) -> (AlphaBalance, AlphaBalance, AlphaBalance) {
         let total = Self::total_coldkey_alpha_on_subnet(coldkey, netuid);
         let locked = Self::get_current_locked(coldkey, netuid);
-        if total > locked {
-            total.saturating_sub(locked)
-        } else {
-            AlphaBalance::ZERO
-        }
+        let available = total.saturating_sub(locked);
+        (total, locked, available)
+    }
+
+    /// Alpha the coldkey can still unstake on this subnet right now.
+    pub fn available_to_unstake(coldkey: &T::AccountId, netuid: NetUid) -> AlphaBalance {
+        let (_, _, available) = Self::stake_availability(coldkey, netuid);
+        available
     }
 
     /// Ensures that the amount can be unstaked

--- a/pallets/subtensor/src/tests/locks.rs
+++ b/pallets/subtensor/src/tests/locks.rs
@@ -860,6 +860,255 @@ fn test_available_to_unstake_fully_locked() {
     });
 }
 
+#[test]
+fn test_stake_availability_for_coldkeys_empty_coldkeys() {
+    new_test_ext(1).execute_with(|| {
+        let result = SubtensorModule::get_stake_availability_for_coldkeys(Vec::new(), None);
+        assert!(result.is_empty());
+    });
+}
+
+#[test]
+fn test_stake_availability_for_coldkeys_empty_netuids() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let result =
+            SubtensorModule::get_stake_availability_for_coldkeys(vec![coldkey], Some(Vec::new()));
+        assert_eq!(result.len(), 1);
+        assert!(result.contains_key(&coldkey));
+        assert!(result.get(&coldkey).unwrap().is_empty());
+    });
+}
+
+#[test]
+fn test_stake_availability_for_coldkeys_filters_empty_rows() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let subnet_owner_coldkey = U256::from(1001);
+        let subnet_owner_hotkey = U256::from(1002);
+        let netuid = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
+
+        let result =
+            SubtensorModule::get_stake_availability_for_coldkeys(vec![coldkey], Some(vec![netuid]));
+
+        assert_eq!(result.len(), 1);
+        assert!(result.contains_key(&coldkey));
+        assert!(result.get(&coldkey).unwrap().is_empty());
+    });
+}
+
+#[test]
+fn test_stake_availability_for_coldkeys_stake_without_lock() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let netuid = setup_subnet_with_stake(coldkey, hotkey, 100_000_000_000);
+        let total = SubtensorModule::total_coldkey_alpha_on_subnet(&coldkey, netuid);
+
+        let result =
+            SubtensorModule::get_stake_availability_for_coldkeys(vec![coldkey], Some(vec![netuid]));
+
+        assert_eq!(result.len(), 1);
+        let availability = result.get(&coldkey).unwrap().get(&netuid).unwrap();
+        assert_eq!(availability.total(), total);
+        assert_eq!(availability.locked(), AlphaBalance::ZERO);
+        assert_eq!(availability.available(), total);
+    });
+}
+
+#[test]
+fn test_stake_availability_for_coldkeys_partial_lock() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let netuid = setup_subnet_with_stake(coldkey, hotkey, 100_000_000_000);
+        let total = SubtensorModule::total_coldkey_alpha_on_subnet(&coldkey, netuid);
+        let lock_amount = total / 2.into();
+
+        assert_ok!(SubtensorModule::do_lock_stake(
+            &coldkey,
+            netuid,
+            &hotkey,
+            lock_amount,
+        ));
+
+        let result =
+            SubtensorModule::get_stake_availability_for_coldkeys(vec![coldkey], Some(vec![netuid]));
+        let availability = result.get(&coldkey).unwrap().get(&netuid).unwrap();
+
+        assert_eq!(availability.total(), total);
+        assert_eq!(
+            availability.locked(),
+            SubtensorModule::get_current_locked(&coldkey, netuid)
+        );
+        assert_eq!(availability.available(), total - availability.locked());
+    });
+}
+
+#[test]
+fn test_stake_availability_for_coldkeys_fully_locked() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let netuid = setup_subnet_with_stake(coldkey, hotkey, 100_000_000_000);
+        let total = SubtensorModule::total_coldkey_alpha_on_subnet(&coldkey, netuid);
+
+        assert_ok!(SubtensorModule::do_lock_stake(
+            &coldkey, netuid, &hotkey, total,
+        ));
+
+        let result =
+            SubtensorModule::get_stake_availability_for_coldkeys(vec![coldkey], Some(vec![netuid]));
+        let availability = result.get(&coldkey).unwrap().get(&netuid).unwrap();
+
+        assert_eq!(availability.total(), total);
+        assert_eq!(availability.locked(), total);
+        assert_eq!(availability.available(), AlphaBalance::ZERO);
+    });
+}
+
+#[test]
+fn test_stake_availability_for_coldkeys_preserves_coldkey_grouping() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey_a = U256::from(1);
+        let hotkey_a = U256::from(2);
+        let coldkey_b = U256::from(3);
+        let hotkey_b = U256::from(4);
+        let netuid_a = setup_subnet_with_stake(coldkey_a, hotkey_a, 100_000_000_000);
+        let netuid_b = setup_subnet_with_stake(coldkey_b, hotkey_b, 100_000_000_000);
+
+        let result = SubtensorModule::get_stake_availability_for_coldkeys(
+            vec![coldkey_a, coldkey_b],
+            Some(vec![netuid_a, netuid_b]),
+        );
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result.get(&coldkey_a).unwrap().len(), 1);
+        assert!(result.get(&coldkey_a).unwrap().contains_key(&netuid_a));
+        assert_eq!(result.get(&coldkey_b).unwrap().len(), 1);
+        assert!(result.get(&coldkey_b).unwrap().contains_key(&netuid_b));
+    });
+}
+
+#[test]
+fn test_stake_availability_for_coldkeys_none_netuids_uses_all_subnets() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let netuid = setup_subnet_with_stake(coldkey, hotkey, 100_000_000_000);
+
+        let result = SubtensorModule::get_stake_availability_for_coldkeys(vec![coldkey], None);
+
+        assert_eq!(result.len(), 1);
+        assert!(result.get(&coldkey).unwrap().contains_key(&netuid));
+    });
+}
+
+#[test]
+fn test_stake_availability_for_coldkeys_one_coldkey_two_subnets() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey_a = U256::from(2);
+        let hotkey_b = U256::from(3);
+        let netuid_a = setup_subnet_with_stake(coldkey, hotkey_a, 100_000_000_000);
+        let netuid_b = setup_subnet_with_stake(coldkey, hotkey_b, 100_000_000_000);
+        let total_a = SubtensorModule::total_coldkey_alpha_on_subnet(&coldkey, netuid_a);
+        let total_b = SubtensorModule::total_coldkey_alpha_on_subnet(&coldkey, netuid_b);
+
+        let result = SubtensorModule::get_stake_availability_for_coldkeys(
+            vec![coldkey],
+            Some(vec![netuid_a, netuid_b]),
+        );
+
+        assert_eq!(result.len(), 1);
+        let subnets = result.get(&coldkey).unwrap();
+        assert_eq!(subnets.len(), 2);
+        assert!(subnets.contains_key(&netuid_a));
+        assert!(subnets.contains_key(&netuid_b));
+
+        let row_a = subnets.get(&netuid_a).unwrap();
+        assert_eq!(row_a.total(), total_a);
+        assert_eq!(row_a.locked(), AlphaBalance::ZERO);
+        assert_eq!(row_a.available(), total_a);
+
+        let row_b = subnets.get(&netuid_b).unwrap();
+        assert_eq!(row_b.total(), total_b);
+        assert_eq!(row_b.locked(), AlphaBalance::ZERO);
+        assert_eq!(row_b.available(), total_b);
+    });
+}
+
+#[test]
+fn test_stake_availability_for_coldkeys_filters_to_requested_netuid() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey_a = U256::from(2);
+        let hotkey_b = U256::from(3);
+        let netuid_a = setup_subnet_with_stake(coldkey, hotkey_a, 100_000_000_000);
+        let netuid_b = setup_subnet_with_stake(coldkey, hotkey_b, 100_000_000_000);
+
+        let result = SubtensorModule::get_stake_availability_for_coldkeys(
+            vec![coldkey],
+            Some(vec![netuid_b]),
+        );
+
+        assert_eq!(result.len(), 1);
+        let subnets = result.get(&coldkey).unwrap();
+        assert_eq!(subnets.len(), 1);
+        assert!(subnets.contains_key(&netuid_b));
+        assert!(!subnets.contains_key(&netuid_a));
+    });
+}
+
+#[test]
+fn test_stake_availability_for_coldkeys_dedups_netuids() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let netuid = setup_subnet_with_stake(coldkey, hotkey, 100_000_000_000);
+
+        let result = SubtensorModule::get_stake_availability_for_coldkeys(
+            vec![coldkey],
+            Some(vec![netuid, netuid]),
+        );
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.get(&coldkey).unwrap().len(), 1);
+        assert!(result.get(&coldkey).unwrap().contains_key(&netuid));
+    });
+}
+
+#[test]
+fn test_stake_availability_for_coldkeys_uses_rolled_forward_lock() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let netuid = setup_subnet_with_stake(coldkey, hotkey, 100_000_000_000);
+        let total = SubtensorModule::total_coldkey_alpha_on_subnet(&coldkey, netuid);
+        let lock_amount = total / 2.into();
+
+        DecayingLock::<Test>::remove(coldkey, netuid);
+        assert_ok!(SubtensorModule::do_lock_stake(
+            &coldkey,
+            netuid,
+            &hotkey,
+            lock_amount,
+        ));
+        let raw_lock = Lock::<Test>::get((coldkey, netuid, hotkey)).unwrap();
+
+        step_block(1000);
+
+        let result =
+            SubtensorModule::get_stake_availability_for_coldkeys(vec![coldkey], Some(vec![netuid]));
+        let availability = result.get(&coldkey).unwrap().get(&netuid).unwrap();
+        let rolled_locked = SubtensorModule::get_current_locked(&coldkey, netuid);
+
+        assert!(rolled_locked < raw_lock.locked_mass);
+        assert_eq!(availability.locked(), rolled_locked);
+        assert_eq!(availability.available(), total - rolled_locked);
+    });
+}
+
 // =========================================================================
 // GROUP 3: Incremental locks (top-up)
 // =========================================================================

--- a/pallets/subtensor/src/tests/locks.rs
+++ b/pallets/subtensor/src/tests/locks.rs
@@ -888,10 +888,8 @@ fn test_stake_availability_for_coldkeys_filters_empty_rows() {
         let subnet_owner_hotkey = U256::from(1002);
         let netuid = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
 
-        let result = SubtensorModule::get_stake_availability_for_coldkeys(
-            vec![coldkey],
-            Some(vec![netuid])
-        );
+        let result =
+            SubtensorModule::get_stake_availability_for_coldkeys(vec![coldkey], Some(vec![netuid]));
 
         assert_eq!(result.len(), 1);
         assert!(result.contains_key(&coldkey));
@@ -907,10 +905,8 @@ fn test_stake_availability_for_coldkeys_stake_without_lock() {
         let netuid = setup_subnet_with_stake(coldkey, hotkey, 100_000_000_000);
         let total = SubtensorModule::total_coldkey_alpha_on_subnet(&coldkey, netuid);
 
-        let result = SubtensorModule::get_stake_availability_for_coldkeys(
-            vec![coldkey],
-            Some(vec![netuid])
-        );
+        let result =
+            SubtensorModule::get_stake_availability_for_coldkeys(vec![coldkey], Some(vec![netuid]));
 
         assert_eq!(result.len(), 1);
         let availability = result.get(&coldkey).unwrap().get(&netuid).unwrap();
@@ -936,10 +932,8 @@ fn test_stake_availability_for_coldkeys_partial_lock() {
             lock_amount,
         ));
 
-        let result = SubtensorModule::get_stake_availability_for_coldkeys(
-            vec![coldkey],
-            Some(vec![netuid])
-        );
+        let result =
+            SubtensorModule::get_stake_availability_for_coldkeys(vec![coldkey], Some(vec![netuid]));
         let availability = result.get(&coldkey).unwrap().get(&netuid).unwrap();
 
         assert_eq!(availability.total(), total);
@@ -963,10 +957,8 @@ fn test_stake_availability_for_coldkeys_fully_locked() {
             &coldkey, netuid, &hotkey, total,
         ));
 
-        let result = SubtensorModule::get_stake_availability_for_coldkeys(
-            vec![coldkey],
-            Some(vec![netuid])
-        );
+        let result =
+            SubtensorModule::get_stake_availability_for_coldkeys(vec![coldkey], Some(vec![netuid]));
         let availability = result.get(&coldkey).unwrap().get(&netuid).unwrap();
 
         assert_eq!(availability.total(), total);
@@ -1005,8 +997,7 @@ fn test_stake_availability_for_coldkeys_none_netuids_uses_all_subnets() {
         let hotkey = U256::from(2);
         let netuid = setup_subnet_with_stake(coldkey, hotkey, 100_000_000_000);
 
-        let result =
-            SubtensorModule::get_stake_availability_for_coldkeys(vec![coldkey], None);
+        let result = SubtensorModule::get_stake_availability_for_coldkeys(vec![coldkey], None);
 
         assert_eq!(result.len(), 1);
         assert!(result.get(&coldkey).unwrap().contains_key(&netuid));
@@ -1136,10 +1127,8 @@ fn test_stake_availability_for_coldkeys_rejects_oversized_netuid_list() {
         assert!(result.contains_key(&coldkey));
         assert!(result.get(&coldkey).unwrap().is_empty());
 
-        let result = SubtensorModule::get_stake_availability_for_coldkeys(
-            vec![coldkey],
-            Some(vec![netuid])
-        );
+        let result =
+            SubtensorModule::get_stake_availability_for_coldkeys(vec![coldkey], Some(vec![netuid]));
         assert_eq!(result.get(&coldkey).unwrap().len(), 1);
         assert!(result.get(&coldkey).unwrap().contains_key(&netuid));
     });
@@ -1165,10 +1154,8 @@ fn test_stake_availability_for_coldkeys_uses_rolled_forward_lock() {
 
         step_block(1000);
 
-        let result = SubtensorModule::get_stake_availability_for_coldkeys(
-            vec![coldkey],
-            Some(vec![netuid])
-        );
+        let result =
+            SubtensorModule::get_stake_availability_for_coldkeys(vec![coldkey], Some(vec![netuid]));
         let availability = result.get(&coldkey).unwrap().get(&netuid).unwrap();
         let rolled_locked = SubtensorModule::get_current_locked(&coldkey, netuid);
 

--- a/pallets/subtensor/src/tests/locks.rs
+++ b/pallets/subtensor/src/tests/locks.rs
@@ -888,8 +888,10 @@ fn test_stake_availability_for_coldkeys_filters_empty_rows() {
         let subnet_owner_hotkey = U256::from(1002);
         let netuid = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
 
-        let result =
-            SubtensorModule::get_stake_availability_for_coldkeys(vec![coldkey], Some(vec![netuid]));
+        let result = SubtensorModule::get_stake_availability_for_coldkeys(
+            vec![coldkey],
+            Some(vec![netuid])
+        );
 
         assert_eq!(result.len(), 1);
         assert!(result.contains_key(&coldkey));
@@ -905,8 +907,10 @@ fn test_stake_availability_for_coldkeys_stake_without_lock() {
         let netuid = setup_subnet_with_stake(coldkey, hotkey, 100_000_000_000);
         let total = SubtensorModule::total_coldkey_alpha_on_subnet(&coldkey, netuid);
 
-        let result =
-            SubtensorModule::get_stake_availability_for_coldkeys(vec![coldkey], Some(vec![netuid]));
+        let result = SubtensorModule::get_stake_availability_for_coldkeys(
+            vec![coldkey],
+            Some(vec![netuid])
+        );
 
         assert_eq!(result.len(), 1);
         let availability = result.get(&coldkey).unwrap().get(&netuid).unwrap();
@@ -932,8 +936,10 @@ fn test_stake_availability_for_coldkeys_partial_lock() {
             lock_amount,
         ));
 
-        let result =
-            SubtensorModule::get_stake_availability_for_coldkeys(vec![coldkey], Some(vec![netuid]));
+        let result = SubtensorModule::get_stake_availability_for_coldkeys(
+            vec![coldkey],
+            Some(vec![netuid])
+        );
         let availability = result.get(&coldkey).unwrap().get(&netuid).unwrap();
 
         assert_eq!(availability.total(), total);
@@ -957,8 +963,10 @@ fn test_stake_availability_for_coldkeys_fully_locked() {
             &coldkey, netuid, &hotkey, total,
         ));
 
-        let result =
-            SubtensorModule::get_stake_availability_for_coldkeys(vec![coldkey], Some(vec![netuid]));
+        let result = SubtensorModule::get_stake_availability_for_coldkeys(
+            vec![coldkey],
+            Some(vec![netuid])
+        );
         let availability = result.get(&coldkey).unwrap().get(&netuid).unwrap();
 
         assert_eq!(availability.total(), total);
@@ -997,7 +1005,8 @@ fn test_stake_availability_for_coldkeys_none_netuids_uses_all_subnets() {
         let hotkey = U256::from(2);
         let netuid = setup_subnet_with_stake(coldkey, hotkey, 100_000_000_000);
 
-        let result = SubtensorModule::get_stake_availability_for_coldkeys(vec![coldkey], None);
+        let result =
+            SubtensorModule::get_stake_availability_for_coldkeys(vec![coldkey], None);
 
         assert_eq!(result.len(), 1);
         assert!(result.get(&coldkey).unwrap().contains_key(&netuid));
@@ -1079,6 +1088,64 @@ fn test_stake_availability_for_coldkeys_dedups_netuids() {
 }
 
 #[test]
+fn test_stake_availability_for_coldkeys_skips_nonexistent_netuid() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let netuid = setup_subnet_with_stake(coldkey, hotkey, 100_000_000_000);
+        let nonexistent = subtensor_runtime_common::NetUid::from(99);
+
+        let result = SubtensorModule::get_stake_availability_for_coldkeys(
+            vec![coldkey],
+            Some(vec![nonexistent]),
+        );
+        assert_eq!(result.len(), 1);
+        assert!(result.get(&coldkey).unwrap().is_empty());
+
+        // Mix real + fake requires at least two subnets on chain so len(requested) <= subnet_count.
+        let subnet_owner_coldkey = U256::from(2001);
+        let subnet_owner_hotkey = U256::from(2002);
+        let _other_netuid = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
+
+        let result = SubtensorModule::get_stake_availability_for_coldkeys(
+            vec![coldkey],
+            Some(vec![netuid, nonexistent]),
+        );
+        assert_eq!(result.len(), 1);
+        let subnets = result.get(&coldkey).unwrap();
+        assert_eq!(subnets.len(), 1);
+        assert!(subnets.contains_key(&netuid));
+        assert!(!subnets.contains_key(&nonexistent));
+    });
+}
+
+#[test]
+fn test_stake_availability_for_coldkeys_rejects_oversized_netuid_list() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let netuid = setup_subnet_with_stake(coldkey, hotkey, 100_000_000_000);
+        let subnet_count = SubtensorModule::get_all_subnet_netuids().len();
+        let requested: Vec<subtensor_runtime_common::NetUid> = (0..=subnet_count as u16)
+            .map(subtensor_runtime_common::NetUid::from)
+            .collect();
+
+        let result =
+            SubtensorModule::get_stake_availability_for_coldkeys(vec![coldkey], Some(requested));
+        assert_eq!(result.len(), 1);
+        assert!(result.contains_key(&coldkey));
+        assert!(result.get(&coldkey).unwrap().is_empty());
+
+        let result = SubtensorModule::get_stake_availability_for_coldkeys(
+            vec![coldkey],
+            Some(vec![netuid])
+        );
+        assert_eq!(result.get(&coldkey).unwrap().len(), 1);
+        assert!(result.get(&coldkey).unwrap().contains_key(&netuid));
+    });
+}
+
+#[test]
 fn test_stake_availability_for_coldkeys_uses_rolled_forward_lock() {
     new_test_ext(1).execute_with(|| {
         let coldkey = U256::from(1);
@@ -1098,8 +1165,10 @@ fn test_stake_availability_for_coldkeys_uses_rolled_forward_lock() {
 
         step_block(1000);
 
-        let result =
-            SubtensorModule::get_stake_availability_for_coldkeys(vec![coldkey], Some(vec![netuid]));
+        let result = SubtensorModule::get_stake_availability_for_coldkeys(
+            vec![coldkey],
+            Some(vec![netuid])
+        );
         let availability = result.get(&coldkey).unwrap().get(&netuid).unwrap();
         let rolled_locked = SubtensorModule::get_current_locked(&coldkey, netuid);
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -18,6 +18,7 @@ pub mod transaction_payment_wrapper;
 
 extern crate alloc;
 
+use alloc::collections::BTreeMap;
 use codec::{Compact, Decode, Encode};
 use ethereum::AuthorizationList;
 use frame_support::{
@@ -38,7 +39,7 @@ use pallet_subtensor::rpc_info::{
     metagraph::{Metagraph, SelectiveMetagraph},
     neuron_info::{NeuronInfo, NeuronInfoLite},
     show_subnet::SubnetState,
-    stake_info::StakeInfo,
+    stake_info::{StakeAvailability, StakeInfo},
     subnet_info::{
         SubnetHyperparams, SubnetHyperparamsV2, SubnetHyperparamsV3, SubnetInfo, SubnetInfov2,
     },
@@ -278,7 +279,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 417,
+    spec_version: 418,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,
@@ -2580,6 +2581,10 @@ impl_runtime_apis! {
 
         fn get_stake_info_for_hotkey_coldkey_netuid( hotkey_account: AccountId32, coldkey_account: AccountId32, netuid: NetUid ) -> Option<StakeInfo<AccountId32>> {
             SubtensorModule::get_stake_info_for_hotkey_coldkey_netuid( hotkey_account, coldkey_account, netuid )
+        }
+
+        fn get_stake_availability_for_coldkeys( coldkey_accounts: Vec<AccountId32>, netuids: Option<Vec<NetUid>> ) -> BTreeMap<AccountId32, BTreeMap<NetUid, StakeAvailability>> {
+            SubtensorModule::get_stake_availability_for_coldkeys( coldkey_accounts, netuids )
         }
 
         fn get_stake_fee( origin: Option<(AccountId32, NetUid)>, origin_coldkey_account: AccountId32, destination: Option<(AccountId32, NetUid)>, destination_coldkey_account: AccountId32, amount: u64 ) -> u64 {


### PR DESCRIPTION
## Summary

This PR adds a new `StakeInfoRuntimeApi` method for wallets and SDKs to batch-query how much alpha a coldkey has on each subnet: total stake, locked mass, and what is free to unstake.

It also refactors `available_to_unstake` to use a shared `stake_availability` helper so on-chain checks and the runtime API use the same logic.

## New API

`get_stake_availability_for_coldkeys(coldkey_accounts, netuids) -> BTreeMap<AccountId, BTreeMap<NetUid, StakeAvailability>>`

Each `StakeAvailability` has three fields:
- `total` - all alpha on the subnet across hotkeys
- `locked` - current locked mass (rolled forward)
- `available` - alpha that can be unstaked now

Parameters:
- `netuids: None` scans all subnets
- `netuids: Some(vec)` limits to those subnets (duplicates are deduped)

Response rules:
- Subnets with zero stake and zero lock are omitted
- Coldkeys from the request are always included (inner map may be empty)
- Lock is subnet-wide, not per hotkey

## Other changes

- `spec_version` bumped to `418`
- `StakeAvailability` uses `freeze_struct` for stable client decoding
- No custom RPC endpoint; clients call via `state_call` / runtime API

## App UI

<img width="1716" height="627" alt="image" src="https://github.com/user-attachments/assets/d23fda24-06db-431d-b47c-72fc91704f94" />

## Python usage
```py
{
    "5HGjWaefgnDnVeiFQ3svKqiWNtM1V3wEf3": {
        2: {"total": 1_500_000_000, "locked": 0, "available": 1_500_000_000},
        3: {"total": 800_000_000, "locked": 200_000_000, "available": 600_000_000},
    }
}

stake_availability = result["5HGj..."][2]["available"]
```