### PR TITLE
Use Fireactions runners for self-hosted CI jobs

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   cargo-audit:
     name: cargo audit
-    runs-on: [self-hosted, type-ccx13]
+    runs-on: [self-hosted, fireactions-light]
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-cargo-audit') }}
     steps:
       - name: Check-out repositoroy under $GITHUB_WORKSPACE

--- a/.github/workflows/check-bittensor-e2e-tests.yml
+++ b/.github/workflows/check-bittensor-e2e-tests.yml
@@ -190,7 +190,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: [self-hosted, type-ccx33]
+          - runner: [self-hosted, fireactions-heavy]
             triple: x86_64-unknown-linux-gnu
             arch: amd64
         runtime: ["fast-runtime", "non-fast-runtime"]

--- a/.github/workflows/check-devnet.yml
+++ b/.github/workflows/check-devnet.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   check-spec-version:
     name: Check spec_version bump
-    runs-on: [self-hosted, type-ccx33]
+    runs-on: [self-hosted, fireactions-tryruntime]
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-spec-version-bump') }}
     steps:
       - name: Dependencies

--- a/.github/workflows/check-docker.yml
+++ b/.github/workflows/check-docker.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: [self-hosted, type-ccx33]
+    runs-on: [self-hosted, fireactions-heavy]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/check-finney.yml
+++ b/.github/workflows/check-finney.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   check-spec-version:
     name: Check spec_version bump
-    runs-on: [self-hosted, type-ccx33]
+    runs-on: [self-hosted, fireactions-tryruntime-finney]
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-spec-version-bump') }}
     steps:
       - name: Dependencies

--- a/.github/workflows/check-node-compat.yml
+++ b/.github/workflows/check-node-compat.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   build:
     name: build ${{ matrix.version.name }}
-    runs-on: [self-hosted, type-ccx33]
+    runs-on: [self-hosted, fireactions-heavy]
     if: contains(github.event.pull_request.labels.*.name, 'check-node-compat')
     env:
         RUST_BACKTRACE: full
@@ -60,7 +60,7 @@ jobs:
           
   test:
     needs: [build]
-    runs-on: [self-hosted, type-ccx33]
+    runs-on: [self-hosted, fireactions-heavy]
     steps:
       - name: Download old node binary
         uses: actions/download-artifact@v4

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -23,7 +23,7 @@ jobs:
   # runs cargo fmt
   cargo-fmt:
     name: cargo fmt
-    runs-on: [self-hosted, type-ccx13]
+    runs-on: [self-hosted, fireactions-light]
     env:
       RUST_BACKTRACE: full
     steps:
@@ -67,7 +67,7 @@ jobs:
 
   cargo-clippy-default-features:
     name: cargo clippy
-    runs-on: [self-hosted, type-ccx13]
+    runs-on: [self-hosted, fireactions-light]
     env:
       RUST_BACKTRACE: full
       SKIP_WASM_BUILD: 1
@@ -97,7 +97,7 @@ jobs:
 
   cargo-check-lints:
     name: check custom lints
-    runs-on: [self-hosted, type-ccx13]
+    runs-on: [self-hosted, fireactions-light]
     env:
       RUSTFLAGS: -D warnings
       RUST_BACKTRACE: full
@@ -130,7 +130,7 @@ jobs:
 
   cargo-clippy-all-features:
     name: cargo clippy --all-features
-    runs-on: [self-hosted, type-ccx13]
+    runs-on: [self-hosted, fireactions-light]
     env:
       RUST_BACKTRACE: full
       SKIP_WASM_BUILD: 1
@@ -161,7 +161,7 @@ jobs:
   # runs cargo test --workspace --all-features
   cargo-test:
     name: cargo test
-    runs-on: [self-hosted, type-ccx43]
+    runs-on: [self-hosted, fireactions-heavy]
     env:
       RUST_BACKTRACE: full
       SKIP_WASM_BUILD: 1
@@ -191,7 +191,7 @@ jobs:
   # ensures cargo fix has no trivial changes that can be applied
   cargo-fix:
     name: cargo fix
-    runs-on: [self-hosted, type-ccx13]
+    runs-on: [self-hosted, fireactions-light]
     env:
       RUST_BACKTRACE: full
       SKIP_WASM_BUILD: 1
@@ -230,7 +230,7 @@ jobs:
 
   check-feature-propagation:
     name: zepter run check
-    runs-on: [self-hosted, type-ccx13]
+    runs-on: [self-hosted, fireactions-light]
 
     steps:
       - name: Checkout

--- a/.github/workflows/check-testnet.yml
+++ b/.github/workflows/check-testnet.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   check-spec-version:
     name: Check spec_version bump
-    runs-on: [self-hosted, type-ccx33]
+    runs-on: [self-hosted, fireactions-tryruntime]
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-spec-version-bump') }}
     steps:
       - name: Dependencies

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   run:
-    runs-on: [self-hosted, type-ccx13]
+    runs-on: [self-hosted, fireactions-light]
     env:
       RUST_BACKTRACE: full
     steps:

--- a/.github/workflows/docker-localnet.yml
+++ b/.github/workflows/docker-localnet.yml
@@ -95,7 +95,7 @@ jobs:
       matrix:
         platform:
           # triple names used `in scripts/install_prebuilt_binaries.sh` file
-          - runner: [self-hosted, type-ccx33]
+          - runner: [self-hosted, fireactions-heavy]
             triple: x86_64-unknown-linux-gnu
             arch: amd64
           - runner: [ubuntu-24.04-arm]
@@ -162,7 +162,7 @@ jobs:
   # Collect all artifacts and publish them to docker repo
   docker:
     needs: [setup, artifacts]
-    runs-on: [self-hosted, type-ccx33]
+    runs-on: [self-hosted, fireactions-heavy]
     defaults:
       run:
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: [self-hosted, type-ccx53, type-ccx43, type-ccx33]
+    runs-on: [self-hosted, fireactions-heavy]
 
     steps:
       - name: Determine Docker tag and ref

--- a/.github/workflows/eco-tests.yml
+++ b/.github/workflows/eco-tests.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   eco-tests:
     name: cargo test (eco-tests)
-    runs-on: [self-hosted, type-ccx43]
+    runs-on: [self-hosted, fireactions-heavy]
     env:
       RUST_BACKTRACE: full
       SKIP_WASM_BUILD: 1

--- a/.github/workflows/hotfixes.yml
+++ b/.github/workflows/hotfixes.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   handle-hotfix-pr:
-    runs-on: [self-hosted, type-ccx13]
+    runs-on: [self-hosted, fireactions-light]
     steps:
       - name: Check if PR is a hotfix into `main`
         if: >

--- a/.github/workflows/label-triggers.yml
+++ b/.github/workflows/label-triggers.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   comment_on_breaking_change:
-    runs-on: [self-hosted, type-ccx13]
+    runs-on: [self-hosted, fireactions-light]
     steps:
       - name: Check if 'breaking change' label is added
         if: github.event.label.name == 'breaking-change'

--- a/.github/workflows/require-clean-merges.yml
+++ b/.github/workflows/require-clean-merges.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   assert-clean-merges:
-    runs-on: [self-hosted, type-ccx13]
+    runs-on: [self-hosted, fireactions-light]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/rustdocs.yml
+++ b/.github/workflows/rustdocs.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build:
-    runs-on: [self-hosted, type-ccx13]
+    runs-on: [self-hosted, fireactions-light]
 
     steps:
       - name: Checkout code
@@ -54,7 +54,7 @@ jobs:
 
   deploy:
         needs: build
-        runs-on: [self-hosted, type-ccx13]
+        runs-on: [self-hosted, fireactions-light]
 
         permissions:
             pages: write

--- a/.github/workflows/scheduled-smoke-tests.yml
+++ b/.github/workflows/scheduled-smoke-tests.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   run-smoke-tests:
-    runs-on: [self-hosted, type-ccx33]
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
 
     strategy:
@@ -20,7 +20,9 @@ jobs:
       matrix:
         include:
           - test: smoke_mainnet
+            runner: [self-hosted, fireactions-tryruntime-finney]
           - test: smoke_testnet
+            runner: [self-hosted, fireactions-tryruntime]
 
     name: "smoke-e2e-${{ matrix.test }}"
 

--- a/.github/workflows/try-runtime.yml
+++ b/.github/workflows/try-runtime.yml
@@ -14,7 +14,7 @@ jobs:
   check-devnet:
     name: check devnet
     if: github.base_ref != 'main'
-    runs-on: [self-hosted, type-ccx33]
+    runs-on: [self-hosted, fireactions-tryruntime]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
   check-testnet:
     name: check testnet
     if: github.base_ref != 'main'
-    runs-on: [self-hosted, type-ccx33]
+    runs-on: [self-hosted, fireactions-tryruntime]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -76,7 +76,7 @@ jobs:
   check-finney:
     name: check finney
     # if: github.base_ref == 'testnet' || github.base_ref == 'devnet' || github.base_ref == 'main'
-    runs-on: [self-hosted, type-ccx33]
+    runs-on: [self-hosted, fireactions-tryruntime-finney]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/typescript-e2e.yml
+++ b/.github/workflows/typescript-e2e.yml
@@ -44,7 +44,7 @@ jobs:
 
   # Build the node binary in both variants and share as artifacts.
   build:
-    runs-on: [self-hosted, type-ccx33]
+    runs-on: [self-hosted, fireactions-heavy]
     needs: [typescript-formatting]
     timeout-minutes: 60
     strategy:
@@ -90,7 +90,7 @@ jobs:
 
   run-e2e-tests:
     needs: [build]
-    runs-on: [self-hosted, type-ccx33]
+    runs-on: [self-hosted, fireactions-heavy]
     timeout-minutes: 30
 
     strategy:

--- a/.github/workflows/update-chainspec.yml
+++ b/.github/workflows/update-chainspec.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   update-chainspecs:
-    runs-on: [self-hosted, type-ccx33]
+    runs-on: [self-hosted, fireactions-heavy]
     permissions:
       contents: write
     if: >


### PR DESCRIPTION
## Summary

- replace existing self-hosted Hetzner CCX runner labels with Fireactions labels
- keep GitHub-hosted jobs and plain `Benchmarking` jobs unchanged
- route devnet/testnet checks to `fireactions-tryruntime` and finney/mainnet checks to `fireactions-tryruntime-finney`

## Capacity mapping

| Category | Runner | Current online capacity | Expected peak from this PR |
|---|---:|---:|---:|
| Short/light jobs | `fireactions-light` | 16 | up to 6 from `check-rust`, plus small metadata jobs |
| Long build/test/docker jobs | `fireactions-heavy` | 16 | up to 5 from TypeScript E2E; most others 1-2 |
| Devnet/testnet try-runtime/spec/smoke | `fireactions-tryruntime` | 2 | `try-runtime.yml` can use both |
| Finney/mainnet try-runtime/spec/smoke | `fireactions-tryruntime-finney` | 1 | intentionally single-lane |

## Notes

- `fireactions-mini` is not used.
- `scheduled-smoke-tests.yml` uses `matrix.runner` so `smoke_mainnet` and `smoke_testnet` can target different try-runtime lanes.
- `Benchmarking` remains only in benchmark workflows.

## Validation

- `git grep -n "type-ccx" -- .github/workflows` returned no matches
- `git grep -n "fireactions-mini" -- .github/workflows` returned no matches
- `git grep -n "runs-on: Benchmarking" -- .github/workflows` only returns `apply-benchmark-patch.yml` and `run-benchmarks.yml`
- `git diff --check -- .github/workflows` passed
- `actionlint v1.7.12 .github/workflows/scheduled-smoke-tests.yml` passed
