### PR TITLE
fix pallet_subtensor_swap weight info

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1147,7 +1147,7 @@ impl pallet_subtensor_swap::Config for Runtime {
     type MaxFeeRate = SwapMaxFeeRate;
     type MinimumLiquidity = SwapMinimumLiquidity;
     type MinimumReserve = SwapMinimumReserve;
-    type WeightInfo = pallet_subtensor_swap::weights::DefaultWeight<Runtime>;
+    type WeightInfo = pallet_subtensor_swap::weights::SubstrateWeight<Runtime>;
     #[cfg(feature = "runtime-benchmarks")]
     type BenchmarkHelper = SwapBenchmarkHelper;
 }


### PR DESCRIPTION
## Description

This PR fixes the runtime `WeightInfo` wiring for `pallet_subtensor_swap`.

The runtime previously configured `pallet_subtensor_swap::weights::DefaultWeight<Runtime>`, but the generated swap pallet weights module defines `SubstrateWeight<T>` and the fallback `()` implementation, not `DefaultWeight`. This change updates `runtime/src/lib.rs` to use `pallet_subtensor_swap::weights::SubstrateWeight<Runtime>` so the runtime points at the generated benchmark weight implementation.

Files of interest:

- `runtime/src/lib.rs`: updates the `pallet_subtensor_swap::Config` `WeightInfo` associated type.

Behavioral impact:

- No storage layout, extrinsic logic, origin checks, or economic formulas are changed.
- The swap pallet runtime config now uses the generated swap pallet weight implementation.

Migration / spec_version implications:

- No storage migration is required.
- This touches runtime configuration; the devnet spec-version check should determine whether the existing local `spec_version` already exceeds the live devnet runtime version or needs a bump.

Testing performed:

- Auditor static review verified that `pallets/swap/src/weights.rs` defines `SubstrateWeight<T>` implementing `WeightInfo` and does not define `DefaultWeight<T>`.
- No build or test command was run during review.