### PR TITLE
fix eco test with two deprecated variables

### DIFF
--- a/eco-tests/src/tests_taocom_indexer.rs
+++ b/eco-tests/src/tests_taocom_indexer.rs
@@ -8,7 +8,6 @@
 use pallet_subtensor::rpc_info::delegate_info::DelegateInfo;
 use pallet_subtensor::rpc_info::stake_info::StakeInfo;
 use pallet_subtensor::*;
-use pallet_subtensor_swap as swap;
 use pallet_subtensor_swap_runtime_api::SwapRuntimeApi;
 use share_pool::SafeFloat;
 use sp_core::U256;
@@ -113,8 +112,6 @@ fn indexer_subnet_pool_and_emissions() {
         let _: AlphaBalance = SubnetAlphaOutEmission::<Test>::get(netuid);
         let _: AlphaBalance = PendingValidatorEmission::<Test>::get(netuid);
         let _: AlphaBalance = PendingServerEmission::<Test>::get(netuid);
-
-        let _: U64F64 = swap::AlphaSqrtPrice::<Test>::get(netuid);
     });
 }
 
@@ -165,7 +162,6 @@ fn indexer_step_and_toggles() {
         let _: u64 = LastMechansimStepBlock::<Test>::get(netuid);
         let _: Option<(RateLimitKey<U256>, u64)> = LastRateLimitedBlock::<Test>::iter().next();
         let _: bool = TransferToggle::<Test>::get(netuid);
-        let _: bool = swap::EnabledUserLiquidity::<Test>::get(netuid);
     });
 }
 


### PR DESCRIPTION
## Description
There are two storage AlphaSqrtPrice  and EnabledUserLiquidity  deprecated, remove them from eco test.


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.