### PR TITLE
Beta basket: delegated weight-vector curation for root yield vaults

### DIFF
--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -2517,6 +2517,24 @@ pub mod pallet {
         DefaultZeroAlpha<T>,
     >;
 
+    /// --- MAP ( delegator root uid ) --> manager root uid | delegated basket weight vector.
+    ///
+    /// A root validator can delegate the *choice* of its beta-basket weight vector to another
+    /// root validator (the manager). When set, `distribute_root_alpha_to_basket` reads the
+    /// manager's `Weights[ROOT]` slot instead of the delegator's own, so the manager curates one
+    /// shared vector for all of its delegators. uid-keyed (both sides) to match the vector itself:
+    /// it follows either validator through hotkey swaps with no migration. A stale/reused uid
+    /// resolves to an empty vector (safe recycle); the fee credit is additionally guarded so value
+    /// never lands on a vacant slot.
+    #[pallet::storage]
+    pub type RootWeightDelegate<T: Config> = StorageMap<_, Identity, u16, u16, OptionQuery>;
+
+    /// --- MAP ( manager root uid ) --> take (bps, 0..=10000) | curation fee a manager charges its
+    /// delegators for setting their basket weight vector. Skimmed from each delegator's root
+    /// dividend (in TAO) and credited to the manager's own root stake during distribution.
+    #[pallet::storage]
+    pub type RootWeightTake<T: Config> = StorageMap<_, Identity, u16, u16, ValueQuery>;
+
     #[pallet::storage] // -- MAP ( cold ) --> root_claim_type enum
     pub type RootClaimType<T: Config> = StorageMap<
         _,

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -117,6 +117,34 @@ mod dispatches {
             Self::do_set_root_weights(origin, dests, weights, version_key)
         }
 
+        /// --- Delegates this root validator's beta-basket weight vector to `manager` (another
+        /// root validator), or clears the delegation by passing the caller's own hotkey. While
+        /// delegated, the manager's vector and curation take apply to this validator's basket.
+        ///
+        /// # Args:
+        /// * `origin`: the delegator root validator hotkey.
+        /// * `manager` (T::AccountId): the manager's root validator hotkey (self = clear).
+        #[pallet::call_index(140)]
+        #[pallet::weight((<T as crate::pallet::Config>::WeightInfo::set_childkey_take(), DispatchClass::Normal, Pays::Yes))]
+        pub fn set_root_weight_delegate(
+            origin: OriginFor<T>,
+            manager: T::AccountId,
+        ) -> DispatchResult {
+            Self::do_set_root_weight_delegate(origin, manager)
+        }
+
+        /// --- Sets the curation take (basis points) this root validator charges its
+        /// weight-vector delegators. Bounded by the childkey-take ceiling; `0` curates for free.
+        ///
+        /// # Args:
+        /// * `origin`: the manager root validator hotkey.
+        /// * `take` (u16): the take in basis points (0..=10000, capped at the childkey-take max).
+        #[pallet::call_index(141)]
+        #[pallet::weight((<T as crate::pallet::Config>::WeightInfo::set_childkey_take(), DispatchClass::Normal, Pays::Yes))]
+        pub fn set_root_weight_take(origin: OriginFor<T>, take: u16) -> DispatchResult {
+            Self::do_set_root_weight_take(origin, take)
+        }
+
         /// --- Sets the caller weights for the incentive mechanism for mechanisms. The call
         /// can be made from the hotkey account so is potentially insecure, however, the damage
         /// of changing weights is minimal if caught early. This function includes all the

--- a/pallets/subtensor/src/macros/errors.rs
+++ b/pallets/subtensor/src/macros/errors.rs
@@ -165,6 +165,10 @@ mod errors {
         NewColdKeyIsHotkey,
         /// Childkey take is invalid.
         InvalidChildkeyTake,
+        /// Root-weight delegation curation take is invalid (exceeds the max).
+        InvalidRootWeightTake,
+        /// Root-weight curation take increase rate limit exceeded.
+        TxRootWeightTakeRateLimitExceeded,
         /// Childkey take rate limit exceeded.
         TxChildkeyTakeRateLimitExceeded,
         /// Invalid identity.

--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -44,6 +44,11 @@ mod events {
         WeightsSet(NetUidStorageIndex, u16),
         /// a root validator set its beta-basket distribution vector (uid on the root subnet).
         RootWeightsSet(u16),
+        /// a root validator delegated its basket weight vector to a manager (or cleared it by
+        /// delegating to itself). Fields: (delegator_uid, manager_uid); equal uids = cleared.
+        RootWeightDelegateSet(u16, u16),
+        /// a manager set the curation take it charges delegators. Fields: (manager_uid, take_bps).
+        RootWeightTakeSet(u16, u16),
         /// a new neuron account has been registered to the chain.
         NeuronRegistered(NetUid, u16, T::AccountId),
         /// multiple uids have been concurrently registered.

--- a/pallets/subtensor/src/staking/claim_root.rs
+++ b/pallets/subtensor/src/staking/claim_root.rs
@@ -89,9 +89,13 @@ impl<T: Config> Pallet<T> {
 
         // Resolve the validator's basket weight vector w = Weights[ROOT][uid]. The vector follows
         // the validator's root uid (so it survives hotkey swaps automatically) and reuses the
-        // existing root weights plumbing.
+        // existing root weights plumbing. If the validator has delegated weight-setting to a
+        // manager, follow that pointer and use the manager's vector instead; the manager's
+        // `RootWeightTake` is skimmed as a curation fee below.
         let maybe_uid = Uids::<T>::try_get(NetUid::ROOT, hotkey).ok();
-        let weights = maybe_uid
+        let manager_uid: Option<u16> = maybe_uid.and_then(|uid| RootWeightDelegate::<T>::get(uid));
+        let vector_uid: Option<u16> = manager_uid.or(maybe_uid);
+        let weights = vector_uid
             .map(|uid| Weights::<T>::get(NetUidStorageIndex::ROOT, uid))
             .unwrap_or_default();
 
@@ -136,7 +140,31 @@ impl<T: Config> Pallet<T> {
             Self::record_protocol_outflow(origin_netuid, tao_total);
 
             // 2. Split the TAO across subnets per w and buy each subnet's alpha.
-            let tao_total_u64: u64 = tao_total.to_u64();
+            let mut tao_total_u64: u64 = tao_total.to_u64();
+
+            // 2a. If this dividend follows a manager's vector, skim the manager's curation take
+            // (bps) from the TAO and credit it to the manager's own root stake. Keeps the round
+            // trip TotalStake-neutral: sell - buys - fee == 0. The buy loop below redeploys only
+            // the post-fee remainder. Guarded by `Keys::try_get` so a stale/vacant manager uid is
+            // never credited (the remainder simply stays with the delegator's basket).
+            if let Some(m_uid) = manager_uid {
+                let take: u16 = RootWeightTake::<T>::get(m_uid);
+                if take > 0 {
+                    if let Ok(manager_hotkey) = Keys::<T>::try_get(NetUid::ROOT, m_uid) {
+                        let fee: u64 = U96F32::saturating_from_num(tao_total_u64)
+                            .saturating_mul(U96F32::saturating_from_num(take))
+                            .checked_div(U96F32::saturating_from_num(10_000u64))
+                            .unwrap_or_default()
+                            .saturating_to_num::<u64>();
+                        if fee > 0 {
+                            let manager_owner = Owner::<T>::get(&manager_hotkey);
+                            Self::credit_root_stake(&manager_hotkey, &manager_owner, fee.into());
+                            tao_total_u64 = tao_total_u64.saturating_sub(fee);
+                        }
+                    }
+                }
+            }
+
             let mut spent: u64 = 0;
             let last_idx = valid.len().saturating_sub(1);
             for (i, (dest_netuid, weight)) in valid.iter().enumerate() {
@@ -275,6 +303,24 @@ impl<T: Config> Pallet<T> {
         owed
     }
 
+    /// Credits `tao` of already-existing TAO as root stake to `(hotkey, coldkey)` and updates the
+    /// root pool totals (SubnetTAO / SubnetAlphaOut / TotalStake; root is 1:1 TAO:alpha). Shared
+    /// by the root-claim payout and the manager curation-fee path. Moves value that already left a
+    /// subnet pool (no mint), so the caller is responsible for the matching outflow record.
+    pub fn credit_root_stake(hotkey: &T::AccountId, coldkey: &T::AccountId, tao: TaoBalance) {
+        Self::increase_stake_for_hotkey_and_coldkey_on_subnet(
+            hotkey,
+            coldkey,
+            NetUid::ROOT,
+            tao.to_u64().into(),
+        );
+        SubnetTAO::<T>::mutate(NetUid::ROOT, |total| *total = total.saturating_add(tao.into()));
+        SubnetAlphaOut::<T>::mutate(NetUid::ROOT, |total| {
+            *total = total.saturating_add(u64::from(tao).into())
+        });
+        TotalStake::<T>::mutate(|total| *total = total.saturating_add(tao.into()));
+    }
+
     pub fn get_root_owed_for_hotkey_coldkey(
         hotkey: &T::AccountId,
         coldkey: &T::AccountId,
@@ -392,27 +438,8 @@ impl<T: Config> Pallet<T> {
             });
             Self::record_protocol_outflow(netuid, root_sell_tao);
 
-            Self::increase_stake_for_hotkey_and_coldkey_on_subnet(
-                hotkey,
-                coldkey,
-                NetUid::ROOT,
-                owed_tao.amount_paid_out.to_u64().into(),
-            );
-
-            // Increase root subnet SubnetTAO
-            SubnetTAO::<T>::mutate(NetUid::ROOT, |total| {
-                *total = total.saturating_add(owed_tao.amount_paid_out.into());
-            });
-
-            // Increase root SubnetAlphaOut
-            SubnetAlphaOut::<T>::mutate(NetUid::ROOT, |total| {
-                *total = total.saturating_add(u64::from(owed_tao.amount_paid_out).into());
-            });
-
-            // Increase Total Stake
-            TotalStake::<T>::mutate(|total| {
-                *total = total.saturating_add(owed_tao.amount_paid_out.into());
-            });
+            // Credit the realized TAO as root stake to the claimer and update the root pool.
+            Self::credit_root_stake(hotkey, coldkey, owed_tao.amount_paid_out);
 
             Self::add_stake_adjust_root_claimed_for_hotkey_and_coldkey(
                 hotkey,

--- a/pallets/subtensor/src/subnets/weights.rs
+++ b/pallets/subtensor/src/subnets/weights.rs
@@ -1010,6 +1010,73 @@ impl<T: Config> Pallet<T> {
         Ok(())
     }
 
+    /// Delegates (or clears) a root validator's beta-basket weight vector to a `manager` root
+    /// validator. While delegated, `distribute_root_alpha_to_basket` resolves the delegator's
+    /// vector from the manager's `Weights[ROOT]` slot and skims the manager's `RootWeightTake`.
+    /// Delegating to oneself clears the delegation (self-manage).
+    pub fn do_set_root_weight_delegate(
+        origin: OriginFor<T>,
+        manager: T::AccountId,
+    ) -> dispatch::DispatchResult {
+        // --- 1. Signed by the delegator root validator hotkey.
+        let hotkey = ensure_signed(origin)?;
+
+        // --- 2. Delegator must be a registered root validator.
+        let delegator_uid = Self::get_uid_for_net_and_hotkey(NetUid::ROOT, &hotkey)?;
+
+        // --- 3. Self-delegation clears the pointer; otherwise the manager must also be a
+        // registered root validator.
+        if manager == hotkey {
+            RootWeightDelegate::<T>::remove(delegator_uid);
+            Self::deposit_event(Event::RootWeightDelegateSet(delegator_uid, delegator_uid));
+        } else {
+            let manager_uid = Self::get_uid_for_net_and_hotkey(NetUid::ROOT, &manager)?;
+            RootWeightDelegate::<T>::insert(delegator_uid, manager_uid);
+            Self::deposit_event(Event::RootWeightDelegateSet(delegator_uid, manager_uid));
+        }
+
+        Ok(())
+    }
+
+    /// Sets the curation take (basis points, `0..=MaxChildkeyTake`) a manager root validator
+    /// charges its delegators. `0` lets a manager curate for free. Bounded by the same ceiling as
+    /// childkey take.
+    pub fn do_set_root_weight_take(origin: OriginFor<T>, take: u16) -> dispatch::DispatchResult {
+        // --- 1. Signed by the manager root validator hotkey.
+        let hotkey = ensure_signed(origin)?;
+
+        // --- 2. Manager must be a registered root validator.
+        let manager_uid = Self::get_uid_for_net_and_hotkey(NetUid::ROOT, &hotkey)?;
+
+        // --- 3. Take must be within the allowed ceiling.
+        ensure!(
+            take <= Self::get_max_childkey_take(),
+            Error::<T>::InvalidRootWeightTake
+        );
+
+        // --- 4. Rate-limit *increases* only (same window as childkey take), so a manager cannot
+        // spike its take on already-committed delegators between their per-block distributions.
+        // Lowering the take is always allowed.
+        let current_block = Self::get_current_block_as_u64();
+        if take > RootWeightTake::<T>::get(manager_uid) {
+            ensure!(
+                TransactionType::SetRootWeightTake
+                    .passes_rate_limit_on_subnet::<T>(&hotkey, NetUid::ROOT),
+                Error::<T>::TxRootWeightTakeRateLimitExceeded
+            );
+        }
+
+        RootWeightTake::<T>::insert(manager_uid, take);
+        TransactionType::SetRootWeightTake.set_last_block_on_subnet::<T>(
+            &hotkey,
+            NetUid::ROOT,
+            current_block,
+        );
+        Self::deposit_event(Event::RootWeightTakeSet(manager_uid, take));
+
+        Ok(())
+    }
+
     /// ---- The implementation for the extrinsic set_weights.
     ///
     /// # Args:

--- a/pallets/subtensor/src/tests/claim_root.rs
+++ b/pallets/subtensor/src/tests/claim_root.rs
@@ -4,9 +4,9 @@ use crate::tests::mock::*;
 use crate::{
     BasketPrincipal, DefaultMinRootClaimAmount, Error, Keys, MAX_NUM_ROOT_CLAIMS,
     MAX_ROOT_CLAIM_THRESHOLD, NetworksAdded, NumRootClaim, NumStakingColdkeys, RootClaimType,
-    RootClaimTypeEnum, RootClaimable, RootClaimableThreshold, RootClaimed, StakingColdkeys,
-    StakingColdkeysByIndex, SubnetAlphaIn, SubnetMovingPrice, SubnetProtocolFlow, SubnetTAO,
-    SubnetworkN, Tempo, TotalStake, Uids, Weights,
+    RootClaimTypeEnum, RootClaimable, RootClaimableThreshold, RootClaimed, RootWeightDelegate,
+    RootWeightTake, StakingColdkeys, StakingColdkeysByIndex, SubnetAlphaIn, SubnetMovingPrice,
+    SubnetProtocolFlow, SubnetTAO, SubnetworkN, Tempo, TotalStake, Uids, Weights,
 };
 use approx::assert_abs_diff_eq;
 use frame_support::dispatch::RawOrigin;
@@ -513,6 +513,103 @@ fn test_root_basket_records_symmetric_protocol_flow() {
         assert!(
             flow_c_after.abs() < flow_c,
             "round-trip residual on C should be smaller than the inflow: {flow_c_after} vs {flow_c}"
+        );
+    });
+}
+
+/// A root validator (the delegator) that sets no vector of its own but points at a manager via
+/// `RootWeightDelegate` has its dividend deployed per the *manager's* vector, and the manager's
+/// `RootWeightTake` is skimmed as a curation fee credited to the manager's own root stake.
+#[test]
+fn test_root_weight_delegation_uses_manager_vector_and_pays_take() {
+    new_test_ext(1).execute_with(|| {
+        // Manager (curator): owns the shared vector + take. Delegator: earns the dividend.
+        let owner_m = U256::from(1001);
+        let hotkey_m = U256::from(1002);
+        let owner_a = U256::from(2001);
+        let hotkey_a = U256::from(2002);
+        let coldkey_a = U256::from(2003);
+        let owner_b = U256::from(3001);
+        let hotkey_b = U256::from(3002);
+
+        // netuid_a = where the delegator earns its root dividend; netuid_b = manager's basket pick.
+        let netuid_a = add_dynamic_network(&hotkey_a, &owner_a);
+        let netuid_b = add_dynamic_network(&hotkey_b, &owner_b);
+        // Give the manager an Owner mapping (for the fee credit) via a throwaway registration.
+        add_dynamic_network(&hotkey_m, &owner_m);
+        remove_owner_registration_stake(netuid_a);
+        fund_pool(netuid_a);
+        fund_pool(netuid_b);
+
+        SubtensorModule::set_tao_weight(u64::MAX);
+        RootClaimableThreshold::<Test>::insert(netuid_b, I96F32::from_num(0));
+
+        // Manager root uid 0 with a vector pointing 100% at B; Keys[ROOT][0] for the fee credit.
+        set_root_weights_direct(&hotkey_m, 0, &[(netuid_b, u16::MAX)]);
+        Keys::<Test>::insert(NetUid::ROOT, 0u16, hotkey_m);
+
+        // Delegator root uid 1 with NO vector of its own — it relies on the manager.
+        Uids::<Test>::insert(NetUid::ROOT, hotkey_a, 1u16);
+        RootWeightDelegate::<Test>::insert(1u16, 0u16); // delegator -> manager
+        RootWeightTake::<Test>::insert(0u16, 1000u16); // manager charges 10%
+
+        // Delegator needs root stake to apportion against, and alpha on A to earn the dividend.
+        mock_increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey_a,
+            &coldkey_a,
+            NetUid::ROOT,
+            2_000_000u64.into(),
+        );
+        mock_increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey_a,
+            &owner_a,
+            netuid_a,
+            10_000_000u64.into(),
+        );
+
+        // Manager starts with no root stake — the fee must create it.
+        assert_eq!(root_stake_of(&hotkey_m, &owner_m), 0);
+
+        SubtensorModule::distribute_emission(
+            netuid_a,
+            AlphaBalance::ZERO,
+            AlphaBalance::ZERO,
+            1_000_000u64.into(),
+            AlphaBalance::ZERO,
+        );
+
+        // The delegator's basket was built on B (the manager's pick), not on A or nowhere.
+        let basket_b = escrow_alpha(&hotkey_a, netuid_b);
+        assert!(basket_b > 0, "delegator basket should follow manager's vector into B");
+        assert_eq!(
+            escrow_alpha(&hotkey_a, netuid_a),
+            0,
+            "nothing should land on the origin subnet"
+        );
+
+        // The manager received the curation fee as its own root stake.
+        let fee = root_stake_of(&hotkey_m, &owner_m);
+        assert!(fee > 0, "manager should receive the curation take");
+
+        // The split is take-proportioned and independent of any validator take: with a 10% fee,
+        // the basket (~90% of gross, at pool price ~1) is ~9x the fee.
+        assert_abs_diff_eq!(basket_b as i64, fee as i64 * 9, epsilon = (fee as i64) / 20);
+
+        // With the take cleared, no fee would be charged — sanity that the fee is driven by the
+        // take alone.
+        RootWeightTake::<Test>::insert(0u16, 0u16);
+        let fee_before = root_stake_of(&hotkey_m, &owner_m);
+        SubtensorModule::distribute_emission(
+            netuid_a,
+            AlphaBalance::ZERO,
+            AlphaBalance::ZERO,
+            1_000_000u64.into(),
+            AlphaBalance::ZERO,
+        );
+        assert_eq!(
+            root_stake_of(&hotkey_m, &owner_m),
+            fee_before,
+            "no take => no fee on the second distribution"
         );
     });
 }

--- a/pallets/subtensor/src/utils/rate_limiting.rs
+++ b/pallets/subtensor/src/utils/rate_limiting.rs
@@ -17,6 +17,7 @@ pub enum TransactionType {
     MechanismEmission,
     MaxUidsTrimming,
     AddStakeBurn,
+    SetRootWeightTake,
 }
 
 impl TransactionType {
@@ -25,6 +26,8 @@ impl TransactionType {
         match self {
             Self::SetChildren => 150, // 30 minutes
             Self::SetChildkeyTake => TxChildkeyTakeRateLimit::<T>::get(),
+            // Root-weight curation take reuses the childkey-take rate window.
+            Self::SetRootWeightTake => TxChildkeyTakeRateLimit::<T>::get(),
             Self::RegisterNetwork => NetworkRateLimit::<T>::get(),
             Self::MechanismCountUpdate => MechanismCountSetRateLimit::<T>::get(),
             Self::MechanismEmission => MechanismEmissionRateLimit::<T>::get(),
@@ -144,6 +147,7 @@ impl From<TransactionType> for u16 {
             TransactionType::MechanismEmission => 8,
             TransactionType::MaxUidsTrimming => 9,
             TransactionType::AddStakeBurn => 10,
+            TransactionType::SetRootWeightTake => 11,
         }
     }
 }
@@ -162,6 +166,7 @@ impl From<u16> for TransactionType {
             8 => TransactionType::MechanismEmission,
             9 => TransactionType::MaxUidsTrimming,
             10 => TransactionType::AddStakeBurn,
+            11 => TransactionType::SetRootWeightTake,
             _ => TransactionType::Unknown,
         }
     }


### PR DESCRIPTION
## Summary

Root Reborn turns each root validator into an on chain yield vault curator: validators set a basket weight vector and their stakers' root dividends compound into it. This PR adds **delegated curation** so a root validator can hand the *choice* of its weight vector to another root validator (a "manager") and pay a take for the service.

It rides almost entirely on the existing root-weights machinery. The net new surface is two storage maps, two extrinsics, and one redirected lookup in the distribution path.

## Mechanism

- **`RootWeightDelegate` (delegator uid → manager uid)** — a pointer, not a copy. When set, `distribute_root_alpha_to_basket` resolves the vector from the manager's existing `Weights[ROOT]` slot instead of the delegator's own. The manager curates one vector (via the existing `set_root_weights`) and every delegator reprices the next block. uid-keyed, so it follows either validator through hotkey swaps with no migration.
- **`RootWeightTake` (manager uid → bps)** — the curation fee. Bounded by the childkey-take ceiling and rate-limited on *increases* (reusing the childkey-take window) so a manager can't spike its take on already-committed delegators between their per-block distributions. Lowering is always allowed.
- **Fee flow** — skimmed from the delegator's dividend in TAO after the origin sell, and credited to the manager's own root stake. The round trip stays TotalStake-neutral: `sell − buys − fee == 0`. Guarded by `Keys::try_get` so the fee never lands on a vacant uid.
- **Extrinsics** — `set_root_weight_delegate(manager)` (self = clear) and `set_root_weight_take(take)`. Extracts `credit_root_stake`, now shared with the root-claim payout.

## Tests

`test_root_weight_delegation_uses_manager_vector_and_pays_take`: a delegator with no vector of its own follows the manager's vector into the manager's chosen subnet, the manager receives the take as root stake, the split is take-proportioned, and clearing the take stops the fee. The existing basket distribution/claim tests still pass, covering the shared `credit_root_stake` refactor.

## Follow-ups (not blocking review)

- **Self-deal / slippage guards on `w` matter more here than in base Root Reborn.** A manager now deploys *other* validators' stakers' capital, so a vector pointed at a manager-held subnet pumps its own bag with delegated funds. Best resolved together with the existing "slippage/self-deal guards on w" follow-up.
- Real benchmarked weights — the two setters currently reuse `set_childkey_take`'s weight.
- Clear `RootWeightDelegate` / `RootWeightTake` on root uid reassignment, alongside the existing `Weights[ROOT]` uid-reuse follow-up.
- one weight vector basket per root validator delegate. a root validator can simultaneously manage multiple independent weight vectors, delegated by other root validators.  