### PR TITLE
Fixed dev tests

### DIFF
--- a/.github/workflows/typescript-e2e.yml
+++ b/.github/workflows/typescript-e2e.yml
@@ -137,7 +137,13 @@ jobs:
         working-directory: ts-tests
         run: pnpm install --frozen-lockfile
 
+      - name: Install lsof (dev foundation RPC port discovery)
+        if: matrix.test == 'dev'
+        run: |
+          sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y --no-install-recommends lsof
+
       - name: Run tests
-        run: | 
+        run: |
           cd ts-tests
           pnpm moonwall test ${{ matrix.test }}

--- a/ts-tests/moonwall.config.json
+++ b/ts-tests/moonwall.config.json
@@ -12,7 +12,7 @@
                 "suites/dev"
             ],
             "runScripts": [],
-            "multiThreads": false,
+            "multiThreads": true,
             "reporters": ["basic"],
             "foundation": {
                 "type": "dev",


### PR DESCRIPTION
## Description
https://github.com/opentensor/subtensor/pull/2748 broke dev tests, because it doesn't have `lsof`, but this is required by moonwall. 


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.