### PR TITLE
Default subnet emission off on registration

### DIFF
--- a/pallets/subtensor/src/subnets/subnet.rs
+++ b/pallets/subtensor/src/subnets/subnet.rs
@@ -287,6 +287,9 @@ impl<T: Config> Pallet<T> {
         log::info!("NetworkAdded( netuid:{netuid_to_register:?}, mechanism:{mechid:?} )");
         Self::deposit_event(Event::NetworkAdded(netuid_to_register, mechid));
 
+        // --- 20. Default emission off
+        SubnetEmissionEnabled::<T>::insert(netuid_to_register, false);
+
         // --- 20. Return success.
         Ok(())
     }

--- a/pallets/subtensor/src/tests/coinbase.rs
+++ b/pallets/subtensor/src/tests/coinbase.rs
@@ -83,6 +83,8 @@ fn test_coinbase_tao_issuance_base() {
         let subnet_owner_ck = U256::from(1001);
         let subnet_owner_hk = U256::from(1002);
         let netuid = add_dynamic_network(&subnet_owner_hk, &subnet_owner_ck);
+        // Dynamic subnets register with emission disabled by default.
+        SubnetEmissionEnabled::<Test>::insert(netuid, true);
         // Price-based emission shares require a non-zero moving price.
         SubnetMovingPrice::<Test>::insert(netuid, I96F32::from_num(1));
         // Keep root_proportion ~1 so the injection cap does not bind.
@@ -2955,6 +2957,8 @@ fn test_coinbase_v3_liquidity_update() {
         // Enable emissions and run coinbase (which will increase position liquidity)
         let emission: u64 = 1_234_567;
         let emission_credit = SubtensorModule::mint_tao(emission.into());
+        // Dynamic subnets register with emission disabled by default.
+        SubnetEmissionEnabled::<Test>::insert(netuid, true);
         // Price-based emission shares require a non-zero moving price.
         SubnetMovingPrice::<Test>::insert(netuid, I96F32::from_num(1));
         // Keep root_proportion ~1 so the injection cap does not bind.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -277,7 +277,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 421,
+    spec_version: 422,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Summary
- New subnets registered via `do_register_network` now start with `SubnetEmissionEnabled` set to `false`, so pool-side emission must be explicitly enabled instead of relying on the `DefaultTrue` storage value.
- Subnets created through `init_new_network` (e.g. the `add_network` test helper) are unaffected, as that path still sets emission to `true`.
- Updated the two coinbase tests that register a dynamic network and expect emission to be on (`test_coinbase_tao_issuance_base`, `test_coinbase_v3_liquidity_update`) to enable emission explicitly.

## Test plan
- `cargo test -p pallet-subtensor --lib` (previously 2 failures, now green)
- `cargo test -p pallet-admin-utils -p subtensor-chain-extensions -p subtensor-transaction-fee --lib`

Made with [Cursor](https://cursor.com)