### PR TITLE
Re-add Swap::AlphaSqrtPrice for backwards compatibility; bump spec to…

### DIFF
--- a/pallets/swap/src/pallet/impls.rs
+++ b/pallets/swap/src/pallet/impls.rs
@@ -34,18 +34,26 @@ impl<T: Config> Pallet<T> {
         }
     }
 
-    /// Refresh the backwards-compatibility `AlphaSqrtPrice` storage for a subnet.
+    /// Store `sqrt(price)` into the backwards-compatibility `AlphaSqrtPrice` map for a subnet.
     ///
     /// The balancer derives price on the fly, but external consumers still read the legacy
-    /// `Swap::AlphaSqrtPrice` map directly. Call this whenever the price may have changed
-    /// (swaps, protocol-liquidity adjustments, initialization) to keep that map in sync.
-    pub(crate) fn refresh_alpha_sqrt_price(netuid: NetUid) {
-        let price = Self::current_price(netuid);
+    /// `Swap::AlphaSqrtPrice` map directly, so we mirror the price wherever it changes:
+    /// initialization, protocol-liquidity adjustment (emission), and each swap. The price is
+    /// passed in rather than re-read from reserves because a swap commits its reserve deltas in
+    /// the caller (outside this pallet) — at swap time we use the swap step's computed
+    /// post-swap price instead.
+    pub(crate) fn store_alpha_sqrt_price(netuid: NetUid, price: U64F64) {
         // Epsilon for the bisection sqrt: 1e-9 is well below the price precision consumers need.
         let epsilon =
             U64F64::saturating_from_num(1).safe_div(U64F64::saturating_from_num(1_000_000_000_u64));
         let sqrt_price = price.checked_sqrt(epsilon).unwrap_or_default();
         AlphaSqrtPrice::<T>::insert(netuid, sqrt_price);
+    }
+
+    /// Refresh `AlphaSqrtPrice` from the current derived price. Safe to call where reserves are
+    /// already up to date (initialization, emission) — not on the swap path.
+    pub(crate) fn refresh_alpha_sqrt_price(netuid: NetUid) {
+        Self::store_alpha_sqrt_price(netuid, Self::current_price(netuid));
     }
 
     // initializes pal-swap (balancer) for a subnet if needed
@@ -90,7 +98,7 @@ impl<T: Config> Pallet<T> {
 
         PalSwapInitialized::<T>::insert(netuid, true);
 
-        // Keep the legacy AlphaSqrtPrice map in sync for backwards compatibility.
+        // Seed the legacy AlphaSqrtPrice mirror for backwards compatibility.
         Self::refresh_alpha_sqrt_price(netuid);
 
         Ok(())
@@ -129,7 +137,8 @@ impl<T: Config> Pallet<T> {
             (TaoBalance::ZERO, AlphaBalance::ZERO)
         } else {
             SwapBalancer::<T>::insert(netuid, balancer);
-            // Keep the legacy AlphaSqrtPrice map in sync for backwards compatibility.
+            // Emission changed reserves/weights; refresh the legacy AlphaSqrtPrice mirror.
+            // Reserves are already committed here, so deriving from current_price is correct.
             Self::refresh_alpha_sqrt_price(netuid);
             (tao_delta, alpha_delta)
         }
@@ -237,9 +246,11 @@ impl<T: Config> Pallet<T> {
         log::trace!("Fees: {}", swap_result.fee_paid);
         log::trace!("======== End Swap ========");
 
-        // Keep the legacy AlphaSqrtPrice map in sync for backwards compatibility. This runs
-        // inside the swap's transactional scope, so it is rolled back on simulation.
-        Self::refresh_alpha_sqrt_price(netuid);
+        // Mirror the post-swap price into the legacy AlphaSqrtPrice map for backwards
+        // compatibility. We use the swap step's computed final price because the reserve deltas
+        // are applied by the caller (outside this pallet) and aren't visible yet. This runs in
+        // the swap's transactional scope, so it is rolled back on simulated swaps.
+        Self::store_alpha_sqrt_price(netuid, swap_result.final_price);
 
         Ok(SwapResult {
             amount_paid_in: swap_result.delta_in,

--- a/pallets/swap/src/pallet/impls.rs
+++ b/pallets/swap/src/pallet/impls.rs
@@ -42,8 +42,8 @@ impl<T: Config> Pallet<T> {
     pub(crate) fn refresh_alpha_sqrt_price(netuid: NetUid) {
         let price = Self::current_price(netuid);
         // Epsilon for the bisection sqrt: 1e-9 is well below the price precision consumers need.
-        let epsilon = U64F64::saturating_from_num(1)
-            .safe_div(U64F64::saturating_from_num(1_000_000_000_u64));
+        let epsilon =
+            U64F64::saturating_from_num(1).safe_div(U64F64::saturating_from_num(1_000_000_000_u64));
         let sqrt_price = price.checked_sqrt(epsilon).unwrap_or_default();
         AlphaSqrtPrice::<T>::insert(netuid, sqrt_price);
     }

--- a/pallets/swap/src/pallet/impls.rs
+++ b/pallets/swap/src/pallet/impls.rs
@@ -34,6 +34,20 @@ impl<T: Config> Pallet<T> {
         }
     }
 
+    /// Refresh the backwards-compatibility `AlphaSqrtPrice` storage for a subnet.
+    ///
+    /// The balancer derives price on the fly, but external consumers still read the legacy
+    /// `Swap::AlphaSqrtPrice` map directly. Call this whenever the price may have changed
+    /// (swaps, protocol-liquidity adjustments, initialization) to keep that map in sync.
+    pub(crate) fn refresh_alpha_sqrt_price(netuid: NetUid) {
+        let price = Self::current_price(netuid);
+        // Epsilon for the bisection sqrt: 1e-9 is well below the price precision consumers need.
+        let epsilon = U64F64::saturating_from_num(1)
+            .safe_div(U64F64::saturating_from_num(1_000_000_000_u64));
+        let sqrt_price = price.checked_sqrt(epsilon).unwrap_or_default();
+        AlphaSqrtPrice::<T>::insert(netuid, sqrt_price);
+    }
+
     // initializes pal-swap (balancer) for a subnet if needed
     pub fn maybe_initialize_palswap(
         netuid: NetUid,
@@ -76,6 +90,9 @@ impl<T: Config> Pallet<T> {
 
         PalSwapInitialized::<T>::insert(netuid, true);
 
+        // Keep the legacy AlphaSqrtPrice map in sync for backwards compatibility.
+        Self::refresh_alpha_sqrt_price(netuid);
+
         Ok(())
     }
 
@@ -112,6 +129,8 @@ impl<T: Config> Pallet<T> {
             (TaoBalance::ZERO, AlphaBalance::ZERO)
         } else {
             SwapBalancer::<T>::insert(netuid, balancer);
+            // Keep the legacy AlphaSqrtPrice map in sync for backwards compatibility.
+            Self::refresh_alpha_sqrt_price(netuid);
             (tao_delta, alpha_delta)
         }
     }
@@ -218,6 +237,10 @@ impl<T: Config> Pallet<T> {
         log::trace!("Fees: {}", swap_result.fee_paid);
         log::trace!("======== End Swap ========");
 
+        // Keep the legacy AlphaSqrtPrice map in sync for backwards compatibility. This runs
+        // inside the swap's transactional scope, so it is rolled back on simulation.
+        Self::refresh_alpha_sqrt_price(netuid);
+
         Ok(SwapResult {
             amount_paid_in: swap_result.delta_in,
             amount_paid_out: swap_result.delta_out,
@@ -276,6 +299,7 @@ impl<T: Config> Pallet<T> {
 
         FeeRate::<T>::remove(netuid);
         SwapBalancer::<T>::remove(netuid);
+        AlphaSqrtPrice::<T>::remove(netuid);
 
         log::debug!(
             "clear_protocol_liquidity: netuid={netuid:?}, protocol_burned: τ={burned_tao:?}, α={burned_alpha:?}; state cleared"

--- a/pallets/swap/src/pallet/migrations/migrate_swapv3_to_balancer.rs
+++ b/pallets/swap/src/pallet/migrations/migrate_swapv3_to_balancer.rs
@@ -2,14 +2,9 @@ use super::*;
 use crate::HasMigrationRun;
 use frame_support::{storage_alias, traits::Get, weights::Weight};
 use scale_info::prelude::string::String;
-use substrate_fixed::types::U64F64;
 
 pub mod deprecated_swap_maps {
     use super::*;
-
-    #[storage_alias]
-    pub type AlphaSqrtPrice<T: Config> =
-        StorageMap<Pallet<T>, Twox64Concat, NetUid, U64F64, ValueQuery>;
 
     /// TAO reservoir for scraps of protocol claimed fees.
     #[storage_alias]
@@ -42,7 +37,10 @@ pub fn migrate_swapv3_to_balancer<T: Config>() -> Weight {
     // ------------------------------
     // Step 1: Initialize swaps with price before price removal
     // ------------------------------
-    for (netuid, price_sqrt) in deprecated_swap_maps::AlphaSqrtPrice::<T>::iter() {
+    // NOTE: `AlphaSqrtPrice` is intentionally NOT cleared below. It is retained as a
+    // backwards-compatibility map (see its definition in the pallet) and the V3 values read
+    // here serve as its initial seed; it is refreshed on every subsequent price change.
+    for (netuid, price_sqrt) in AlphaSqrtPrice::<T>::iter() {
         let price = price_sqrt.saturating_mul(price_sqrt);
         if let Err(error) = crate::Pallet::<T>::maybe_initialize_palswap(netuid, Some(price)) {
             log::warn!(
@@ -60,7 +58,6 @@ pub fn migrate_swapv3_to_balancer<T: Config>() -> Weight {
     // ------------------------------
     // Step 2: Clear Map entries
     // ------------------------------
-    remove_prefix::<T>("Swap", "AlphaSqrtPrice", &mut weight);
     remove_prefix::<T>("Swap", "CurrentTick", &mut weight);
     remove_prefix::<T>("Swap", "EnabledUserLiquidity", &mut weight);
     remove_prefix::<T>("Swap", "FeeGlobalTao", &mut weight);

--- a/pallets/swap/src/pallet/mod.rs
+++ b/pallets/swap/src/pallet/mod.rs
@@ -2,6 +2,7 @@ use core::num::NonZeroU64;
 
 use frame_support::{PalletId, pallet_prelude::*, traits::Get};
 use frame_system::pallet_prelude::*;
+use substrate_fixed::types::U64F64;
 use subtensor_runtime_common::{
     AlphaBalance, BalanceOps, NetUid, SubnetInfo, TaoBalance, TokenReserve,
 };
@@ -112,6 +113,18 @@ mod pallet {
     /// Storage to determine whether balancer swap was initialized for a specific subnet.
     #[pallet::storage]
     pub type PalSwapInitialized<T> = StorageMap<_, Twox64Concat, NetUid, bool, ValueQuery>;
+
+    /// Square root of the current alpha price per subnet.
+    ///
+    /// This map is NOT used by the balancer (price is derived on the fly from reserves and
+    /// weights via [`Pallet::current_price`]). It is maintained purely for backwards
+    /// compatibility: external consumers (indexers, dashboards, wallets, SDKs) read the
+    /// `Swap::AlphaSqrtPrice` storage directly to obtain the subnet price, as they did under
+    /// the Uniswap V3 implementation. It is refreshed whenever the price changes via
+    /// [`Pallet::refresh_alpha_sqrt_price`].
+    #[pallet::storage]
+    pub type AlphaSqrtPrice<T> =
+        StorageMap<_, Twox64Concat, NetUid, U64F64, ValueQuery>;
 
     /// --- Storage for migration run status
     #[pallet::storage]

--- a/pallets/swap/src/pallet/mod.rs
+++ b/pallets/swap/src/pallet/mod.rs
@@ -123,8 +123,7 @@ mod pallet {
     /// the Uniswap V3 implementation. It is refreshed whenever the price changes via
     /// [`Pallet::refresh_alpha_sqrt_price`].
     #[pallet::storage]
-    pub type AlphaSqrtPrice<T> =
-        StorageMap<_, Twox64Concat, NetUid, U64F64, ValueQuery>;
+    pub type AlphaSqrtPrice<T> = StorageMap<_, Twox64Concat, NetUid, U64F64, ValueQuery>;
 
     /// --- Storage for migration run status
     #[pallet::storage]

--- a/pallets/swap/src/pallet/swap_step.rs
+++ b/pallets/swap/src/pallet/swap_step.rs
@@ -130,6 +130,7 @@ where
             delta_in: self.delta_in,
             delta_out,
             fee_to_block_author,
+            final_price: self.final_price,
         })
     }
 }
@@ -256,4 +257,7 @@ where
     pub(crate) delta_in: PaidIn,
     pub(crate) delta_out: PaidOut,
     pub(crate) fee_to_block_author: PaidIn,
+    /// Price after this swap step. Used to keep the backwards-compatibility
+    /// `AlphaSqrtPrice` mirror in sync without re-reading not-yet-committed reserves.
+    pub(crate) final_price: U64F64,
 }

--- a/pallets/swap/src/pallet/tests.rs
+++ b/pallets/swap/src/pallet/tests.rs
@@ -806,8 +806,9 @@ fn test_migrate_swapv3_to_balancer() {
             crate::migrations::migrate_swapv3_to_balancer::migrate_swapv3_to_balancer::<Test>;
         let netuid = NetUid::from(1);
 
-        // Insert deprecated maps values
-        deprecated_swap_maps::AlphaSqrtPrice::<Test>::insert(netuid, U64F64::from_num(1.23));
+        // Insert deprecated maps values. AlphaSqrtPrice is retained for backwards
+        // compatibility, so it is inserted via the live pallet storage.
+        AlphaSqrtPrice::<Test>::insert(netuid, U64F64::from_num(1.23));
         deprecated_swap_maps::ScrapReservoirTao::<Test>::insert(netuid, TaoBalance::from(9876));
         deprecated_swap_maps::ScrapReservoirAlpha::<Test>::insert(netuid, AlphaBalance::from(9876));
 
@@ -818,10 +819,13 @@ fn test_migrate_swapv3_to_balancer() {
         // Run migration
         migration();
 
-        // Test that values are removed from state
-        assert!(!deprecated_swap_maps::AlphaSqrtPrice::<Test>::contains_key(
-            netuid
-        ));
+        // V3-only state is removed, but AlphaSqrtPrice is retained as a backwards-compat seed.
+        assert!(AlphaSqrtPrice::<Test>::contains_key(netuid));
+        assert_abs_diff_eq!(
+            AlphaSqrtPrice::<Test>::get(netuid).to_num::<f64>(),
+            1.23,
+            epsilon = 0.001
+        );
         assert!(!deprecated_swap_maps::ScrapReservoirAlpha::<Test>::contains_key(netuid));
 
         // Test that subnet price is still 1.23^2
@@ -845,7 +849,7 @@ fn test_migrate_swapv3_to_balancer_falls_back_to_default_when_price_init_fails()
             frame_support::BoundedVec::truncate_from(b"migrate_swapv3_to_balancer".to_vec());
         let netuid = NetUid::from(1);
 
-        deprecated_swap_maps::AlphaSqrtPrice::<Test>::insert(netuid, U64F64::from_num(1));
+        AlphaSqrtPrice::<Test>::insert(netuid, U64F64::from_num(1));
         deprecated_swap_maps::ScrapReservoirTao::<Test>::insert(netuid, TaoBalance::from(9876));
         deprecated_swap_maps::ScrapReservoirAlpha::<Test>::insert(netuid, AlphaBalance::from(9876));
 
@@ -854,9 +858,8 @@ fn test_migrate_swapv3_to_balancer_falls_back_to_default_when_price_init_fails()
 
         migration();
 
-        assert!(!deprecated_swap_maps::AlphaSqrtPrice::<Test>::contains_key(
-            netuid
-        ));
+        // AlphaSqrtPrice is retained even when the balancer falls back to default.
+        assert!(AlphaSqrtPrice::<Test>::contains_key(netuid));
         assert!(!deprecated_swap_maps::ScrapReservoirTao::<Test>::contains_key(netuid));
         assert!(!deprecated_swap_maps::ScrapReservoirAlpha::<Test>::contains_key(netuid));
         assert!(PalSwapInitialized::<Test>::get(netuid));

--- a/pallets/swap/src/pallet/tests.rs
+++ b/pallets/swap/src/pallet/tests.rs
@@ -870,3 +870,77 @@ fn test_migrate_swapv3_to_balancer_falls_back_to_default_when_price_init_fails()
         assert!(HasMigrationRun::<Test>::get(&migration_name));
     });
 }
+
+// Backwards-compat: the legacy `AlphaSqrtPrice` mirror is seeded on init, tracks the post-swap
+// price, is unaffected by simulated swaps, and is cleared on dissolve.
+// cargo test --package pallet-subtensor-swap --lib -- pallet::tests::test_alpha_sqrt_price_backcompat_mirror --exact --nocapture
+#[test]
+fn test_alpha_sqrt_price_backcompat_mirror() {
+    new_test_ext().execute_with(|| {
+        let netuid = NetUid::from(1);
+
+        // No mirror entry before the subnet is initialized.
+        assert!(!AlphaSqrtPrice::<Test>::contains_key(netuid));
+
+        // Initialize at price 0.25 (tao/alpha = 1e9 / 4e9).
+        let initial_tao = TaoBalance::from(1_000_000_000u64);
+        let initial_alpha = AlphaBalance::from(4_000_000_000u64);
+        TaoReserve::set_mock_reserve(netuid, initial_tao);
+        AlphaReserve::set_mock_reserve(netuid, initial_alpha);
+        assert_ok!(Pallet::<Test>::maybe_initialize_palswap(netuid, None));
+
+        // Init seeds the mirror with sqrt(0.25) = 0.5, and mirror^2 == the derived price.
+        let seeded = AlphaSqrtPrice::<Test>::get(netuid).to_num::<f64>();
+        assert_abs_diff_eq!(seeded, 0.5, epsilon = 0.0001);
+        assert_abs_diff_eq!(
+            seeded * seeded,
+            Pallet::<Test>::current_price(netuid).to_num::<f64>(),
+            epsilon = 0.0001
+        );
+
+        // Buy alpha with tao -> price rises. The mirror tracks the post-swap price even though
+        // the reserve deltas are applied by the caller afterwards.
+        let order = GetAlphaForTao::with_amount(100_000_000);
+        let swap_result =
+            Pallet::<Test>::do_swap(netuid, order, U64F64::from_num(1000.0), false, false).unwrap();
+
+        // Apply the reserve deltas the way the real caller (stake_utils) does.
+        TaoReserve::set_mock_reserve(
+            netuid,
+            TaoBalance::from(
+                (u64::from(initial_tao) as i128 + swap_result.paid_in_reserve_delta()) as u64,
+            ),
+        );
+        AlphaReserve::set_mock_reserve(
+            netuid,
+            AlphaBalance::from(
+                (u64::from(initial_alpha) as i128 + swap_result.paid_out_reserve_delta()) as u64,
+            ),
+        );
+
+        // Mirror rose and, once reserves are committed, mirror^2 == the new derived price.
+        let after = AlphaSqrtPrice::<Test>::get(netuid).to_num::<f64>();
+        assert!(after > seeded);
+        assert_abs_diff_eq!(
+            after * after,
+            Pallet::<Test>::current_price(netuid).to_num::<f64>(),
+            epsilon = 0.001
+        );
+
+        // A simulated swap must not move the mirror (the write is rolled back).
+        let before_sim = AlphaSqrtPrice::<Test>::get(netuid);
+        let _ = Pallet::<Test>::do_swap(
+            netuid,
+            GetAlphaForTao::with_amount(100_000_000),
+            U64F64::from_num(1000.0),
+            false,
+            true, // simulate
+        )
+        .unwrap();
+        assert_eq!(AlphaSqrtPrice::<Test>::get(netuid), before_sim);
+
+        // Dissolve clears the mirror.
+        assert_ok!(Pallet::<Test>::do_clear_protocol_liquidity(netuid));
+        assert!(!AlphaSqrtPrice::<Test>::contains_key(netuid));
+    });
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -234,7 +234,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 423,
+    spec_version: 424,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description

The balancer migration shipped in `v3.4.8-423` deleted the `Swap::AlphaSqrtPrice` storage map. It was removed as collateral of the Uniswap-V3 → balancer engine rewrite: under V3, `AlphaSqrtPrice` was the *primary* price state variable, but under the balancer price became a **derived** quantity (computed on the fly from reserves + weights in `current_price`), so the stored variable was dropped along with the rest of the V3 machinery (ticks, positions, liquidity, fee-growth accumulators).

That map is a **de-facto public interface**: external consumers (indexers, dashboards, wallets, SDKs) read `Swap.AlphaSqrtPrice` directly via `state_getStorage` to obtain the subnet price, exactly as they did under V3. Removing it without a deprecation path broke them.

This PR re-adds it as a **backwards-compatibility shim**:

- Re-introduces the storage map with its **exact prior definition** (`StorageMap<_, Twox64Concat, NetUid, U64F64, ValueQuery>`), so consumers get the same key/hasher/value/units as before.
- Maintains it as a **read-only mirror** of the derived balancer price (`sqrt(current_price)`), refreshed at every price-change point: subnet init, swap, and protocol-liquidity adjustment; removed on dissolve.
- The `migrate_swapv3_to_balancer` migration now **retains** the old V3 values as the initial seed (the `remove_prefix("Swap", "AlphaSqrtPrice", …)` line is dropped) instead of clearing them, so there is **no gap** at upgrade.

**No V3 engine logic is reintroduced** — the map is purely a price mirror for back-compat. The other removed V3 maps (`Ticks`, `Positions`, `CurrentTick`, `CurrentLiquidity`, `TickIndexBitmapWords`, `FeeGlobalTao/Alpha`, `LastPositionId`, `EnabledUserLiquidity`, `SwapV3Initialized`) are intentionally left removed — they have no balancer equivalent and restoring them would mean fabricating meaningless values.

Also bumps `spec_version` `423 → 424`.

## Related Issue(s)

N/A — addresses downstream reports of `Swap.AlphaSqrtPrice` reads returning empty after the balancer upgrade.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

None. This **restores** a previously-broken interface and adds no new constraints. The storage layout is identical to `v3.4.7-422`.

## Notes for reviewers

**Why storage and not just the runtime API?** A supported price API already exists — `current_alpha_price(netuid)` (since `v3.1.6`) and `current_alpha_price_all()` (since `v3.3.10-380`). Consumers *should* migrate to those, and the restored map is documented as back-compat-only. But the convenient bulk `_all` variant is only a few months old, so a lot of existing tooling still reads raw storage; this shim unbreaks them now. If the map is ever dropped again it should go through an explicit deprecation notice rather than a silent removal.

**State bloat?** Bounded and self-cleaning: one `U64F64` (16 bytes) per subnet, capped by `SubnetLimit` (default 128) → ~2 KB of values. Same cardinality as existing per-subnet maps written every block (`SubnetMovingPrice`, `RootProp`). Created on init, removed on dissolve — does not grow with swaps, accounts, or time. None of the genuinely bloaty V3 structures are reintroduced.

**Consistency:** `refresh_alpha_sqrt_price` runs inside the swap's transactional scope, so it is correctly rolled back on simulated swaps. For emitting subnets it is refreshed every block via `adjust_protocol_liquidity`; for idle subnets the value stays correct because price only moves via swaps/emission.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] `cargo fmt` + `cargo clippy --all-targets --all-features` run clean on the affected crate (no new warnings)
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Testing

- `cargo test -p pallet-subtensor-swap --lib` — 44 passed. The two `migrate_swapv3_to_balancer` tests were updated to assert `AlphaSqrtPrice` is **retained** (seeded) across the migration rather than cleared.
- Full runtime Rust integration verified via `SKIP_WASM_BUILD=1 cargo check -p node-subtensor-runtime` (clean). The WASM build itself is left to CI (local clang here can't target `wasm32` for the `zstd-sys` C dependency — an environment issue, not a code issue).
