### PR TITLE
Enforce conviction

### DIFF
--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -411,9 +411,8 @@ impl<T: Config> Pallet<T> {
                 );
                 epochs_run_this_block = epochs_run_this_block.saturating_add(1);
 
-                // Reserved for potential future enhancements.
-                // Ownership update logic based on conviction is currently inactive by design.
-                // Self::change_subnet_owner_if_needed(netuid);
+                // Change subnet owner based on conviction.
+                Self::change_subnet_owner_if_needed(netuid);
             } else {
                 // Schedule advances below; execution skipped. Pending emissions accumulate
                 // and will be drained by the next successful epoch.

--- a/pallets/subtensor/src/coinbase/subnet_emissions.rs
+++ b/pallets/subtensor/src/coinbase/subnet_emissions.rs
@@ -36,7 +36,7 @@ impl<T: Config> Pallet<T> {
         block_emission: U96F32,
     ) -> BTreeMap<NetUid, U96F32> {
         // Disabled subnets get zero TAO-side emission, redistributed to enabled subnets.
-        // They stay in the map so the normal alpha_out/root-prop path still runs.
+        // They stay in the map so the normal alpha_out path still runs.
         let shares = Self::get_shares(subnets_to_emit_to);
         log::debug!("Subnet emission shares = {shares:?}");
 
@@ -354,11 +354,9 @@ impl<T: Config> Pallet<T> {
     pub(crate) fn get_shares(subnets_to_emit_to: &[NetUid]) -> BTreeMap<NetUid, U64F64> {
         let price_shares = Self::get_shares_price_ema(subnets_to_emit_to);
 
-        // Weight each subnet's price share by root_proportion * (1 - miner_burned), then
-        // renormalize. The effective emission is therefore proportional to
-        //   root_proportion_i * price_i * (1 - miner_burned_i).
-        // - root_proportion shrinks as a subnet's alpha issuance grows, so emission is
-        //   reallocated away from older subnets toward newer ones (easier entrance).
+        // Weight each subnet's price share by (1 - miner_burned), then
+        // renormalize. The effective emission is proportional to
+        // price_i * (1 - miner_burned_i).
         // - (1 - miner_burned) reallocates away from subnets that withhold miner emission.
         let zero = U64F64::saturating_from_num(0);
         let one = U64F64::saturating_from_num(1);
@@ -366,8 +364,8 @@ impl<T: Config> Pallet<T> {
             .iter()
             .map(|(netuid, share)| {
                 let burned = U64F64::saturating_from_num(MinerBurned::<T>::get(netuid)).min(one);
-                let root_prop = U64F64::saturating_from_num(Self::root_proportion(*netuid));
-                let factor = root_prop.saturating_mul(one.saturating_sub(burned));
+                let factor = one.saturating_sub(burned);
+
                 (*netuid, share.saturating_mul(factor))
             })
             .collect();

--- a/pallets/subtensor/src/tests/locks.rs
+++ b/pallets/subtensor/src/tests/locks.rs
@@ -2952,6 +2952,60 @@ fn test_change_subnet_owner_if_needed_reassigns_to_subnet_king() {
 }
 
 #[test]
+fn test_run_coinbase_reassigns_subnet_owner_by_conviction_on_epoch() {
+    new_test_ext(1).execute_with(|| {
+        let old_owner_coldkey = U256::from(1);
+        let old_owner_hotkey = U256::from(2);
+        let netuid = setup_subnet_with_stake(old_owner_coldkey, old_owner_hotkey, 100_000_000_000);
+        SubnetOwner::<Test>::insert(netuid, old_owner_coldkey);
+        SubnetOwnerHotkey::<Test>::insert(netuid, old_owner_hotkey);
+
+        let new_owner_coldkey = U256::from(5);
+        let king_hotkey = U256::from(6);
+        assert_ok!(SubtensorModule::create_account_if_non_existent(
+            &new_owner_coldkey,
+            &king_hotkey
+        ));
+
+        let now = crate::staking::lock::ONE_YEAR + 1;
+        System::set_block_number(now);
+        NetworkRegisteredAt::<Test>::insert(netuid, 1);
+        SubnetAlphaOut::<Test>::insert(netuid, AlphaBalance::from(10_000u64));
+        SubtensorModule::set_tempo_unchecked(netuid, 1);
+        LastEpochBlock::<Test>::insert(netuid, now.saturating_sub(1));
+        PendingEpochAt::<Test>::insert(netuid, 0);
+
+        let locked_mass = AlphaBalance::from(1_000u64);
+        Lock::<Test>::insert(
+            (new_owner_coldkey, netuid, king_hotkey),
+            LockState {
+                locked_mass,
+                conviction: U64F64::from_num(1_000),
+                last_update: now,
+            },
+        );
+        HotkeyLock::<Test>::insert(
+            netuid,
+            king_hotkey,
+            LockState {
+                locked_mass,
+                conviction: U64F64::from_num(1_000),
+                last_update: now,
+            },
+        );
+
+        assert_eq!(SubnetOwner::<Test>::get(netuid), old_owner_coldkey);
+        assert_eq!(SubnetOwnerHotkey::<Test>::get(netuid), old_owner_hotkey);
+
+        SubtensorModule::run_coinbase(SubtensorModule::mint_tao(0.into()));
+
+        assert_eq!(SubnetOwner::<Test>::get(netuid), new_owner_coldkey);
+        assert_eq!(SubnetOwnerHotkey::<Test>::get(netuid), king_hotkey);
+        assert_eq!(LastEpochBlock::<Test>::get(netuid), now);
+    });
+}
+
+#[test]
 fn test_change_subnet_owner_rebuilds_old_owner_hotkey_by_lock_mode() {
     new_test_ext(1).execute_with(|| {
         let old_owner_coldkey = U256::from(1);

--- a/pallets/subtensor/src/tests/subnet_emissions.rs
+++ b/pallets/subtensor/src/tests/subnet_emissions.rs
@@ -151,6 +151,47 @@ fn inplace_pow_normalize_fractional_exponent() {
         })
 }
 
+#[test]
+fn get_shares_ignores_root_prop_storage_when_prices_and_burns_match() {
+    new_test_ext(1).execute_with(|| {
+        let owner_hotkey = U256::from(70);
+        let owner_coldkey = U256::from(71);
+        let n1 = add_dynamic_network(&owner_hotkey, &owner_coldkey);
+        let n2 = add_dynamic_network(&owner_hotkey, &owner_coldkey);
+
+        // Equal prices and equal miner-burn values should produce equal shares,
+        // regardless of the stored root proportion.
+        SubnetMovingPrice::<Test>::insert(n1, i96f32(1.0));
+        SubnetMovingPrice::<Test>::insert(n2, i96f32(1.0));
+        MinerBurned::<Test>::insert(n1, U96F32::saturating_from_num(0.0));
+        MinerBurned::<Test>::insert(n2, U96F32::saturating_from_num(0.0));
+
+        // Deliberately make root-prop unequal. The old formula would weight
+        // these equal-price subnets as 1.0 : 0.1 and fail the equality checks.
+        RootProp::<Test>::insert(n1, U96F32::saturating_from_num(1.0));
+        RootProp::<Test>::insert(n2, U96F32::saturating_from_num(0.1));
+
+        assert_abs_diff_eq!(
+            RootProp::<Test>::get(n1).to_num::<f64>(),
+            1.0_f64,
+            epsilon = 1e-9
+        );
+        assert_abs_diff_eq!(
+            RootProp::<Test>::get(n2).to_num::<f64>(),
+            0.1_f64,
+            epsilon = 1e-9
+        );
+
+        let shares = SubtensorModule::get_shares(&[n1, n2]);
+        let s1 = shares.get(&n1).copied().unwrap().to_num::<f64>();
+        let s2 = shares.get(&n2).copied().unwrap().to_num::<f64>();
+
+        assert_abs_diff_eq!(s1, 0.5_f64, epsilon = 1e-9);
+        assert_abs_diff_eq!(s2, 0.5_f64, epsilon = 1e-9);
+        assert_abs_diff_eq!(s1 + s2, 1.0_f64, epsilon = 1e-9);
+    });
+}
+
 // /// Normal (moderate, non-zero) EMA flows across 3 subnets.
 // /// Expect: shares sum to ~1 and are monotonic with flows.
 // #[test]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -234,7 +234,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 424,
+    spec_version: 425,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description

### This PR enables conviction enforcement. If 

- a non-owner hotkey A has conviction higher than owner's hotkey,
- total conviction on the subnet is >= 10% of SubnetAlphaOut, and
- subnet is at least 1 year old,

the ownership will be changed to coldkey that is owner of hotkey A.

### This PR also removes `root_prop` from the emission calculation
and adds a unit test for it
