### PR TITLE
Hotifx: Allow locked alpha transfers in coldkey swaps

### DIFF
--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2639,15 +2639,7 @@ mod dispatches {
         ))]
         pub fn set_reject_locked_alpha(origin: OriginFor<T>, enabled: bool) -> DispatchResult {
             let coldkey = ensure_signed(origin)?;
-            AccountFlags::<T>::mutate_exists(&coldkey, |maybe_flags| {
-                let mut flags = maybe_flags.unwrap_or_default();
-                if enabled {
-                    flags &= !crate::ACCOUNT_FLAGS_ACCEPT_LOCKED_ALPHA;
-                } else {
-                    flags |= crate::ACCOUNT_FLAGS_ACCEPT_LOCKED_ALPHA;
-                }
-                *maybe_flags = if flags == 0 { None } else { Some(flags) };
-            });
+            Self::set_accept_locked_alpha(&coldkey, !enabled);
             Self::deposit_event(Event::RejectLockedAlphaUpdated { coldkey, enabled });
             Ok(())
         }

--- a/pallets/subtensor/src/staking/lock.rs
+++ b/pallets/subtensor/src/staking/lock.rs
@@ -471,6 +471,18 @@ impl<T: Config> Pallet<T> {
         AccountFlags::<T>::get(coldkey) & crate::ACCOUNT_FLAGS_ACCEPT_LOCKED_ALPHA != 1
     }
 
+    pub fn set_accept_locked_alpha(coldkey: &T::AccountId, enabled: bool) {
+        AccountFlags::<T>::mutate_exists(coldkey, |maybe_flags| {
+            let mut flags = maybe_flags.unwrap_or_default();
+            if enabled {
+                flags |= crate::ACCOUNT_FLAGS_ACCEPT_LOCKED_ALPHA;
+            } else {
+                flags &= !crate::ACCOUNT_FLAGS_ACCEPT_LOCKED_ALPHA;
+            }
+            *maybe_flags = if flags == 0 { None } else { Some(flags) };
+        });
+    }
+
     pub fn ensure_can_receive_locked_alpha(
         coldkey: &T::AccountId,
         amount: AlphaBalance,
@@ -1432,6 +1444,14 @@ impl<T: Config> Pallet<T> {
             if let Some(decaying) = DecayingLock::<T>::take(old_coldkey, netuid) {
                 DecayingLock::<T>::insert(new_coldkey, netuid, decaying);
             }
+        }
+
+        let flags = AccountFlags::<T>::get(old_coldkey);
+        AccountFlags::<T>::remove(old_coldkey);
+        if flags != 0 {
+            AccountFlags::<T>::insert(new_coldkey, flags);
+        } else {
+            AccountFlags::<T>::remove(new_coldkey);
         }
 
         // Insert locks for the new coldkey and add to the destination aggregate

--- a/pallets/subtensor/src/swap/swap_coldkey.rs
+++ b/pallets/subtensor/src/swap/swap_coldkey.rs
@@ -23,6 +23,10 @@ impl<T: Config> Pallet<T> {
             IdentitiesV2::<T>::insert(new_coldkey.clone(), identity);
         }
 
+        // Temporarily allow the destination coldkey to receive this stake even if some of it is
+        // locked; swap_coldkey_locks will copy the source AccountFlags over afterward.
+        Self::set_accept_locked_alpha(new_coldkey, true);
+
         for netuid in Self::get_all_subnet_netuids() {
             Self::transfer_subnet_ownership(netuid, old_coldkey, new_coldkey);
             Self::transfer_auto_stake_destination(netuid, old_coldkey, new_coldkey);

--- a/pallets/subtensor/src/tests/swap_coldkey.rs
+++ b/pallets/subtensor/src/tests/swap_coldkey.rs
@@ -499,6 +499,105 @@ fn test_swap_coldkey_works() {
     });
 }
 
+#[test]
+fn test_swap_coldkey_announced_transfers_locked_alpha() {
+    new_test_ext(1000).execute_with(|| {
+        let old_coldkey = U256::from(1);
+        let new_coldkey = U256::from(2);
+        let new_coldkey_hash = <Test as frame_system::Config>::Hashing::hash_of(&new_coldkey);
+        let hotkey1 = U256::from(1001);
+        let hotkey2 = U256::from(1002);
+        let hotkey3 = U256::from(1003);
+        let ed = ExistentialDeposit::get();
+        let swap_cost = SubtensorModule::get_key_swap_cost();
+        let min_stake = DefaultMinStake::<Test>::get();
+        let stake1 = min_stake * 10.into();
+        let stake2 = min_stake * 20.into();
+        let stake3 = min_stake * 30.into();
+
+        add_balance_to_coldkey_account(&old_coldkey, swap_cost + stake1 + stake2 + stake3 + ed);
+
+        let (
+            netuid1,
+            _netuid2,
+            _hotkeys,
+            hk1_alpha,
+            _hk2_alpha,
+            _hk3_alpha,
+            _total_ck_stake,
+            _identity,
+            _balance_before,
+            _total_stake_before,
+        ) = comprehensive_setup!(
+            old_coldkey,
+            new_coldkey,
+            new_coldkey_hash,
+            stake1,
+            stake2,
+            stake3,
+            hotkey1,
+            hotkey2,
+            hotkey3,
+            swap_cost + ed
+        );
+
+        let lock_amount = hk1_alpha / 2.into();
+        assert!(!lock_amount.is_zero());
+        assert_ok!(SubtensorModule::do_lock_stake(
+            &old_coldkey,
+            netuid1,
+            &hotkey1,
+            lock_amount,
+        ));
+
+        let old_stake_before = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey1,
+            &old_coldkey,
+            netuid1,
+        );
+        let new_stake_before = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey1,
+            &new_coldkey,
+            netuid1,
+        );
+        let old_lock_before =
+            Lock::<Test>::get((old_coldkey, netuid1, hotkey1)).expect("lock should exist");
+
+        ColdkeySwapAnnouncements::<Test>::insert(
+            old_coldkey,
+            (System::block_number(), new_coldkey_hash),
+        );
+
+        assert_ok!(SubtensorModule::swap_coldkey_announced(
+            <Test as frame_system::Config>::RuntimeOrigin::signed(old_coldkey),
+            new_coldkey,
+        ));
+
+        assert!(ColdkeySwapAnnouncements::<Test>::get(old_coldkey).is_none());
+        assert_eq!(
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+                &hotkey1,
+                &old_coldkey,
+                netuid1,
+            ),
+            AlphaBalance::ZERO
+        );
+        assert_eq!(
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+                &hotkey1,
+                &new_coldkey,
+                netuid1,
+            ),
+            old_stake_before + new_stake_before
+        );
+        assert!(Lock::<Test>::get((old_coldkey, netuid1, hotkey1)).is_none());
+        assert_eq!(
+            Lock::<Test>::get((new_coldkey, netuid1, hotkey1)),
+            Some(old_lock_before)
+        );
+    });
+}
+
 // cargo test --package pallet-subtensor --lib -- tests::swap_coldkey::test_swap_coldkey_works_with_zero_cost --exact --nocapture
 #[test]
 fn test_swap_coldkey_works_with_zero_cost() {


### PR DESCRIPTION
## Description

This hotfix allows transfers of locked alpha in coldkey swaps.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

