### PR TITLE
Apply tx & dispatch extensions conditionally

### DIFF
--- a/pallets/subtensor/src/extensions/subtensor.rs
+++ b/pallets/subtensor/src/extensions/subtensor.rs
@@ -1,6 +1,6 @@
 use crate::{
     Call, CheckColdkeySwap, CheckDelegateTake, CheckEvmKeyAssociation, CheckRateLimits,
-    CheckServingEndpoints, CheckWeights, Config, Error,
+    CheckServingEndpoints, CheckWeights, Config, Error, guards::applicable_call,
 };
 use codec::{Decode, DecodeWithMemTracking, Encode};
 use frame_support::{
@@ -89,15 +89,23 @@ impl<T: Config + Send + Sync + TypeInfo> SubtensorTransactionExtension<T> {
 
         CheckColdkeySwap::<T>::check(who, call)?;
 
-        let Some(call) = call.is_sub_type() else {
-            return Ok(());
-        };
+        if let Some(call) = applicable_call(call, CheckWeights::<T>::applies_to) {
+            CheckWeights::<T>::check(who, call)?;
+        }
+        if let Some(call) = applicable_call(call, CheckRateLimits::<T>::applies_to) {
+            CheckRateLimits::<T>::check(who, call)?;
+        }
+        if let Some(call) = applicable_call(call, CheckDelegateTake::<T>::applies_to) {
+            CheckDelegateTake::<T>::check(who, call)?;
+        }
+        if let Some(call) = applicable_call(call, CheckServingEndpoints::<T>::applies_to) {
+            CheckServingEndpoints::<T>::check(who, call)?;
+        }
+        if let Some(call) = applicable_call(call, CheckEvmKeyAssociation::<T>::applies_to) {
+            CheckEvmKeyAssociation::<T>::check(who, call)?;
+        }
 
-        CheckWeights::<T>::check(who, call)?;
-        CheckRateLimits::<T>::check(who, call)?;
-        CheckDelegateTake::<T>::check(who, call)?;
-        CheckServingEndpoints::<T>::check(who, call)?;
-        CheckEvmKeyAssociation::<T>::check(who, call)
+        Ok(())
     }
 }
 

--- a/pallets/subtensor/src/guards/check_coldkey_swap.rs
+++ b/pallets/subtensor/src/guards/check_coldkey_swap.rs
@@ -1,3 +1,4 @@
+use super::{CallOf, DispatchableOriginOf};
 use crate::weights::WeightInfo;
 use crate::{Call, ColdkeySwapAnnouncements, ColdkeySwapDisputes, Config, Error};
 use frame_support::{
@@ -7,9 +8,6 @@ use frame_support::{
 };
 use sp_runtime::traits::Dispatchable;
 use sp_std::marker::PhantomData;
-
-type CallOf<T> = <T as frame_system::Config>::RuntimeCall;
-type DispatchableOriginOf<T> = <CallOf<T> as Dispatchable>::RuntimeOrigin;
 
 /// Dispatch extension that blocks most calls when a coldkey swap is active.
 ///
@@ -96,9 +94,14 @@ where
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::CheckColdkeySwap;
-    use crate::{ColdkeySwapAnnouncements, ColdkeySwapDisputes, Error, tests::mock::*};
+    use crate::{
+        ColdkeySwapAnnouncements, ColdkeySwapDisputes, Error, tests::mock::*,
+        weights::WeightInfo as _,
+    };
     use frame_support::{
-        BoundedVec, assert_ok, dispatch::DispatchResultWithPostInfo, traits::ExtendedDispatchable,
+        BoundedVec, assert_ok,
+        dispatch::{DispatchExtension, DispatchResultWithPostInfo},
+        traits::ExtendedDispatchable,
     };
     use frame_system::Call as SystemCall;
     use pallet_subtensor_proxy::Call as ProxyCall;
@@ -174,6 +177,18 @@ mod tests {
         <CheckColdkeySwap<Test> as ExtendedDispatchable<RuntimeCall>>::dispatch_with_extension(
             origin, call,
         )
+    }
+
+    #[test]
+    fn weight_charges_all_calls_because_swap_state_can_block_any_signed_call() {
+        let expected = <Test as crate::Config>::WeightInfo::check_coldkey_swap_extension();
+
+        for call in forbidden_calls().into_iter().chain(authorized_calls()) {
+            assert_eq!(
+                <CheckColdkeySwap<Test> as DispatchExtension<RuntimeCall>>::weight(&call),
+                expected
+            );
+        }
     }
 
     #[test]

--- a/pallets/subtensor/src/guards/check_delegate_take.rs
+++ b/pallets/subtensor/src/guards/check_delegate_take.rs
@@ -1,3 +1,4 @@
+use super::{CallOf, DispatchableOriginOf, applicable_call};
 use crate::weights::WeightInfo;
 use crate::{Call, Config, Error, Pallet};
 use frame_support::{
@@ -8,9 +9,6 @@ use frame_support::{
 use sp_runtime::traits::Dispatchable;
 use sp_std::marker::PhantomData;
 
-type CallOf<T> = <T as frame_system::Config>::RuntimeCall;
-type DispatchableOriginOf<T> = <CallOf<T> as Dispatchable>::RuntimeOrigin;
-
 /// Dispatch extension for delegate-take bounds and ownership preconditions.
 ///
 /// Signed increase/decrease take calls are checked before dispatch; unrelated
@@ -18,6 +16,13 @@ type DispatchableOriginOf<T> = <CallOf<T> as Dispatchable>::RuntimeOrigin;
 pub struct CheckDelegateTake<T: Config>(PhantomData<T>);
 
 impl<T: Config> CheckDelegateTake<T> {
+    pub(crate) fn applies_to(call: &Call<T>) -> bool {
+        matches!(
+            call,
+            Call::increase_take { .. } | Call::decrease_take { .. }
+        )
+    }
+
     pub fn check(who: &T::AccountId, call: &Call<T>) -> Result<(), Error<T>> {
         match call {
             Call::increase_take { hotkey, take } | Call::decrease_take { hotkey, take } => {
@@ -42,8 +47,10 @@ where
 {
     type Pre = ();
 
-    fn weight(_call: &CallOf<T>) -> Weight {
-        <T as Config>::WeightInfo::check_delegate_take_extension()
+    fn weight(call: &CallOf<T>) -> Weight {
+        applicable_call(call, Self::applies_to)
+            .map(|_| <T as Config>::WeightInfo::check_delegate_take_extension())
+            .unwrap_or(Weight::zero())
     }
 
     fn pre_dispatch(
@@ -54,7 +61,7 @@ where
             return Ok(());
         };
 
-        let Some(call) = call.is_sub_type() else {
+        let Some(call) = applicable_call(call, Self::applies_to) else {
             return Ok(());
         };
 
@@ -68,7 +75,10 @@ mod tests {
     use super::*;
     use crate::{Error, tests::mock::*};
     use frame_support::{
-        assert_ok, dispatch::DispatchResultWithPostInfo, traits::ExtendedDispatchable,
+        assert_ok,
+        dispatch::{DispatchExtension, DispatchResultWithPostInfo},
+        traits::ExtendedDispatchable,
+        weights::Weight,
     };
     use sp_core::U256;
     use sp_runtime::DispatchError;
@@ -89,6 +99,39 @@ mod tests {
 
     fn err(result: DispatchResultWithPostInfo) -> DispatchError {
         result.unwrap_err().error
+    }
+
+    fn add_stake_call() -> RuntimeCall {
+        RuntimeCall::SubtensorModule(SubtensorCall::add_stake {
+            hotkey: U256::from(1),
+            netuid: 1u16.into(),
+            amount_staked: 1_000u64.into(),
+        })
+    }
+
+    #[test]
+    fn weight_only_charges_delegate_take_calls() {
+        let expected = <Test as crate::Config>::WeightInfo::check_delegate_take_extension();
+
+        for call in [
+            RuntimeCall::System(frame_system::Call::remark { remark: vec![] }),
+            add_stake_call(),
+        ] {
+            assert_eq!(
+                <CheckDelegateTake<Test> as DispatchExtension<RuntimeCall>>::weight(&call),
+                Weight::zero()
+            );
+        }
+
+        for call in [
+            increase_take_call(U256::from(1), 0),
+            decrease_take_call(U256::from(1), 0),
+        ] {
+            assert_eq!(
+                <CheckDelegateTake<Test> as DispatchExtension<RuntimeCall>>::weight(&call),
+                expected
+            );
+        }
     }
 
     #[test]

--- a/pallets/subtensor/src/guards/check_evm_key_association.rs
+++ b/pallets/subtensor/src/guards/check_evm_key_association.rs
@@ -1,3 +1,4 @@
+use super::{CallOf, DispatchableOriginOf, applicable_call};
 use crate::weights::WeightInfo;
 use crate::{Call, Config, Error, Pallet};
 use frame_support::{
@@ -8,9 +9,6 @@ use frame_support::{
 use sp_runtime::traits::Dispatchable;
 use sp_std::marker::PhantomData;
 
-type CallOf<T> = <T as frame_system::Config>::RuntimeCall;
-type DispatchableOriginOf<T> = <CallOf<T> as Dispatchable>::RuntimeOrigin;
-
 /// Dispatch extension for EVM-key association preconditions.
 ///
 /// Signed EVM-key association calls are checked for subnet registration and
@@ -18,6 +16,10 @@ type DispatchableOriginOf<T> = <CallOf<T> as Dispatchable>::RuntimeOrigin;
 pub struct CheckEvmKeyAssociation<T: Config>(PhantomData<T>);
 
 impl<T: Config> CheckEvmKeyAssociation<T> {
+    pub(crate) fn applies_to(call: &Call<T>) -> bool {
+        matches!(call, Call::associate_evm_key { .. })
+    }
+
     pub fn check(who: &T::AccountId, call: &Call<T>) -> Result<(), Error<T>> {
         match call {
             Call::associate_evm_key { netuid, .. } => {
@@ -40,8 +42,10 @@ where
 {
     type Pre = ();
 
-    fn weight(_call: &CallOf<T>) -> Weight {
-        <T as Config>::WeightInfo::check_evm_key_association_extension()
+    fn weight(call: &CallOf<T>) -> Weight {
+        applicable_call(call, Self::applies_to)
+            .map(|_| <T as Config>::WeightInfo::check_evm_key_association_extension())
+            .unwrap_or(Weight::zero())
     }
 
     fn pre_dispatch(
@@ -52,7 +56,7 @@ where
             return Ok(());
         };
 
-        let Some(call) = call.is_sub_type() else {
+        let Some(call) = applicable_call(call, Self::applies_to) else {
             return Ok(());
         };
 
@@ -64,10 +68,13 @@ where
 #[allow(clippy::unwrap_used, clippy::arithmetic_side_effects)]
 mod tests {
     use super::CheckEvmKeyAssociation;
-    use crate::{AssociatedEvmAddress, Error, tests::mock::*};
+    use crate::{AssociatedEvmAddress, Error, tests::mock::*, weights::WeightInfo as _};
     use codec::Encode;
     use frame_support::{
-        assert_ok, dispatch::DispatchResultWithPostInfo, traits::ExtendedDispatchable,
+        assert_ok,
+        dispatch::{DispatchExtension, DispatchResultWithPostInfo},
+        traits::ExtendedDispatchable,
+        weights::Weight,
     };
     use frame_system::Call as SystemCall;
     use sp_core::{H160, Pair, U256, ecdsa, keccak_256};
@@ -137,6 +144,37 @@ mod tests {
             associate_call(netuid, evm_key, block_number, signature),
             evm_key,
         )
+    }
+
+    fn add_stake_call() -> RuntimeCall {
+        RuntimeCall::SubtensorModule(SubtensorCall::add_stake {
+            hotkey: U256::from(1),
+            netuid: 1u16.into(),
+            amount_staked: 1_000u64.into(),
+        })
+    }
+
+    #[test]
+    fn weight_only_charges_evm_key_association_calls() {
+        let netuid = NetUid::from(1);
+        let expected = <Test as crate::Config>::WeightInfo::check_evm_key_association_extension();
+
+        for call in [
+            RuntimeCall::System(SystemCall::remark { remark: vec![] }),
+            add_stake_call(),
+        ] {
+            assert_eq!(
+                <CheckEvmKeyAssociation<Test> as DispatchExtension<RuntimeCall>>::weight(&call),
+                Weight::zero()
+            );
+        }
+
+        assert_eq!(
+            <CheckEvmKeyAssociation<Test> as DispatchExtension<RuntimeCall>>::weight(
+                &dummy_associate_call(netuid)
+            ),
+            expected
+        );
     }
 
     #[test]

--- a/pallets/subtensor/src/guards/check_rate_limits.rs
+++ b/pallets/subtensor/src/guards/check_rate_limits.rs
@@ -1,3 +1,4 @@
+use super::{CallOf, DispatchableOriginOf, applicable_call};
 use crate::weights::WeightInfo;
 use crate::{Call, Config, Error, Pallet, TransactionType};
 use frame_support::{
@@ -9,9 +10,6 @@ use sp_runtime::traits::Dispatchable;
 use sp_std::marker::PhantomData;
 use subtensor_runtime_common::{NetUid, NetUidStorageIndex};
 
-type CallOf<T> = <T as frame_system::Config>::RuntimeCall;
-type DispatchableOriginOf<T> = <CallOf<T> as Dispatchable>::RuntimeOrigin;
-
 /// Dispatch extension for rate-limit checks that are safe to reject before dispatch.
 ///
 /// Signed weight and network-registration calls are checked before dispatch;
@@ -19,6 +17,17 @@ type DispatchableOriginOf<T> = <CallOf<T> as Dispatchable>::RuntimeOrigin;
 pub struct CheckRateLimits<T: Config>(PhantomData<T>);
 
 impl<T: Config> CheckRateLimits<T> {
+    pub(crate) fn applies_to(call: &Call<T>) -> bool {
+        matches!(
+            call,
+            Call::commit_weights { .. }
+                | Call::commit_mechanism_weights { .. }
+                | Call::set_weights { .. }
+                | Call::set_mechanism_weights { .. }
+                | Call::register_network { .. }
+        )
+    }
+
     fn check_weights_rate_limit(
         who: &T::AccountId,
         netuid: NetUid,
@@ -89,8 +98,10 @@ where
 {
     type Pre = ();
 
-    fn weight(_call: &CallOf<T>) -> Weight {
-        <T as Config>::WeightInfo::check_rate_limits_extension()
+    fn weight(call: &CallOf<T>) -> Weight {
+        applicable_call(call, Self::applies_to)
+            .map(|_| <T as Config>::WeightInfo::check_rate_limits_extension())
+            .unwrap_or(Weight::zero())
     }
 
     fn pre_dispatch(
@@ -101,7 +112,7 @@ where
             return Ok(());
         };
 
-        let Some(call) = call.is_sub_type() else {
+        let Some(call) = applicable_call(call, Self::applies_to) else {
             return Ok(());
         };
 
@@ -113,9 +124,12 @@ where
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::CheckRateLimits;
-    use crate::{Error, tests::mock::*};
+    use crate::{Error, tests::mock::*, weights::WeightInfo as _};
     use frame_support::{
-        assert_ok, dispatch::DispatchResultWithPostInfo, traits::ExtendedDispatchable,
+        assert_ok,
+        dispatch::{DispatchExtension, DispatchResultWithPostInfo},
+        traits::ExtendedDispatchable,
+        weights::Weight,
     };
     use frame_system::Call as SystemCall;
     use sp_core::U256;
@@ -153,6 +167,57 @@ mod tests {
 
     fn fund(coldkey: U256, amount: TaoBalance) {
         add_balance_to_coldkey_account(&coldkey, amount);
+    }
+
+    fn add_stake_call() -> RuntimeCall {
+        RuntimeCall::SubtensorModule(SubtensorCall::add_stake {
+            hotkey: U256::from(1),
+            netuid: 1u16.into(),
+            amount_staked: 1_000u64.into(),
+        })
+    }
+
+    #[test]
+    fn weight_only_charges_rate_limited_calls() {
+        let netuid = NetUid::from(1);
+        let expected = <Test as crate::Config>::WeightInfo::check_rate_limits_extension();
+        let charged_calls = [
+            RuntimeCall::SubtensorModule(SubtensorCall::commit_weights {
+                netuid,
+                commit_hash: sp_core::H256::zero(),
+            }),
+            RuntimeCall::SubtensorModule(SubtensorCall::commit_mechanism_weights {
+                netuid,
+                mecid: MechId::MAIN,
+                commit_hash: sp_core::H256::zero(),
+            }),
+            set_weights_call(netuid, 0),
+            RuntimeCall::SubtensorModule(SubtensorCall::set_mechanism_weights {
+                netuid,
+                mecid: MechId::MAIN,
+                dests: vec![0],
+                weights: vec![1],
+                version_key: 0,
+            }),
+            register_network_call(U256::from(1)),
+        ];
+
+        for call in [
+            RuntimeCall::System(SystemCall::remark { remark: vec![] }),
+            add_stake_call(),
+        ] {
+            assert_eq!(
+                <CheckRateLimits<Test> as DispatchExtension<RuntimeCall>>::weight(&call),
+                Weight::zero()
+            );
+        }
+
+        for call in charged_calls {
+            assert_eq!(
+                <CheckRateLimits<Test> as DispatchExtension<RuntimeCall>>::weight(&call),
+                expected
+            );
+        }
     }
 
     #[test]

--- a/pallets/subtensor/src/guards/check_serving_endpoints.rs
+++ b/pallets/subtensor/src/guards/check_serving_endpoints.rs
@@ -1,3 +1,4 @@
+use super::{CallOf, DispatchableOriginOf, applicable_call};
 use crate::weights::WeightInfo;
 use crate::{Call, Config, Error, Pallet};
 use frame_support::{
@@ -8,9 +9,6 @@ use frame_support::{
 use sp_runtime::traits::Dispatchable;
 use sp_std::marker::PhantomData;
 
-type CallOf<T> = <T as frame_system::Config>::RuntimeCall;
-type DispatchableOriginOf<T> = <CallOf<T> as Dispatchable>::RuntimeOrigin;
-
 /// Dispatch extension for axon/prometheus endpoint validation.
 ///
 /// Signed serving calls are checked before dispatch; unrelated calls and
@@ -18,6 +16,13 @@ type DispatchableOriginOf<T> = <CallOf<T> as Dispatchable>::RuntimeOrigin;
 pub struct CheckServingEndpoints<T: Config>(PhantomData<T>);
 
 impl<T: Config> CheckServingEndpoints<T> {
+    pub(crate) fn applies_to(call: &Call<T>) -> bool {
+        matches!(
+            call,
+            Call::serve_axon { .. } | Call::serve_axon_tls { .. } | Call::serve_prometheus { .. }
+        )
+    }
+
     pub fn check(who: &T::AccountId, call: &Call<T>) -> Result<(), Error<T>> {
         match call {
             Call::serve_axon {
@@ -74,8 +79,10 @@ where
 {
     type Pre = ();
 
-    fn weight(_call: &CallOf<T>) -> Weight {
-        <T as Config>::WeightInfo::check_serving_endpoints_extension()
+    fn weight(call: &CallOf<T>) -> Weight {
+        applicable_call(call, Self::applies_to)
+            .map(|_| <T as Config>::WeightInfo::check_serving_endpoints_extension())
+            .unwrap_or(Weight::zero())
     }
 
     fn pre_dispatch(
@@ -86,7 +93,7 @@ where
             return Ok(());
         };
 
-        let Some(call) = call.is_sub_type() else {
+        let Some(call) = applicable_call(call, Self::applies_to) else {
             return Ok(());
         };
 
@@ -98,9 +105,12 @@ where
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::CheckServingEndpoints;
-    use crate::{Error, tests::mock::*};
+    use crate::{Error, tests::mock::*, weights::WeightInfo as _};
     use frame_support::{
-        assert_ok, dispatch::DispatchResultWithPostInfo, traits::ExtendedDispatchable,
+        assert_ok,
+        dispatch::{DispatchExtension, DispatchResultWithPostInfo},
+        traits::ExtendedDispatchable,
+        weights::Weight,
     };
     use frame_system::Call as SystemCall;
     use sp_core::U256;
@@ -158,6 +168,41 @@ mod tests {
         add_network(netuid, 1, 0);
         setup_reserves(netuid, DEFAULT_RESERVE.into(), DEFAULT_RESERVE.into());
         register_ok_neuron(netuid, hotkey, coldkey, 0);
+    }
+
+    fn add_stake_call() -> RuntimeCall {
+        RuntimeCall::SubtensorModule(SubtensorCall::add_stake {
+            hotkey: U256::from(1),
+            netuid: 1u16.into(),
+            amount_staked: 1_000u64.into(),
+        })
+    }
+
+    #[test]
+    fn weight_only_charges_serving_endpoint_calls() {
+        let netuid = NetUid::from(1);
+        let expected = <Test as crate::Config>::WeightInfo::check_serving_endpoints_extension();
+
+        for call in [
+            RuntimeCall::System(SystemCall::remark { remark: vec![] }),
+            add_stake_call(),
+        ] {
+            assert_eq!(
+                <CheckServingEndpoints<Test> as DispatchExtension<RuntimeCall>>::weight(&call),
+                Weight::zero()
+            );
+        }
+
+        for call in [
+            serve_axon_call(netuid),
+            serve_axon_tls_call(netuid),
+            serve_prometheus_call(netuid),
+        ] {
+            assert_eq!(
+                <CheckServingEndpoints<Test> as DispatchExtension<RuntimeCall>>::weight(&call),
+                expected
+            );
+        }
     }
 
     #[test]

--- a/pallets/subtensor/src/guards/check_weights.rs
+++ b/pallets/subtensor/src/guards/check_weights.rs
@@ -1,3 +1,4 @@
+use super::{CallOf, DispatchableOriginOf, applicable_call};
 use crate::weights::WeightInfo;
 use crate::{Call, Config, Error, Pallet, WeightCommits};
 use frame_support::{
@@ -10,8 +11,6 @@ use sp_runtime::traits::Dispatchable;
 use sp_std::{collections::vec_deque::VecDeque, marker::PhantomData, vec::Vec};
 use subtensor_runtime_common::{NetUid, NetUidStorageIndex};
 
-type CallOf<T> = <T as frame_system::Config>::RuntimeCall;
-type DispatchableOriginOf<T> = <CallOf<T> as Dispatchable>::RuntimeOrigin;
 type WeightCommitQueue = VecDeque<(H256, u64, u64, u64)>;
 
 /// Dispatch extension for weight-setting preconditions.
@@ -21,6 +20,24 @@ type WeightCommitQueue = VecDeque<(H256, u64, u64, u64)>;
 pub struct CheckWeights<T: Config>(PhantomData<T>);
 
 impl<T: Config> CheckWeights<T> {
+    pub(crate) fn applies_to(call: &Call<T>) -> bool {
+        matches!(
+            call,
+            Call::batch_commit_weights { .. }
+                | Call::batch_reveal_weights { .. }
+                | Call::batch_set_weights { .. }
+                | Call::commit_weights { .. }
+                | Call::commit_mechanism_weights { .. }
+                | Call::reveal_weights { .. }
+                | Call::reveal_mechanism_weights { .. }
+                | Call::set_weights { .. }
+                | Call::set_mechanism_weights { .. }
+                | Call::commit_timelocked_weights { .. }
+                | Call::commit_timelocked_mechanism_weights { .. }
+                | Call::commit_crv3_mechanism_weights { .. }
+        )
+    }
+
     pub fn check(who: &T::AccountId, call: &Call<T>) -> Result<(), Error<T>> {
         Self::check_input_lengths(call)?;
         Self::check_min_stake(who, call)?;
@@ -227,8 +244,10 @@ where
 {
     type Pre = ();
 
-    fn weight(_call: &CallOf<T>) -> Weight {
-        <T as Config>::WeightInfo::check_weights_extension()
+    fn weight(call: &CallOf<T>) -> Weight {
+        applicable_call(call, Self::applies_to)
+            .map(|_| <T as Config>::WeightInfo::check_weights_extension())
+            .unwrap_or(Weight::zero())
     }
 
     fn pre_dispatch(
@@ -239,7 +258,7 @@ where
             return Ok(());
         };
 
-        let Some(call) = call.is_sub_type() else {
+        let Some(call) = applicable_call(call, Self::applies_to) else {
             return Ok(());
         };
 
@@ -251,11 +270,14 @@ where
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::CheckWeights;
-    use crate::{Error, MAX_CRV3_COMMIT_SIZE_BYTES, tests::mock::*};
+    use crate::{Error, MAX_CRV3_COMMIT_SIZE_BYTES, tests::mock::*, weights::WeightInfo as _};
     use codec::Compact;
     use frame_support::{
-        BoundedVec, assert_ok, dispatch::DispatchResultWithPostInfo, traits::ConstU32,
+        BoundedVec, assert_ok,
+        dispatch::{DispatchExtension, DispatchResultWithPostInfo},
+        traits::ConstU32,
         traits::ExtendedDispatchable,
+        weights::Weight,
     };
     use frame_system::Call as SystemCall;
     use pallet_drand::LastStoredRound;
@@ -309,6 +331,99 @@ mod tests {
         })
     }
 
+    fn add_stake_call() -> RuntimeCall {
+        RuntimeCall::SubtensorModule(SubtensorCall::add_stake {
+            hotkey: U256::from(1),
+            netuid: 1u16.into(),
+            amount_staked: 1_000u64.into(),
+        })
+    }
+
+    fn checked_weight_calls(netuid: NetUid) -> Vec<RuntimeCall> {
+        let bounded_commit =
+            BoundedVec::<u8, ConstU32<MAX_CRV3_COMMIT_SIZE_BYTES>>::try_from(vec![0]).unwrap();
+
+        vec![
+            set_weights_call(netuid, 0),
+            RuntimeCall::SubtensorModule(SubtensorCall::set_mechanism_weights {
+                netuid,
+                mecid: MechId::MAIN,
+                dests: vec![0],
+                weights: vec![1],
+                version_key: 0,
+            }),
+            RuntimeCall::SubtensorModule(SubtensorCall::batch_set_weights {
+                netuids: vec![Compact(netuid)],
+                weights: vec![vec![(Compact(0_u16), Compact(1_u16))]],
+                version_keys: vec![Compact(0_u64)],
+            }),
+            RuntimeCall::SubtensorModule(SubtensorCall::commit_weights {
+                netuid,
+                commit_hash: H256::zero(),
+            }),
+            RuntimeCall::SubtensorModule(SubtensorCall::commit_mechanism_weights {
+                netuid,
+                mecid: MechId::MAIN,
+                commit_hash: H256::zero(),
+            }),
+            RuntimeCall::SubtensorModule(SubtensorCall::batch_commit_weights {
+                netuids: vec![Compact(netuid)],
+                commit_hashes: vec![H256::zero()],
+            }),
+            reveal_weights_call(netuid),
+            reveal_mechanism_weights_call(netuid, MechId::MAIN),
+            RuntimeCall::SubtensorModule(SubtensorCall::batch_reveal_weights {
+                netuid,
+                uids_list: vec![vec![0]],
+                values_list: vec![vec![1]],
+                salts_list: vec![vec![1]],
+                version_keys: vec![0],
+            }),
+            RuntimeCall::SubtensorModule(SubtensorCall::commit_timelocked_weights {
+                netuid,
+                commit: bounded_commit.clone(),
+                reveal_round: 0,
+                commit_reveal_version: 0,
+            }),
+            RuntimeCall::SubtensorModule(SubtensorCall::commit_timelocked_mechanism_weights {
+                netuid,
+                mecid: MechId::MAIN,
+                commit: bounded_commit.clone(),
+                reveal_round: 0,
+                commit_reveal_version: 0,
+            }),
+            RuntimeCall::SubtensorModule(SubtensorCall::commit_crv3_mechanism_weights {
+                netuid,
+                mecid: MechId::MAIN,
+                commit: bounded_commit,
+                reveal_round: 0,
+            }),
+        ]
+    }
+
+    #[test]
+    fn weight_only_charges_weight_related_calls() {
+        let netuid = NetUid::from(1);
+        let expected = <Test as crate::Config>::WeightInfo::check_weights_extension();
+
+        for call in [
+            RuntimeCall::System(SystemCall::remark { remark: vec![] }),
+            add_stake_call(),
+        ] {
+            assert_eq!(
+                <CheckWeights<Test> as DispatchExtension<RuntimeCall>>::weight(&call),
+                Weight::zero()
+            );
+        }
+
+        for call in checked_weight_calls(netuid) {
+            assert_eq!(
+                <CheckWeights<Test> as DispatchExtension<RuntimeCall>>::weight(&call),
+                expected
+            );
+        }
+    }
+
     #[test]
     fn unrelated_calls_pass_through() {
         new_test_ext(0).execute_with(|| {
@@ -360,72 +475,13 @@ mod tests {
             let netuid = NetUid::from(1);
             let hotkey = U256::from(1);
             let coldkey = U256::from(2);
-            let bounded_commit =
-                BoundedVec::<u8, ConstU32<MAX_CRV3_COMMIT_SIZE_BYTES>>::try_from(vec![0]).unwrap();
             add_network_disable_commit_reveal(netuid, 1, 0);
             setup_reserves(netuid, DEFAULT_RESERVE.into(), DEFAULT_RESERVE.into());
             SubtensorModule::append_neuron(netuid, &hotkey, 0);
             crate::Owner::<Test>::insert(hotkey, coldkey);
             SubtensorModule::set_stake_threshold(1_000_000_000_000_u64);
 
-            let calls = [
-                set_weights_call(netuid, 0),
-                RuntimeCall::SubtensorModule(SubtensorCall::set_mechanism_weights {
-                    netuid,
-                    mecid: MechId::MAIN,
-                    dests: vec![0],
-                    weights: vec![1],
-                    version_key: 0,
-                }),
-                RuntimeCall::SubtensorModule(SubtensorCall::batch_set_weights {
-                    netuids: vec![Compact(netuid)],
-                    weights: vec![vec![(Compact(0_u16), Compact(1_u16))]],
-                    version_keys: vec![Compact(0_u64)],
-                }),
-                RuntimeCall::SubtensorModule(SubtensorCall::commit_weights {
-                    netuid,
-                    commit_hash: H256::zero(),
-                }),
-                RuntimeCall::SubtensorModule(SubtensorCall::commit_mechanism_weights {
-                    netuid,
-                    mecid: MechId::MAIN,
-                    commit_hash: H256::zero(),
-                }),
-                RuntimeCall::SubtensorModule(SubtensorCall::batch_commit_weights {
-                    netuids: vec![Compact(netuid)],
-                    commit_hashes: vec![H256::zero()],
-                }),
-                reveal_weights_call(netuid),
-                reveal_mechanism_weights_call(netuid, MechId::MAIN),
-                RuntimeCall::SubtensorModule(SubtensorCall::batch_reveal_weights {
-                    netuid,
-                    uids_list: vec![vec![0]],
-                    values_list: vec![vec![1]],
-                    salts_list: vec![vec![1]],
-                    version_keys: vec![0],
-                }),
-                RuntimeCall::SubtensorModule(SubtensorCall::commit_timelocked_weights {
-                    netuid,
-                    commit: bounded_commit.clone(),
-                    reveal_round: 0,
-                    commit_reveal_version: 0,
-                }),
-                RuntimeCall::SubtensorModule(SubtensorCall::commit_timelocked_mechanism_weights {
-                    netuid,
-                    mecid: MechId::MAIN,
-                    commit: bounded_commit.clone(),
-                    reveal_round: 0,
-                    commit_reveal_version: 0,
-                }),
-                RuntimeCall::SubtensorModule(SubtensorCall::commit_crv3_mechanism_weights {
-                    netuid,
-                    mecid: MechId::MAIN,
-                    commit: bounded_commit,
-                    reveal_round: 0,
-                }),
-            ];
-
-            for call in calls {
+            for call in checked_weight_calls(netuid) {
                 assert_eq!(
                     err(dispatch_with_ext(call, RuntimeOrigin::signed(hotkey))),
                     Error::<Test>::NotEnoughStakeToSetWeights.into()

--- a/pallets/subtensor/src/guards/mod.rs
+++ b/pallets/subtensor/src/guards/mod.rs
@@ -5,9 +5,28 @@ mod check_rate_limits;
 mod check_serving_endpoints;
 mod check_weights;
 
+use crate::{Call, Config};
+use frame_support::traits::IsSubType;
+use sp_runtime::traits::Dispatchable;
+
 pub use check_coldkey_swap::*;
 pub use check_delegate_take::*;
 pub use check_evm_key_association::*;
 pub use check_rate_limits::*;
 pub use check_serving_endpoints::*;
 pub use check_weights::*;
+
+pub(crate) type CallOf<T> = <T as frame_system::Config>::RuntimeCall;
+pub(crate) type DispatchableOriginOf<T> = <CallOf<T> as Dispatchable>::RuntimeOrigin;
+
+pub(crate) fn applicable_call<T>(
+    call: &CallOf<T>,
+    applies_to: impl FnOnce(&Call<T>) -> bool,
+) -> Option<&Call<T>>
+where
+    T: Config,
+    CallOf<T>: IsSubType<Call<T>>,
+{
+    let call = call.is_sub_type()?;
+    applies_to(call).then_some(call)
+}


### PR DESCRIPTION
## Summary

This PR reduces the overall fee charged by the subtensor transaction extension by making most dispatch-extension weights conditional on the call they actually validate.

Previously, every transaction paid the benchmarked weight for each subtensor dispatch extension, even when the call could not be affected by that extension. This meant unrelated calls, such as staking calls, could pay for delegate-take, serving-endpoint, EVM-key-association, rate-limit, and weights checks.

The change introduces a shared `applicable_call` helper that downcasts runtime calls to subtensor calls and filters them through each guard's `applies_to` predicate. The same filter is used by:

- `DispatchExtension::weight`
- `DispatchExtension::pre_dispatch`
- `SubtensorTransactionExtension::check`

`CheckColdkeySwap` remains unconditional because coldkey swap state can block any signed runtime call.

## Changes

- Charge `CheckDelegateTake` weight only for `increase_take` and `decrease_take`.
- Charge `CheckWeights` weight only for weight commit, reveal, set, batch, and timelocked weight calls.
- Charge `CheckRateLimits` weight only for rate-limited weight calls and `register_network`.
- Charge `CheckServingEndpoints` weight only for axon and prometheus serving calls.
- Charge `CheckEvmKeyAssociation` weight only for `associate_evm_key`.
- Keep `CheckColdkeySwap` charged for all calls, since it can reject any signed call during a swap.
- Align transaction validation with dispatch-extension applicability filtering.
- Add focused tests covering zero weight for unrelated calls and expected weight for applicable calls.