### PR TITLE
No capping on locked alpha transfers

### DIFF
--- a/pallets/subtensor/src/staking/move_stake.rs
+++ b/pallets/subtensor/src/staking/move_stake.rs
@@ -303,15 +303,6 @@ impl<T: Config> Pallet<T> {
         maybe_allow_partial: Option<bool>,
         check_transfer_toggle: bool,
     ) -> Result<TaoBalance, DispatchError> {
-        // Cap the alpha_amount at available Alpha because user might be paying transaxtion fees
-        // in Alpha and their total is already reduced by now.
-        let alpha_available = Self::get_stake_for_hotkey_and_coldkey_on_subnet(
-            origin_hotkey,
-            origin_coldkey,
-            origin_netuid,
-        );
-        let alpha_amount = alpha_amount.min(alpha_available);
-
         // Calculate the maximum amount that can be executed
         let max_amount = if origin_netuid != destination_netuid {
             if let Some(limit_price) = maybe_limit_price {

--- a/pallets/subtensor/src/tests/move_stake.rs
+++ b/pallets/subtensor/src/tests/move_stake.rs
@@ -515,7 +515,7 @@ fn test_do_move_wrong_origin() {
                 netuid,
                 alpha,
             ),
-            Error::<Test>::AmountTooLow
+            Error::<Test>::NotEnoughStakeToWithdraw
         );
 
         // Check that no stake was moved
@@ -1100,7 +1100,7 @@ fn test_do_transfer_wrong_origin() {
                 netuid,
                 stake_amount.into()
             ),
-            Error::<Test>::AmountTooLow
+            Error::<Test>::NotEnoughStakeToWithdraw
         );
     });
 }
@@ -1350,13 +1350,16 @@ fn test_do_swap_insufficient_stake() {
         )
         .unwrap();
 
-        assert_ok!(SubtensorModule::do_swap_stake(
-            RuntimeOrigin::signed(coldkey),
-            hotkey,
-            netuid1,
-            netuid2,
-            attempted_swap.into()
-        ));
+        assert_noop!(
+            SubtensorModule::do_swap_stake(
+                RuntimeOrigin::signed(coldkey),
+                hotkey,
+                netuid1,
+                netuid2,
+                attempted_swap.into()
+            ),
+            Error::<Test>::NotEnoughStakeToWithdraw
+        );
     });
 }
 
@@ -1393,7 +1396,7 @@ fn test_do_swap_wrong_origin() {
                 netuid2,
                 stake_amount.into()
             ),
-            Error::<Test>::AmountTooLow
+            Error::<Test>::NotEnoughStakeToWithdraw
         );
     });
 }

--- a/pallets/subtensor/src/tests/move_stake.rs
+++ b/pallets/subtensor/src/tests/move_stake.rs
@@ -1023,17 +1023,45 @@ fn test_do_transfer_insufficient_stake() {
         )
         .unwrap();
 
-        // Amount over available stake succeeds (because fees can be paid in Alpha,
-        // this limitation is removed)
+        let origin_alpha_before = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey,
+            &origin_coldkey,
+            netuid,
+        );
+        let destination_alpha_before = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey,
+            &destination_coldkey,
+            netuid,
+        );
+
         let alpha = stake_amount * 2;
-        assert_ok!(SubtensorModule::do_transfer_stake(
-            RuntimeOrigin::signed(origin_coldkey),
-            destination_coldkey,
-            hotkey,
-            netuid,
-            netuid,
-            alpha.into()
-        ));
+        assert_noop!(
+            SubtensorModule::do_transfer_stake(
+                RuntimeOrigin::signed(origin_coldkey),
+                destination_coldkey,
+                hotkey,
+                netuid,
+                netuid,
+                alpha.into()
+            ),
+            Error::<Test>::NotEnoughStakeToWithdraw
+        );
+        assert_eq!(
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+                &hotkey,
+                &origin_coldkey,
+                netuid
+            ),
+            origin_alpha_before
+        );
+        assert_eq!(
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+                &hotkey,
+                &destination_coldkey,
+                netuid
+            ),
+            destination_alpha_before
+        );
     });
 }
 

--- a/pallets/transaction-fee/src/tests/mod.rs
+++ b/pallets/transaction-fee/src/tests/mod.rs
@@ -10,6 +10,7 @@ use sp_runtime::{
     transaction_validity::{InvalidTransaction, TransactionValidityError},
 };
 use subtensor_runtime_common::AlphaBalance;
+use subtensor_swap_interface::SwapHandler;
 
 use mock::*;
 mod mock;
@@ -1255,6 +1256,135 @@ fn test_transfer_stake_fees_alpha() {
         // Extrinsic should pay fees in Alpha
         assert_eq!(actual_tao_fee, 0.into());
         assert!(actual_alpha_fee > 0.into());
+    });
+}
+
+// cargo test --package subtensor-transaction-fee --lib -- tests::test_transfer_stake_full_amount_fails_when_alpha_fee_reduces_available_stake --exact --show-output
+#[test]
+fn test_transfer_stake_full_amount_fails_when_alpha_fee_reduces_available_stake() {
+    new_test_ext().execute_with(|| {
+        let destination_coldkey = U256::from(100000);
+        let stake_amount = TAO;
+        let sn = setup_subnets(2, 2);
+        setup_stake(
+            sn.subnets[0].netuid,
+            &sn.coldkey,
+            &sn.hotkeys[0],
+            stake_amount,
+        );
+
+        let current_balance = Balances::free_balance(sn.coldkey);
+        remove_balance_from_coldkey_account(&sn.coldkey, current_balance);
+        assert_eq!(Balances::free_balance(sn.coldkey), TaoBalance::ZERO);
+
+        let alpha_before = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+            &sn.hotkeys[0],
+            &sn.coldkey,
+            sn.subnets[0].netuid,
+        );
+        let call = RuntimeCall::SubtensorModule(pallet_subtensor::Call::transfer_stake {
+            destination_coldkey,
+            hotkey: sn.hotkeys[0],
+            origin_netuid: sn.subnets[0].netuid,
+            destination_netuid: sn.subnets[1].netuid,
+            alpha_amount: alpha_before,
+        });
+        let info = call.get_dispatch_info();
+        let ext = pallet_transaction_payment::ChargeTransactionPayment::<Test>::from(0.into());
+
+        let inner = ext
+            .dispatch_transaction(RuntimeOrigin::signed(sn.coldkey).into(), call, &info, 0, 0)
+            .expect("alpha fee payment should validate");
+        assert_eq!(
+            inner.unwrap_err().error,
+            Error::<Test>::NotEnoughStakeToWithdraw.into()
+        );
+
+        let alpha_after = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+            &sn.hotkeys[0],
+            &sn.coldkey,
+            sn.subnets[0].netuid,
+        );
+        let actual_alpha_fee = alpha_before - alpha_after;
+        assert!(actual_alpha_fee > AlphaBalance::ZERO);
+        assert_eq!(
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+                &sn.hotkeys[0],
+                &destination_coldkey,
+                sn.subnets[1].netuid,
+            ),
+            AlphaBalance::ZERO
+        );
+    });
+
+    new_test_ext().execute_with(|| {
+        let destination_coldkey = U256::from(100000);
+        let stake_amount = TAO;
+        let sn = setup_subnets(2, 2);
+        setup_stake(
+            sn.subnets[0].netuid,
+            &sn.coldkey,
+            &sn.hotkeys[0],
+            stake_amount,
+        );
+
+        let current_balance = Balances::free_balance(sn.coldkey);
+        remove_balance_from_coldkey_account(&sn.coldkey, current_balance);
+        assert_eq!(Balances::free_balance(sn.coldkey), TaoBalance::ZERO);
+
+        let alpha_before = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+            &sn.hotkeys[0],
+            &sn.coldkey,
+            sn.subnets[0].netuid,
+        );
+        let full_amount_call =
+            RuntimeCall::SubtensorModule(pallet_subtensor::Call::transfer_stake {
+                destination_coldkey,
+                hotkey: sn.hotkeys[0],
+                origin_netuid: sn.subnets[0].netuid,
+                destination_netuid: sn.subnets[1].netuid,
+                alpha_amount: alpha_before,
+            });
+        let info = full_amount_call.get_dispatch_info();
+        let tao_fee = pallet_transaction_payment::Pallet::<Test>::compute_fee(0, &info, 0.into());
+        let alpha_fee = pallet_subtensor_swap::Pallet::<Test>::get_alpha_amount_for_tao(
+            sn.subnets[0].netuid,
+            tao_fee,
+        );
+        assert!(alpha_fee > AlphaBalance::ZERO);
+
+        let transfer_amount = alpha_before - alpha_fee;
+        let call = RuntimeCall::SubtensorModule(pallet_subtensor::Call::transfer_stake {
+            destination_coldkey,
+            hotkey: sn.hotkeys[0],
+            origin_netuid: sn.subnets[0].netuid,
+            destination_netuid: sn.subnets[1].netuid,
+            alpha_amount: transfer_amount,
+        });
+        let info = call.get_dispatch_info();
+        let ext = pallet_transaction_payment::ChargeTransactionPayment::<Test>::from(0.into());
+
+        let inner = ext
+            .dispatch_transaction(RuntimeOrigin::signed(sn.coldkey).into(), call, &info, 0, 0)
+            .expect("alpha fee payment should validate");
+        assert_ok!(inner);
+
+        assert_eq!(Balances::free_balance(sn.coldkey), TaoBalance::ZERO);
+        assert_eq!(
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+                &sn.hotkeys[0],
+                &sn.coldkey,
+                sn.subnets[0].netuid,
+            ),
+            AlphaBalance::ZERO
+        );
+        assert!(
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+                &sn.hotkeys[0],
+                &destination_coldkey,
+                sn.subnets[1].netuid,
+            ) > AlphaBalance::ZERO
+        );
     });
 }
 


### PR DESCRIPTION
## Description

**Note: This is a good PR for the community to discuss and possibly vote.**

When transferring alpha between subnets, the extrinsics currently silently cap transfer amount by available alpha: If more alpha is requested to transfer, the extrinsic transfers only what's available and succeeds. There are two concurrent and conflicting issues:

1. If the chain silently caps (current behavior): The extrinsic reports success and mis-accounting may occur because less alpha was transferred than was requested yet the extrinsic result is Ok.
2. If the chain does not silently cap (new behavior implemented in this PR): When the user requests exactly available alpha to transfer and has no TAO on the signing coldkey, the tx fees are paid in alpha _before_ the transfer amount is checked, which results in transaction error (and loss of fees). The client software needs to account for alpha fees to prevent this.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

Some clients may be broken if they request transfer amounts above the unlocked alpha.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
