### PR TITLE
Add eco-tests for Mentat

### DIFF
--- a/chain-extensions/src/tests.rs
+++ b/chain-extensions/src/tests.rs
@@ -1297,14 +1297,25 @@ fn add_stake_recycle_rollback_on_recycle_failure() {
 
         let netuid = mock::add_dynamic_network(&owner_hotkey, &owner_coldkey);
 
-        // Set up very low reserves so recycle will fail with InsufficientLiquidity
-        mock::setup_reserves(
+        mock::register_ok_neuron(netuid, hotkey, coldkey, 0);
+        pallet_subtensor::Pallet::<mock::Test>::insert_lock_state(
+            &coldkey,
             netuid,
-            TaoBalance::from(1_000_u64),
-            AlphaBalance::from(1_000_u64),
+            &hotkey,
+            pallet_subtensor::staking::lock::LockState {
+                locked_mass: AlphaBalance::from(u64::MAX / 4),
+                conviction: U64F64::saturating_from_num(0),
+                last_update: pallet_subtensor::Pallet::<mock::Test>::get_current_block_as_u64(),
+            },
         );
 
-        mock::register_ok_neuron(netuid, hotkey, coldkey, 0);
+        // Leave enough input-side liquidity for add_stake to pass the 1000x swap input cap.
+        // The lock above makes the recycle leg fail, exercising atomic rollback.
+        mock::setup_reserves(
+            netuid,
+            TaoBalance::from(tao_amount_raw / 1000 + 1),
+            AlphaBalance::from(1_000_u64),
+        );
 
         add_balance_to_coldkey_account(
             &coldkey,
@@ -1368,14 +1379,25 @@ fn add_stake_burn_rollback_on_burn_failure() {
 
         let netuid = mock::add_dynamic_network(&owner_hotkey, &owner_coldkey);
 
-        // Set up very low reserves so burn will fail with InsufficientLiquidity
-        mock::setup_reserves(
+        mock::register_ok_neuron(netuid, hotkey, coldkey, 0);
+        pallet_subtensor::Pallet::<mock::Test>::insert_lock_state(
+            &coldkey,
             netuid,
-            TaoBalance::from(1_000_u64),
-            AlphaBalance::from(1_000_u64),
+            &hotkey,
+            pallet_subtensor::staking::lock::LockState {
+                locked_mass: AlphaBalance::from(u64::MAX / 4),
+                conviction: U64F64::saturating_from_num(0),
+                last_update: pallet_subtensor::Pallet::<mock::Test>::get_current_block_as_u64(),
+            },
         );
 
-        mock::register_ok_neuron(netuid, hotkey, coldkey, 0);
+        // Leave enough input-side liquidity for add_stake to pass the 1000x swap input cap.
+        // The lock above makes the burn leg fail, exercising atomic rollback.
+        mock::setup_reserves(
+            netuid,
+            TaoBalance::from(tao_amount_raw / 1000 + 1),
+            AlphaBalance::from(1_000_u64),
+        );
 
         add_balance_to_coldkey_account(
             &coldkey,

--- a/eco-tests/src/lib.rs
+++ b/eco-tests/src/lib.rs
@@ -7,3 +7,6 @@ mod tests;
 
 #[cfg(test)]
 mod tests_taocom_indexer;
+
+#[cfg(test)]
+mod tests_mentat_indexer;

--- a/eco-tests/src/mock.rs
+++ b/eco-tests/src/mock.rs
@@ -612,11 +612,19 @@ pub fn add_balance_to_coldkey_account(coldkey: &U256, tao: TaoBalance) {
 mod api_mocks {
     use codec::Compact;
     use pallet_subtensor::rpc_info::delegate_info::DelegateInfo;
+    use pallet_subtensor::rpc_info::dynamic_info::DynamicInfo;
+    use pallet_subtensor::rpc_info::metagraph::{Metagraph, SelectiveMetagraph};
+    use pallet_subtensor::rpc_info::show_subnet::SubnetState;
     use pallet_subtensor::rpc_info::stake_info::StakeInfo;
+    use pallet_subtensor::rpc_info::subnet_info::{
+        SubnetHyperparams, SubnetHyperparamsV2, SubnetHyperparamsV3, SubnetInfo, SubnetInfov2,
+    };
     use pallet_subtensor_swap_runtime_api::{SimSwapResult, SubnetPrice, SwapRuntimeApi};
     use sp_runtime::AccountId32;
-    use subtensor_custom_rpc_runtime_api::{DelegateInfoRuntimeApi, StakeInfoRuntimeApi};
-    use subtensor_runtime_common::{AlphaBalance, NetUid, TaoBalance};
+    use subtensor_custom_rpc_runtime_api::{
+        DelegateInfoRuntimeApi, StakeInfoRuntimeApi, SubnetInfoRuntimeApi,
+    };
+    use subtensor_runtime_common::{AlphaBalance, MechId, NetUid, TaoBalance};
 
     use super::Block;
 
@@ -658,6 +666,31 @@ mod api_mocks {
             ) -> u64 {
                 0
             }
+        }
+
+        impl SubnetInfoRuntimeApi<Block> for MockApi {
+            fn get_subnet_info(_netuid: NetUid) -> Option<SubnetInfo<AccountId32>> { None }
+            fn get_subnets_info() -> Vec<Option<SubnetInfo<AccountId32>>> { Vec::new() }
+            fn get_subnet_info_v2(_netuid: NetUid) -> Option<SubnetInfov2<AccountId32>> { None }
+            fn get_subnets_info_v2() -> Vec<Option<SubnetInfov2<AccountId32>>> { Vec::new() }
+            #[allow(deprecated)]
+            fn get_subnet_hyperparams(_netuid: NetUid) -> Option<SubnetHyperparams> { None }
+            #[allow(deprecated)]
+            fn get_subnet_hyperparams_v2(_netuid: NetUid) -> Option<SubnetHyperparamsV2> { None }
+            fn get_subnet_hyperparams_v3(_netuid: NetUid) -> Option<SubnetHyperparamsV3> { None }
+            fn get_all_dynamic_info() -> Vec<Option<DynamicInfo<AccountId32>>> { Vec::new() }
+            fn get_all_metagraphs() -> Vec<Option<Metagraph<AccountId32>>> { Vec::new() }
+            fn get_metagraph(_netuid: NetUid) -> Option<Metagraph<AccountId32>> { None }
+            fn get_all_mechagraphs() -> Vec<Option<Metagraph<AccountId32>>> { Vec::new() }
+            fn get_mechagraph(_netuid: NetUid, _mecid: MechId) -> Option<Metagraph<AccountId32>> { None }
+            fn get_dynamic_info(_netuid: NetUid) -> Option<DynamicInfo<AccountId32>> { None }
+            fn get_subnet_state(_netuid: NetUid) -> Option<SubnetState<AccountId32>> { None }
+            fn get_selective_metagraph(_netuid: NetUid, _metagraph_indexes: Vec<u16>) -> Option<SelectiveMetagraph<AccountId32>> { None }
+            fn get_coldkey_auto_stake_hotkey(_coldkey: AccountId32, _netuid: NetUid) -> Option<AccountId32> { None }
+            fn get_selective_mechagraph(_netuid: NetUid, _subid: MechId, _metagraph_indexes: Vec<u16>) -> Option<SelectiveMetagraph<AccountId32>> { None }
+            fn get_subnet_to_prune() -> Option<NetUid> { None }
+            fn get_subnet_account_id(_netuid: NetUid) -> Option<AccountId32> { None }
+            fn get_next_epoch_start_block(_netuid: NetUid) -> Option<u64> { None }
         }
 
         impl SwapRuntimeApi<Block> for MockApi {

--- a/eco-tests/src/tests_mentat_indexer.rs
+++ b/eco-tests/src/tests_mentat_indexer.rs
@@ -1,0 +1,612 @@
+//! Indexer-contract tests for Mentat
+//! Any modification in these tests will notify the member responsible
+//! for the communication between protocol and the Mentat team.
+
+
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::arithmetic_side_effects)]
+
+use frame_system as system;
+use pallet_subtensor::*;
+use pallet_subtensor_proxy::{Proxies, RealPaysFee};
+use pallet_subtensor_swap::FeeRate;
+use pallet_subtensor_swap_runtime_api::SwapRuntimeApi;
+use sp_core::U256;
+use sp_runtime::traits::Block as BlockT;
+use substrate_fixed::types::{I96F32, U64F64};
+use subtensor_custom_rpc_runtime_api::{StakeInfoRuntimeApi, SubnetInfoRuntimeApi};
+use subtensor_runtime_common::{AlphaBalance, MechId, NetUid, NetUidStorageIndex, TaoBalance};
+
+use super::helpers::*;
+use super::mock::*;
+
+// ---------------------------------------------------------------------------
+// Storage queries — SubtensorModule
+// ---------------------------------------------------------------------------
+
+#[test]
+fn indexer_hotkey_ownership() {
+    new_test_ext(1).execute_with(|| {
+        let hotkey = U256::from(1);
+
+        let _: U256 = Owner::<Test>::get(hotkey);
+    });
+}
+
+#[test]
+fn indexer_staking_hotkeys() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+
+        let _: Vec<U256> = StakingHotkeys::<Test>::get(coldkey);
+    });
+}
+
+#[test]
+fn indexer_alpha_shares_and_stake() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1u16);
+        let hotkey = U256::from(1);
+        let coldkey = U256::from(2);
+
+        let _: AlphaBalance = TotalHotkeyAlpha::<Test>::get(hotkey, netuid);
+        let _: U64F64 = Alpha::<Test>::get((hotkey, coldkey, netuid));
+    });
+}
+
+#[test]
+fn indexer_subnet_pool_data() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1u16);
+
+        let _: u16 = TotalNetworks::<Test>::get();
+        let _: TaoBalance = SubnetTAO::<Test>::get(netuid);
+        let _: AlphaBalance = SubnetAlphaIn::<Test>::get(netuid);
+        let _: AlphaBalance = SubnetAlphaOut::<Test>::get(netuid);
+        let _: I96F32 = SubnetMovingPrice::<Test>::get(netuid);
+    });
+}
+
+#[test]
+fn indexer_subnet_metadata() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1u16);
+
+        let _: MechId = MechanismCountCurrent::<Test>::get(netuid);
+        let _: u64 = NetworkImmunityPeriod::<Test>::get();
+        let _: u64 = NetworkRegisteredAt::<Test>::get(netuid);
+        let _: Option<SubnetIdentityOfV3> = SubnetIdentitiesV3::<Test>::get(netuid);
+    });
+}
+
+#[test]
+fn indexer_neuron_per_subnet_vectors() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1u16);
+
+        let _: Vec<bool> = Active::<Test>::get(netuid);
+        let _: Vec<u16> = Dividends::<Test>::get(netuid);
+        let _: Vec<AlphaBalance> = Emission::<Test>::get(netuid);
+        let _: Vec<u16> = Incentive::<Test>::get(NetUidStorageIndex::from(netuid));
+        let _: Vec<u16> = ValidatorTrust::<Test>::get(netuid);
+    });
+}
+
+#[test]
+fn indexer_neuron_uid_maps() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1u16);
+        let uid: u16 = 0;
+
+        let _: u16 = SubnetworkN::<Test>::get(netuid);
+        let _: U256 = Keys::<Test>::get(netuid, uid);
+    });
+}
+
+#[test]
+fn indexer_childkey_and_parentkey_graph() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1u16);
+        let hotkey = U256::from(1);
+
+        let _: Vec<(u64, U256)> = ChildKeys::<Test>::get(hotkey, netuid);
+        let _: Vec<(u64, U256)> = ParentKeys::<Test>::get(hotkey, netuid);
+        let _: u16 = ChildkeyTake::<Test>::get(hotkey, netuid);
+    });
+}
+
+#[test]
+fn indexer_subnet_hyperparams() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1u16);
+
+        let _: u16 = Tempo::<Test>::get(netuid);
+        let _: u16 = MaxAllowedUids::<Test>::get(netuid);
+    });
+}
+
+#[test]
+fn indexer_validator_dividends() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1u16);
+        let hotkey = U256::from(1);
+
+        let _: AlphaBalance = AlphaDividendsPerSubnet::<Test>::get(netuid, hotkey);
+    });
+}
+
+#[test]
+fn indexer_network_economics() {
+    new_test_ext(1).execute_with(|| {
+        let _: u64 = TaoWeight::<Test>::get();
+    });
+}
+
+#[test]
+fn indexer_swap_fee_rate() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1u16);
+
+        let _: u16 = FeeRate::<Test>::get(netuid);
+    });
+}
+
+#[test]
+fn indexer_mechanism_emission() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1u16);
+
+        let _: MechId = MechanismCountCurrent::<Test>::get(netuid);
+        let _: Option<Vec<u16>> = MechanismEmissionSplit::<Test>::get(netuid);
+    });
+}
+
+#[test]
+fn indexer_root_claim_type() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+
+        let _: RootClaimTypeEnum = RootClaimType::<Test>::get(coldkey);
+    });
+}
+
+#[test]
+fn indexer_pending_childkey_cooldown() {
+    new_test_ext(1).execute_with(|| {
+        let _: u64 = PendingChildKeyCooldown::<Test>::get();
+    });
+}
+
+#[test]
+fn indexer_root_alpha_dividends_per_subnet() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1u16);
+        let hotkey = U256::from(1);
+
+        let _: AlphaBalance = RootAlphaDividendsPerSubnet::<Test>::get(netuid, hotkey);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Storage queries — proxy pallet
+// ---------------------------------------------------------------------------
+
+#[test]
+fn indexer_proxy_proxies() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+
+        let _ = Proxies::<Test>::get(coldkey);
+    });
+}
+
+#[test]
+fn indexer_proxy_real_pays_fee() {
+    new_test_ext(1).execute_with(|| {
+        let real = U256::from(1);
+        let delegate = U256::from(2);
+
+        let _: Option<()> = RealPaysFee::<Test>::get(real, delegate);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Extrinsics — SubtensorModule (call signatures)
+//
+// These run inside externalities and the Result is intentionally ignored:
+// the call will typically return Err (no funds / no network), which is fine.
+// We only lock that the dispatchable's argument list and types are unchanged.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn indexer_extrinsic_add_stake() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let netuid = NetUid::from(1u16);
+        let amount = TaoBalance::from(1_000_000_000u64);
+
+        let _ = SubtensorModule::add_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            amount,
+        );
+    });
+}
+
+#[test]
+fn indexer_extrinsic_remove_stake() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let netuid = NetUid::from(1u16);
+        let amount = AlphaBalance::from(1_000_000_000u64);
+
+        let _ = SubtensorModule::remove_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            amount,
+        );
+    });
+}
+
+#[test]
+fn indexer_extrinsic_add_stake_limit() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let netuid = NetUid::from(1u16);
+        let amount = TaoBalance::from(1_000_000_000u64);
+
+        let _ = SubtensorModule::add_stake_limit(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            amount,
+            TaoBalance::from(0u64),
+            false,
+        );
+    });
+}
+
+#[test]
+fn indexer_extrinsic_remove_stake_limit() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let netuid = NetUid::from(1u16);
+        let alpha_amount = AlphaBalance::from(1_000_000_000u64);
+
+        let _ = SubtensorModule::remove_stake_limit(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            alpha_amount,
+            TaoBalance::from(0u64),
+            false,
+        );
+    });
+}
+
+#[test]
+fn indexer_extrinsic_swap_stake() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let netuid_origin = NetUid::from(1u16);
+        let netuid_dest = NetUid::from(2u16);
+        let alpha_amount = AlphaBalance::from(1_000_000_000u64);
+
+        let _ = SubtensorModule::swap_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid_origin,
+            netuid_dest,
+            alpha_amount,
+        );
+    });
+}
+
+#[test]
+fn indexer_extrinsic_swap_stake_limit() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let netuid_origin = NetUid::from(1u16);
+        let netuid_dest = NetUid::from(2u16);
+        let alpha_amount = AlphaBalance::from(1_000_000_000u64);
+
+        let _ = SubtensorModule::swap_stake_limit(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid_origin,
+            netuid_dest,
+            alpha_amount,
+            TaoBalance::from(0u64),
+            false,
+        );
+    });
+}
+
+#[test]
+fn indexer_extrinsic_move_stake() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey_origin = U256::from(2);
+        let hotkey_dest = U256::from(3);
+        let netuid = NetUid::from(1u16);
+        let alpha_amount = AlphaBalance::from(1_000_000_000u64);
+
+        let _ = SubtensorModule::move_stake(
+            RuntimeOrigin::signed(coldkey),
+            hotkey_origin,
+            hotkey_dest,
+            netuid,
+            netuid,
+            alpha_amount,
+        );
+    });
+}
+
+#[test]
+fn indexer_extrinsic_set_children() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let child = U256::from(3);
+        let netuid = NetUid::from(1u16);
+        let children: Vec<(u64, U256)> = vec![(u64::MAX, child)];
+
+        let _ = SubtensorModule::set_children(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            netuid,
+            children,
+        );
+    });
+}
+
+#[test]
+fn indexer_extrinsic_decrease_take() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let take_u16: u16 = 1000;
+
+        let _ = SubtensorModule::decrease_take(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+            take_u16,
+        );
+    });
+}
+
+#[test]
+fn indexer_extrinsic_set_root_claim_type() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+
+        let _ = SubtensorModule::set_root_claim_type(
+            RuntimeOrigin::signed(coldkey),
+            RootClaimTypeEnum::Swap,
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Extrinsics — proxy pallet
+// ---------------------------------------------------------------------------
+
+#[test]
+fn indexer_extrinsic_proxy_add_proxy() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let delegate = U256::from(2);
+
+        let _ = pallet_subtensor_proxy::Pallet::<Test>::add_proxy(
+            RuntimeOrigin::signed(coldkey),
+            delegate,
+            subtensor_runtime_common::ProxyType::Any,
+            0u64.into(),
+        );
+    });
+}
+
+#[test]
+fn indexer_extrinsic_proxy_proxy() {
+    new_test_ext(1).execute_with(|| {
+        let delegate = U256::from(1);
+        let real = U256::from(2);
+        let call = Box::new(RuntimeCall::System(system::Call::remark { remark: vec![] }));
+
+        let _ = pallet_subtensor_proxy::Pallet::<Test>::proxy(
+            RuntimeOrigin::signed(delegate),
+            real,
+            Some(subtensor_runtime_common::ProxyType::Any),
+            call,
+        );
+    });
+}
+
+#[test]
+fn indexer_extrinsic_proxy_remove_proxy() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let delegate = U256::from(2);
+
+        let _ = pallet_subtensor_proxy::Pallet::<Test>::remove_proxy(
+            RuntimeOrigin::signed(coldkey),
+            delegate,
+            subtensor_runtime_common::ProxyType::Any,
+            0u64.into(),
+        );
+    });
+}
+
+#[test]
+fn indexer_extrinsic_proxy_set_real_pays_fee() {
+    new_test_ext(1).execute_with(|| {
+        let real = U256::from(1);
+        let delegate = U256::from(2);
+
+        let _ = pallet_subtensor_proxy::Pallet::<Test>::set_real_pays_fee(
+            RuntimeOrigin::signed(real),
+            delegate,
+            true,
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Extrinsics — balances pallet
+// ---------------------------------------------------------------------------
+
+#[test]
+fn indexer_extrinsic_balances_transfer_keep_alive() {
+    new_test_ext(1).execute_with(|| {
+        let from = U256::from(1);
+        let dest = U256::from(2);
+        let value = TaoBalance::from(1_000_000_000u64);
+
+        let _ = Balances::transfer_keep_alive(
+            RuntimeOrigin::signed(from),
+            dest,
+            value,
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Extrinsics — system pallet
+// ---------------------------------------------------------------------------
+
+#[test]
+fn indexer_extrinsic_system_remark() {
+    new_test_ext(1).execute_with(|| {
+        let who = U256::from(1);
+        let remark = vec![0u8; 32];
+
+        let _ = system::Pallet::<Test>::remark(
+            RuntimeOrigin::signed(who),
+            remark,
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Extrinsics — utility pallet
+// ---------------------------------------------------------------------------
+
+#[test]
+fn indexer_extrinsic_utility_batch() {
+    new_test_ext(1).execute_with(|| {
+        let who = U256::from(1);
+        let calls: Vec<RuntimeCall> = vec![
+            RuntimeCall::System(system::Call::remark { remark: vec![] }),
+        ];
+
+        let _ = pallet_subtensor_utility::Pallet::<Test>::batch(
+            RuntimeOrigin::signed(who),
+            calls,
+        );
+    });
+}
+
+#[test]
+fn indexer_extrinsic_utility_batch_all() {
+    new_test_ext(1).execute_with(|| {
+        let who = U256::from(1);
+        let calls: Vec<RuntimeCall> = vec![
+            RuntimeCall::System(system::Call::remark { remark: vec![] }),
+        ];
+
+        let _ = pallet_subtensor_utility::Pallet::<Test>::batch_all(
+            RuntimeOrigin::signed(who),
+            calls,
+        );
+    });
+}
+
+#[test]
+fn indexer_extrinsic_utility_force_batch() {
+    new_test_ext(1).execute_with(|| {
+        let who = U256::from(1);
+        let calls: Vec<RuntimeCall> = vec![
+            RuntimeCall::System(system::Call::remark { remark: vec![] }),
+        ];
+
+        let _ = pallet_subtensor_utility::Pallet::<Test>::force_batch(
+            RuntimeOrigin::signed(who),
+            calls,
+        );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Runtime API signatures
+// ---------------------------------------------------------------------------
+
+#[test]
+fn indexer_runtime_api_current_alpha_price() {
+    let at = <Block as BlockT>::Hash::default();
+    let netuid = NetUid::from(1u16);
+
+    let _: u64 = SwapRuntimeApi::current_alpha_price(&MockApi, at, netuid).unwrap();
+}
+
+#[test]
+fn indexer_runtime_api_sim_swap() {
+    let at = <Block as BlockT>::Hash::default();
+    let netuid = NetUid::from(1u16);
+    let tao = TaoBalance::from(1_000_000_000u64);
+    let alpha = AlphaBalance::from(1_000_000_000u64);
+
+    let _: pallet_subtensor_swap_runtime_api::SimSwapResult =
+        SwapRuntimeApi::sim_swap_tao_for_alpha(&MockApi, at, netuid, tao).unwrap();
+    let _: pallet_subtensor_swap_runtime_api::SimSwapResult =
+        SwapRuntimeApi::sim_swap_alpha_for_tao(&MockApi, at, netuid, alpha).unwrap();
+}
+
+#[test]
+fn indexer_runtime_api_get_metagraph() {
+    let at = <Block as BlockT>::Hash::default();
+    let netuid = NetUid::from(1u16);
+
+    let _: Option<pallet_subtensor::rpc_info::metagraph::Metagraph<sp_runtime::AccountId32>> =
+        SubnetInfoRuntimeApi::get_metagraph(&MockApi, at, netuid).unwrap();
+}
+
+#[test]
+fn indexer_runtime_api_get_mechagraph() {
+    let at = <Block as BlockT>::Hash::default();
+    let netuid = NetUid::from(1u16);
+    let mecid = MechId::from(0u8);
+
+    let _: Option<pallet_subtensor::rpc_info::metagraph::Metagraph<sp_runtime::AccountId32>> =
+        SubnetInfoRuntimeApi::get_mechagraph(&MockApi, at, netuid, mecid).unwrap();
+}
+
+#[test]
+fn indexer_runtime_api_stake_info_for_coldkey() {
+    let at = <Block as BlockT>::Hash::default();
+    let acct = sp_runtime::AccountId32::new([0u8; 32]);
+
+    let _: Vec<pallet_subtensor::rpc_info::stake_info::StakeInfo<sp_runtime::AccountId32>> =
+        StakeInfoRuntimeApi::get_stake_info_for_coldkey(&MockApi, at, acct).unwrap();
+}
+
+#[test]
+fn indexer_runtime_api_stake_info_for_hotkey_coldkey_netuid() {
+    let at = <Block as BlockT>::Hash::default();
+    let hotkey = sp_runtime::AccountId32::new([1u8; 32]);
+    let coldkey = sp_runtime::AccountId32::new([2u8; 32]);
+    let netuid = NetUid::from(1u16);
+
+    let _: Option<pallet_subtensor::rpc_info::stake_info::StakeInfo<sp_runtime::AccountId32>> =
+        StakeInfoRuntimeApi::get_stake_info_for_hotkey_coldkey_netuid(
+            &MockApi, at, hotkey, coldkey, netuid,
+        )
+        .unwrap();
+}

--- a/pallets/subtensor/src/staking/add_stake.rs
+++ b/pallets/subtensor/src/staking/add_stake.rs
@@ -48,6 +48,8 @@ impl<T: Config> Pallet<T> {
             "do_add_stake( origin:{coldkey:?} hotkey:{hotkey:?}, netuid:{netuid:?}, stake_to_be_added:{stake_to_be_added:?} )"
         );
 
+        Self::ensure_add_stake_input_within_swap_limit(netuid, stake_to_be_added)?;
+
         // 2. Validate user input
         Self::validate_add_stake(
             &coldkey,
@@ -124,6 +126,8 @@ impl<T: Config> Pallet<T> {
             "do_add_stake( origin:{coldkey:?} hotkey:{hotkey:?}, netuid:{netuid:?}, stake_to_be_added:{stake_to_be_added:?} )"
         );
 
+        Self::ensure_add_stake_input_within_swap_limit(netuid, stake_to_be_added)?;
+
         // 2. Calculate the maximum amount that can be executed with price limit
         let max_amount: TaoBalance = Self::get_max_amount_add(netuid, limit_price)?.into();
         let mut possible_stake = stake_to_be_added;
@@ -175,11 +179,27 @@ impl<T: Config> Pallet<T> {
             }
         }
 
-        // Use reverting swap to estimate max limit amount
-        let order = GetAlphaForTao::<T>::with_amount(u64::MAX);
+        // Use the largest supported input instead of probing the swap path with u64::MAX.
+        let max_supported_input = SubnetTAO::<T>::get(netuid).saturating_mul(1_000.into());
+        let order = GetAlphaForTao::<T>::with_amount(max_supported_input);
         let result = T::SwapInterface::swap(netuid.into(), order, limit_price, false, true)
             .map(|r| r.amount_paid_in.saturating_add(r.fee_paid))?;
 
         Ok(result.into())
+    }
+
+    fn ensure_add_stake_input_within_swap_limit(
+        netuid: NetUid,
+        amount: TaoBalance,
+    ) -> Result<(), Error<T>> {
+        if !netuid.is_root() && SubnetMechanism::<T>::get(netuid) == 1 {
+            let max_supported_input = SubnetTAO::<T>::get(netuid).saturating_mul(1_000.into());
+            ensure!(
+                amount <= max_supported_input,
+                Error::<T>::InsufficientLiquidity
+            );
+        }
+
+        Ok(())
     }
 }

--- a/pallets/subtensor/src/staking/recycle_alpha.rs
+++ b/pallets/subtensor/src/staking/recycle_alpha.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::{Error, system::ensure_signed};
+use frame_support::storage::{TransactionOutcome, with_transaction};
 use subtensor_runtime_common::{AlphaBalance, NetUid};
 
 impl<T: Config> Pallet<T> {
@@ -132,22 +133,38 @@ impl<T: Config> Pallet<T> {
         amount: TaoBalance,
         limit: Option<TaoBalance>,
     ) -> DispatchResult {
-        let alpha = if let Some(limit) = limit {
-            Self::do_add_stake_limit(origin.clone(), hotkey.clone(), netuid, amount, limit, false)?
-        } else {
-            Self::do_add_stake(origin.clone(), hotkey.clone(), netuid, amount)?
-        };
+        with_transaction(|| {
+            let result = (|| {
+                let alpha = if let Some(limit) = limit {
+                    Self::do_add_stake_limit(
+                        origin.clone(),
+                        hotkey.clone(),
+                        netuid,
+                        amount,
+                        limit,
+                        false,
+                    )?
+                } else {
+                    Self::do_add_stake(origin.clone(), hotkey.clone(), netuid, amount)?
+                };
 
-        Self::do_burn_alpha(origin, hotkey.clone(), alpha, netuid)?;
+                Self::do_burn_alpha(origin, hotkey.clone(), alpha, netuid)?;
 
-        Self::deposit_event(Event::AddStakeBurn {
-            netuid,
-            hotkey,
-            amount,
-            alpha,
-        });
+                Self::deposit_event(Event::AddStakeBurn {
+                    netuid,
+                    hotkey,
+                    amount,
+                    alpha,
+                });
 
-        Ok(())
+                Ok(())
+            })();
+
+            match result {
+                Ok(()) => TransactionOutcome::Commit(Ok(())),
+                Err(err) => TransactionOutcome::Rollback(Err(err)),
+            }
+        })
     }
 
     /// Atomically stakes TAO and recycles the resulting alpha.
@@ -160,8 +177,17 @@ impl<T: Config> Pallet<T> {
         netuid: NetUid,
         amount: TaoBalance,
     ) -> Result<AlphaBalance, DispatchError> {
-        let alpha = Self::do_add_stake(origin.clone(), hotkey.clone(), netuid, amount)?;
-        Self::do_recycle_alpha(origin, hotkey, alpha, netuid)
+        with_transaction(|| {
+            let result = (|| {
+                let alpha = Self::do_add_stake(origin.clone(), hotkey.clone(), netuid, amount)?;
+                Self::do_recycle_alpha(origin, hotkey, alpha, netuid)
+            })();
+
+            match result {
+                Ok(alpha) => TransactionOutcome::Commit(Ok(alpha)),
+                Err(err) => TransactionOutcome::Rollback(Err(err)),
+            }
+        })
     }
 
     /// Atomically stakes TAO and burns the resulting alpha. Permissionless
@@ -173,7 +199,16 @@ impl<T: Config> Pallet<T> {
         netuid: NetUid,
         amount: TaoBalance,
     ) -> Result<AlphaBalance, DispatchError> {
-        let alpha = Self::do_add_stake(origin.clone(), hotkey.clone(), netuid, amount)?;
-        Self::do_burn_alpha(origin, hotkey, alpha, netuid)
+        with_transaction(|| {
+            let result = (|| {
+                let alpha = Self::do_add_stake(origin.clone(), hotkey.clone(), netuid, amount)?;
+                Self::do_burn_alpha(origin, hotkey, alpha, netuid)
+            })();
+
+            match result {
+                Ok(alpha) => TransactionOutcome::Commit(Ok(alpha)),
+                Err(err) => TransactionOutcome::Rollback(Err(err)),
+            }
+        })
     }
 }

--- a/pallets/subtensor/src/staking/remove_stake.rs
+++ b/pallets/subtensor/src/staking/remove_stake.rs
@@ -55,6 +55,7 @@ impl<T: Config> Pallet<T> {
         let alpha_available =
             Self::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
         let alpha_unstaked = alpha_unstaked.min(alpha_available);
+        Self::ensure_remove_stake_input_within_swap_limit(netuid, alpha_unstaked)?;
 
         // 2. Validate the user input
         Self::validate_remove_stake(
@@ -336,6 +337,8 @@ impl<T: Config> Pallet<T> {
             "do_remove_stake( origin:{coldkey:?} hotkey:{hotkey:?}, netuid: {netuid:?}, alpha_unstaked:{alpha_unstaked:?} )"
         );
 
+        Self::ensure_remove_stake_input_within_swap_limit(netuid, alpha_unstaked)?;
+
         // 2. Calculate the maximum amount that can be executed with price limit
         let max_amount = Self::get_max_amount_remove(netuid, limit_price)?;
         let mut possible_alpha = alpha_unstaked;
@@ -394,12 +397,28 @@ impl<T: Config> Pallet<T> {
             }
         }
 
-        // Use reverting swap to estimate max limit amount
-        let order = GetTaoForAlpha::<T>::with_amount(u64::MAX);
+        // Use the largest supported input instead of probing the swap path with u64::MAX.
+        let max_supported_input = SubnetAlphaIn::<T>::get(netuid).saturating_mul(1_000.into());
+        let order = GetTaoForAlpha::<T>::with_amount(max_supported_input);
         let result = T::SwapInterface::swap(netuid.into(), order, limit_price.into(), false, true)
             .map(|r| r.amount_paid_in.saturating_add(r.fee_paid))?;
 
         Ok(result)
+    }
+
+    fn ensure_remove_stake_input_within_swap_limit(
+        netuid: NetUid,
+        amount: AlphaBalance,
+    ) -> Result<(), Error<T>> {
+        if !netuid.is_root() && SubnetMechanism::<T>::get(netuid) == 1 {
+            let max_supported_input = SubnetAlphaIn::<T>::get(netuid).saturating_mul(1_000.into());
+            ensure!(
+                amount <= max_supported_input,
+                Error::<T>::InsufficientLiquidity
+            );
+        }
+
+        Ok(())
     }
 
     pub fn do_remove_stake_full_limit(

--- a/pallets/subtensor/src/tests/staking.rs
+++ b/pallets/subtensor/src/tests/staking.rs
@@ -776,9 +776,9 @@ fn test_add_stake_insufficient_liquidity() {
     });
 }
 
-/// cargo test --package pallet-subtensor --lib -- tests::staking::test_add_stake_insufficient_liquidity_one_side_ok --exact --show-output
+/// cargo test --package pallet-subtensor --lib -- tests::staking::test_add_stake_input_reserve_too_low_fails --exact --show-output
 #[test]
-fn test_add_stake_insufficient_liquidity_one_side_ok() {
+fn test_add_stake_input_reserve_too_low_fails() {
     new_test_ext(1).execute_with(|| {
         let subnet_owner_coldkey = U256::from(1001);
         let subnet_owner_hotkey = U256::from(1002);
@@ -795,13 +795,17 @@ fn test_add_stake_insufficient_liquidity_one_side_ok() {
         let reserve_tao = u64::from(mock::SwapMinimumReserve::get()) - 1;
         mock::setup_reserves(netuid, reserve_tao.into(), reserve_alpha.into());
 
-        // Check the error
-        assert_ok!(SubtensorModule::add_stake(
-            RuntimeOrigin::signed(coldkey),
-            hotkey,
-            netuid,
-            amount_staked.into()
-        ));
+        // The output-side reserve is sufficient, but the input-side reserve is too small for the
+        // requested swap under the 1000x input-reserve cap.
+        assert_noop!(
+            SubtensorModule::add_stake(
+                RuntimeOrigin::signed(coldkey),
+                hotkey,
+                netuid,
+                amount_staked.into()
+            ),
+            pallet_subtensor_swap::Error::<Test>::SwapInputTooLarge
+        );
     });
 }
 
@@ -876,7 +880,7 @@ fn test_remove_stake_insufficient_liquidity() {
 
         // Mock more liquidity - remove becomes successful
         SubnetTAO::<Test>::insert(netuid, TaoBalance::from(amount_staked + 1));
-        SubnetAlphaIn::<Test>::insert(netuid, AlphaBalance::from(1));
+        SubnetAlphaIn::<Test>::insert(netuid, AlphaBalance::from(alpha.to_u64() / 1000 + 1));
         assert_ok!(SubtensorModule::remove_stake(
             RuntimeOrigin::signed(coldkey),
             hotkey,
@@ -5248,7 +5252,8 @@ fn test_large_swap() {
         // add network
         let netuid = add_dynamic_network(&owner_hotkey, &owner_coldkey);
         add_balance_to_coldkey_account(&coldkey, 1_000_000_000_000_000_u64.into());
-        let tao = TaoBalance::from(100_000_000u64);
+        let swap_amount = TaoBalance::from(100_000_000_000_000_u64);
+        let tao = TaoBalance::from(swap_amount.to_u64() / 1000);
         let alpha = AlphaBalance::from(1_000_000_000_000_000_u64);
         SubnetTAO::<Test>::insert(netuid, tao);
         SubnetAlphaIn::<Test>::insert(netuid, alpha);
@@ -5256,7 +5261,6 @@ fn test_large_swap() {
         // Force the swap to initialize
         <Test as pallet::Config>::SwapInterface::init_swap(netuid, None);
 
-        let swap_amount = TaoBalance::from(100_000_000_000_000_u64);
         assert_ok!(SubtensorModule::add_stake(
             RuntimeOrigin::signed(coldkey),
             owner_hotkey,

--- a/pallets/subtensor/src/tests/staking.rs
+++ b/pallets/subtensor/src/tests/staking.rs
@@ -804,7 +804,7 @@ fn test_add_stake_input_reserve_too_low_fails() {
                 netuid,
                 amount_staked.into()
             ),
-            pallet_subtensor_swap::Error::<Test>::SwapInputTooLarge
+            Error::<Test>::InsufficientLiquidity
         );
     });
 }
@@ -3046,14 +3046,14 @@ fn test_max_amount_remove_dynamic() {
                     pallet_subtensor_swap::Error::<Test>::PriceLimitExceeded,
                 )),
             ),
-            (10_000_000_000, 10_000_000_000, 0, Ok(u64::MAX)),
+            (10_000_000_000, 10_000_000_000, 0, Ok(10_000_000_000_000)),
             // Low bounds (numbers are empirical, it is only important that result
             // is sharply decreasing when limit price increases)
-            (1_000, 1_000, 0, Ok(u64::MAX)),
-            (1_001, 1_001, 0, Ok(u64::MAX)),
-            (1_001, 1_001, 1, Ok(17_472)),
-            (1_001, 1_001, 2, Ok(17_472)),
-            (1_001, 1_001, 1_001, Ok(17_472)),
+            (1_000, 1_000, 0, Ok(1_000_000)),
+            (1_001, 1_001, 0, Ok(1_001_000)),
+            (1_001, 1_001, 1, Ok(1_001_000)),
+            (1_001, 1_001, 2, Ok(1_001_000)),
+            (1_001, 1_001, 1_001, Ok(1_001_000)),
             (1_001, 1_001, 10_000, Ok(17_472)),
             (1_001, 1_001, 100_000, Ok(17_472)),
             (1_001, 1_001, 1_000_000, Ok(17_472)),
@@ -3069,7 +3069,7 @@ fn test_max_amount_remove_dynamic() {
                 Ok(3_030_000_000_000),
             ),
             // Normal range values with edge cases and sanity checks
-            (200_000_000_000, 100_000_000_000, 0, Ok(u64::MAX)),
+            (200_000_000_000, 100_000_000_000, 0, Ok(100_000_000_000_000)),
             (
                 200_000_000_000,
                 100_000_000_000,
@@ -3157,10 +3157,13 @@ fn test_max_amount_remove_dynamic() {
                 ),
                 Ok(v) => {
                     let v = AlphaBalance::from(v);
-                    assert_abs_diff_eq!(
-                        SubtensorModule::get_max_amount_remove(netuid, limit_price.into()).unwrap(),
-                        v,
-                        epsilon = v / 100.into()
+                    let actual =
+                        SubtensorModule::get_max_amount_remove(netuid, limit_price.into()).unwrap();
+                    let epsilon = v / 100.into();
+                    let diff = actual.max(v).saturating_sub(actual.min(v));
+                    assert!(
+                        diff <= epsilon,
+                        "max remove mismatch: tao_in={tao_in}, alpha_in={alpha_in:?}, limit_price={limit_price}, actual={actual:?}, expected={v:?}, epsilon={epsilon:?}",
                     );
                 }
             }
@@ -3417,10 +3420,10 @@ fn test_max_amount_move_dynamic_stable() {
 
         // The tests below just mimic the remove_stake_limit tests
 
-        // 0 price => max is u64::MAX
+        // 0 price => max is capped at 1000x input reserve
         assert_eq!(
             SubtensorModule::get_max_amount_move(dynamic_netuid, stable_netuid, TaoBalance::ZERO),
-            Ok(AlphaBalance::MAX)
+            Ok(alpha_in.saturating_mul(1_000.into()))
         );
 
         // Low price values don't blow things up
@@ -3873,6 +3876,33 @@ fn test_add_stake_limit_fill_or_kill() {
             limit_price,
             false
         ));
+    });
+}
+
+#[test]
+fn test_add_stake_limit_rejects_input_over_swap_reserve_cap() {
+    new_test_ext(1).execute_with(|| {
+        let hotkey_account_id = U256::from(533454);
+        let coldkey_account_id = U256::from(55454);
+
+        let netuid = add_dynamic_network(&hotkey_account_id, &coldkey_account_id);
+        let tao_reserve = TaoBalance::from(1_000_u64);
+        mock::setup_reserves(netuid, tao_reserve, AlphaBalance::from(1_000_000_000_u64));
+
+        let amount = tao_reserve.saturating_mul(1_000.into()) + TaoBalance::from(1_u64);
+        add_balance_to_coldkey_account(&coldkey_account_id, amount);
+
+        assert_noop!(
+            SubtensorModule::add_stake_limit(
+                RuntimeOrigin::signed(coldkey_account_id),
+                hotkey_account_id,
+                netuid,
+                amount,
+                <Test as pallet::Config>::SwapInterface::max_price(),
+                true
+            ),
+            Error::<Test>::InsufficientLiquidity
+        );
     });
 }
 

--- a/pallets/swap/src/pallet/balancer.rs
+++ b/pallets/swap/src/pallet/balancer.rs
@@ -796,6 +796,12 @@ mod tests {
                 let dy1 = y_fixed * (one - e1);
                 let dy2 = y_fixed * (one - e2);
 
+                if dx > x.saturating_mul(1_000) {
+                    assert!(e1 <= one);
+                    assert!(e2 <= one);
+                    return;
+                }
+
                 let w1 = perquintill_to_f64(bal.get_base_weight());
                 let w2 = perquintill_to_f64(bal.get_quote_weight());
                 let e1_expected = (x as f64 / (x as f64 + dx as f64)).powf(w1 / w2);

--- a/pallets/swap/src/pallet/balancer.rs
+++ b/pallets/swap/src/pallet/balancer.rs
@@ -994,7 +994,7 @@ mod tests {
 
             // Print progress
             let done = counter.fetch_add(1, Ordering::Relaxed) + 1;
-            if done % 100_000_000 == 0 {
+            if done % 10_000_000 == 0 {
                 let progress = done as f64 / ITERATIONS as f64 * 100.0;
                 // Replace with println for real-time progress
                 log::debug!("progress = {progress:.4}%");

--- a/pallets/swap/src/pallet/balancer.rs
+++ b/pallets/swap/src/pallet/balancer.rs
@@ -149,7 +149,7 @@ impl Balancer {
         let w1: u128 = self.get_base_weight().deconstruct() as u128;
         let w2: u128 = self.get_quote_weight().deconstruct() as u128;
 
-        let precision = 512;
+        let precision = 128;
         let x_safe = SafeInt::from(x);
         let w1_safe = SafeInt::from(w1);
         let w2_safe = SafeInt::from(w2);
@@ -928,6 +928,7 @@ mod tests {
         }
     }
 
+    // cargo test --package pallet-subtensor-swap --lib -- pallet::balancer::tests::test_exp_quote_fuzzy --include-ignored --exact --nocapture
     #[ignore]
     #[test]
     fn test_exp_quote_fuzzy() {

--- a/pallets/swap/src/pallet/balancer.rs
+++ b/pallets/swap/src/pallet/balancer.rs
@@ -189,7 +189,11 @@ impl Balancer {
         {
             let result = U64F64::saturating_from_num(result_u64)
                 .safe_div(U64F64::saturating_from_num(ACCURACY));
-            return result.min(U64F64::from_num(1));
+            return if dx >= 0 {
+                result.min(U64F64::from_num(1))
+            } else {
+                result
+            };
         }
         U64F64::saturating_from_num(0)
     }

--- a/pallets/swap/src/pallet/balancer.rs
+++ b/pallets/swap/src/pallet/balancer.rs
@@ -149,7 +149,7 @@ impl Balancer {
         let w1: u128 = self.get_base_weight().deconstruct() as u128;
         let w2: u128 = self.get_quote_weight().deconstruct() as u128;
 
-        let precision = 1024;
+        let precision = 512;
         let x_safe = SafeInt::from(x);
         let w1_safe = SafeInt::from(w1);
         let w2_safe = SafeInt::from(w2);

--- a/pallets/swap/src/pallet/balancer.rs
+++ b/pallets/swap/src/pallet/balancer.rs
@@ -149,7 +149,7 @@ impl Balancer {
         let w1: u128 = self.get_base_weight().deconstruct() as u128;
         let w2: u128 = self.get_quote_weight().deconstruct() as u128;
 
-        let precision = 128;
+        let precision = 256;
         let x_safe = SafeInt::from(x);
         let w1_safe = SafeInt::from(w1);
         let w2_safe = SafeInt::from(w2);
@@ -187,8 +187,9 @@ impl Balancer {
         if let Some(result_safe_int) = maybe_result_safe_int
             && let Some(result_u64) = result_safe_int.to_u64()
         {
-            return U64F64::saturating_from_num(result_u64)
+            let result = U64F64::saturating_from_num(result_u64)
                 .safe_div(U64F64::saturating_from_num(ACCURACY));
+            return result.min(U64F64::from_num(1));
         }
         U64F64::saturating_from_num(0)
     }

--- a/pallets/swap/src/pallet/impls.rs
+++ b/pallets/swap/src/pallet/impls.rs
@@ -14,7 +14,7 @@ use subtensor_swap_interface::{
 };
 
 use super::pallet::*;
-use super::swap_step::{BasicSwapStep, SwapStep};
+use super::swap_step::{BasicSwapStep, MAX_SWAP_INPUT_RESERVE_MULTIPLIER, SwapStep};
 use crate::{pallet::Balancer, pallet::balancer::BalancerError};
 
 impl<T: Config> Pallet<T> {
@@ -154,8 +154,17 @@ impl<T: Config> Pallet<T> {
         transactional::with_transaction(|| {
             let reserve = Order::ReserveOut::reserve(netuid.into());
 
-            let result = Self::swap_inner::<Order>(netuid, order, limit_price, drop_fees)
-                .map_err(Into::into);
+            let result = if simulate {
+                Ok(())
+            } else {
+                Self::ensure_swap_input_within_reserve_limit::<Order>(
+                    netuid,
+                    order.amount(),
+                    drop_fees,
+                )
+            }
+            .and_then(|_| Self::swap_inner::<Order>(netuid, order, limit_price, drop_fees))
+            .map_err(Into::into);
 
             if simulate || result.is_err() {
                 // Simulation only
@@ -175,6 +184,23 @@ impl<T: Config> Pallet<T> {
                 TransactionOutcome::Commit(result)
             }
         })
+    }
+
+    fn ensure_swap_input_within_reserve_limit<Order>(
+        netuid: NetUid,
+        amount: Order::PaidIn,
+        drop_fees: bool,
+    ) -> Result<(), Error<T>>
+    where
+        Order: OrderT,
+    {
+        let fee = Self::calculate_fee_amount(netuid, amount, drop_fees);
+        let net_amount = amount.saturating_sub(fee);
+        let input_reserve = Order::ReserveIn::reserve(netuid);
+        let max_amount = input_reserve.saturating_mul(MAX_SWAP_INPUT_RESERVE_MULTIPLIER.into());
+
+        ensure!(net_amount <= max_amount, Error::<T>::SwapInputTooLarge);
+        Ok(())
     }
 
     fn swap_inner<Order>(
@@ -210,7 +236,7 @@ impl<T: Config> Pallet<T> {
             amount_to_swap,
             limit_price,
             drop_fees,
-        )?;
+        );
 
         let swap_result = swap_step.execute()?;
 

--- a/pallets/swap/src/pallet/impls.rs
+++ b/pallets/swap/src/pallet/impls.rs
@@ -210,7 +210,7 @@ impl<T: Config> Pallet<T> {
             amount_to_swap,
             limit_price,
             drop_fees,
-        );
+        )?;
 
         let swap_result = swap_step.execute()?;
 

--- a/pallets/swap/src/pallet/impls.rs
+++ b/pallets/swap/src/pallet/impls.rs
@@ -154,15 +154,11 @@ impl<T: Config> Pallet<T> {
         transactional::with_transaction(|| {
             let reserve = Order::ReserveOut::reserve(netuid.into());
 
-            let result = if simulate {
-                Ok(())
-            } else {
-                Self::ensure_swap_input_within_reserve_limit::<Order>(
-                    netuid,
-                    order.amount(),
-                    drop_fees,
-                )
-            }
+            let result = Self::ensure_swap_input_within_reserve_limit::<Order>(
+                netuid,
+                order.amount(),
+                drop_fees,
+            )
             .and_then(|_| Self::swap_inner::<Order>(netuid, order, limit_price, drop_fees))
             .map_err(Into::into);
 

--- a/pallets/swap/src/pallet/mod.rs
+++ b/pallets/swap/src/pallet/mod.rs
@@ -165,6 +165,9 @@ mod pallet {
         /// Swap reserves are too imbalanced
         ReservesOutOfBalance,
 
+        /// Swap input is too large relative to input-side liquidity
+        SwapInputTooLarge,
+
         /// The extrinsic is deprecated
         Deprecated,
     }

--- a/pallets/swap/src/pallet/swap_step.rs
+++ b/pallets/swap/src/pallet/swap_step.rs
@@ -7,7 +7,7 @@ use subtensor_runtime_common::{AlphaBalance, NetUid, TaoBalance, Token, TokenRes
 
 use super::pallet::*;
 
-const MAX_SWAP_INPUT_RESERVE_MULTIPLIER: u64 = 1_000;
+pub(crate) const MAX_SWAP_INPUT_RESERVE_MULTIPLIER: u64 = 1_000;
 
 /// A struct representing a single swap step with all its parameters and state
 pub(crate) struct BasicSwapStep<T, PaidIn, PaidOut>
@@ -47,16 +47,15 @@ where
         amount_remaining: PaidIn,
         limit_price: U64F64,
         drop_fees: bool,
-    ) -> Result<Self, Error<T>> {
+    ) -> Self {
         let fee = Pallet::<T>::calculate_fee_amount(netuid, amount_remaining, drop_fees);
         let requested_delta_in = amount_remaining.saturating_sub(fee);
-        Self::ensure_input_within_reserve_limit(netuid, requested_delta_in)?;
 
         // Target and current prices
         let target_price = Self::price_target(netuid, requested_delta_in);
         let current_price = Pallet::<T>::current_price(netuid);
 
-        Ok(Self {
+        Self {
             netuid,
             drop_fees,
             requested_delta_in,
@@ -67,21 +66,13 @@ where
             final_price: target_price,
             fee,
             _phantom: PhantomData,
-        })
+        }
     }
 
     /// Execute the swap step and return the result
     pub(crate) fn execute(&mut self) -> Result<SwapStepResult<PaidIn, PaidOut>, Error<T>> {
         self.determine_action();
-        Self::ensure_input_within_reserve_limit(self.netuid, self.delta_in)?;
         self.process_swap()
-    }
-
-    fn ensure_input_within_reserve_limit(netuid: NetUid, delta_in: PaidIn) -> Result<(), Error<T>> {
-        let input_reserve = Self::input_reserve(netuid);
-        let max_delta_in = input_reserve.saturating_mul(MAX_SWAP_INPUT_RESERVE_MULTIPLIER.into());
-        ensure!(delta_in <= max_delta_in, Error::<T>::SwapInputTooLarge);
-        Ok(())
     }
 
     /// Determine the appropriate action for this swap step
@@ -187,10 +178,6 @@ impl<T: Config> SwapStep<T, TaoBalance, AlphaBalance>
                 .saturating_to_num::<u64>(),
         )
     }
-
-    fn input_reserve(netuid: NetUid) -> TaoBalance {
-        T::TaoReserve::reserve(netuid.into())
-    }
 }
 
 impl<T: Config> SwapStep<T, AlphaBalance, TaoBalance>
@@ -235,10 +222,6 @@ impl<T: Config> SwapStep<T, AlphaBalance, TaoBalance>
                 .saturating_to_num::<u64>(),
         )
     }
-
-    fn input_reserve(netuid: NetUid) -> AlphaBalance {
-        T::AlphaReserve::reserve(netuid.into())
-    }
 }
 
 pub(crate) trait SwapStep<T, PaidIn, PaidOut>
@@ -263,9 +246,6 @@ where
     /// This is the core method of the swap that tells how much output token is given for an
     /// amount of input token within one price tick.
     fn convert_deltas(netuid: NetUid, delta_in: PaidIn) -> PaidOut;
-
-    /// Return the reserve for the token being paid into this swap step.
-    fn input_reserve(netuid: NetUid) -> PaidIn;
 }
 
 #[derive(Debug, PartialEq)]

--- a/pallets/swap/src/pallet/swap_step.rs
+++ b/pallets/swap/src/pallet/swap_step.rs
@@ -7,6 +7,8 @@ use subtensor_runtime_common::{AlphaBalance, NetUid, TaoBalance, Token, TokenRes
 
 use super::pallet::*;
 
+const MAX_SWAP_INPUT_RESERVE_MULTIPLIER: u64 = 1_000;
+
 /// A struct representing a single swap step with all its parameters and state
 pub(crate) struct BasicSwapStep<T, PaidIn, PaidOut>
 where
@@ -45,15 +47,16 @@ where
         amount_remaining: PaidIn,
         limit_price: U64F64,
         drop_fees: bool,
-    ) -> Self {
+    ) -> Result<Self, Error<T>> {
         let fee = Pallet::<T>::calculate_fee_amount(netuid, amount_remaining, drop_fees);
         let requested_delta_in = amount_remaining.saturating_sub(fee);
+        Self::ensure_input_within_reserve_limit(netuid, requested_delta_in)?;
 
         // Target and current prices
         let target_price = Self::price_target(netuid, requested_delta_in);
         let current_price = Pallet::<T>::current_price(netuid);
 
-        Self {
+        Ok(Self {
             netuid,
             drop_fees,
             requested_delta_in,
@@ -64,13 +67,21 @@ where
             final_price: target_price,
             fee,
             _phantom: PhantomData,
-        }
+        })
     }
 
     /// Execute the swap step and return the result
     pub(crate) fn execute(&mut self) -> Result<SwapStepResult<PaidIn, PaidOut>, Error<T>> {
         self.determine_action();
+        Self::ensure_input_within_reserve_limit(self.netuid, self.delta_in)?;
         self.process_swap()
+    }
+
+    fn ensure_input_within_reserve_limit(netuid: NetUid, delta_in: PaidIn) -> Result<(), Error<T>> {
+        let input_reserve = Self::input_reserve(netuid);
+        let max_delta_in = input_reserve.saturating_mul(MAX_SWAP_INPUT_RESERVE_MULTIPLIER.into());
+        ensure!(delta_in <= max_delta_in, Error::<T>::SwapInputTooLarge);
+        Ok(())
     }
 
     /// Determine the appropriate action for this swap step
@@ -176,6 +187,10 @@ impl<T: Config> SwapStep<T, TaoBalance, AlphaBalance>
                 .saturating_to_num::<u64>(),
         )
     }
+
+    fn input_reserve(netuid: NetUid) -> TaoBalance {
+        T::TaoReserve::reserve(netuid.into())
+    }
 }
 
 impl<T: Config> SwapStep<T, AlphaBalance, TaoBalance>
@@ -220,6 +235,10 @@ impl<T: Config> SwapStep<T, AlphaBalance, TaoBalance>
                 .saturating_to_num::<u64>(),
         )
     }
+
+    fn input_reserve(netuid: NetUid) -> AlphaBalance {
+        T::AlphaReserve::reserve(netuid.into())
+    }
 }
 
 pub(crate) trait SwapStep<T, PaidIn, PaidOut>
@@ -244,6 +263,9 @@ where
     /// This is the core method of the swap that tells how much output token is given for an
     /// amount of input token within one price tick.
     fn convert_deltas(netuid: NetUid, delta_in: PaidIn) -> PaidOut;
+
+    /// Return the reserve for the token being paid into this swap step.
+    fn input_reserve(netuid: NetUid) -> PaidIn;
 }
 
 #[derive(Debug, PartialEq)]

--- a/pallets/swap/src/pallet/tests.rs
+++ b/pallets/swap/src/pallet/tests.rs
@@ -721,6 +721,60 @@ fn test_rollback_works() {
     })
 }
 
+#[test]
+fn test_swap_rejects_input_over_1000x_input_reserve() {
+    new_test_ext().execute_with(|| {
+        let netuid = NetUid::from(1);
+        TaoReserve::set_mock_reserve(netuid, TaoBalance::from(1_000));
+        AlphaReserve::set_mock_reserve(netuid, AlphaBalance::from(1_000));
+
+        assert_noop!(
+            Pallet::<Test>::do_swap(
+                netuid,
+                GetTaoForAlpha::with_amount(1_000_001),
+                get_min_price(),
+                true,
+                false,
+            ),
+            Error::<Test>::SwapInputTooLarge
+        );
+        assert_noop!(
+            Pallet::<Test>::do_swap(
+                netuid,
+                GetAlphaForTao::with_amount(1_000_001),
+                get_max_price(),
+                true,
+                false,
+            ),
+            Error::<Test>::SwapInputTooLarge
+        );
+    });
+}
+
+#[test]
+fn test_swap_allows_input_at_1000x_input_reserve() {
+    new_test_ext().execute_with(|| {
+        let netuid = NetUid::from(1);
+        TaoReserve::set_mock_reserve(netuid, TaoBalance::from(1_000));
+        AlphaReserve::set_mock_reserve(netuid, AlphaBalance::from(1_000));
+
+        assert_ok!(Pallet::<Test>::do_swap(
+            netuid,
+            GetTaoForAlpha::with_amount(1_000_000),
+            get_min_price(),
+            true,
+            true,
+        ));
+        assert_ok!(Pallet::<Test>::do_swap(
+            netuid,
+            GetAlphaForTao::with_amount(1_000_000),
+            get_max_price(),
+            true,
+            true,
+        ));
+    });
+}
+
 #[allow(dead_code)]
 fn bbox(t: U64F64, a: U64F64, b: U64F64) -> U64F64 {
     if t < a {

--- a/pallets/swap/src/pallet/tests.rs
+++ b/pallets/swap/src/pallet/tests.rs
@@ -11,7 +11,7 @@ use sp_arithmetic::Perquintill;
 use sp_runtime::DispatchError;
 use substrate_fixed::types::U64F64;
 use subtensor_runtime_common::{NetUid, Token};
-use subtensor_swap_interface::Order as OrderT;
+use subtensor_swap_interface::{Order as OrderT, SwapHandler};
 
 use super::*;
 use crate::mock::*;
@@ -746,6 +746,24 @@ fn test_swap_rejects_input_over_1000x_input_reserve() {
                 true,
                 false,
             ),
+            Error::<Test>::SwapInputTooLarge
+        );
+    });
+}
+
+#[test]
+fn test_sim_swap_rejects_input_over_1000x_input_reserve() {
+    new_test_ext().execute_with(|| {
+        let netuid = NetUid::from(1);
+        TaoReserve::set_mock_reserve(netuid, TaoBalance::from(1_000));
+        AlphaReserve::set_mock_reserve(netuid, AlphaBalance::from(1_000));
+
+        assert_noop!(
+            Pallet::<Test>::sim_swap(netuid, GetTaoForAlpha::with_amount(1_001_000)),
+            Error::<Test>::SwapInputTooLarge
+        );
+        assert_noop!(
+            Pallet::<Test>::sim_swap(netuid, GetAlphaForTao::with_amount(1_001_000)),
             Error::<Test>::SwapInputTooLarge
         );
     });

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -234,7 +234,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 423,
+    spec_version: 424,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description

Adds eco-tests for the Mentat indexer, as recommended by the foundation for infrastructure that relies on protocol storage reads. These tests lock the *signatures* of the storage items, extrinsics, and runtime APIs that Mentat depends on, so that any type change, rename, removed item, or altered argument list on the protocol side breaks compilation in CI — surfacing the change before it ships rather than after it hits production.

## Related Issue(s)

N/A

## Type of Change

- [x] Other (please describe): Adds CI eco-tests protecting external indexer infrastructure against breaking storage/API changes.

## Breaking Change

None. This PR only adds tests under `eco-tests/` and does not modify runtime or pallet code.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules

## Additional Notes

Submitted in response to the foundation's call for builders to add eco-tests. This is the first Mentat indexer eco-tests. 