### PR TITLE
Enforce ensure_subtoken_enabled validation for remove_stake

### DIFF
--- a/pallets/subtensor/src/staking/remove_stake.rs
+++ b/pallets/subtensor/src/staking/remove_stake.rs
@@ -48,8 +48,6 @@ impl<T: Config> Pallet<T> {
             "do_remove_stake( origin:{coldkey:?} hotkey:{hotkey:?}, netuid: {netuid:?}, alpha_unstaked:{alpha_unstaked:?} )"
         );
 
-        Self::ensure_subtoken_enabled(netuid)?;
-
         // 1.1. Cap the alpha_unstaked at available Alpha because user might be paying transaxtion fees
         // in Alpha and their total is already reduced by now.
         let alpha_available =

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -1144,7 +1144,7 @@ impl<T: Config> Pallet<T> {
         ensure!(Self::if_subnet_exist(netuid), Error::<T>::SubnetNotExists);
 
         // Ensure that the subnet is enabled.
-        // Self::ensure_subtoken_enabled(netuid)?;
+        Self::ensure_subtoken_enabled(netuid)?;
 
         // Do not allow zero unstake amount
         ensure!(!alpha_unstaked.is_zero(), Error::<T>::AmountTooLow);

--- a/pallets/subtensor/src/tests/staking.rs
+++ b/pallets/subtensor/src/tests/staking.rs
@@ -4006,6 +4006,85 @@ fn test_remove_stake_limit_ok() {
 }
 
 #[test]
+fn test_remove_stake_limit_blocked_when_subtoken_disabled() {
+    new_test_ext(1).execute_with(|| {
+        let hotkey_account_id = U256::from(533453);
+        let coldkey_account_id = U256::from(55453);
+        let stake_amount = TaoBalance::from(300_000_000_000_u64);
+
+        let netuid = add_dynamic_network(&hotkey_account_id, &coldkey_account_id);
+        add_balance_to_coldkey_account(
+            &coldkey_account_id,
+            stake_amount + ExistentialDeposit::get(),
+        );
+
+        // Force-set sufficient reserves so a swap would otherwise fill.
+        SubnetTAO::<Test>::insert(netuid, TaoBalance::from(100_000_000_000_u64));
+        SubnetAlphaIn::<Test>::insert(netuid, AlphaBalance::from(100_000_000_000_u64));
+
+        // Stake while subtoken trading is still enabled.
+        assert_ok!(SubtensorModule::add_stake(
+            RuntimeOrigin::signed(coldkey_account_id),
+            hotkey_account_id,
+            netuid,
+            stake_amount
+        ));
+        let alpha_before = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey_account_id,
+            &coldkey_account_id,
+            netuid,
+        );
+        let subnet_tao_before = SubnetTAO::<Test>::get(netuid);
+
+        // Admin freezes subtoken trading on the live subnet.
+        SubtokenEnabled::<Test>::insert(netuid, false);
+
+        // A permissive limit price that the current pool would otherwise satisfy.
+        let limit_price = TaoBalance::from(1_u64);
+
+        // Every remove path must be rejected uniformly while the freeze is active.
+        assert_noop!(
+            SubtensorModule::remove_stake(
+                RuntimeOrigin::signed(coldkey_account_id),
+                hotkey_account_id,
+                netuid,
+                alpha_before / 2.into(),
+            ),
+            Error::<Test>::SubtokenDisabled
+        );
+        assert_noop!(
+            SubtensorModule::remove_stake_limit(
+                RuntimeOrigin::signed(coldkey_account_id),
+                hotkey_account_id,
+                netuid,
+                alpha_before / 2.into(),
+                limit_price,
+                true
+            ),
+            Error::<Test>::SubtokenDisabled
+        );
+        assert_noop!(
+            SubtensorModule::remove_stake_full_limit(
+                RuntimeOrigin::signed(coldkey_account_id),
+                hotkey_account_id,
+                netuid,
+                Some(limit_price),
+            ),
+            Error::<Test>::SubtokenDisabled
+        );
+
+        // Nothing was drawn down: the staker's alpha and the subnet reserve are untouched.
+        let alpha_after = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey_account_id,
+            &coldkey_account_id,
+            netuid,
+        );
+        assert_eq!(alpha_after, alpha_before);
+        assert_eq!(SubnetTAO::<Test>::get(netuid), subnet_tao_before);
+    });
+}
+
+#[test]
 fn test_remove_stake_limit_fill_or_kill() {
     new_test_ext(1).execute_with(|| {
         let hotkey_account_id = U256::from(533453);

--- a/pallets/subtensor/src/tests/subnet.rs
+++ b/pallets/subtensor/src/tests/subnet.rs
@@ -496,15 +496,17 @@ fn test_subtoken_enable_reject_trading_before_enable() {
             stake_bal
         );
 
-        SubtensorModule::remove_stake_limit(
-            RuntimeOrigin::signed(coldkey_account_id),
-            hotkey_account_id,
-            netuid,
-            amount.into(),
-            limit_price,
-            false,
-        )
-        .unwrap();
+        assert_noop!(
+            SubtensorModule::remove_stake_limit(
+                RuntimeOrigin::signed(coldkey_account_id),
+                hotkey_account_id,
+                netuid,
+                amount.into(),
+                limit_price,
+                false,
+            ),
+            Error::<Test>::SubtokenDisabled
+        );
 
         assert_noop!(
             SubtensorModule::remove_stake(


### PR DESCRIPTION
## Description
Removed the explicit check for ensure_subtoken_enabled and put it in validate_remove_stake to make it consistent with all the remove stake calls. 


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.