### PR TITLE
practice deploy

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -234,7 +234,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 424,
+    spec_version: 425,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Description

This PR bumps the runtime `spec_version` in `runtime/src/lib.rs` from `424` to `425`.

## Motivation

The change is intended to produce a new runtime version for the `devnet-ready` deployment flow / practice deployment path without introducing any runtime logic changes.

## Files of Interest

- `runtime/src/lib.rs` - updates the `RuntimeVersion::spec_version` value.

## Behavioral Impact

There are no extrinsic, storage, migration, weight, or economic-logic changes in this PR. The only behavioral effect is that nodes and tooling will observe a new runtime spec version.

## Migration / Spec Version

This PR is itself a spec-version bump. No storage migration is introduced.

## Testing

No targeted tests are required for this metadata-only change.