### PR TITLE
Make `uidLookup` O(1) and bound its cost

### DIFF
--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -2718,27 +2718,17 @@ fn test_trim_to_max_allowed_uids() {
         let now = frame_system::Pallet::<Test>::block_number();
         BlockAtRegistration::<Test>::set(netuid, 6, now);
 
-        // Set some evm addresses (include both kept + trimmed uids)
-        AssociatedEvmAddress::<Test>::insert(
-            netuid,
-            6,
-            (sp_core::H160::from_slice(b"12345678901234567891"), now),
-        );
-        AssociatedEvmAddress::<Test>::insert(
-            netuid,
-            10,
-            (sp_core::H160::from_slice(b"12345678901234567892"), now),
-        );
-        AssociatedEvmAddress::<Test>::insert(
-            netuid,
-            12,
-            (sp_core::H160::from_slice(b"12345678901234567893"), now),
-        );
-        AssociatedEvmAddress::<Test>::insert(
-            netuid,
-            14,
-            (sp_core::H160::from_slice(b"12345678901234567894"), now),
-        );
+        // Set some evm addresses (include both kept + trimmed uids). Go through the normal
+        // setter so both the forward map and the reverse index are populated, exactly as the
+        // association extrinsic does in production.
+        let evm_addr_uid6 = sp_core::H160::from_slice(b"12345678901234567891");
+        let evm_addr_uid10 = sp_core::H160::from_slice(b"12345678901234567892");
+        let evm_addr_uid12 = sp_core::H160::from_slice(b"12345678901234567893");
+        let evm_addr_uid14 = sp_core::H160::from_slice(b"12345678901234567894");
+        SubtensorModule::set_associated_evm_address(netuid, 6, evm_addr_uid6, now);
+        SubtensorModule::set_associated_evm_address(netuid, 10, evm_addr_uid10, now);
+        SubtensorModule::set_associated_evm_address(netuid, 12, evm_addr_uid12, now);
+        SubtensorModule::set_associated_evm_address(netuid, 14, evm_addr_uid14, now);
 
         // Populate Weights and Bonds storage items to test trimming
         for uid in 0..max_n {
@@ -2879,11 +2869,30 @@ fn test_trim_to_max_allowed_uids() {
         // EVM association have been remapped correctly (uids: 6 -> 2, 14 -> 7)
         assert_eq!(
             AssociatedEvmAddress::<Test>::get(netuid, 2),
-            Some((sp_core::H160::from_slice(b"12345678901234567891"), now))
+            Some((evm_addr_uid6, now))
         );
         assert_eq!(
             AssociatedEvmAddress::<Test>::get(netuid, 7),
-            Some((sp_core::H160::from_slice(b"12345678901234567894"), now))
+            Some((evm_addr_uid14, now))
+        );
+
+        // The reverse index has been remapped in place to the new UIDs (6 -> 2, 14 -> 7),
+        // without rebuilding it from scratch.
+        assert_eq!(
+            AssociatedUidsByEvmAddress::<Test>::get(netuid, evm_addr_uid6).into_inner(),
+            vec![(2u16, now)]
+        );
+        assert_eq!(
+            AssociatedUidsByEvmAddress::<Test>::get(netuid, evm_addr_uid14).into_inner(),
+            vec![(7u16, now)]
+        );
+        // Trimmed UIDs (10, 12) were dropped from the reverse index entirely.
+        assert!(AssociatedUidsByEvmAddress::<Test>::get(netuid, evm_addr_uid10).is_empty());
+        assert!(AssociatedUidsByEvmAddress::<Test>::get(netuid, evm_addr_uid12).is_empty());
+        // uid_lookup resolves the remapped UID.
+        assert_eq!(
+            SubtensorModule::uid_lookup(netuid, evm_addr_uid6, u16::MAX),
+            vec![(2u16, now)]
         );
 
         // Non existent subnet

--- a/pallets/subtensor/src/benchmarks.rs
+++ b/pallets/subtensor/src/benchmarks.rs
@@ -2277,6 +2277,10 @@ mod pallet_benchmarks {
             AssociatedEvmAddress::<T>::get(netuid, uid),
             Some((evm_key, block_number))
         );
+        assert_eq!(
+            AssociatedUidsByEvmAddress::<T>::get(netuid, evm_key).into_inner(),
+            vec![(uid, block_number)]
+        );
     }
 
     #[benchmark]

--- a/pallets/subtensor/src/coinbase/root.rs
+++ b/pallets/subtensor/src/coinbase/root.rs
@@ -376,7 +376,7 @@ impl<T: Config> Pallet<T> {
         let _ = Prometheus::<T>::clear_prefix(netuid, u32::MAX, None);
         let _ = AlphaDividendsPerSubnet::<T>::clear_prefix(netuid, u32::MAX, None);
         let _ = PendingChildKeys::<T>::clear_prefix(netuid, u32::MAX, None);
-        let _ = AssociatedEvmAddress::<T>::clear_prefix(netuid, u32::MAX, None);
+        Self::clear_associated_evm_addresses(netuid);
 
         // Commit-reveal / weights commits (all per-net prefixes):
         let mechanisms: u8 = MechanismCountCurrent::<T>::get(netuid).into();

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -67,6 +67,15 @@ pub const MAX_SUBNET_CLAIMS: usize = 5;
 
 pub const MAX_ROOT_CLAIM_THRESHOLD: u64 = 10_000_000;
 
+/// Maximum number of UIDs (per subnet) that may be associated with a single EVM address.
+///
+/// This bounds the size of the `AssociatedUidsByEvmAddress` reverse-index value, keeping
+/// `uid_lookup` reads and association writes cheap and their PoV footprint small. Only the
+/// holder of an EVM key's private key can grow its bucket (each association requires a
+/// signature from that key), so this only limits how many of one's own UIDs may point at a
+/// single EVM address.
+pub const MAX_ASSOCIATED_UIDS_PER_EVM_ADDRESS: u32 = 32;
+
 /// Account flag bit that opts into receiving locked alpha transfers.
 pub const ACCOUNT_FLAGS_ACCEPT_LOCKED_ALPHA: u128 = 1u128 << 0;
 
@@ -81,10 +90,10 @@ pub const ACCOUNT_FLAGS_ACCEPT_LOCKED_ALPHA: u128 = 1u128 << 0;
 #[frame_support::pallet]
 #[allow(clippy::expect_used)]
 pub mod pallet {
-    use crate::RateLimitKey;
     use crate::migrations;
     use crate::staking::lock::LockState;
     use crate::subnets::leasing::{LeaseId, SubnetLeaseOf};
+    use crate::{MAX_ASSOCIATED_UIDS_PER_EVM_ADDRESS, RateLimitKey};
     use frame_support::Twox64Concat;
     use frame_support::{
         BoundedVec,
@@ -2593,6 +2602,18 @@ pub mod pallet {
     #[pallet::storage]
     pub type AssociatedEvmAddress<T: Config> =
         StorageDoubleMap<_, Twox64Concat, NetUid, Twox64Concat, u16, (H160, u64), OptionQuery>;
+
+    /// --- DMAP (netuid, H160) --> associated UIDs and last block where ownership was proven.
+    #[pallet::storage]
+    pub type AssociatedUidsByEvmAddress<T: Config> = StorageDoubleMap<
+        _,
+        Twox64Concat,
+        NetUid,
+        Twox64Concat,
+        H160,
+        BoundedVec<(u16, u64), ConstU32<MAX_ASSOCIATED_UIDS_PER_EVM_ADDRESS>>,
+        ValueQuery,
+    >;
 
     /// ========================
     /// ==== Subnet Leasing ====

--- a/pallets/subtensor/src/macros/errors.rs
+++ b/pallets/subtensor/src/macros/errors.rs
@@ -257,6 +257,8 @@ mod errors {
         CannotAffordLockCost,
         /// exceeded the rate limit for associating an EVM key.
         EvmKeyAssociateRateLimitExceeded,
+        /// The EVM address already has the maximum number of associated UIDs on this subnet.
+        EvmKeyAssociationLimitExceeded,
         /// Same auto stake hotkey already set
         SameAutoStakeHotkeyAlreadySet,
         /// The UID map for the subnet could not be cleared

--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -177,7 +177,9 @@ mod hooks {
                 // Capture the runtime-upgrade block for TAO-in refund cutover.
                 .saturating_add(migrations::migrate_tao_in_refund_deployment_block::migrate_tao_in_refund_deployment_block::<T>())
                 // Fix lock state left behind by subnet-scoped hotkey swaps.
-                .saturating_add(migrations::migrate_fix_subnet_hotkey_lock_swaps::migrate_fix_subnet_hotkey_lock_swaps::<T>());
+                .saturating_add(migrations::migrate_fix_subnet_hotkey_lock_swaps::migrate_fix_subnet_hotkey_lock_swaps::<T>())
+                // Populate reverse lookup index for EVM address associations.
+                .saturating_add(migrations::migrate_associated_evm_address_index::migrate_associated_evm_address_index::<T>());
             weight
         }
 

--- a/pallets/subtensor/src/migrations/migrate_associated_evm_address_index.rs
+++ b/pallets/subtensor/src/migrations/migrate_associated_evm_address_index.rs
@@ -1,6 +1,19 @@
 use super::*;
 use frame_support::{traits::Get, weights::Weight};
 use scale_info::prelude::string::String;
+use sp_std::vec::Vec;
+
+/// Upper bound on the number of `AssociatedEvmAddress` entries this migration will process in a
+/// single `on_runtime_upgrade`.
+///
+/// `AssociatedEvmAddress` is grown only through `do_associate_evm_key` — an opt-in, signature-gated,
+/// rate-limited extrinsic — so in practice it holds at most a handful of entries per subnet. This
+/// cap gives the one-shot migration a *verified* bound on the reads/writes it can perform, so a
+/// pathologically large map can never turn the upgrade block into unbounded Wasm work. The value is
+/// orders of magnitude above any realistic association count while keeping the upgrade block's work
+/// safely bounded. If the map ever exceeds it, the migration refuses to mark itself complete and
+/// logs an error, rather than silently indexing only a prefix of the map.
+const MAX_MIGRATION_ENTRIES: u64 = 50_000;
 
 pub fn migrate_associated_evm_address_index<T: Config>() -> Weight {
     let migration_name = b"migrate_associated_evm_address_index".to_vec();
@@ -20,10 +33,23 @@ pub fn migrate_associated_evm_address_index<T: Config>() -> Weight {
     );
 
     let mut migrated = 0_u64;
-    let mut overflowed = 0_u64;
+    let mut processed = 0_u64;
+    let mut capped = false;
+
+    // Forward-map entries whose address bucket is already full and therefore cannot be represented
+    // in the bounded reverse index. Collected here and pruned from the forward map after the scan
+    // so both maps agree on the pallet's cap (see the reconciliation loop below).
+    let mut overflow = Vec::new();
+
     for (netuid, uid, (evm_key, block_associated)) in AssociatedEvmAddress::<T>::iter() {
+        if processed >= MAX_MIGRATION_ENTRIES {
+            capped = true;
+            break;
+        }
+        processed = processed.saturating_add(1);
         weight.saturating_accrue(T::DbWeight::get().reads(1));
 
+        let mut overflowed = false;
         AssociatedUidsByEvmAddress::<T>::mutate(netuid, evm_key, |uids| {
             if let Some((_, stored_block)) =
                 uids.iter_mut().find(|(stored_uid, _)| *stored_uid == uid)
@@ -33,21 +59,52 @@ pub fn migrate_associated_evm_address_index<T: Config>() -> Weight {
             }
 
             if uids.try_push((uid, block_associated)).is_err() {
-                overflowed = overflowed.saturating_add(1);
+                overflowed = true;
             }
         });
         weight.saturating_accrue(T::DbWeight::get().reads_writes(1, 1));
-        migrated = migrated.saturating_add(1);
+
+        if overflowed {
+            overflow.push((netuid, uid));
+        } else {
+            migrated = migrated.saturating_add(1);
+        }
+    }
+
+    // Reconcile over-cap buckets. An address that already holds
+    // `MAX_ASSOCIATED_UIDS_PER_EVM_ADDRESS` UIDs cannot index any further ones. Leaving those extra
+    // UIDs in the forward map would make the two maps disagree: `uid_lookup` would silently miss
+    // them, and the capacity check would see a full bucket and refuse to let them refresh — so they
+    // could never recover. Instead we drop the excess from the forward map too, so both maps agree
+    // on the cap the pallet now enforces; a dropped UID can re-associate later, reusing a freed
+    // slot. This branch is unreachable for any real chain state (observed peak reuse of a single
+    // address is far below the cap); it exists so the migration can never silently produce an
+    // inconsistent index.
+    for (netuid, uid) in &overflow {
+        AssociatedEvmAddress::<T>::remove(*netuid, *uid);
+        weight.saturating_accrue(T::DbWeight::get().writes(1));
+        log::warn!(
+            "migrate_associated_evm_address_index: dropped over-cap association (netuid={netuid:?}, uid={uid}) to keep the forward map and reverse index consistent"
+        );
+    }
+
+    if capped {
+        log::error!(
+            "Migration 'migrate_associated_evm_address_index' hit the {MAX_MIGRATION_ENTRIES}-entry \
+             processing cap and was left incomplete. This indicates an unexpectedly large \
+             AssociatedEvmAddress map and requires manual attention."
+        );
+        return weight;
     }
 
     HasMigrationRun::<T>::insert(&migration_name, true);
     weight.saturating_accrue(T::DbWeight::get().writes(1));
 
     log::info!(
-        "Migration '{:?}' completed successfully. {} associations indexed, {} skipped.",
+        "Migration '{:?}' completed successfully. {} associations indexed, {} over-cap associations dropped.",
         String::from_utf8_lossy(&migration_name),
         migrated,
-        overflowed
+        overflow.len(),
     );
 
     weight

--- a/pallets/subtensor/src/migrations/migrate_associated_evm_address_index.rs
+++ b/pallets/subtensor/src/migrations/migrate_associated_evm_address_index.rs
@@ -3,18 +3,14 @@ use frame_support::{traits::Get, weights::Weight};
 use scale_info::prelude::string::String;
 use sp_std::vec::Vec;
 
-/// Upper bound on the number of `AssociatedEvmAddress` entries this migration will process in a
-/// single `on_runtime_upgrade`.
+/// Backfill the reverse index `AssociatedUidsByEvmAddress` from the existing
+/// `AssociatedEvmAddress` forward map. One-time, idempotent, guarded by `HasMigrationRun`.
 ///
-/// `AssociatedEvmAddress` is grown only through `do_associate_evm_key` — an opt-in, signature-gated,
-/// rate-limited extrinsic — so in practice it holds at most a handful of entries per subnet. This
-/// cap gives the one-shot migration a *verified* bound on the reads/writes it can perform, so a
-/// pathologically large map can never turn the upgrade block into unbounded Wasm work. The value is
-/// orders of magnitude above any realistic association count while keeping the upgrade block's work
-/// safely bounded. If the map ever exceeds it, the migration refuses to mark itself complete and
-/// logs an error, rather than silently indexing only a prefix of the map.
-const MAX_MIGRATION_ENTRIES: u64 = 50_000;
-
+/// This scans the whole forward map in a single block. That is safe because the map is tiny: it
+/// grows only through `do_associate_evm_key`, an opt-in, signature-gated, rate-limited extrinsic.
+/// Measured on 2026-07-07, the entire map holds **100 entries on Finney and 20 on testnet**, with a
+/// largest single-`(netuid, evm_key)` bucket of **3** (against the cap of 32). There is no realistic
+/// chain state in which this scan is expensive, so no chunked / multi-block migration is warranted.
 pub fn migrate_associated_evm_address_index<T: Config>() -> Weight {
     let migration_name = b"migrate_associated_evm_address_index".to_vec();
     let mut weight = T::DbWeight::get().reads(1);
@@ -33,8 +29,6 @@ pub fn migrate_associated_evm_address_index<T: Config>() -> Weight {
     );
 
     let mut migrated = 0_u64;
-    let mut processed = 0_u64;
-    let mut capped = false;
 
     // Forward-map entries whose address bucket is already full and therefore cannot be represented
     // in the bounded reverse index. Collected here and pruned from the forward map after the scan
@@ -42,11 +36,6 @@ pub fn migrate_associated_evm_address_index<T: Config>() -> Weight {
     let mut overflow = Vec::new();
 
     for (netuid, uid, (evm_key, block_associated)) in AssociatedEvmAddress::<T>::iter() {
-        if processed >= MAX_MIGRATION_ENTRIES {
-            capped = true;
-            break;
-        }
-        processed = processed.saturating_add(1);
         weight.saturating_accrue(T::DbWeight::get().reads(1));
 
         let mut overflowed = false;
@@ -78,7 +67,7 @@ pub fn migrate_associated_evm_address_index<T: Config>() -> Weight {
     // could never recover. Instead we drop the excess from the forward map too, so both maps agree
     // on the cap the pallet now enforces; a dropped UID can re-associate later, reusing a freed
     // slot. This branch is unreachable for any real chain state (observed peak reuse of a single
-    // address is far below the cap); it exists so the migration can never silently produce an
+    // address is 3, far below the cap); it exists so the migration can never silently produce an
     // inconsistent index.
     for (netuid, uid) in &overflow {
         AssociatedEvmAddress::<T>::remove(*netuid, *uid);
@@ -86,15 +75,6 @@ pub fn migrate_associated_evm_address_index<T: Config>() -> Weight {
         log::warn!(
             "migrate_associated_evm_address_index: dropped over-cap association (netuid={netuid:?}, uid={uid}) to keep the forward map and reverse index consistent"
         );
-    }
-
-    if capped {
-        log::error!(
-            "Migration 'migrate_associated_evm_address_index' hit the {MAX_MIGRATION_ENTRIES}-entry \
-             processing cap and was left incomplete. This indicates an unexpectedly large \
-             AssociatedEvmAddress map and requires manual attention."
-        );
-        return weight;
     }
 
     HasMigrationRun::<T>::insert(&migration_name, true);

--- a/pallets/subtensor/src/migrations/migrate_associated_evm_address_index.rs
+++ b/pallets/subtensor/src/migrations/migrate_associated_evm_address_index.rs
@@ -1,0 +1,54 @@
+use super::*;
+use frame_support::{traits::Get, weights::Weight};
+use scale_info::prelude::string::String;
+
+pub fn migrate_associated_evm_address_index<T: Config>() -> Weight {
+    let migration_name = b"migrate_associated_evm_address_index".to_vec();
+    let mut weight = T::DbWeight::get().reads(1);
+
+    if HasMigrationRun::<T>::get(&migration_name) {
+        log::info!(
+            "Migration '{:?}' has already run. Skipping.",
+            String::from_utf8_lossy(&migration_name)
+        );
+        return weight;
+    }
+
+    log::info!(
+        "Running migration '{}'",
+        String::from_utf8_lossy(&migration_name)
+    );
+
+    let mut migrated = 0_u64;
+    let mut overflowed = 0_u64;
+    for (netuid, uid, (evm_key, block_associated)) in AssociatedEvmAddress::<T>::iter() {
+        weight.saturating_accrue(T::DbWeight::get().reads(1));
+
+        AssociatedUidsByEvmAddress::<T>::mutate(netuid, evm_key, |uids| {
+            if let Some((_, stored_block)) =
+                uids.iter_mut().find(|(stored_uid, _)| *stored_uid == uid)
+            {
+                *stored_block = block_associated;
+                return;
+            }
+
+            if uids.try_push((uid, block_associated)).is_err() {
+                overflowed = overflowed.saturating_add(1);
+            }
+        });
+        weight.saturating_accrue(T::DbWeight::get().reads_writes(1, 1));
+        migrated = migrated.saturating_add(1);
+    }
+
+    HasMigrationRun::<T>::insert(&migration_name, true);
+    weight.saturating_accrue(T::DbWeight::get().writes(1));
+
+    log::info!(
+        "Migration '{:?}' completed successfully. {} associations indexed, {} skipped.",
+        String::from_utf8_lossy(&migration_name),
+        migrated,
+        overflowed
+    );
+
+    weight
+}

--- a/pallets/subtensor/src/migrations/mod.rs
+++ b/pallets/subtensor/src/migrations/mod.rs
@@ -4,6 +4,7 @@ use frame_support::pallet_prelude::Weight;
 use sp_io::KillStorageResult;
 use sp_io::hashing::twox_128;
 use sp_io::storage::clear_prefix;
+pub mod migrate_associated_evm_address_index;
 pub mod migrate_auto_stake_destination;
 pub mod migrate_cleanup_swap_v3;
 pub mod migrate_clear_deprecated_registration_maps;

--- a/pallets/subtensor/src/subnets/uids.rs
+++ b/pallets/subtensor/src/subnets/uids.rs
@@ -77,7 +77,7 @@ impl<T: Config> Pallet<T> {
 
         // 2. Remove previous set memberships.
         Uids::<T>::remove(netuid, old_hotkey.clone());
-        AssociatedEvmAddress::<T>::remove(netuid, uid_to_replace);
+        Self::remove_associated_evm_address(netuid, uid_to_replace);
         IsNetworkMember::<T>::remove(old_hotkey.clone(), netuid);
         #[allow(unknown_lints)]
         Keys::<T>::remove(netuid, uid_to_replace);
@@ -213,7 +213,7 @@ impl<T: Config> Pallet<T> {
                     #[allow(unknown_lints)]
                     Keys::<T>::remove(netuid, neuron_uid);
                     BlockAtRegistration::<T>::remove(netuid, neuron_uid);
-                    AssociatedEvmAddress::<T>::remove(netuid, neuron_uid);
+                    Self::remove_associated_evm_address(netuid, neuron_uid);
                     for mecid in 0..mechanisms_count {
                         let netuid_index = Self::get_mechanism_storage_index(netuid, mecid.into());
                         Weights::<T>::remove(netuid_index, neuron_uid);
@@ -345,6 +345,8 @@ impl<T: Config> Pallet<T> {
                     });
                 }
             }
+
+            Self::remap_associated_evm_address_index(netuid, &old_to_new_uid);
 
             // Clear the UID map for the subnet
             let clear_result = Uids::<T>::clear_prefix(netuid, u32::MAX, None);

--- a/pallets/subtensor/src/tests/evm.rs
+++ b/pallets/subtensor/src/tests/evm.rs
@@ -340,6 +340,130 @@ fn test_associate_evm_key_rate_limit_exceeded() {
 }
 
 #[test]
+fn test_associate_evm_key_cap_exceeded() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+
+        let tempo: u16 = 2;
+        let modality: u16 = 2;
+        add_network(netuid, tempo, modality);
+        System::set_block_number(EvmKeyAssociateRateLimit::get());
+
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let _ = SubtensorModule::create_account_if_non_existent(&coldkey, &hotkey);
+        register_ok_neuron(netuid, hotkey, coldkey, 0);
+        let uid = SubtensorModule::get_uid_for_net_and_hotkey(netuid, &hotkey).unwrap();
+
+        let pair = ecdsa::Pair::generate().0;
+        let evm_key = public_to_evm_key(&pair.public());
+
+        // Fill the reverse-index bucket for `evm_key` to capacity with other UIDs.
+        for i in 0..MAX_ASSOCIATED_UIDS_PER_EVM_ADDRESS as u16 {
+            SubtensorModule::set_associated_evm_address(netuid, uid + 1 + i, evm_key, 1);
+        }
+        assert_eq!(
+            AssociatedUidsByEvmAddress::<Test>::get(netuid, evm_key).len(),
+            MAX_ASSOCIATED_UIDS_PER_EVM_ADDRESS as usize
+        );
+
+        // A valid association for the real neuron's UID must be rejected: it would need a
+        // brand-new slot in an already-full bucket.
+        let block_number = frame_system::Pallet::<Test>::block_number();
+        let hashed_block_number = keccak_256(block_number.encode().as_ref());
+        let hotkey_bytes = hotkey.encode();
+        let message = [
+            hotkey_bytes.as_ref(),
+            <[u8; 32] as AsRef<[u8]>>::as_ref(&hashed_block_number),
+        ]
+        .concat();
+        let signature = sign_evm_message(&pair, message);
+
+        assert_noop!(
+            SubtensorModule::associate_evm_key(
+                RuntimeOrigin::signed(hotkey),
+                netuid,
+                evm_key,
+                block_number,
+                signature,
+            ),
+            Error::<Test>::EvmKeyAssociationLimitExceeded
+        );
+    });
+}
+
+#[test]
+fn test_evm_address_index_capacity_allows_refresh_when_full() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let evm_key = H160::from_slice(&[7u8; 20]);
+
+        // Fill the bucket to capacity with distinct UIDs 0..MAX.
+        for uid in 0..MAX_ASSOCIATED_UIDS_PER_EVM_ADDRESS as u16 {
+            SubtensorModule::set_associated_evm_address(netuid, uid, evm_key, 1);
+        }
+
+        // A UID already tracked by the full bucket may be re-associated (e.g. block refresh):
+        // it consumes no new slot.
+        let tracked_uid = 0u16;
+        assert_ok!(SubtensorModule::ensure_evm_address_index_capacity(
+            netuid,
+            tracked_uid,
+            evm_key
+        ));
+
+        // The refresh updates the stored block in place without growing the bucket.
+        SubtensorModule::set_associated_evm_address(netuid, tracked_uid, evm_key, 42);
+        let bucket = AssociatedUidsByEvmAddress::<Test>::get(netuid, evm_key);
+        assert_eq!(bucket.len(), MAX_ASSOCIATED_UIDS_PER_EVM_ADDRESS as usize);
+        assert_eq!(
+            bucket.iter().find(|(u, _)| *u == tracked_uid).unwrap().1,
+            42
+        );
+
+        // A brand-new UID is rejected once the bucket is full.
+        assert_err!(
+            SubtensorModule::ensure_evm_address_index_capacity(
+                netuid,
+                MAX_ASSOCIATED_UIDS_PER_EVM_ADDRESS as u16,
+                evm_key
+            ),
+            Error::<Test>::EvmKeyAssociationLimitExceeded
+        );
+    });
+}
+
+#[test]
+fn test_evm_address_index_capacity_rejects_switch_onto_full_address() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let addr_a = H160::from_slice(&[0xaa; 20]);
+        let addr_b = H160::from_slice(&[0xbb; 20]);
+
+        // UID 100 currently associated to addr_a.
+        let uid = 100u16;
+        SubtensorModule::set_associated_evm_address(netuid, uid, addr_a, 1);
+
+        // addr_b is filled to capacity with other UIDs.
+        for u in 0..MAX_ASSOCIATED_UIDS_PER_EVM_ADDRESS as u16 {
+            SubtensorModule::set_associated_evm_address(netuid, u, addr_b, 1);
+        }
+
+        // Moving UID 100 onto the full addr_b must be rejected...
+        assert_err!(
+            SubtensorModule::ensure_evm_address_index_capacity(netuid, uid, addr_b),
+            Error::<Test>::EvmKeyAssociationLimitExceeded
+        );
+
+        // ...leaving UID 100 still associated to addr_a.
+        assert_eq!(
+            AssociatedEvmAddress::<Test>::get(netuid, uid).map(|(k, _)| k),
+            Some(addr_a)
+        );
+    });
+}
+
+#[test]
 fn test_associate_evm_key_uid_not_found() {
     new_test_ext(1).execute_with(|| {
         let netuid = NetUid::from(1);

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -28,7 +28,7 @@ use frame_system::Config;
 use pallet_drand::types::RoundNumber;
 use pallet_scheduler::ScheduledOf;
 use scale_info::prelude::collections::VecDeque;
-use sp_core::{H256, U256, crypto::Ss58Codec};
+use sp_core::{H160, H256, U256, crypto::Ss58Codec};
 use sp_io::hashing::twox_128;
 use sp_runtime::{
     AccountId32,
@@ -37,7 +37,7 @@ use sp_runtime::{
 use sp_std::marker::PhantomData;
 use substrate_fixed::types::{I96F32, U64F64};
 use substrate_fixed::{traits::ToFixed, types::extra::U2};
-use subtensor_runtime_common::{AlphaBalance, NetUidStorageIndex, TaoBalance};
+use subtensor_runtime_common::{AlphaBalance, NetUid, NetUidStorageIndex, TaoBalance};
 
 #[allow(clippy::arithmetic_side_effects)]
 fn close(value: u64, target: u64, eps: u64) {
@@ -45,6 +45,37 @@ fn close(value: u64, target: u64, eps: u64) {
         (value as i64 - target as i64).abs() < eps as i64,
         "Assertion failed: value = {value}, target = {target}, eps = {eps}"
     )
+}
+
+#[test]
+fn test_migrate_associated_evm_address_index() {
+    new_test_ext(1).execute_with(|| {
+        let migration_name = b"migrate_associated_evm_address_index".to_vec();
+        let netuid = NetUid::from(1);
+        let other_netuid = NetUid::from(2);
+        let evm_key = H160::repeat_byte(1);
+        let other_evm_key = H160::repeat_byte(2);
+
+        HasMigrationRun::<Test>::remove(&migration_name);
+        AssociatedUidsByEvmAddress::<Test>::remove(netuid, evm_key);
+        AssociatedUidsByEvmAddress::<Test>::remove(other_netuid, other_evm_key);
+
+        AssociatedEvmAddress::<Test>::insert(netuid, 0, (evm_key, 10));
+        AssociatedEvmAddress::<Test>::insert(netuid, 1, (evm_key, 11));
+        AssociatedEvmAddress::<Test>::insert(other_netuid, 0, (other_evm_key, 12));
+
+        crate::migrations::migrate_associated_evm_address_index::migrate_associated_evm_address_index::<Test>();
+
+        assert_eq!(
+            AssociatedUidsByEvmAddress::<Test>::get(netuid, evm_key).into_inner(),
+            vec![(0, 10), (1, 11)]
+        );
+        assert_eq!(
+            AssociatedUidsByEvmAddress::<Test>::get(other_netuid, other_evm_key).into_inner(),
+            vec![(0, 12)]
+        );
+        assert!(HasMigrationRun::<Test>::get(&migration_name));
+    });
 }
 
 #[test]

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -79,6 +79,52 @@ fn test_migrate_associated_evm_address_index() {
 }
 
 #[test]
+fn test_migrate_associated_evm_address_index_reconciles_over_cap_buckets() {
+    new_test_ext(1).execute_with(|| {
+        let migration_name = b"migrate_associated_evm_address_index".to_vec();
+        let netuid = NetUid::from(1);
+        let evm_key = H160::repeat_byte(1);
+
+        HasMigrationRun::<Test>::remove(&migration_name);
+        AssociatedUidsByEvmAddress::<Test>::remove(netuid, evm_key);
+
+        // Seed more forward-map associations for a single address than the reverse index can hold.
+        let cap = MAX_ASSOCIATED_UIDS_PER_EVM_ADDRESS;
+        let total = cap + 8;
+        for uid in 0..total {
+            AssociatedEvmAddress::<Test>::insert(netuid, uid as u16, (evm_key, 100 + uid as u64));
+        }
+
+        crate::migrations::migrate_associated_evm_address_index::migrate_associated_evm_address_index::<Test>();
+
+        // The reverse index is bounded by the cap.
+        let bucket = AssociatedUidsByEvmAddress::<Test>::get(netuid, evm_key);
+        assert_eq!(bucket.len() as u32, cap);
+
+        // The forward map was pruned to match, so the two maps agree on the cap: every remaining
+        // forward entry is present in the reverse index, and there are no extras on either side.
+        let forward: Vec<u16> = AssociatedEvmAddress::<Test>::iter_prefix(netuid)
+            .map(|(uid, _)| uid)
+            .collect();
+        assert_eq!(forward.len() as u32, cap);
+        for uid in &forward {
+            assert!(
+                bucket.iter().any(|(stored_uid, _)| stored_uid == uid),
+                "forward uid {uid} missing from reverse index"
+            );
+        }
+        for (uid, _) in bucket.iter() {
+            assert!(
+                forward.contains(uid),
+                "reverse uid {uid} missing from forward map"
+            );
+        }
+
+        assert!(HasMigrationRun::<Test>::get(&migration_name));
+    });
+}
+
+#[test]
 fn test_migrate_tao_in_refund_deployment_block() {
     new_test_ext(1).execute_with(|| {
         let deployment_block: u64 = 42;

--- a/pallets/subtensor/src/tests/networks.rs
+++ b/pallets/subtensor/src/tests/networks.rs
@@ -468,7 +468,7 @@ fn dissolve_clears_all_per_subnet_storages() {
         TransactionKeyLastBlock::<Test>::insert((owner_hot, net, 1u16), 1u64);
 
         // EVM association indexed by (netuid, uid)
-        AssociatedEvmAddress::<Test>::insert(net, 0u16, (sp_core::H160::zero(), 1u64));
+        SubtensorModule::set_associated_evm_address(net, 0u16, sp_core::H160::zero(), 1u64);
 
         // (Optional) subnet -> lease link
         SubnetUidToLeaseId::<Test>::insert(net, 42u32);
@@ -632,6 +632,7 @@ fn dissolve_clears_all_per_subnet_storages() {
 
         // EVM association
         assert!(AssociatedEvmAddress::<Test>::get(net, 0u16).is_none());
+        assert!(AssociatedUidsByEvmAddress::<Test>::get(net, sp_core::H160::zero()).is_empty());
 
         // Subnet -> lease link
         assert!(!SubnetUidToLeaseId::<Test>::contains_key(net));

--- a/pallets/subtensor/src/tests/uids.rs
+++ b/pallets/subtensor/src/tests/uids.rs
@@ -62,7 +62,7 @@ fn test_replace_neuron() {
             NeuronCertificateOf::default(),
         );
         Prometheus::<Test>::insert(netuid, hotkey_account_id, PrometheusInfoOf::default());
-        AssociatedEvmAddress::<Test>::insert(netuid, neuron_uid, (evm_address, 1));
+        SubtensorModule::set_associated_evm_address(netuid, neuron_uid, evm_address, 1);
 
         // Replace the neuron.
         SubtensorModule::replace_neuron(netuid, neuron_uid, &new_hotkey_account_id, block_number);
@@ -126,6 +126,7 @@ fn test_replace_neuron() {
             vec![]
         );
         assert_eq!(AssociatedEvmAddress::<Test>::get(netuid, neuron_uid), None);
+        assert!(AssociatedUidsByEvmAddress::<Test>::get(netuid, evm_address).is_empty());
     });
 }
 
@@ -154,7 +155,7 @@ fn test_bonds_cleared_on_replace() {
         let neuron_uid = SubtensorModule::get_uid_for_net_and_hotkey(netuid, &hotkey_account_id);
         assert_ok!(neuron_uid);
         let neuron_uid = neuron_uid.unwrap();
-        AssociatedEvmAddress::<Test>::insert(netuid, neuron_uid, (evm_address, 1));
+        SubtensorModule::set_associated_evm_address(netuid, neuron_uid, evm_address, 1);
 
         // Set non-default bonds.
         Bonds::<Test>::insert(NetUidStorageIndex::from(netuid), neuron_uid, vec![(0, 1)]);
@@ -187,6 +188,7 @@ fn test_bonds_cleared_on_replace() {
             vec![]
         );
         assert_eq!(AssociatedEvmAddress::<Test>::get(netuid, neuron_uid), None);
+        assert!(AssociatedUidsByEvmAddress::<Test>::get(netuid, evm_address).is_empty());
     });
 }
 
@@ -314,7 +316,7 @@ fn test_replace_neuron_multiple_subnets() {
             &hotkey_account_id
         ));
 
-        AssociatedEvmAddress::<Test>::insert(netuid, neuron_uid.unwrap(), (evm_address, 1));
+        SubtensorModule::set_associated_evm_address(netuid, neuron_uid.unwrap(), evm_address, 1);
 
         // Replace the neuron (ONLY on ONE network).
         SubtensorModule::replace_neuron(
@@ -340,6 +342,7 @@ fn test_replace_neuron_multiple_subnets() {
             AssociatedEvmAddress::<Test>::get(netuid, neuron_uid.unwrap()),
             None
         );
+        assert!(AssociatedUidsByEvmAddress::<Test>::get(netuid, evm_address).is_empty());
     });
 }
 
@@ -375,7 +378,7 @@ fn test_replace_neuron_subnet_owner_not_replaced() {
         let netuid = add_dynamic_network(&owner_hotkey, &owner_coldkey);
         let neuron_uid = SubtensorModule::get_uid_for_net_and_hotkey(netuid, &owner_hotkey)
             .expect("Owner neuron should be registered by add_dynamic_network");
-        AssociatedEvmAddress::<Test>::insert(netuid, neuron_uid, (evm_address, 1));
+        SubtensorModule::set_associated_evm_address(netuid, neuron_uid, evm_address, 1);
         let current_block = SubtensorModule::get_current_block_as_u64();
         SubtensorModule::replace_neuron(netuid, neuron_uid, &new_hotkey_account_id, current_block);
 
@@ -391,6 +394,10 @@ fn test_replace_neuron_subnet_owner_not_replaced() {
             SubtensorModule::get_uid_for_net_and_hotkey(netuid, &new_hotkey_account_id);
         assert_err!(new_key_uid, Error::<Test>::HotKeyNotRegisteredInSubNet,);
         assert!(AssociatedEvmAddress::<Test>::get(netuid, neuron_uid).is_some());
+        assert_eq!(
+            AssociatedUidsByEvmAddress::<Test>::get(netuid, evm_address).into_inner(),
+            vec![(neuron_uid, 1)]
+        );
     });
 }
 
@@ -411,7 +418,7 @@ fn test_replace_neuron_subnet_owner_not_replaced_if_in_sn_owner_hotkey_map() {
         let owner_uid = SubtensorModule::get_uid_for_net_and_hotkey(netuid, &owner_hotkey)
             .expect("Owner neuron should already be registered by add_dynamic_network");
 
-        AssociatedEvmAddress::<Test>::insert(netuid, owner_uid, (evm_address, 1));
+        SubtensorModule::set_associated_evm_address(netuid, owner_uid, evm_address, 1);
 
         // Register another hotkey for the owner
         register_ok_neuron(netuid, other_owner_hotkey, owner_coldkey, 0);
@@ -433,10 +440,14 @@ fn test_replace_neuron_subnet_owner_not_replaced_if_in_sn_owner_hotkey_map() {
             "Owner's first hotkey should remain registered"
         );
         assert!(AssociatedEvmAddress::<Test>::get(netuid, owner_uid).is_some());
+        assert_eq!(
+            AssociatedUidsByEvmAddress::<Test>::get(netuid, evm_address).into_inner(),
+            vec![(owner_uid, 1)]
+        );
 
         let new_key_uid = SubtensorModule::get_uid_for_net_and_hotkey(netuid, &additional_hotkey_1);
         assert_err!(new_key_uid, Error::<Test>::HotKeyNotRegisteredInSubNet,);
-        AssociatedEvmAddress::<Test>::insert(netuid, other_owner_uid, (evm_address, 1));
+        SubtensorModule::set_associated_evm_address(netuid, other_owner_uid, evm_address, 1);
 
         // Try to replace the other owner hotkey
         SubtensorModule::replace_neuron(

--- a/pallets/subtensor/src/utils/evm.rs
+++ b/pallets/subtensor/src/utils/evm.rs
@@ -114,8 +114,7 @@ impl<T: Config> Pallet<T> {
         let bucket = AssociatedUidsByEvmAddress::<T>::get(netuid, evm_key);
         let already_tracked = bucket.iter().any(|(stored_uid, _)| *stored_uid == uid);
         ensure!(
-            already_tracked
-                || (bucket.len() as u32) < crate::MAX_ASSOCIATED_UIDS_PER_EVM_ADDRESS,
+            already_tracked || (bucket.len() as u32) < crate::MAX_ASSOCIATED_UIDS_PER_EVM_ADDRESS,
             Error::<T>::EvmKeyAssociationLimitExceeded
         );
         Ok(())

--- a/pallets/subtensor/src/utils/evm.rs
+++ b/pallets/subtensor/src/utils/evm.rs
@@ -4,6 +4,7 @@ use frame_support::ensure;
 use frame_system::ensure_signed;
 
 use sp_core::{H160, ecdsa::Signature, hashing::keccak_256};
+use sp_std::collections::btree_map::BTreeMap;
 use sp_std::vec::Vec;
 use subtensor_runtime_common::NetUid;
 
@@ -82,9 +83,11 @@ impl<T: Config> Pallet<T> {
             Error::<T>::InvalidRecoveredPublicKey
         );
 
+        Self::ensure_evm_address_index_capacity(netuid, uid, evm_key)?;
+
         let current_block_number = Self::get_current_block_as_u64();
 
-        AssociatedEvmAddress::<T>::insert(netuid, uid, (evm_key, current_block_number));
+        Self::set_associated_evm_address(netuid, uid, evm_key, current_block_number);
 
         Self::deposit_event(Event::EvmKeyAssociated {
             netuid,
@@ -96,18 +99,133 @@ impl<T: Config> Pallet<T> {
         Ok(())
     }
 
-    pub fn uid_lookup(netuid: NetUid, evm_key: H160, limit: u16) -> Vec<(u16, u64)> {
-        let mut ret_val = AssociatedEvmAddress::<T>::iter_prefix(netuid)
-            .take(limit as usize)
-            .filter_map(|(uid, (stored_evm_key, block_associated))| {
-                if stored_evm_key != evm_key {
-                    return None;
-                }
+    /// Ensure `evm_key` can accept an association for `uid` on `netuid` without exceeding
+    /// [`MAX_ASSOCIATED_UIDS_PER_EVM_ADDRESS`].
+    ///
+    /// Re-associating a UID that is already tracked for this address (e.g. refreshing its
+    /// block) never consumes a new slot, so it is always permitted. This is the only path
+    /// that grows a bucket, so enforcing the cap here keeps the forward map
+    /// (`AssociatedEvmAddress`) and reverse index (`AssociatedUidsByEvmAddress`) consistent.
+    pub fn ensure_evm_address_index_capacity(
+        netuid: NetUid,
+        uid: u16,
+        evm_key: H160,
+    ) -> DispatchResult {
+        let bucket = AssociatedUidsByEvmAddress::<T>::get(netuid, evm_key);
+        let already_tracked = bucket.iter().any(|(stored_uid, _)| *stored_uid == uid);
+        ensure!(
+            already_tracked
+                || (bucket.len() as u32) < crate::MAX_ASSOCIATED_UIDS_PER_EVM_ADDRESS,
+            Error::<T>::EvmKeyAssociationLimitExceeded
+        );
+        Ok(())
+    }
 
-                Some((uid, block_associated))
+    pub fn set_associated_evm_address(
+        netuid: NetUid,
+        uid: u16,
+        evm_key: H160,
+        block_associated: u64,
+    ) {
+        if let Some((old_evm_key, _)) = AssociatedEvmAddress::<T>::get(netuid, uid)
+            && old_evm_key != evm_key
+        {
+            Self::remove_uid_from_evm_address_index(netuid, old_evm_key, uid);
+        }
+
+        Self::upsert_uid_in_evm_address_index(netuid, evm_key, uid, block_associated);
+        AssociatedEvmAddress::<T>::insert(netuid, uid, (evm_key, block_associated));
+    }
+
+    pub fn remove_associated_evm_address(netuid: NetUid, uid: u16) {
+        if let Some((evm_key, _)) = AssociatedEvmAddress::<T>::take(netuid, uid) {
+            Self::remove_uid_from_evm_address_index(netuid, evm_key, uid);
+        }
+    }
+
+    pub fn clear_associated_evm_addresses(netuid: NetUid) {
+        let _ = AssociatedEvmAddress::<T>::clear_prefix(netuid, u32::MAX, None);
+        let _ = AssociatedUidsByEvmAddress::<T>::clear_prefix(netuid, u32::MAX, None);
+    }
+
+    /// Remap the UIDs stored in the EVM-address reverse index after a subnet UID compaction.
+    ///
+    /// [`Self::trim_to_max_allowed_uids`] compacts kept UIDs into new, lower positions described
+    /// by `old_to_new_uid`; trimmed UIDs have already been dropped from both the forward map and
+    /// this reverse index. Only the UID *positions* of kept associations change (their EVM key
+    /// and block are untouched), so we rewrite each bucket's UIDs through the mapping rather than
+    /// clearing the whole index and rebuilding it from the forward map.
+    ///
+    /// Work is bounded by the number of distinct EVM addresses associated on the subnet: each
+    /// reverse-index entry is read once and written at most once, and the forward map is never
+    /// re-scanned.
+    pub fn remap_associated_evm_address_index(
+        netuid: NetUid,
+        old_to_new_uid: &BTreeMap<usize, usize>,
+    ) {
+        // Collect first: rewriting entries while iterating the same storage prefix is unsafe.
+        let updates: Vec<_> = AssociatedUidsByEvmAddress::<T>::iter_prefix(netuid)
+            .filter_map(|(evm_key, mut bucket)| {
+                let mut changed = false;
+                for (uid, _) in bucket.iter_mut() {
+                    if let Some(&new_uid) = old_to_new_uid.get(&(*uid as usize))
+                        && *uid != new_uid as u16
+                    {
+                        *uid = new_uid as u16;
+                        changed = true;
+                    }
+                }
+                changed.then_some((evm_key, bucket))
             })
+            .collect();
+
+        for (evm_key, bucket) in updates {
+            AssociatedUidsByEvmAddress::<T>::insert(netuid, evm_key, bucket);
+        }
+    }
+
+    fn upsert_uid_in_evm_address_index(
+        netuid: NetUid,
+        evm_key: H160,
+        uid: u16,
+        block_associated: u64,
+    ) {
+        AssociatedUidsByEvmAddress::<T>::mutate(netuid, evm_key, |uids| {
+            if let Some((_, stored_block)) =
+                uids.iter_mut().find(|(stored_uid, _)| *stored_uid == uid)
+            {
+                *stored_block = block_associated;
+                return;
+            }
+
+            if uids.try_push((uid, block_associated)).is_err() {
+                log::error!(
+                    "AssociatedUidsByEvmAddress overflow for netuid {netuid:?}, evm_key {evm_key:?}"
+                );
+            }
+        });
+    }
+
+    fn remove_uid_from_evm_address_index(netuid: NetUid, evm_key: H160, uid: u16) {
+        AssociatedUidsByEvmAddress::<T>::mutate_exists(netuid, evm_key, |maybe_uids| {
+            let Some(uids) = maybe_uids else {
+                return;
+            };
+
+            uids.retain(|(stored_uid, _)| *stored_uid != uid);
+
+            if uids.is_empty() {
+                *maybe_uids = None;
+            }
+        });
+    }
+
+    pub fn uid_lookup(netuid: NetUid, evm_key: H160, limit: u16) -> Vec<(u16, u64)> {
+        let mut ret_val = AssociatedUidsByEvmAddress::<T>::get(netuid, evm_key)
+            .into_iter()
             .collect::<Vec<(u16, u64)>>();
         ret_val.sort_by(|(_, block1), (_, block2)| block1.cmp(block2));
+        ret_val.truncate(limit as usize);
         ret_val
     }
 

--- a/pallets/subtensor/src/weights.rs
+++ b/pallets/subtensor/src/weights.rs
@@ -2405,14 +2405,16 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `SubtensorModule::Uids` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::AssociatedEvmAddress` (r:1 w:1)
 	/// Proof: `SubtensorModule::AssociatedEvmAddress` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::AssociatedUidsByEvmAddress` (r:2 w:2)
+	/// Proof: `SubtensorModule::AssociatedUidsByEvmAddress` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	fn associate_evm_key() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `950`
 		//  Estimated: `4415`
-		// Minimum execution time: 665_262_000 picoseconds.
-		Weight::from_parts(683_967_000, 4415)
-			.saturating_add(T::DbWeight::get().reads(3_u64))
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+		// Minimum execution time: 665_186_000 picoseconds.
+		Weight::from_parts(684_242_000, 4415)
+			.saturating_add(T::DbWeight::get().reads(6_u64))
+			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
 	/// Storage: `SubtensorModule::SubnetOwner` (r:1 w:0)
 	/// Proof: `SubtensorModule::SubnetOwner` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -4889,14 +4891,16 @@ impl WeightInfo for () {
 	/// Proof: `SubtensorModule::Uids` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `SubtensorModule::AssociatedEvmAddress` (r:1 w:1)
 	/// Proof: `SubtensorModule::AssociatedEvmAddress` (`max_values`: None, `max_size`: None, mode: `Measured`)
+	/// Storage: `SubtensorModule::AssociatedUidsByEvmAddress` (r:2 w:2)
+	/// Proof: `SubtensorModule::AssociatedUidsByEvmAddress` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	fn associate_evm_key() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `950`
 		//  Estimated: `4415`
-		// Minimum execution time: 665_262_000 picoseconds.
-		Weight::from_parts(683_967_000, 4415)
-			.saturating_add(RocksDbWeight::get().reads(3_u64))
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+		// Minimum execution time: 665_186_000 picoseconds.
+		Weight::from_parts(684_242_000, 4415)
+			.saturating_add(RocksDbWeight::get().reads(6_u64))
+			.saturating_add(RocksDbWeight::get().writes(3_u64))
 	}
 	/// Storage: `SubtensorModule::SubnetOwner` (r:1 w:0)
 	/// Proof: `SubtensorModule::SubnetOwner` (`max_values`: None, `max_size`: None, mode: `Measured`)

--- a/precompiles/src/uid_lookup.rs
+++ b/precompiles/src/uid_lookup.rs
@@ -44,7 +44,7 @@ where
         evm_address: Address,
         limit: u16,
     ) -> EvmResult<Vec<(u16, u64)>> {
-        handle.record_db_reads::<R>(u64::from(limit))?;
+        handle.record_db_reads::<R>(1)?;
         Ok(pallet_subtensor::Pallet::<R>::uid_lookup(
             netuid.into(),
             evm_address.0,
@@ -59,6 +59,7 @@ mod tests {
 
     use super::*;
     use crate::mock::{Runtime, addr_from_index, new_test_ext, precompiles, selector_u32};
+    use precompile_utils::prelude::RuntimeHelper;
     use precompile_utils::solidity::{codec::Address, encode_return_value, encode_with_selector};
     use precompile_utils::testing::PrecompileTesterExt;
     use subtensor_runtime_common::NetUid;
@@ -78,10 +79,11 @@ mod tests {
             let block_associated = 42u64;
             let limit = 1024u16;
 
-            pallet_subtensor::AssociatedEvmAddress::<Runtime>::insert(
+            pallet_subtensor::Pallet::<Runtime>::set_associated_evm_address(
                 netuid,
                 uid,
-                (evm_address, block_associated),
+                evm_address,
+                block_associated,
             );
 
             let expected =
@@ -98,6 +100,7 @@ mod tests {
                     ),
                 )
                 .with_static_call(true)
+                .expect_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())
                 .execute_returns_raw(encode_return_value(expected));
         });
     }


### PR DESCRIPTION
# Make `uidLookup` O(1) and bound its cost

## Why

The `uidLookup(netuid, evm_address, limit)` precompile answers "which UIDs on this
subnet are associated with this EVM address?". It was implemented by iterating the
whole `AssociatedEvmAddress` map for the subnet and filtering by address:

```rust
AssociatedEvmAddress::<T>::iter_prefix(netuid)
    .take(limit as usize)
    .filter_map(|(uid, (stored_evm_key, block))| (stored_evm_key == evm_key).then_some((uid, block)))
```

Two problems fall out of this:

1. **Unbounded work / gas.** The lookup scans every association on the subnet — up to
   one entry per UID (65k). The precompile charged a flat `record_db_reads(1)`, so the
   gas billed did not reflect the real number of storage reads. A large subnet made the
   call arbitrarily expensive relative to what it charged.

2. **Wrong results under `limit`.** `.take(limit)` ran *before* the sort, so it kept an
   arbitrary `limit` entries in UID order and only then sorted them by block — not the
   `limit` earliest associations the API implies.

Because the query is "by EVM address" but the data was stored "by UID", every call paid
a full subnet scan. The fix is to store the data the way it is queried.

## How

### 1. A reverse index, kept in lockstep with the forward map

Add `AssociatedUidsByEvmAddress: (netuid, H160) -> BoundedVec<(uid, block)>`. `uid_lookup`
now does a single read of that entry, sorts by block, and truncates to `limit`:

```rust
let mut ret = AssociatedUidsByEvmAddress::<T>::get(netuid, evm_key).into_iter().collect::<Vec<_>>();
ret.sort_by(|(_, b1), (_, b2)| b1.cmp(b2));
ret.truncate(limit as usize);
```

This is O(entries for that one address), and the flat `record_db_reads(1)` is now honest
(one storage item). The pre-sort `truncate` also fixes the `limit` bug.

The correctness of everything downstream rests on one invariant: **the forward map is
only ever written through helpers that also update the reverse index** —
`set_associated_evm_address`, `remove_associated_evm_address`, and
`clear_associated_evm_addresses`. All previous direct `AssociatedEvmAddress` writes
(neuron replacement, pruning, subnet dissolve) were routed through these. The two maps
therefore never drift apart.

### 2. A hard cap so the value — and the lookup — stays small

Reading a single storage item is only cheap if the item is small. Add
`MAX_ASSOCIATED_UIDS_PER_EVM_ADDRESS = 32`, which is the `BoundedVec` bound, so a bucket
is at most ~320 bytes. That caps the read/PoV cost of `uid_lookup` and of every
association write.

The cap is safe because **an association requires a signature from the EVM key**, so only
that key's holder can add UIDs to its bucket. The cap limits how many of *your own* UIDs
you may point at a single address, not anything an attacker can inflate. (On Finney today
the maximum reuse of any address is 3, so 32 is ~10x current peak.)

Over-cap associations are rejected at the extrinsic with a new
`EvmKeyAssociationLimitExceeded` error, checked by `ensure_evm_address_index_capacity`
*before* any storage mutation — so a rejected call leaves both maps untouched.
Re-associating a UID that is already in a full bucket (a block refresh, or the same key
again) is always allowed, because it reuses an existing slot rather than growing the
bucket.

### 3. In-place remap on subnet compaction (no full rebuild)

`trim_to_max_allowed_uids` compacts kept UIDs into new, lower positions. An earlier
version rebuilt the reverse index from scratch after compaction (clear the whole index,
then re-scan the forward map). That is unbounded work we don't need: trimmed UIDs are
already removed from both maps before the swap loop, and we already hold the exact
`old_uid -> new_uid` mapping. So `remap_associated_evm_address_index` walks the reverse
index once and rewrites only the UID positions that changed — single pass, bounded by the
number of distinct EVM addresses on the subnet, with no forward re-scan.

### 4. Migration

`migrate_associated_evm_address_index` backfills the reverse index from existing
`AssociatedEvmAddress` entries on runtime upgrade. It is one-time and guarded by
`HasMigrationRun`.

Two properties keep it safe on a live chain:

- **Bounded work.** The backfill processes at most `MAX_MIGRATION_ENTRIES` (50k)
  forward-map entries in the upgrade block, so it can never perform unbounded
  reads/writes in Wasm. If the map ever exceeds that (it does not — see below), the
  migration logs an error and leaves itself incomplete rather than silently indexing
  only a prefix. Measured against real state, the whole map is 100 entries on Finney and
  20 on testnet, so the cap is ~500x headroom.

- **Consistent by construction.** If a pre-existing `(netuid, evm_key)` bucket already
  holds `MAX_ASSOCIATED_UIDS_PER_EVM_ADDRESS` (32) UIDs, the extra forward entries are
  pruned from the forward map too, so `AssociatedEvmAddress` and the reverse index always
  agree on the cap (a pruned UID can re-associate later into a freed slot). This branch is
  unreachable for real state — the largest bucket on Finney is 3 — and is logged if ever
  hit.
