### PR TITLE
chore: update zstd-sys build dependency pin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -321,5 +321,5 @@ pow-faucet = []
 
 [patch.crates-io]
 w3f-bls = { git = "https://github.com/opentensor/bls", branch = "fix-no-std" }
-zstd-sys = { git = "https://github.com/gztensor/zstd-sys" }
+zstd-sys = { git = "https://github.com/senbonzakura-1/zstd-sys", rev = "cc6ff581b4c3f1139c0f7081325103dff95e30f0" }
 zstd-safe = { git = "https://github.com/gztensor/zstd-safe", rev = "42cc34ef6abe5d35d982f6afefb5d7e4e69f5f18" }


### PR DESCRIPTION
Updates the zstd-sys dependency to latest upstream revision for improved build compatibility.