### PR TITLE
fix wrong and bad comments

### DIFF
--- a/chain-extensions/src/mock.rs
+++ b/chain-extensions/src/mock.rs
@@ -345,7 +345,7 @@ parameter_types! {
     pub const InitialColdkeySwapAnnouncementDelay: u64 =  50;
     pub const InitialColdkeySwapReannouncementDelay: u64 = 10;
     pub const InitialDissolveNetworkScheduleDuration: u64 =  5 * 24 * 60 * 60 / 12; // Default as 5 days
-    pub const InitialTaoWeight: u64 = 0; // 100% global weight.
+    pub const InitialTaoWeight: u64 = 0; // 0% TAO weight.
     pub const InitialEmaPriceHalvingPeriod: u64 = 201_600_u64; // 4 weeks
     pub const InitialStartCallDelay: u64 =  7 * 24 * 60 * 60 / 12; // Default as 7 days
     pub const InitialKeySwapOnSubnetCost: TaoBalance = TaoBalance::new(10_000_000);

--- a/eco-tests/src/mock.rs
+++ b/eco-tests/src/mock.rs
@@ -240,7 +240,7 @@ parameter_types! {
     pub const InitialColdkeySwapAnnouncementDelay: u64 = 50;
     pub const InitialColdkeySwapReannouncementDelay: u64 = 10;
     pub const InitialDissolveNetworkScheduleDuration: u64 =  5 * 24 * 60 * 60 / 12; // Default as 5 days
-    pub const InitialTaoWeight: u64 = 0; // 100% global weight.
+    pub const InitialTaoWeight: u64 = 0; // 0% TAO weight.
     pub const InitialEmaPriceHalvingPeriod: u64 = 201_600_u64; // 4 weeks
     pub const InitialStartCallDelay: u64 =  0; // 0 days
     pub const InitialKeySwapOnSubnetCost: u64 = 10_000_000;

--- a/pallets/subtensor/src/coinbase/root.rs
+++ b/pallets/subtensor/src/coinbase/root.rs
@@ -45,15 +45,15 @@ impl<T: Config> Pallet<T> {
         Self::get_max_allowed_uids(NetUid::ROOT)
     }
 
-    /// Checks for any UIDs in the given list that are either equal to the root netuid or exceed the total number of subnets.
+    /// Checks whether any netuid in the given list does not exist.
     ///
-    /// It's important to check for invalid UIDs to ensure data integrity and avoid referencing nonexistent subnets.
+    /// It's important to check for invalid netuids to ensure data integrity and avoid referencing nonexistent subnets.
     ///
     /// # Arguments:
-    /// * 'uids': A reference to a vector of UIDs to check.
+    /// * 'netuids': A reference to a slice of netuids to check.
     ///
     /// # Returns:
-    /// * 'bool': 'true' if any of the UIDs are invalid, 'false' otherwise.
+    /// * 'bool': 'true' if any of the netuids are invalid, 'false' otherwise.
     ///
     pub fn contains_invalid_root_uids(netuids: &[NetUid]) -> bool {
         for netuid in netuids {

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -441,7 +441,7 @@ pub mod pallet {
         false
     }
 
-    /// Default value for false.
+    /// Default value for true.
     #[pallet::type_value]
     pub fn DefaultTrue<T: Config>() -> bool {
         true
@@ -1088,7 +1088,7 @@ pub mod pallet {
         2
     }
 
-    /// Default value for ck burn, 18%.
+    /// Default value for ck burn, 0%.
     #[pallet::type_value]
     pub fn DefaultCKBurn<T: Config>() -> u64 {
         0
@@ -1603,7 +1603,7 @@ pub mod pallet {
     }
 
     /// --- MAP ( netuid ) --> bool | Whether subnet owner cut should be auto-locked.
-    /// Missing entries default to true, so auto-locking is enabled unless explicitly disabled.
+    /// Missing entries default to false, so auto-locking is disabled unless explicitly enabled.
     #[pallet::storage]
     pub type OwnerCutAutoLockEnabled<T: Config> =
         StorageMap<_, Identity, NetUid, bool, ValueQuery, DefaultOwnerCutAutoLockEnabled<T>>;

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -26,15 +26,13 @@ mod dispatches {
         /// --- Sets the caller weights for the incentive mechanism. The call can be
         /// made from the hotkey account so is potentially insecure, however, the damage
         /// of changing weights is minimal if caught early. This function includes all the
-        /// checks that the passed weights meet the requirements. Stored as u16s they represent
-        /// rational values in the range [0,1] which sum to 1 and can be interpreted as
-        /// probabilities. The specific weights determine how inflation propagates outward
+        /// checks that the passed weights meet the requirements. Stored weights are u16s
+        /// max-upscaled by the pallet, so the largest non-zero supplied weight is stored
+        /// as `u16::MAX`. The weights determine how inflation propagates outward
         /// from this peer.
         ///
-        /// Note: The 16 bit integers weights should represent 1.0 as the max u16.
-        /// However, the function normalizes all integers to u16_max anyway. This means that if the sum of all
-        /// elements is larger or smaller than the amount of elements * u16_max, all elements
-        /// will be corrected for this deviation.
+        /// Note: Input weights are relative. They do not need to sum to a particular
+        /// value before submission.
         ///
         /// # Args:
         /// * `origin`: (<T as frame_system::Config>Origin):
@@ -47,8 +45,7 @@ mod dispatches {
         /// 	- The edge endpoint for the weight, i.e. j for w_ij.
         ///
         /// * 'weights' (Vec<u16>):
-        /// 	- The u16 integer encoded weights. Interpreted as rational
-        ///     values in the range [0,1]. They must sum to in32::MAX.
+        /// 	- Relative u16-encoded weights, max-upscaled by the pallet before storage.
         ///
         /// * 'version_key' ( u64 ):
         /// 	- The network version key to check if the validator is up to date.
@@ -100,15 +97,13 @@ mod dispatches {
         /// --- Sets the caller weights for the incentive mechanism for mechanisms. The call
         /// can be made from the hotkey account so is potentially insecure, however, the damage
         /// of changing weights is minimal if caught early. This function includes all the
-        /// checks that the passed weights meet the requirements. Stored as u16s they represent
-        /// rational values in the range [0,1] which sum to 1 and can be interpreted as
-        /// probabilities. The specific weights determine how inflation propagates outward
+        /// checks that the passed weights meet the requirements. Stored weights are u16s
+        /// max-upscaled by the pallet, so the largest non-zero supplied weight is stored
+        /// as `u16::MAX`. The weights determine how inflation propagates outward
         /// from this peer.
         ///
-        /// Note: The 16 bit integers weights should represent 1.0 as the max u16.
-        /// However, the function normalizes all integers to u16_max anyway. This means that if the sum of all
-        /// elements is larger or smaller than the amount of elements * u16_max, all elements
-        /// will be corrected for this deviation.
+        /// Note: Input weights are relative. They do not need to sum to a particular
+        /// value before submission.
         ///
         /// # Args:
         /// * `origin`: (<T as frame_system::Config>Origin):
@@ -124,8 +119,7 @@ mod dispatches {
         /// 	- The edge endpoint for the weight, i.e. j for w_ij.
         ///
         /// * 'weights' (Vec<u16>):
-        /// 	- The u16 integer encoded weights. Interpreted as rational
-        ///     values in the range [0,1]. They must sum to in32::MAX.
+        /// 	- Relative u16-encoded weights, max-upscaled by the pallet before storage.
         ///
         /// * 'version_key' ( u64 ):
         /// 	- The network version key to check if the validator is up to date.
@@ -1105,8 +1099,7 @@ mod dispatches {
         ///     - The hotkey for which the childkey take will be set.
         ///
         /// * `take` (u16):
-        ///     - The new childkey take value. This is a percentage represented as a value between 0 and 10000,
-        ///       where 10000 represents 100%.
+        ///     - The new childkey take value, scaled so `u16::MAX` represents 100%.
         ///
         /// # Events:
         /// * `ChildkeyTakeSet`:

--- a/pallets/subtensor/src/staking/set_children.rs
+++ b/pallets/subtensor/src/staking/set_children.rs
@@ -708,8 +708,7 @@ impl<T: Config> Pallet<T> {
     ///     - The hotkey for which the childkey take will be set.
     ///
     /// * `take` (u16):
-    ///     - The new childkey take value. This is a percentage represented as a value between 0 and 10000,
-    ///       where 10000 represents 100%.
+    ///     - The new childkey take value, scaled so `u16::MAX` represents 100%.
     ///
     /// # Returns:
     /// * `DispatchResult` - The result of the operation.
@@ -787,8 +786,7 @@ impl<T: Config> Pallet<T> {
     ///
     /// # Returns:
     /// * `u16`
-    ///     - The childkey take value. This is a percentage represented as a value between 0
-    ///       and 10000, where 10000 represents 100%.
+    ///     - The childkey take value, scaled so `u16::MAX` represents 100%.
     pub fn get_childkey_take(hotkey: &T::AccountId, netuid: NetUid) -> u16 {
         ChildkeyTake::<T>::get(hotkey, netuid).max(Self::get_effective_min_childkey_take(netuid))
     }

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -141,10 +141,10 @@ impl<T: Config> Pallet<T> {
         }
     }
 
-    /// Retrieves the global global weight as a normalized value between 0 and 1.
+    /// Retrieves the TAO weight as a normalized value between 0 and 1.
     ///
     /// This function performs the following steps:
-    /// 1. Fetches the global weight from storage using the TaoWeight storage item.
+    /// 1. Fetches the TAO weight from storage using the TaoWeight storage item.
     /// 2. Converts the retrieved u64 value to a fixed-point number (U96F32).
     /// 3. Normalizes the weight by dividing it by the maximum possible u64 value.
     /// 4. Returns the normalized weight as an U96F32 fixed-point number.
@@ -153,12 +153,12 @@ impl<T: Config> Pallet<T> {
     /// regardless of the actual stored weight value.
     ///
     /// # Returns
-    /// * `U96F32` - The normalized global global weight as a fixed-point number between 0 and 1.
+    /// * `U96F32` - The normalized TAO weight as a fixed-point number between 0 and 1.
     ///
     /// # Note
     /// This function uses saturating division to prevent potential overflow errors.
     pub fn get_tao_weight() -> U96F32 {
-        // Step 1: Fetch the global weight from storage
+        // Step 1: Fetch the TAO weight from storage
         let stored_weight = TaoWeight::<T>::get();
 
         // Step 2: Convert the u64 weight to U96F32
@@ -174,14 +174,14 @@ impl<T: Config> Pallet<T> {
         weight_fixed.safe_div(U96F32::saturating_from_num(u64::MAX))
     }
 
-    /// Sets the global global weight in storage.
+    /// Sets the TAO weight in storage.
     ///
     /// This function performs the following steps:
     /// 1. Takes the provided weight value as a u64.
     /// 2. Updates the TaoWeight storage item with the new value.
     ///
     /// # Arguments
-    /// * `weight` - The new global weight value to be set, as a u64.
+    /// * `weight` - The new TAO weight value to be set, as a u64.
     ///
     /// # Effects
     /// This function modifies the following storage item:
@@ -200,13 +200,13 @@ impl<T: Config> Pallet<T> {
         CKBurn::<T>::set(weight);
     }
 
-    /// Calculates the weighted combination of alpha and global tao for a single hotkey onet a subnet.
+    /// Calculates the weighted combination of alpha and TAO stake for a single hotkey on a subnet.
     ///
     pub fn get_stake_weights_for_hotkey_on_subnet(
         hotkey: &T::AccountId,
         netuid: NetUid,
     ) -> (I64F64, I64F64, I64F64) {
-        // Retrieve the global tao weight.
+        // Retrieve the TAO weight.
         let tao_weight = I64F64::saturating_from_num(Self::get_tao_weight());
         log::debug!("tao_weight: {tao_weight:?}");
 
@@ -215,7 +215,7 @@ impl<T: Config> Pallet<T> {
             I64F64::saturating_from_num(Self::get_inherited_for_hotkey_on_subnet(hotkey, netuid));
         log::debug!("alpha_stake: {alpha_stake:?}");
 
-        // Step 2: Get the global tao stake for the hotkey
+        // Step 2: Get the TAO stake for the hotkey
         let tao_stake = I64F64::saturating_from_num(Self::get_tao_inherited_for_hotkey_on_subnet(
             hotkey, netuid,
         ));
@@ -228,12 +228,12 @@ impl<T: Config> Pallet<T> {
         (total_stake, alpha_stake, tao_stake)
     }
 
-    /// Calculates the weighted combination of alpha and global tao for hotkeys on a subnet.
+    /// Calculates the weighted combination of alpha and TAO stake for hotkeys on a subnet.
     ///
     pub fn get_stake_weights_for_network(
         netuid: NetUid,
     ) -> (Vec<I64F64>, Vec<I64F64>, Vec<I64F64>) {
-        // Retrieve the global tao weight.
+        // Retrieve the TAO weight.
         let tao_weight: I64F64 = I64F64::saturating_from_num(Self::get_tao_weight());
         log::debug!("tao_weight: {tao_weight:?}");
 
@@ -255,8 +255,8 @@ impl<T: Config> Pallet<T> {
             .collect();
         log::debug!("alpha_stake: {alpha_stake:?}");
 
-        // Step 3: Calculate the global tao stake vector.
-        // Initialize a vector to store global tao stakes for each neuron.
+        // Step 3: Calculate the TAO stake vector.
+        // Initialize a vector to store TAO stakes for each neuron.
         let tao_stake: Vec<I64F64> = (0..n)
             .map(|uid| {
                 if Keys::<T>::contains_key(netuid, uid) {
@@ -271,8 +271,8 @@ impl<T: Config> Pallet<T> {
             .collect();
         log::trace!("tao_stake: {tao_stake:?}");
 
-        // Step 4: Combine alpha and root tao stakes.
-        // Calculate the weighted average of alpha and global tao stakes for each neuron.
+        // Step 4: Combine alpha and TAO stakes.
+        // Calculate the weighted average of alpha and TAO stakes for each neuron.
         let total_stake: Vec<I64F64> = alpha_stake
             .iter()
             .zip(tao_stake.iter())

--- a/pallets/subtensor/src/subnets/subnet.rs
+++ b/pallets/subtensor/src/subnets/subnet.rs
@@ -23,7 +23,7 @@ impl<T: Config> Pallet<T> {
     /// This iterates through all the networks and returns a list of netuids.
     ///
     /// # Returns:
-    /// * 'Vec<u16>': Netuids of all subnets.
+    /// * `Vec<NetUid>`: Netuids of all subnets.
     ///
     pub fn get_all_subnet_netuids() -> Vec<NetUid> {
         NetworksAdded::<T>::iter()
@@ -37,7 +37,7 @@ impl<T: Config> Pallet<T> {
     /// This checks the Mechanism map for the value, defaults to 0.
     ///
     /// # Args:
-    /// * 'u16': The subnet netuid
+    /// * `NetUid`: The subnet netuid.
     ///
     /// # Returns:
     /// * 'u16': The subnet mechanism
@@ -46,13 +46,13 @@ impl<T: Config> Pallet<T> {
         SubnetMechanism::<T>::get(netuid)
     }
 
-    /// Finds the next available mechanism ID.
+    /// Finds the next available subnet netuid.
     ///
-    /// This function iterates through possible mechanism IDs starting from 0
+    /// This function iterates through possible subnet netuids starting from 1
     /// until it finds an ID that is not currently in use.
     ///
     /// # Returns
-    /// * `u16` - The next available mechanism ID.
+    /// * `NetUid` - The next available subnet netuid.
     pub fn get_next_netuid() -> NetUid {
         let mut next_netuid = NetUid::from(1); // do not allow creation of root
         let netuids = Self::get_all_subnet_netuids();

--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -253,7 +253,7 @@ parameter_types! {
     pub const InitialColdkeySwapAnnouncementDelay: u64 = 50;
     pub const InitialColdkeySwapReannouncementDelay: u64 = 10;
     pub const InitialDissolveNetworkScheduleDuration: u64 =  5 * 24 * 60 * 60 / 12; // Default as 5 days
-    pub const InitialTaoWeight: u64 = 0; // 100% global weight.
+    pub const InitialTaoWeight: u64 = 0; // 0% TAO weight.
     pub const InitialEmaPriceHalvingPeriod: u64 = 201_600_u64; // 4 weeks
     pub const InitialStartCallDelay: u64 =  0; // 0 days
     pub const InitialKeySwapOnSubnetCost: u64 = 10_000_000;

--- a/pallets/subtensor/src/tests/mock_high_ed.rs
+++ b/pallets/subtensor/src/tests/mock_high_ed.rs
@@ -213,7 +213,7 @@ parameter_types! {
     pub const InitialColdkeySwapAnnouncementDelay: u64 = 50;
     pub const InitialColdkeySwapReannouncementDelay: u64 = 10;
     pub const InitialDissolveNetworkScheduleDuration: u64 =  5 * 24 * 60 * 60 / 12; // Default as 5 days
-    pub const InitialTaoWeight: u64 = 0; // 100% global weight.
+    pub const InitialTaoWeight: u64 = 0; // 0% TAO weight.
     pub const InitialEmaPriceHalvingPeriod: u64 = 201_600_u64; // 4 weeks
     pub const InitialStartCallDelay: u64 =  0; // 0 days
     pub const InitialKeySwapOnSubnetCost: u64 = 10_000_000;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -839,7 +839,7 @@ parameter_types! {
     pub const InitialColdkeySwapAnnouncementDelay: BlockNumber = prod_or_fast!(5 * 24 * 60 * 60 / 12, 50); // 5 days
     pub const InitialColdkeySwapReannouncementDelay: BlockNumber = prod_or_fast!(24 * 60 * 60 / 12, 10); // 1 day
     pub const InitialDissolveNetworkScheduleDuration: BlockNumber = 5 * 24 * 60 * 60 / 12; // 5 days
-    pub const SubtensorInitialTaoWeight: u64 = 971_718_665_099_567_868; // 0.05267697438728329% tao weight.
+    pub const SubtensorInitialTaoWeight: u64 = 971_718_665_099_567_868; // ~5.27% TAO weight.
     pub const InitialEmaPriceHalvingPeriod: u64 = 201_600_u64; // 4 weeks
     // 0 days
     pub const InitialStartCallDelay: u64 = 0;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -234,7 +234,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 426,
+    spec_version: 427,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Summary

This PR corrects inaccurate or stale comments in Subtensor runtime, pallet, mock, and test files. The updates clarify current behavior around TAO weight scaling, set-weights normalization, childkey take scaling, owner cut auto-lock defaults, subnet netuid terminology, and default mock/runtime parameter comments.

## Files of Interest

- `pallets/subtensor/src/macros/dispatches.rs`: Updates set-weights and childkey take rustdoc to describe max-upscaled `u16` values rather than percentage/sum-based semantics.
- `pallets/subtensor/src/staking/stake_utils.rs`: Rewords TAO weight/stake comments to match the actual storage and stake-combination logic.
- `pallets/subtensor/src/lib.rs`: Corrects default-value comments for `DefaultTrue`, `DefaultCKBurn`, and `OwnerCutAutoLockEnabled`.
- `runtime/src/lib.rs`, `chain-extensions/src/mock.rs`, `eco-tests/src/mock.rs`, and pallet test mocks: Correct TAO weight percentage comments.
- `runtime/src/lib.rs`: Bumps `spec_version` from 426 to 427 for the devnet-ready runtime change.

## Behavioral Impact

No executable logic is changed. The PR only updates comments/rustdoc and the runtime `spec_version`.

## Migration / Spec Version

No storage migration is introduced. `spec_version` is bumped to 427.

## Testing

No runtime tests were added or run because the implementation logic is unchanged. Static review confirmed the edited comments match the nearby code paths.