### PR TITLE
Benchmark `reveal_timelocked_commitments`

### DIFF
--- a/pallets/commitments/src/benchmarking.rs
+++ b/pallets/commitments/src/benchmarking.rs
@@ -5,9 +5,14 @@ use super::*;
 
 #[allow(unused)]
 use crate::Pallet as Commitments;
+use ark_serialize::CanonicalSerialize;
 use frame_benchmarking::v2::*;
+use frame_support::{assert_ok, traits::ConstU32};
 use frame_system::RawOrigin;
+use rand_chacha::{ChaCha20Rng, rand_core::SeedableRng};
+use sha2::Digest;
 use sp_std::vec;
+use tle::{ibe::fullident::Identity as TleIdentity, tlock::tle};
 
 use sp_runtime::traits::Bounded;
 
@@ -16,6 +21,20 @@ fn assert_last_event<T: frame_system::pallet::Config>(
 ) {
     frame_system::Pallet::<T>::assert_last_event(generic_event.into());
 }
+
+const BENCHMARK_REVEAL_ROUND: u64 = 1000;
+const DRAND_QUICKNET_PUBKEY_BYTES: [u8; 96] = [
+    131, 207, 15, 40, 150, 173, 238, 126, 184, 181, 240, 31, 202, 211, 145, 34, 18, 196, 55, 224,
+    7, 62, 145, 31, 185, 0, 34, 211, 231, 96, 24, 60, 140, 75, 69, 11, 106, 10, 108, 58, 198, 165,
+    119, 106, 45, 16, 100, 81, 13, 31, 236, 117, 140, 146, 28, 194, 43, 14, 23, 230, 58, 175, 75,
+    203, 94, 214, 99, 4, 222, 156, 248, 9, 189, 39, 76, 167, 59, 171, 74, 245, 166, 233, 199, 106,
+    75, 192, 158, 118, 234, 232, 153, 30, 245, 236, 228, 90,
+];
+const DRAND_QUICKNET_SIGNATURE_BYTES: [u8; 48] = [
+    180, 70, 121, 185, 165, 154, 242, 236, 135, 107, 26, 107, 26, 213, 46, 169, 177, 97, 95, 195,
+    152, 43, 25, 87, 99, 80, 249, 52, 71, 203, 17, 37, 227, 66, 183, 58, 141, 210, 186, 203, 228,
+    126, 75, 107, 99, 237, 94, 57,
+];
 
 // This creates an `IdentityInfo` object with `num_fields` extra fields.
 // All data is pre-populated with some arbitrary bytes.
@@ -29,6 +48,81 @@ fn create_identity_info<T: Config>(_num_fields: u32) -> CommitmentInfo<T::MaxFie
     CommitmentInfo {
         fields: Default::default(),
     }
+}
+
+fn produce_benchmark_ciphertext(
+    plaintext: &[u8],
+    round: u64,
+) -> BoundedVec<u8, ConstU32<MAX_TIMELOCK_COMMITMENT_SIZE_BYTES>> {
+    let pub_key = <TinyBLS381 as EngineBLS>::PublicKeyGroup::deserialize_compressed(
+        &DRAND_QUICKNET_PUBKEY_BYTES[..],
+    )
+    .expect("benchmark drand public key is valid");
+
+    let msg = {
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(round.to_be_bytes());
+        hasher.finalize().to_vec()
+    };
+    let identity = TleIdentity::new(b"", vec![msg]);
+    let esk = [2u8; 32];
+    let rng = ChaCha20Rng::seed_from_u64(0);
+
+    let ciphertext = tle::<TinyBLS381, AESGCMStreamCipherProvider, ChaCha20Rng>(
+        pub_key, esk, plaintext, identity, rng,
+    )
+    .expect("benchmark timelock encryption succeeds");
+
+    let mut ciphertext_bytes = Vec::new();
+    ciphertext
+        .serialize_compressed(&mut ciphertext_bytes)
+        .expect("benchmark timelock ciphertext serializes");
+
+    ciphertext_bytes
+        .try_into()
+        .expect("benchmark timelock ciphertext fits max size")
+}
+
+fn insert_benchmark_pulse<T: Config>(round: u64) {
+    let randomness: BoundedVec<u8, ConstU32<32>> = vec![0_u8; 32]
+        .try_into()
+        .expect("benchmark randomness fits bounded vec");
+    let signature: BoundedVec<u8, ConstU32<144>> = DRAND_QUICKNET_SIGNATURE_BYTES
+        .to_vec()
+        .try_into()
+        .expect("benchmark signature fits bounded vec");
+
+    pallet_drand::Pulses::<T>::insert(
+        round,
+        pallet_drand::types::Pulse {
+            round,
+            randomness,
+            signature,
+        },
+    );
+}
+
+fn timelocked_commitment_info<T: Config>() -> CommitmentInfo<T::MaxFields> {
+    let raw = Data::Raw(
+        b"timelock benchmark"
+            .to_vec()
+            .try_into()
+            .expect("benchmark raw data fits bounded vec"),
+    );
+    let inner_fields: BoundedVec<Data, T::MaxFields> =
+        BoundedVec::try_from(vec![raw]).expect("benchmark max fields allows raw");
+    let inner_info: CommitmentInfo<T::MaxFields> = CommitmentInfo {
+        fields: inner_fields,
+    };
+    let encrypted = produce_benchmark_ciphertext(&inner_info.encode(), BENCHMARK_REVEAL_ROUND);
+    let timelock = Data::TimelockEncrypted {
+        encrypted,
+        reveal_round: BENCHMARK_REVEAL_ROUND,
+    };
+    let fields =
+        BoundedVec::try_from(vec![timelock]).expect("benchmark max fields allows timelock");
+
+    CommitmentInfo { fields }
 }
 
 #[benchmarks]
@@ -65,6 +159,28 @@ mod benchmarks {
         _(RawOrigin::Root, new_space);
 
         assert_eq!(MaxSpace::<T>::get(), new_space);
+    }
+
+    #[benchmark(skip_meta)]
+    fn reveal_timelocked_commitments() {
+        let netuid = NetUid::from(1);
+        let caller: T::AccountId = whitelisted_caller();
+        let _ = T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
+        let info = timelocked_commitment_info::<T>();
+
+        assert_ok!(Commitments::<T>::set_commitment(
+            RawOrigin::Signed(caller.clone()).into(),
+            netuid,
+            Box::new(info),
+        ));
+        insert_benchmark_pulse::<T>(BENCHMARK_REVEAL_ROUND);
+
+        #[block]
+        {
+            assert_ok!(Commitments::<T>::reveal_timelocked_commitments());
+        }
+
+        assert!(RevealedCommitments::<T>::get(netuid, caller).is_some());
     }
 
     impl_benchmark_test_suite!(Commitments, crate::mock::new_test_ext(), crate::mock::Test);

--- a/pallets/commitments/src/lib.rs
+++ b/pallets/commitments/src/lib.rs
@@ -342,10 +342,11 @@ pub mod pallet {
     impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
         fn on_initialize(n: BlockNumberFor<T>) -> Weight {
             match Self::reveal_timelocked_commitments() {
-                Ok(w) => w,
+                Ok(w) => <T as pallet::Config>::WeightInfo::reveal_timelocked_commitments()
+                    .saturating_add(w),
                 Err(e) => {
                     log::debug!("Failed to unveil matured commitments on block {n:?}: {e:?}");
-                    Weight::from_parts(0, 0)
+                    <T as pallet::Config>::WeightInfo::reveal_timelocked_commitments()
                 }
             }
         }

--- a/pallets/commitments/src/mock.rs
+++ b/pallets/commitments/src/mock.rs
@@ -4,6 +4,7 @@ use frame_support::{
     derive_impl,
     pallet_prelude::{Get, TypeInfo},
     traits::{ConstU32, ConstU64},
+    weights::{Weight, constants::RocksDbWeight},
 };
 use sp_core::H256;
 use sp_runtime::{
@@ -34,7 +35,7 @@ impl frame_system::Config for Test {
     type BaseCallFilter = frame_support::traits::Everything;
     type BlockWeights = ();
     type BlockLength = ();
-    type DbWeight = ();
+    type DbWeight = RocksDbWeight;
     type RuntimeOrigin = RuntimeOrigin;
     type RuntimeCall = RuntimeCall;
     type Hash = H256;
@@ -94,9 +95,24 @@ impl pallet_commitments::CanCommit<u64> for TestCanCommit {
     }
 }
 
+pub struct TestWeightInfo;
+impl pallet_commitments::WeightInfo for TestWeightInfo {
+    fn set_commitment() -> Weight {
+        Weight::from_parts(0, 0)
+    }
+
+    fn set_max_space() -> Weight {
+        Weight::from_parts(0, 0)
+    }
+
+    fn reveal_timelocked_commitments() -> Weight {
+        Weight::from_parts(42, 0)
+    }
+}
+
 impl pallet_commitments::Config for Test {
     type Currency = Balances;
-    type WeightInfo = ();
+    type WeightInfo = TestWeightInfo;
     type MaxFields = TestMaxFields;
     type CanCommit = TestCanCommit;
     type FieldDeposit = ConstTao<0>;

--- a/pallets/commitments/src/tests.rs
+++ b/pallets/commitments/src/tests.rs
@@ -8,7 +8,7 @@ use subtensor_runtime_common::{NetUid, TaoBalance};
 use crate::{
     BalanceOf, CommitmentInfo, CommitmentOf, Config, Data, Error, Event, LastBondsReset,
     LastCommitment, MaxSpace, Pallet, Registration, RevealedCommitments, TimelockedIndex,
-    UsageTracker, UsedSpaceOf,
+    UsageTracker, UsedSpaceOf, WeightInfo,
     mock::{
         Balances, DRAND_QUICKNET_SIG_2000_HEX, DRAND_QUICKNET_SIG_HEX, RuntimeEvent, RuntimeOrigin,
         Test, TestMaxFields, insert_drand_pulse, new_test_ext, produce_ciphertext,
@@ -18,6 +18,7 @@ use frame_support::pallet_prelude::Hooks;
 use frame_support::{
     BoundedVec, assert_noop, assert_ok,
     traits::{Currency, Get, ReservableCurrency},
+    weights::constants::RocksDbWeight,
 };
 use frame_system::{Pallet as System, RawOrigin};
 
@@ -1126,7 +1127,11 @@ fn on_initialize_reveals_matured_timelocks() {
         assert!(RevealedCommitments::<Test>::get(netuid, who).is_none());
 
         System::<Test>::set_block_number(2);
-        <Pallet<Test> as Hooks<u64>>::on_initialize(2);
+        let weight = <Pallet<Test> as Hooks<u64>>::on_initialize(2);
+        let expected_weight = <Test as Config>::WeightInfo::reveal_timelocked_commitments()
+            .saturating_add(RocksDbWeight::get().reads(5))
+            .saturating_add(RocksDbWeight::get().writes(3));
+        assert_eq!(weight, expected_weight);
 
         let revealed_opt = RevealedCommitments::<Test>::get(netuid, who);
         assert!(

--- a/pallets/commitments/src/weights.rs
+++ b/pallets/commitments/src/weights.rs
@@ -31,6 +31,7 @@ use core::marker::PhantomData;
 pub trait WeightInfo {
 	fn set_commitment() -> Weight;
 	fn set_max_space() -> Weight;
+	fn reveal_timelocked_commitments() -> Weight;
 }
 
 /// Weights for `pallet_commitments` using the Substrate node and recommended hardware.
@@ -45,6 +46,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		Weight::from_parts(2_856_000, 0)
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
+	fn reveal_timelocked_commitments() -> Weight {
+		Weight::from_parts(7_481_733_000, 635)
+	}
 }
 
 // For backwards compatibility and tests.
@@ -57,5 +61,8 @@ impl WeightInfo for () {
 	fn set_max_space() -> Weight {
 		Weight::from_parts(2_856_000, 0)
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+	fn reveal_timelocked_commitments() -> Weight {
+		Weight::from_parts(7_481_733_000, 635)
 	}
 }


### PR DESCRIPTION
## Description
This PR benchmarks `reveal_timelocked_commitments` so that on_initialize returns the full weight rather than only reads/writes in the same way we do `block_step` in the subtensor pallet.