### PR TITLE
Fix testnet warp sync with trusted GRANDPA checkpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,7 +1114,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "assets-common"
 version = "0.22.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "cumulus-primitives-core",
  "ethereum-standards",
@@ -1493,7 +1493,7 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 [[package]]
 name = "binary-merkle-tree"
 version = "16.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "hash-db",
  "log",
@@ -1802,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
@@ -1819,7 +1819,7 @@ dependencies = [
 [[package]]
 name = "bp-messages"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -1835,7 +1835,7 @@ dependencies = [
 [[package]]
 name = "bp-parachains"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -1852,7 +1852,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot-core"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1868,7 +1868,7 @@ dependencies = [
 [[package]]
 name = "bp-relayers"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1886,7 +1886,7 @@ dependencies = [
 [[package]]
 name = "bp-runtime"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1909,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -1929,7 +1929,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub"
 version = "0.7.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1946,7 +1946,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.18.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1958,7 +1958,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-common"
 version = "0.14.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1977,7 +1977,7 @@ dependencies = [
 [[package]]
 name = "bridge-runtime-common"
 version = "0.22.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -2890,7 +2890,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-bootnodes"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -2916,7 +2916,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.24.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -2933,7 +2933,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.24.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -2956,7 +2956,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.24.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -3003,7 +3003,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.24.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -3035,7 +3035,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.20.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3050,7 +3050,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.24.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -3073,7 +3073,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.24.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -3100,7 +3100,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.18.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3110,7 +3110,7 @@ dependencies = [
  "parity-scale-codec",
  "sc-client-api",
  "sc-consensus-babe",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490)",
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
@@ -3121,7 +3121,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.24.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3149,7 +3149,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.25.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-channel 1.9.0",
  "cumulus-client-cli",
@@ -3189,7 +3189,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -3206,7 +3206,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "cumulus-primitives-core",
  "frame-benchmarking",
@@ -3223,7 +3223,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -3260,7 +3260,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -3271,7 +3271,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "22.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3284,7 +3284,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-solo-to-para"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -3299,7 +3299,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-weight-reclaim"
 version = "0.3.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "derive-where",
@@ -3318,7 +3318,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.20.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3333,7 +3333,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "approx",
  "bounded-collections 0.2.4",
@@ -3358,7 +3358,7 @@ dependencies = [
 [[package]]
 name = "cumulus-ping"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-primitives-core",
@@ -3373,7 +3373,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.18.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -3382,7 +3382,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.19.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -3399,7 +3399,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.19.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3413,7 +3413,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.13.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -3423,7 +3423,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "12.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -3440,7 +3440,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3457,7 +3457,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.25.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -3485,7 +3485,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.24.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3505,7 +3505,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.25.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -3541,7 +3541,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.24.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3582,7 +3582,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-streams"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "cumulus-relay-chain-interface",
  "futures",
@@ -3596,7 +3596,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.20.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -4404,7 +4404,7 @@ dependencies = [
 [[package]]
 name = "ethereum-standards"
 version = "0.1.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "alloy-core",
 ]
@@ -4794,7 +4794,7 @@ dependencies = [
  "rustc-hex",
  "serde",
  "serde_json",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490)",
 ]
 
 [[package]]
@@ -4978,7 +4978,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -5105,7 +5105,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 [[package]]
 name = "frame-benchmarking"
 version = "41.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -5129,7 +5129,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "49.1.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.3",
@@ -5194,7 +5194,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-pallet-pov"
 version = "31.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5222,7 +5222,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "16.1.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -5233,7 +5233,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -5250,7 +5250,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "41.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -5303,7 +5303,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.9.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "array-bytes 6.2.3",
  "const-hex",
@@ -5319,7 +5319,7 @@ dependencies = [
 [[package]]
 name = "frame-storage-access-test-runtime"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "parity-scale-codec",
@@ -5333,7 +5333,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "aquamarine",
  "array-bytes 6.2.3",
@@ -5374,20 +5374,33 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "34.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "Inflector",
  "cfg-expr",
  "derive-syn-parse",
  "docify",
  "expander",
+ "frame-support-procedural-core",
  "frame-support-procedural-tools 13.0.1",
  "itertools 0.11.0",
  "macro_magic",
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490)",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "frame-support-procedural-core"
+version = "34.0.0"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
+dependencies = [
+ "cfg-expr",
+ "frame-support-procedural-tools 13.0.1",
+ "proc-macro2",
+ "quote",
  "syn 2.0.106",
 ]
 
@@ -5407,7 +5420,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-support-procedural-tools-derive 12.0.0",
  "proc-macro-crate 3.4.0",
@@ -5430,7 +5443,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5440,7 +5453,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "cfg-if",
  "docify",
@@ -5459,7 +5472,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5473,7 +5486,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -5483,7 +5496,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.47.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -8192,7 +8205,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "46.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "futures",
  "log",
@@ -8211,7 +8224,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -8588,6 +8601,7 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
  "hex",
+ "hex-literal",
  "jsonrpsee",
  "log",
  "memmap2 0.9.8",
@@ -9164,7 +9178,7 @@ dependencies = [
 [[package]]
 name = "pallet-alliance"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "array-bytes 6.2.3",
  "frame-benchmarking",
@@ -9176,7 +9190,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490)",
  "sp-io",
  "sp-runtime",
 ]
@@ -9200,7 +9214,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "23.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9218,7 +9232,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-ops"
 version = "0.9.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9236,7 +9250,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-tx-payment"
 version = "23.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9251,7 +9265,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "20.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9265,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rewards"
 version = "0.3.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9283,7 +9297,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9299,7 +9313,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "43.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "ethereum-standards",
  "frame-benchmarking",
@@ -9317,7 +9331,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-freezer"
 version = "0.8.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "log",
  "pallet-assets",
@@ -9329,7 +9343,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-holder"
 version = "0.3.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9344,7 +9358,7 @@ dependencies = [
 [[package]]
 name = "pallet-atomic-swap"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9354,7 +9368,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9370,7 +9384,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9385,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9398,7 +9412,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9421,7 +9435,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "aquamarine",
  "docify",
@@ -9442,7 +9456,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "42.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9472,7 +9486,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "42.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9491,7 +9505,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "42.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "array-bytes 6.2.3",
  "binary-merkle-tree",
@@ -9516,7 +9530,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9533,7 +9547,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -9552,7 +9566,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -9571,7 +9585,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-parachains"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -9591,7 +9605,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-relayers"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -9614,7 +9628,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.20.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -9632,7 +9646,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9650,7 +9664,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "22.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9669,7 +9683,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9686,7 +9700,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective-content"
 version = "0.19.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9727,7 +9741,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -9758,7 +9772,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-mock-network"
 version = "18.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9789,7 +9803,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "23.0.3"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9799,7 +9813,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-uapi"
 version = "14.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -9810,7 +9824,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -9826,7 +9840,7 @@ dependencies = [
 [[package]]
 name = "pallet-core-fellowship"
 version = "25.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9864,7 +9878,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "8.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9879,7 +9893,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9896,7 +9910,7 @@ dependencies = [
 [[package]]
 name = "pallet-dev-mode"
 version = "23.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9945,7 +9959,7 @@ dependencies = [
 [[package]]
 name = "pallet-dummy-dim"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9963,7 +9977,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-block"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9984,7 +9998,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10005,7 +10019,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10018,7 +10032,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "42.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10145,7 +10159,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10163,7 +10177,7 @@ dependencies = [
 [[package]]
 name = "pallet-glutton"
 version = "27.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "blake2 0.10.6",
  "frame-benchmarking",
@@ -10181,7 +10195,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10218,7 +10232,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -10234,7 +10248,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10253,7 +10267,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10268,7 +10282,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "29.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10301,7 +10315,7 @@ dependencies = [
 [[package]]
 name = "pallet-lottery"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10314,7 +10328,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10330,7 +10344,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "44.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -10349,7 +10363,7 @@ dependencies = [
 [[package]]
 name = "pallet-meta-tx"
 version = "0.3.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10367,7 +10381,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "11.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10386,7 +10400,7 @@ dependencies = [
 [[package]]
 name = "pallet-mixnet"
 version = "0.17.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10400,7 +10414,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10412,7 +10426,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10423,7 +10437,7 @@ dependencies = [
 [[package]]
 name = "pallet-nft-fractionalization"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "log",
  "pallet-assets",
@@ -10436,7 +10450,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts"
 version = "35.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -10453,7 +10467,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10463,7 +10477,7 @@ dependencies = [
 [[package]]
 name = "pallet-node-authorization"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10474,7 +10488,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "39.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10492,7 +10506,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "39.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10512,7 +10526,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -10522,7 +10536,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10537,7 +10551,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10560,7 +10574,7 @@ dependencies = [
 [[package]]
 name = "pallet-origin-restriction"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10578,7 +10592,7 @@ dependencies = [
 [[package]]
 name = "pallet-paged-list"
 version = "0.19.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -10589,7 +10603,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.12.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10606,7 +10620,7 @@ dependencies = [
 [[package]]
 name = "pallet-people"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10624,7 +10638,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10640,8 +10654,10 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
+ "frame-support",
+ "frame-system",
  "parity-scale-codec",
  "polkadot-sdk-frame",
  "scale-info",
@@ -10650,7 +10666,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10668,7 +10684,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10678,7 +10694,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -10696,7 +10712,7 @@ dependencies = [
 [[package]]
 name = "pallet-remark"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10711,7 +10727,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive"
 version = "0.7.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "alloy-core",
  "derive_more 0.99.20",
@@ -10757,7 +10773,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-fixtures"
 version = "0.4.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -10771,7 +10787,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-proc-macro"
 version = "0.3.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10781,7 +10797,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-uapi"
 version = "0.5.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bitflags 1.3.2",
  "pallet-revive-proc-macro",
@@ -10793,7 +10809,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-offences"
 version = "38.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10809,7 +10825,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "17.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10822,7 +10838,7 @@ dependencies = [
 [[package]]
 name = "pallet-safe-mode"
 version = "22.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "docify",
  "pallet-balances",
@@ -10836,7 +10852,7 @@ dependencies = [
 [[package]]
 name = "pallet-salary"
 version = "26.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "log",
  "pallet-ranked-collective",
@@ -10848,7 +10864,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "42.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10865,7 +10881,7 @@ dependencies = [
 [[package]]
 name = "pallet-scored-pool"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10878,7 +10894,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10899,7 +10915,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10945,7 +10961,7 @@ dependencies = [
 [[package]]
 name = "pallet-skip-feeless-payment"
 version = "16.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10957,7 +10973,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10974,7 +10990,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10996,7 +11012,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -11019,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-ah-client"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11038,7 +11054,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-rc-client"
 version = "0.2.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11055,7 +11071,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "12.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -11066,7 +11082,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "23.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -11075,7 +11091,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "27.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -11085,7 +11101,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "46.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11101,7 +11117,7 @@ dependencies = [
 [[package]]
 name = "pallet-statement"
 version = "23.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11265,7 +11281,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11280,7 +11296,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11298,7 +11314,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11316,7 +11332,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11331,7 +11347,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "44.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -11347,7 +11363,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -11359,7 +11375,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-storage"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "array-bytes 6.2.3",
  "frame-benchmarking",
@@ -11378,7 +11394,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11397,7 +11413,7 @@ dependencies = [
 [[package]]
 name = "pallet-tx-pause"
 version = "22.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -11408,7 +11424,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11422,7 +11438,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11437,7 +11453,7 @@ dependencies = [
 [[package]]
 name = "pallet-verify-signature"
 version = "0.4.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11452,7 +11468,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11466,7 +11482,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -11476,7 +11492,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "20.1.3"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bounded-collections 0.2.4",
  "frame-benchmarking",
@@ -11502,7 +11518,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "21.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11519,7 +11535,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub"
 version = "0.17.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -11541,7 +11557,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub-router"
 version = "0.19.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-benchmarking",
@@ -11561,7 +11577,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "22.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -11923,7 +11939,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "futures",
  "futures-timer",
@@ -11941,7 +11957,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "futures",
  "futures-timer",
@@ -11956,7 +11972,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "fatality",
  "futures",
@@ -11979,7 +11995,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "fatality",
@@ -12012,7 +12028,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "25.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -12036,7 +12052,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12059,7 +12075,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "18.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12070,7 +12086,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "fatality",
  "futures",
@@ -12092,7 +12108,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "20.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -12106,7 +12122,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "24.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12119,7 +12135,7 @@ dependencies = [
  "sc-network",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490)",
  "sp-keystore",
  "tracing-gum",
 ]
@@ -12127,7 +12143,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -12150,7 +12166,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -12168,7 +12184,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -12200,7 +12216,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting-parallel"
 version = "0.7.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "futures",
@@ -12224,7 +12240,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bitvec",
  "futures",
@@ -12243,7 +12259,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12264,7 +12280,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -12279,7 +12295,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "futures",
@@ -12301,7 +12317,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -12315,7 +12331,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "futures",
  "futures-timer",
@@ -12331,7 +12347,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "fatality",
  "futures",
@@ -12349,7 +12365,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "futures",
@@ -12366,7 +12382,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "23.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "fatality",
  "futures",
@@ -12380,7 +12396,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12397,7 +12413,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "always-assert",
  "array-bytes 6.2.3",
@@ -12425,7 +12441,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -12438,7 +12454,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "20.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "cpu-time",
  "futures",
@@ -12453,7 +12469,7 @@ dependencies = [
  "sc-executor-wasmtime",
  "seccompiler",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490)",
  "sp-externalities",
  "sp-io",
  "sp-tracing",
@@ -12464,7 +12480,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -12479,7 +12495,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bs58",
  "futures",
@@ -12496,7 +12512,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -12521,7 +12537,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "20.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -12545,7 +12561,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
@@ -12554,7 +12570,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "derive_more 0.99.20",
@@ -12582,7 +12598,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "24.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "fatality",
  "futures",
@@ -12613,7 +12629,7 @@ dependencies = [
 [[package]]
 name = "polkadot-omni-node-lib"
 version = "0.7.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "clap",
@@ -12701,7 +12717,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "futures",
@@ -12721,7 +12737,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "17.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bounded-collections 0.2.4",
  "derive_more 0.99.20",
@@ -12737,7 +12753,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "19.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bitvec",
  "bounded-collections 0.2.4",
@@ -12766,7 +12782,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "25.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -12799,7 +12815,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "20.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -12849,7 +12865,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "21.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -12861,7 +12877,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "20.0.2"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -12909,7 +12925,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk"
 version = "2506.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "assets-common",
  "bridge-hub-common",
@@ -13067,7 +13083,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.10.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -13102,7 +13118,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "25.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -13212,7 +13228,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bitvec",
  "fatality",
@@ -13232,7 +13248,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "20.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -13541,7 +13557,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490)",
  "syn 2.0.106",
 ]
 
@@ -13723,7 +13739,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490)",
  "syn 2.0.106",
 ]
 
@@ -14544,7 +14560,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "24.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -14642,7 +14658,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "21.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -15072,7 +15088,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "32.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "log",
  "sp-core",
@@ -15083,7 +15099,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.51.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "futures",
@@ -15114,7 +15130,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.50.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "futures",
  "log",
@@ -15136,7 +15152,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.45.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -15151,7 +15167,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "44.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "array-bytes 6.2.3",
  "clap",
@@ -15167,7 +15183,7 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490)",
  "sp-genesis-builder",
  "sp-io",
  "sp-runtime",
@@ -15178,7 +15194,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -15189,7 +15205,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.53.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "array-bytes 6.2.3",
  "chrono",
@@ -15231,7 +15247,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "fnv",
  "futures",
@@ -15257,7 +15273,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.47.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -15285,7 +15301,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.50.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "futures",
@@ -15308,7 +15324,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.51.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "futures",
@@ -15337,7 +15353,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.51.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -15362,7 +15378,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-slots",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490)",
  "sp-inherents",
  "sp-keystore",
  "sp-runtime",
@@ -15373,7 +15389,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.51.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -15395,7 +15411,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "30.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15429,7 +15445,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "30.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -15449,7 +15465,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.50.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -15462,7 +15478,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.36.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "ahash 0.8.12",
  "array-bytes 6.2.3",
@@ -15496,7 +15512,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490)",
  "sp-keystore",
  "sp-runtime",
  "substrate-prometheus-endpoint",
@@ -15506,7 +15522,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.36.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -15526,7 +15542,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.52.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -15561,7 +15577,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.50.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "futures",
@@ -15584,7 +15600,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.43.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -15607,7 +15623,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.39.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "polkavm 0.24.0",
  "sc-allocator",
@@ -15620,7 +15636,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.36.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "log",
  "polkavm 0.24.0",
@@ -15631,7 +15647,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.39.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "anyhow",
  "log",
@@ -15647,7 +15663,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.50.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "console",
  "futures",
@@ -15663,7 +15679,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "36.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "array-bytes 6.2.3",
  "parking_lot 0.12.5",
@@ -15677,7 +15693,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "array-bytes 6.2.3",
  "arrayvec 0.7.6",
@@ -15705,7 +15721,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.51.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15755,7 +15771,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.49.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -15765,7 +15781,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.51.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "ahash 0.8.12",
  "futures",
@@ -15784,7 +15800,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.50.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15805,7 +15821,7 @@ dependencies = [
 [[package]]
 name = "sc-network-statement"
 version = "0.33.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15825,7 +15841,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.50.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15860,7 +15876,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.50.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "array-bytes 6.2.3",
  "futures",
@@ -15879,7 +15895,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.17.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bs58",
  "bytes",
@@ -15900,7 +15916,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "46.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bytes",
  "fnv",
@@ -15934,7 +15950,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.20.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -15943,7 +15959,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "46.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -15975,7 +15991,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.50.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -15995,7 +16011,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "23.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -16019,7 +16035,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.51.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "array-bytes 6.2.3",
  "futures",
@@ -16052,13 +16068,13 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.3.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
  "sc-executor-common",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490)",
  "sp-state-machine",
  "sp-wasm-interface",
  "thiserror 1.0.69",
@@ -16067,7 +16083,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.52.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "directories",
@@ -16131,7 +16147,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.39.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -16142,7 +16158,7 @@ dependencies = [
 [[package]]
 name = "sc-statement-store"
 version = "22.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "log",
  "parity-db",
@@ -16161,7 +16177,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.25.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "clap",
  "fs4",
@@ -16174,7 +16190,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.51.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -16193,7 +16209,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "43.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "derive_more 0.99.20",
  "futures",
@@ -16206,14 +16222,14 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490)",
  "sp-io",
 ]
 
 [[package]]
 name = "sc-telemetry"
 version = "29.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "chrono",
  "futures",
@@ -16232,7 +16248,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "chrono",
  "console",
@@ -16260,7 +16276,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -16271,7 +16287,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "40.1.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "futures",
@@ -16288,7 +16304,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490)",
  "sp-runtime",
  "sp-tracing",
  "sp-transaction-pool",
@@ -16302,7 +16318,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "futures",
@@ -16319,7 +16335,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "19.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -17074,7 +17090,7 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 [[package]]
 name = "slot-range-helper"
 version = "18.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -17337,7 +17353,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-core"
 version = "0.14.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bp-relayers",
  "frame-support",
@@ -17432,7 +17448,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "docify",
  "hash-db",
@@ -17454,7 +17470,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "23.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -17468,7 +17484,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "41.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17480,7 +17496,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "27.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -17494,7 +17510,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17506,7 +17522,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -17516,7 +17532,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -17535,7 +17551,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.43.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "futures",
@@ -17549,7 +17565,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.43.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17565,7 +17581,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.43.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17583,7 +17599,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "25.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17591,7 +17607,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490)",
  "sp-io",
  "sp-keystore",
  "sp-mmr-primitives",
@@ -17603,7 +17619,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "24.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -17620,7 +17636,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.43.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17631,7 +17647,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "ark-vrf",
  "array-bytes 6.2.3",
@@ -17662,7 +17678,7 @@ dependencies = [
  "secrecy 0.8.0",
  "serde",
  "sha2 0.10.9",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490)",
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
@@ -17679,7 +17695,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.16.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
@@ -17713,7 +17729,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -17726,17 +17742,17 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490)",
  "syn 2.0.106",
 ]
 
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.5",
@@ -17745,7 +17761,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -17755,7 +17771,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.30.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -17765,7 +17781,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.18.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17777,7 +17793,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -17790,7 +17806,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "41.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bytes",
  "docify",
@@ -17802,7 +17818,7 @@ dependencies = [
  "rustversion",
  "secp256k1 0.28.2",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490)",
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
@@ -17816,7 +17832,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "42.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -17826,7 +17842,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.43.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -17837,7 +17853,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -17846,7 +17862,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.11.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-metadata 23.0.0",
  "parity-scale-codec",
@@ -17856,7 +17872,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.15.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17867,7 +17883,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -17884,7 +17900,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17897,7 +17913,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -17907,7 +17923,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "backtrace",
  "regex",
@@ -17916,7 +17932,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "35.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -17926,7 +17942,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "42.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -17955,7 +17971,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "30.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -17974,7 +17990,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "19.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "Inflector",
  "expander",
@@ -17987,7 +18003,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "39.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18001,7 +18017,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "39.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -18014,7 +18030,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.46.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "hash-db",
  "log",
@@ -18034,7 +18050,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "21.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -18047,7 +18063,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490)",
  "sp-externalities",
  "sp-runtime",
  "sp-runtime-interface",
@@ -18058,12 +18074,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -18075,7 +18091,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -18087,7 +18103,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.1.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -18098,7 +18114,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -18107,7 +18123,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "37.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -18121,7 +18137,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "ahash 0.8.12",
  "foldhash 0.1.5",
@@ -18146,7 +18162,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "40.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -18163,7 +18179,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -18175,7 +18191,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "22.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -18187,7 +18203,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "32.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "bounded-collections 0.2.4",
  "parity-scale-codec",
@@ -18361,7 +18377,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-chain-spec-builder"
 version = "12.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "clap",
  "docify",
@@ -18374,7 +18390,7 @@ dependencies = [
 [[package]]
 name = "staging-node-inspect"
 version = "0.29.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -18392,7 +18408,7 @@ dependencies = [
 [[package]]
 name = "staging-parachain-info"
 version = "0.21.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -18405,7 +18421,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "17.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections 0.2.4",
@@ -18426,7 +18442,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "21.1.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "environmental",
  "frame-support",
@@ -18450,7 +18466,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "20.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -18504,7 +18520,7 @@ dependencies = [
 [[package]]
 name = "stc-shield"
 version = "0.1.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -18525,7 +18541,7 @@ dependencies = [
 [[package]]
 name = "stp-shield"
 version = "0.1.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -18595,7 +18611,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2 0.12.2",
@@ -18620,7 +18636,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 
 [[package]]
 name = "substrate-fixed"
@@ -18636,7 +18652,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "45.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -18656,7 +18672,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.6"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "http-body-util",
  "hyper 1.7.0",
@@ -18670,7 +18686,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "44.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -18697,7 +18713,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "27.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "array-bytes 6.2.3",
  "build-helper",
@@ -19754,7 +19770,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "20.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -19765,7 +19781,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "expander",
  "proc-macro-crate 3.4.0",
@@ -20765,7 +20781,7 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 [[package]]
 name = "westend-runtime"
 version = "24.0.1"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -20872,7 +20888,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "21.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -21522,7 +21538,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -21533,7 +21549,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.8.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -21547,7 +21563,7 @@ dependencies = [
 [[package]]
 name = "xcm-simulator"
 version = "21.0.0"
-source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=7cc54bf2d50ae3921d718736dfeb0de9468539c7#7cc54bf2d50ae3921d718736dfeb0de9468539c7"
+source = "git+https://github.com/RaoFoundation/polkadot-sdk.git?rev=fc504e78be7284046316c95e6e09602df4d5a490#fc504e78be7284046316c95e6e09602df4d5a490"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,8 +77,8 @@ subtensor-runtime-common = { default-features = false, path = "common" }
 subtensor-swap-interface = { default-features = false, path = "primitives/swap-interface" }
 subtensor-transaction-fee = { default-features = false, path = "pallets/transaction-fee" }
 subtensor-chain-extensions = { default-features = false, path = "chain-extensions" }
-stp-shield = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-stc-shield = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+stp-shield = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+stc-shield = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
 
 ed25519-dalek = { version = "2.1.0", default-features = false }
 async-trait = "0.1"
@@ -134,122 +134,122 @@ num_enum = { version = "0.7.4", default-features = false }
 environmental = { version = "1.1.4", default-features = false }
 tokio = { version = "1.38", default-features = false }
 
-frame = { package = "polkadot-sdk-frame", git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-frame-support = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-frame-system = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-frame-executive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-frame-system-benchmarking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-frame-try-runtime = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-frame-benchmarking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-frame-benchmarking-cli = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-frame-metadata-hash-extension = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+frame = { package = "polkadot-sdk-frame", git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+frame-support = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+frame-system = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+frame-executive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+frame-system-benchmarking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+frame-try-runtime = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+frame-benchmarking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+frame-benchmarking-cli = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+frame-metadata-hash-extension = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
 frame-metadata = { version = "23.0.0", default-features = false }
 
 pallet-subtensor-proxy = { path = "pallets/proxy", default-features = false }
 pallet-subtensor-utility = { path = "pallets/utility", default-features = false }
-pallet-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-balances = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-grandpa = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-insecure-randomness-collective-flip = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-multisig = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-preimage = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-safe-mode = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-scheduler = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-sudo = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-timestamp = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-transaction-payment-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-root-testing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-contracts = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+pallet-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-balances = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-grandpa = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-insecure-randomness-collective-flip = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-multisig = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-preimage = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-safe-mode = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-scheduler = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-sudo = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-timestamp = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-transaction-payment-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-root-testing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-contracts = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
 
 # NPoS
-frame-election-provider-support = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-authority-discovery = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-authorship = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-bags-list = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-election-provider-multi-phase = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-fast-unstake = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-nomination-pools = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-nomination-pools-runtime-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-session = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-staking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-staking-runtime-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-staking-reward-fn = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-staking-reward-curve = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-pallet-offences = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+frame-election-provider-support = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-authority-discovery = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-authorship = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-bags-list = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-election-provider-multi-phase = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-fast-unstake = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-nomination-pools = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-nomination-pools-runtime-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-session = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-staking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-staking-runtime-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-staking-reward-fn = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-staking-reward-curve = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+pallet-offences = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
 
-sc-basic-authorship = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-cli = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-client-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-consensus = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-consensus-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-consensus-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-consensus-babe-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-consensus-grandpa = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-consensus-grandpa-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-consensus-epochs = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-chain-spec-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-chain-spec = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-consensus-slots = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-executor = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-keystore = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-network = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-offchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-rpc-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-service = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-telemetry = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-transaction-pool = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-transaction-pool-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-consensus-manual-seal = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sc-network-sync = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sc-basic-authorship = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sc-cli = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sc-client-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sc-consensus = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sc-consensus-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sc-consensus-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sc-consensus-babe-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sc-consensus-grandpa = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sc-consensus-grandpa-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sc-consensus-epochs = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sc-chain-spec-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sc-chain-spec = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sc-consensus-slots = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sc-executor = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sc-keystore = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sc-network = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sc-offchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sc-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sc-rpc-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sc-service = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sc-telemetry = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sc-transaction-pool = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sc-transaction-pool-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sc-consensus-manual-seal = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sc-network-sync = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
 
-sp-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-authority-discovery = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-arithmetic = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-block-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-blockchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-staking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-consensus = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-consensus-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-consensus-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-consensus-slots = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-npos-elections = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-consensus-grandpa = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-genesis-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-core = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-inherents = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-io = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-keyring = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-offchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-runtime = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-session = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-std = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-storage = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-timestamp = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-tracing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-transaction-pool = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-version = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-weights = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-crypto-hashing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-application-crypto = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-debug-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-externalities = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-runtime-interface = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-authority-discovery = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-arithmetic = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-block-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-blockchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-staking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-consensus = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-consensus-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-consensus-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-consensus-slots = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-npos-elections = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-consensus-grandpa = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-genesis-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-core = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-inherents = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-io = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-keyring = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-offchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-runtime = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-session = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-std = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-storage = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-timestamp = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-tracing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-transaction-pool = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-version = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-weights = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-crypto-hashing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-application-crypto = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-debug-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-externalities = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-runtime-interface = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
 
-substrate-build-script-utils = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+substrate-build-script-utils = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
 substrate-fixed = { git = "https://github.com/encointer/substrate-fixed.git", tag = "v0.6.0", default-features = false }
-substrate-frame-rpc-system = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-substrate-wasm-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-substrate-prometheus-endpoint = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+substrate-frame-rpc-system = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+substrate-wasm-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+substrate-prometheus-endpoint = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
 
-polkadot-sdk = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+polkadot-sdk = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
 
-runtime-common = { package = "polkadot-runtime-common", git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+runtime-common = { package = "polkadot-runtime-common", git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
 
 # Frontier
 # current frontier branch is polkadot-stable2506-2-otf-get-call-indices-metadata
@@ -285,8 +285,8 @@ pallet-hotfix-sufficients = { git = "https://github.com/RaoFoundation/frontier",
 
 #DRAND
 pallet-drand = { path = "pallets/drand", default-features = false }
-sp-crypto-ec-utils = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
-sp-keystore = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7", default-features = false }
+sp-crypto-ec-utils = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
+sp-keystore = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490", default-features = false }
 w3f-bls = { git = "https://github.com/RaoFoundation/bls", branch = "fix-no-std", default-features = false }
 ark-crypto-primitives = { version = "0.4.0", default-features = false }
 ark-scale = { version = "0.0.11", default-features = false }
@@ -337,104 +337,104 @@ zstd-safe = { git = "https://github.com/gztensor/zstd-safe", rev = "42cc34ef6abe
 # build. Redirect the frontier-side polkadot-sdk crates to the RaoFoundation
 # remote at the same rev so the whole graph resolves to a single copy.
 [patch."https://github.com/opentensor/polkadot-sdk"]
-binary-merkle-tree = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-cumulus-primitives-core = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-cumulus-primitives-proof-size-hostfunction = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-fork-tree = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-frame-benchmarking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-frame-support = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-frame-support-procedural = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-frame-support-procedural-tools = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-frame-support-procedural-tools-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-frame-system = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-polkadot-core-primitives = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-polkadot-parachain-primitives = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-polkadot-primitives = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-allocator = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-block-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-chain-spec = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-chain-spec-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-client-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-client-db = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-consensus = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-consensus-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-consensus-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-consensus-epochs = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-consensus-slots = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-executor = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-executor-common = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-executor-polkavm = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-executor-wasmtime = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-informant = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-keystore = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-mixnet = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-network = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-network-common = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-network-light = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-network-sync = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-network-transactions = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-network-types = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-rpc-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-rpc-server = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-rpc-spec-v2 = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-service = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-state-db = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-sysinfo = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-telemetry = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-tracing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-tracing-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-transaction-pool = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-transaction-pool-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sc-utils = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-api-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-application-crypto = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-arithmetic = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-authority-discovery = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-block-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-blockchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-consensus = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-consensus-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-consensus-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-consensus-grandpa = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-consensus-slots = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-core = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-crypto-hashing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-crypto-hashing-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-database = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-debug-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-externalities = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-genesis-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-inherents = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-io = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-keystore = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-maybe-compressed-blob = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-metadata-ir = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-mixnet = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-offchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-panic-handler = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-runtime = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-runtime-interface = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-runtime-interface-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-session = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-staking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-state-machine = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-statement-store = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-std = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-storage = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-timestamp = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-tracing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-transaction-pool = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-transaction-storage-proof = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-trie = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-version = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-version-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-wasm-interface = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-sp-weights = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-staging-xcm = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-substrate-bip39 = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-substrate-prometheus-endpoint = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
-xcm-procedural = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "7cc54bf2d50ae3921d718736dfeb0de9468539c7" }
+binary-merkle-tree = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+cumulus-primitives-core = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+cumulus-primitives-proof-size-hostfunction = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+cumulus-primitives-storage-weight-reclaim = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+fork-tree = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+frame-benchmarking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+frame-support = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+frame-support-procedural = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+frame-support-procedural-tools = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+frame-support-procedural-tools-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+frame-system = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+polkadot-core-primitives = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+polkadot-parachain-primitives = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+polkadot-primitives = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-allocator = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-block-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-chain-spec = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-chain-spec-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-client-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-client-db = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-consensus = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-consensus-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-consensus-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-consensus-epochs = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-consensus-slots = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-executor = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-executor-common = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-executor-polkavm = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-executor-wasmtime = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-informant = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-keystore = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-mixnet = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-network = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-network-common = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-network-light = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-network-sync = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-network-transactions = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-network-types = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-rpc-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-rpc-server = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-rpc-spec-v2 = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-service = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-state-db = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-sysinfo = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-telemetry = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-tracing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-tracing-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-transaction-pool = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-transaction-pool-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sc-utils = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-api = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-api-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-application-crypto = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-arithmetic = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-authority-discovery = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-block-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-blockchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-consensus = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-consensus-aura = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-consensus-babe = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-consensus-grandpa = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-consensus-slots = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-core = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-crypto-hashing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-crypto-hashing-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-database = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-debug-derive = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-externalities = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-genesis-builder = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-inherents = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-io = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-keystore = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-maybe-compressed-blob = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-metadata-ir = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-mixnet = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-offchain = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-panic-handler = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-rpc = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-runtime = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-runtime-interface = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-runtime-interface-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-session = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-staking = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-state-machine = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-statement-store = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-std = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-storage = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-timestamp = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-tracing = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-transaction-pool = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-transaction-storage-proof = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-trie = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-version = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-version-proc-macro = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-wasm-interface = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+sp-weights = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+staging-xcm = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+substrate-bip39 = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+substrate-prometheus-endpoint = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }
+xcm-procedural = { git = "https://github.com/RaoFoundation/polkadot-sdk.git", rev = "fc504e78be7284046316c95e6e09602df4d5a490" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -26,6 +26,7 @@ clap = { workspace = true, features = ["derive"] }
 futures = { workspace = true, features = ["thread-pool"] }
 serde = { workspace = true, features = ["derive"] }
 hex.workspace = true
+hex-literal.workspace = true
 tokio = { workspace = true, features = ["time", "rt", "net"] }
 
 # Storage import

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -40,6 +40,62 @@ use crate::ethereum::{
 
 const LOG_TARGET: &str = "node-service";
 
+fn is_testnet_genesis(hash: H256) -> bool {
+    hash == H256::from(hex_literal::hex!(
+        "8f9cf856bf558a14440e75569c9e58594757048d7b3a84b5d25f6bd978263105"
+    ))
+}
+
+#[allow(clippy::expect_used)]
+fn testnet_genesis_grandpa_authorities() -> sp_consensus_grandpa::AuthorityList {
+    use sp_consensus_grandpa::AuthorityId;
+    use sp_core::ByteArray;
+
+    [
+        hex_literal::hex!("dc832c3b7bdfc721e90e5ee9e532c06b62a0def3c79dab5324460d938db6600a"),
+        hex_literal::hex!("c8a00ef71912b3868b101cb70ebd029999d1c9b6a1390122a98f60d72b9a0fc4"),
+        hex_literal::hex!("ee70f7b52998c2b4f3d42e509e8360cda92b0cd4ca100cd4d32be5a1ac297909"),
+        hex_literal::hex!("b57a038c9139a060358f3b654df74a1cb6d15bcdb8438bcebd64ce67ec4301eb"),
+        hex_literal::hex!("755f75dfc66aaa3b1e761a8845249509b8bd2fdf0d94cb74e1e12e1e0f4d3519"),
+        hex_literal::hex!("d97a64267f177505b0565a18677c9f5d4284d7f2eb96d515556e7e52217f82e9"),
+    ]
+    .into_iter()
+    .map(|bytes| {
+        (
+            AuthorityId::from_slice(&bytes).expect("authority IDs are exactly 32 bytes"),
+            1,
+        )
+    })
+    .collect()
+}
+
+fn testnet_warp_hard_forks() -> Vec<sc_consensus_grandpa::AuthoritySetHardFork<Block>> {
+    let authorities = testnet_genesis_grandpa_authorities();
+
+    [
+        (
+            1,
+            4_589_686,
+            hex_literal::hex!("2b001bfdec34d007ab2ac07f712e64d0cb1a6fb4b51f7d47bfb3c7d7336a689b"),
+        ),
+        (
+            3,
+            5_534_451,
+            hex_literal::hex!("4d643da5fd7cd2b9ceb795091643e7223819e2a01f942ac049c5b928f7e30dc4"),
+        ),
+    ]
+    .into_iter()
+    .map(
+        |(set_id, number, hash)| sc_consensus_grandpa::AuthoritySetHardFork {
+            set_id,
+            block: (H256::from(hash), number),
+            authorities: authorities.clone(),
+            last_finalized: None,
+        },
+    )
+    .collect()
+}
+
 /// The minimum period of blocks on which justifications will be
 /// imported and generated.
 const GRANDPA_JUSTIFICATION_PERIOD: u32 = 512;
@@ -320,25 +376,35 @@ where
     let warp_sync_config = if sealing.is_some() {
         None
     } else {
-        let set_id = match config.chain_spec.chain_type() {
-            // Finney patch
-            ChainType::Live => 3,
-            // Testnet patch
-            ChainType::Development => 2,
-            // All others (e.g. localnet)
-            _ => 0,
-        };
-        log::warn!(
-            "Grandpa warp sync patch enabled. Chain type = {:?}. Set ID = {set_id}",
-            config.chain_spec.chain_type()
-        );
         net_config.add_notification_protocol(grandpa_protocol_config);
-        let warp_sync: Arc<dyn WarpSyncProvider<Block>> =
+        let genesis_hash = client.block_hash(0u32)?.expect("Genesis block exists; qed");
+        let shared_authority_set = grandpa_link.shared_authority_set().clone();
+        let warp_sync: Arc<dyn WarpSyncProvider<Block>> = if is_testnet_genesis(genesis_hash) {
+            log::warn!("Testnet GRANDPA warp sync checkpoints enabled.");
             Arc::new(sc_consensus_grandpa::warp_proof::NetworkProvider::new(
                 backend.clone(),
-                grandpa_link.shared_authority_set().clone(),
+                shared_authority_set,
+                sc_consensus_grandpa::warp_proof::HardForks::new_hard_forked_authorities(
+                    testnet_warp_hard_forks(),
+                ),
+            ))
+        } else {
+            let set_id = match config.chain_spec.chain_type() {
+                // Finney patch
+                ChainType::Live => 3,
+                // All others (e.g. localnet)
+                _ => 0,
+            };
+            log::warn!(
+                "Grandpa warp sync patch enabled. Chain type = {:?}. Set ID = {set_id}",
+                config.chain_spec.chain_type()
+            );
+            Arc::new(sc_consensus_grandpa::warp_proof::NetworkProvider::new(
+                backend.clone(),
+                shared_authority_set,
                 sc_consensus_grandpa::warp_proof::HardForks::new_initial_set_id(set_id),
-            ));
+            ))
+        };
 
         Some(WarpSyncConfig::WithProvider(warp_sync))
     };
@@ -892,4 +958,39 @@ fn copy_keys(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn testnet_warp_checkpoints_are_genesis_scoped_and_ordered() {
+        let genesis = H256::from(hex_literal::hex!(
+            "8f9cf856bf558a14440e75569c9e58594757048d7b3a84b5d25f6bd978263105"
+        ));
+        assert!(is_testnet_genesis(genesis));
+        assert!(!is_testnet_genesis(H256::zero()));
+
+        let checkpoints = testnet_warp_hard_forks();
+        assert_eq!(checkpoints.len(), 2);
+        assert_eq!(checkpoints[0].set_id, 1);
+        assert_eq!(checkpoints[0].block.1, 4_589_686);
+        assert_eq!(
+            checkpoints[0].block.0,
+            H256::from(hex_literal::hex!(
+                "2b001bfdec34d007ab2ac07f712e64d0cb1a6fb4b51f7d47bfb3c7d7336a689b"
+            ))
+        );
+        assert_eq!(checkpoints[1].set_id, 3);
+        assert_eq!(checkpoints[1].block.1, 5_534_451);
+        assert_eq!(
+            checkpoints[1].block.0,
+            H256::from(hex_literal::hex!(
+                "4d643da5fd7cd2b9ceb795091643e7223819e2a01f942ac049c5b928f7e30dc4"
+            ))
+        );
+        assert_eq!(checkpoints[0].authorities.len(), 6);
+        assert_eq!(checkpoints[0].authorities, checkpoints[1].authorities);
+    }
 }


### PR DESCRIPTION
# Fix testnet warp sync with trusted GRANDPA checkpoints

Base: `mono-bittensor`

Depends on: [RaoFoundation/polkadot-sdk#28](https://github.com/RaoFoundation/polkadot-sdk/pull/28) at commit `fc504e78be7284046316c95e6e09602df4d5a490`.

## Summary

- Identify testnet by its immutable genesis hash.
- Configure justified GRANDPA checkpoints at blocks `4,589,686` (set 1) and `5,534,451` (set 3).
- Pin all RaoFoundation Polkadot SDK dependencies to the checkpoint-aware SDK commit.
- Leave protocol IDs and the warp-proof wire format unchanged.

## Motivation

Testnet block `4,589,660` scheduled a delayed GRANDPA change with delay 3 but has no stored justification. A normal warp proof therefore cannot include that scheduling header. Blocks `4,589,686` and `5,534,451` are finalized, justified immediate-change blocks and provide safe weak-subjectivity checkpoints from which the existing verifier can continue.

Activation is keyed to the exact testnet genesis hash so local development chains and other networks are unaffected.

## Rollout

1. Publish and land the SDK PR first.
2. Confirm its commit hash remains `fc504e78be7284046316c95e6e09602df4d5a490`; update this branch if the SDK PR is rebased or squash-merged so the pin names a commit permanently reachable from the target branch.
3. Publish this PR against `mono-bittensor`.

The SDK change is backward-compatible and has no effect until hard-fork checkpoints are supplied. This avoids requiring an atomic two-repository deployment. Testnet checkpoint-aware proof generation becomes active when this branch resolves the new SDK dependency pin.

## Verification

- SDK checkpoint proof test passes.
- `cargo test -p node-subtensor testnet_warp_checkpoints_are_genesis_scoped_and_ordered --lib` passes.
- `SKIP_WASM_BUILD=1 cargo check -p node-subtensor` passes with the exact local SDK commit.
- `git diff --check` passes in both repositories.
- Live testnet RPC confirmed the genesis hash, checkpoint hashes, authority lists, immediate-change digests, and stored justifications.

Full native WASM compilation remains unavailable on the test machine because Clang lacks the `wasm32-unknown-unknown` C target required by `zstd-sys`.
