### PR TITLE
ci: benchmark PR jobs on fireactions turbo

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,6 +3,7 @@ self-hosted-runner:
   labels:
     - fireactions-light
     - fireactions-heavy
+    - fireactions-turbo
     - fireactions-tryruntime
     - fireactions-tryruntime-finney
     - Benchmarking

--- a/.github/actions/build-production-binary/action.yml
+++ b/.github/actions/build-production-binary/action.yml
@@ -36,6 +36,7 @@ runs:
         set -euo pipefail
         rust_sysroot=$(rustc --print sysroot)
         export LD_LIBRARY_PATH="${rust_sysroot}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+        export WASM_BUILD_WORKSPACE_HINT="$GITHUB_WORKSPACE"
         cross build \
           --target "$TARGET" \
           --package node-subtensor \

--- a/.github/actions/build-production-binary/action.yml
+++ b/.github/actions/build-production-binary/action.yml
@@ -1,0 +1,64 @@
+name: "Build production node binary"
+description: "Build and validate a production node binary for one Linux architecture"
+
+inputs:
+  arch:
+    description: "OCI architecture name (amd64 or arm64)"
+    required: true
+  target:
+    description: "Rust target triple"
+    required: true
+  cache-key:
+    description: "Architecture-specific Rust cache key"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - uses: ./.github/actions/rust-setup
+      with:
+        cache-key: ${{ inputs.cache-key }}
+
+    - name: Install pinned cross compiler driver
+      shell: bash
+      run: |
+        cargo install cross \
+          --git https://github.com/cross-rs/cross \
+          --rev 64b5bb4d3d34de062552b9a2093affe77b4ad16a \
+          --locked
+
+    - name: Build production binary
+      shell: bash
+      env:
+        ARCH: ${{ inputs.arch }}
+        TARGET: ${{ inputs.target }}
+      run: |
+        set -euo pipefail
+        cross build \
+          --target "$TARGET" \
+          --package node-subtensor \
+          --profile production \
+          --features metadata-hash \
+          --locked
+
+    - name: Validate and stage binary
+      shell: bash
+      env:
+        ARCH: ${{ inputs.arch }}
+        TARGET: ${{ inputs.target }}
+      run: |
+        set -euo pipefail
+        binary="target/${TARGET}/production/node-subtensor"
+        test -x "$binary"
+
+        machine=$(readelf -h "$binary" | awk -F: '/Machine:/ {gsub(/^[[:space:]]+/, "", $2); print $2}')
+        case "$ARCH:$machine" in
+          amd64:*X86-64*|arm64:AArch64) ;;
+          *)
+            echo "Unexpected ELF architecture for $ARCH: $machine" >&2
+            exit 1
+            ;;
+        esac
+
+        install -Dm0755 "$binary" "build/ci_target/${ARCH}/node-subtensor"
+        echo "Staged $ARCH binary: $(du -h "build/ci_target/${ARCH}/node-subtensor" | cut -f1)"

--- a/.github/actions/build-production-binary/action.yml
+++ b/.github/actions/build-production-binary/action.yml
@@ -34,6 +34,8 @@ runs:
         TARGET: ${{ inputs.target }}
       run: |
         set -euo pipefail
+        rust_sysroot=$(rustc --print sysroot)
+        export LD_LIBRARY_PATH="${rust_sysroot}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
         cross build \
           --target "$TARGET" \
           --package node-subtensor \

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -19,7 +19,7 @@ jobs:
   cargo-audit:
     name: cargo audit
     needs: trusted-pr
-    runs-on: [self-hosted, fireactions-light]
+    runs-on: [self-hosted, fireactions-turbo]
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-cargo-audit') }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/check-bittensor-e2e-tests.yml
+++ b/.github/workflows/check-bittensor-e2e-tests.yml
@@ -128,7 +128,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: [self-hosted, fireactions-heavy]
+          - runner: [self-hosted, fireactions-turbo]
             triple: x86_64-unknown-linux-gnu
             arch: amd64
         runtime: ["fast-runtime", "non-fast-runtime"]

--- a/.github/workflows/check-clone-upgrade.yml
+++ b/.github/workflows/check-clone-upgrade.yml
@@ -28,7 +28,7 @@ jobs:
   clone-upgrade:
     name: Sudo-upgrade mainnet clone and test
     needs: trusted-pr
-    runs-on: [self-hosted, fireactions-heavy]
+    runs-on: [self-hosted, fireactions-turbo]
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-clone-upgrade') }}
     timeout-minutes: 180
     steps:
@@ -127,7 +127,7 @@ jobs:
   docs-website:
     name: Docs and website build
     needs: trusted-pr
-    runs-on: [self-hosted, fireactions-heavy]
+    runs-on: [self-hosted, fireactions-turbo]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/check-docker.yml
+++ b/.github/workflows/check-docker.yml
@@ -7,6 +7,9 @@ concurrency:
   group: check-docker-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   trusted-pr:
     name: Trusted PR source (non-fork)
@@ -15,18 +18,73 @@ jobs:
     steps:
       - run: echo "Non-fork PR; self-hosted runners may execute checkout."
 
-  build:
-    name: docker build
+  binary:
+    name: production binary (${{ matrix.platform.arch }})
     needs: trusted-pr
     runs-on: [self-hosted, fireactions-turbo]
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - arch: amd64
+            target: x86_64-unknown-linux-gnu
+          - arch: arm64
+            target: aarch64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v4
 
+      - uses: ./.github/actions/build-production-binary
+        with:
+          arch: ${{ matrix.platform.arch }}
+          target: ${{ matrix.platform.target }}
+          cache-key: docker-production-${{ matrix.platform.arch }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: production-node-${{ matrix.platform.arch }}
+          path: build/ci_target/${{ matrix.platform.arch }}/node-subtensor
+          if-no-files-found: error
+
+  image:
+    name: docker image (${{ matrix.arch }}, no push)
+    needs: [trusted-pr, binary]
+    runs-on: [self-hosted, fireactions-turbo]
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v5
+        with:
+          name: production-node-${{ matrix.arch }}
+          path: build/ci_target/${{ matrix.arch }}
+
       - name: Set up QEMU
+        if: matrix.arch == 'arm64'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker image
-        run: docker build .
+      - name: Build Docker image without publishing
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.prebuilt
+          platforms: linux/${{ matrix.arch }}
+          tags: subtensor-ci:${{ matrix.arch }}
+          load: true
+          push: false
+
+      - name: Verify image architecture and executable
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual=$(docker image inspect subtensor-ci:${{ matrix.arch }} --format '{{.Architecture}}')
+          test "$actual" = "${{ matrix.arch }}"
+          docker run --rm --platform linux/${{ matrix.arch }} \
+            subtensor-ci:${{ matrix.arch }} --version

--- a/.github/workflows/check-docker.yml
+++ b/.github/workflows/check-docker.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     name: docker build
     needs: trusted-pr
-    runs-on: [self-hosted, fireactions-heavy]
+    runs-on: [self-hosted, fireactions-turbo]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/check-node-compat.yml
+++ b/.github/workflows/check-node-compat.yml
@@ -26,7 +26,7 @@ jobs:
   build:
     name: build ${{ matrix.version.name }}
     needs: trusted-pr
-    runs-on: [self-hosted, fireactions-heavy]
+    runs-on: [self-hosted, fireactions-turbo]
     if: contains(github.event.pull_request.labels.*.name, 'check-node-compat')
     env:
       RUST_BACKTRACE: full
@@ -73,7 +73,7 @@ jobs:
   test:
     name: run compat harness
     needs: [trusted-pr, build]
-    runs-on: [self-hosted, fireactions-heavy]
+    runs-on: [self-hosted, fireactions-turbo]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -28,7 +28,7 @@ jobs:
   fmt:
     name: cargo fmt
     needs: trusted-pr
-    runs-on: [self-hosted, fireactions-light]
+    runs-on: [self-hosted, fireactions-turbo]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/rust-setup
@@ -48,7 +48,7 @@ jobs:
   clippy:
     name: cargo clippy (${{ matrix.features.name }})
     needs: trusted-pr
-    runs-on: [self-hosted, fireactions-light]
+    runs-on: [self-hosted, fireactions-turbo]
     env:
       SKIP_WASM_BUILD: 1
     strategy:
@@ -71,7 +71,7 @@ jobs:
   warnings:
     name: no cargo check warnings
     needs: trusted-pr
-    runs-on: [self-hosted, fireactions-light]
+    runs-on: [self-hosted, fireactions-turbo]
     env:
       RUSTFLAGS: -D warnings
       SKIP_WASM_BUILD: 1
@@ -90,7 +90,7 @@ jobs:
   test:
     name: cargo test
     needs: trusted-pr
-    runs-on: [self-hosted, fireactions-heavy]
+    runs-on: [self-hosted, fireactions-turbo]
     env:
       SKIP_WASM_BUILD: 1
     steps:
@@ -104,7 +104,7 @@ jobs:
   fix:
     name: cargo fix leaves no diff
     needs: trusted-pr
-    runs-on: [self-hosted, fireactions-light]
+    runs-on: [self-hosted, fireactions-turbo]
     env:
       SKIP_WASM_BUILD: 1
     steps:
@@ -120,7 +120,7 @@ jobs:
   zepter:
     name: zepter feature propagation
     needs: trusted-pr
-    runs-on: [self-hosted, fireactions-light]
+    runs-on: [self-hosted, fireactions-turbo]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/rust-setup

--- a/.github/workflows/check-spec-version.yml
+++ b/.github/workflows/check-spec-version.yml
@@ -36,7 +36,7 @@ jobs:
   check-spec-version:
     name: spec_version newer than mainnet
     needs: trusted-pr
-    runs-on: [self-hosted, fireactions-tryruntime-finney]
+    runs-on: [self-hosted, fireactions-turbo]
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-spec-version-bump') }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,8 +24,97 @@ permissions:
   packages: write
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.ref.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref_name }}
+
+      - name: Resolve immutable source revision
+        id: ref
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+  binary:
+    name: production binary (${{ matrix.platform.arch }})
+    needs: setup
+    runs-on: [self-hosted, fireactions-turbo]
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - arch: amd64
+            target: x86_64-unknown-linux-gnu
+          - arch: arm64
+            target: aarch64-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.setup.outputs.sha }}
+
+      - uses: ./.github/actions/build-production-binary
+        with:
+          arch: ${{ matrix.platform.arch }}
+          target: ${{ matrix.platform.target }}
+          cache-key: docker-production-${{ matrix.platform.arch }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: production-node-${{ matrix.platform.arch }}
+          path: build/ci_target/${{ matrix.platform.arch }}/node-subtensor
+          if-no-files-found: error
+
+  image:
+    name: validate image (${{ matrix.arch }}, no push)
+    needs: [setup, binary]
+    runs-on: [self-hosted, fireactions-turbo]
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.setup.outputs.sha }}
+
+      - uses: actions/download-artifact@v5
+        with:
+          name: production-node-${{ matrix.arch }}
+          path: build/ci_target/${{ matrix.arch }}
+
+      - name: Set up QEMU
+        if: matrix.arch == 'arm64'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image without publishing
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.prebuilt
+          platforms: linux/${{ matrix.arch }}
+          tags: subtensor-release-check:${{ matrix.arch }}
+          load: true
+          push: false
+
+      - name: Verify image architecture and executable
+        run: |
+          set -euo pipefail
+          actual=$(docker image inspect subtensor-release-check:${{ matrix.arch }} --format '{{.Architecture}}')
+          test "$actual" = "${{ matrix.arch }}"
+          docker run --rm --platform linux/${{ matrix.arch }} \
+            subtensor-release-check:${{ matrix.arch }} --version
+
   publish:
-    runs-on: [self-hosted, fireactions-heavy]
+    needs: [setup, binary, image]
+    runs-on: [self-hosted, fireactions-turbo]
+    timeout-minutes: 30
     steps:
       - name: Determine tag, ref, and image name
         env:
@@ -52,7 +141,19 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ env.ref }}
+          ref: ${{ needs.setup.outputs.sha }}
+
+      - name: Download AMD64 production binary
+        uses: actions/download-artifact@v5
+        with:
+          name: production-node-amd64
+          path: build/ci_target/amd64
+
+      - name: Download ARM64 production binary
+        uses: actions/download-artifact@v5
+        with:
+          name: production-node-arm64
+          path: build/ci_target/arm64
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -71,10 +172,8 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          file: Dockerfile.prebuilt
           push: true
-          # The Dockerfile's last stage is subtensor-local; without an explicit
-          # target this workflow would publish the localnet image as production.
-          target: subtensor
           platforms: linux/amd64,linux/arm64
           tags: |
             ${{ env.image }}:${{ env.tag }}

--- a/.github/workflows/eco-tests.yml
+++ b/.github/workflows/eco-tests.yml
@@ -25,7 +25,7 @@ jobs:
   eco-tests:
     name: cargo test (eco-tests)
     needs: trusted-pr
-    runs-on: [self-hosted, fireactions-heavy]
+    runs-on: [self-hosted, fireactions-turbo]
     env:
       RUST_BACKTRACE: full
       SKIP_WASM_BUILD: 1

--- a/.github/workflows/label-triggers.yml
+++ b/.github/workflows/label-triggers.yml
@@ -21,7 +21,7 @@ jobs:
 
   comment_on_breaking_change:
     needs: trusted-pr
-    runs-on: [self-hosted, fireactions-light]
+    runs-on: [self-hosted, fireactions-turbo]
     steps:
       - name: Check if 'breaking change' label is added
         if: github.event.label.name == 'breaking-change'

--- a/.github/workflows/mainnet-clone-preview.yml
+++ b/.github/workflows/mainnet-clone-preview.yml
@@ -44,7 +44,7 @@ env:
 jobs:
   clone-preview:
     name: Sudo-upgrade mainnet clone, expose endpoint
-    runs-on: [self-hosted, fireactions-heavy]
+    runs-on: [self-hosted, fireactions-turbo]
     if: >-
       contains(github.event.pull_request.labels.*.name, 'mainnet-clone') &&
       github.event.pull_request.head.repo.fork == false

--- a/.github/workflows/try-runtime.yml
+++ b/.github/workflows/try-runtime.yml
@@ -39,15 +39,15 @@ jobs:
           - name: devnet
             uri: wss://dev.chain.opentensor.ai:443
             genesis: "0x077899043eb684c5277b6814a39161f4ce072b45e782e12c81a521c63fb4f3e5"
-            runner: [self-hosted, fireactions-tryruntime]
+            runner: [self-hosted, fireactions-turbo]
           - name: testnet
             uri: wss://archive.dev.opentensor.ai:8443
             genesis: "0x8f9cf856bf558a14440e75569c9e58594757048d7b3a84b5d25f6bd978263105"
-            runner: [self-hosted, fireactions-tryruntime]
+            runner: [self-hosted, fireactions-turbo]
           - name: mainnet
             uri: wss://archive.dev.opentensor.ai:443
             genesis: "0x2f0555cc76fc2840a25a6ea3b9637146806f1f44b090c175ffde2a7e5ab36c03"
-            runner: [self-hosted, fireactions-tryruntime-finney]
+            runner: [self-hosted, fireactions-turbo]
     steps:
       - name: Verify endpoint serves the expected network
         run: |

--- a/.github/workflows/typescript-e2e.yml
+++ b/.github/workflows/typescript-e2e.yml
@@ -55,7 +55,7 @@ jobs:
 
   # Build the node binary in both variants and share as artifacts.
   build:
-    runs-on: [self-hosted, fireactions-heavy]
+    runs-on: [self-hosted, fireactions-turbo]
     needs: [trusted-pr, typescript-formatting]
     timeout-minutes: 60
     strategy:
@@ -99,7 +99,7 @@ jobs:
 
   run-e2e-tests:
     needs: [trusted-pr, build]
-    runs-on: [self-hosted, fireactions-heavy]
+    runs-on: [self-hosted, fireactions-turbo]
     timeout-minutes: 30
 
     strategy:

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,16 +1,16 @@
 [build.env]
-passthrough = ["LD_LIBRARY_PATH"]
+passthrough = ["LD_LIBRARY_PATH", "WASM_BUILD_WORKSPACE_HINT"]
 
 [target.x86_64-unknown-linux-gnu]
 pre-build = [
   "dpkg --add-architecture $CROSS_DEB_ARCH",
   "apt-get update",
-  "DEBIAN_FRONTEND=noninteractive apt-get --assume-yes install clang libclang-dev libssl-dev:$CROSS_DEB_ARCH libudev-dev:$CROSS_DEB_ARCH protobuf-compiler",
+  "DEBIAN_FRONTEND=noninteractive apt-get --assume-yes install clang libclang-dev libssl-dev libssl-dev:$CROSS_DEB_ARCH libudev-dev libudev-dev:$CROSS_DEB_ARCH protobuf-compiler",
 ]
 
 [target.aarch64-unknown-linux-gnu]
 pre-build = [
   "dpkg --add-architecture $CROSS_DEB_ARCH",
   "apt-get update",
-  "DEBIAN_FRONTEND=noninteractive apt-get --assume-yes install clang libclang-dev libssl-dev:$CROSS_DEB_ARCH libudev-dev:$CROSS_DEB_ARCH protobuf-compiler",
+  "DEBIAN_FRONTEND=noninteractive apt-get --assume-yes install clang libclang-dev libssl-dev libssl-dev:$CROSS_DEB_ARCH libudev-dev libudev-dev:$CROSS_DEB_ARCH protobuf-compiler",
 ]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,3 +1,6 @@
+[build.env]
+passthrough = ["LD_LIBRARY_PATH"]
+
 [target.x86_64-unknown-linux-gnu]
 pre-build = [
   "dpkg --add-architecture $CROSS_DEB_ARCH",

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,13 @@
+[target.x86_64-unknown-linux-gnu]
+pre-build = [
+  "dpkg --add-architecture $CROSS_DEB_ARCH",
+  "apt-get update",
+  "DEBIAN_FRONTEND=noninteractive apt-get --assume-yes install clang libclang-dev libssl-dev:$CROSS_DEB_ARCH libudev-dev:$CROSS_DEB_ARCH protobuf-compiler",
+]
+
+[target.aarch64-unknown-linux-gnu]
+pre-build = [
+  "dpkg --add-architecture $CROSS_DEB_ARCH",
+  "apt-get update",
+  "DEBIAN_FRONTEND=noninteractive apt-get --assume-yes install clang libclang-dev libssl-dev:$CROSS_DEB_ARCH libudev-dev:$CROSS_DEB_ARCH protobuf-compiler",
+]

--- a/Dockerfile.prebuilt
+++ b/Dockerfile.prebuilt
@@ -2,7 +2,7 @@
 
 # Production image assembled from a CI-built, architecture-specific binary.
 # TARGETARCH is supplied automatically by BuildKit for --platform builds.
-ARG BASE_IMAGE=debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df
+ARG BASE_IMAGE=debian:trixie-slim@sha256:28de0877c2189802884ccd20f15ee41c203573bd87bb6b883f5f46362d24c5c2
 FROM ${BASE_IMAGE} AS subtensor
 
 ARG TARGETARCH

--- a/Dockerfile.prebuilt
+++ b/Dockerfile.prebuilt
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1
+
+# Production image assembled from a CI-built, architecture-specific binary.
+# TARGETARCH is supplied automatically by BuildKit for --platform builds.
+ARG BASE_IMAGE=debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df
+FROM ${BASE_IMAGE} AS subtensor
+
+ARG TARGETARCH
+
+LABEL com.bittensor.image.authors="operations@bittensor.com" \
+  com.bittensor.image.vendor="Rao Foundation" \
+  com.bittensor.image.title="raofoundation/subtensor" \
+  com.bittensor.image.description="Bittensor Subtensor Blockchain" \
+  com.bittensor.image.documentation="https://bittensor.com/docs"
+
+RUN addgroup --system --gid 10001 subtensor && \
+  adduser --system --uid 10001 --gid 10001 --home /home/subtensor --disabled-password subtensor
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  ca-certificates gosu libssl3 libstdc++6 libudev1 && \
+  rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /data && chown -R subtensor:subtensor /data
+WORKDIR /home/subtensor
+
+COPY --chown=subtensor:subtensor ./*.json ./
+COPY --chown=subtensor:subtensor ./chainspecs/*.json ./chainspecs/
+COPY --chmod=0755 build/ci_target/${TARGETARCH}/node-subtensor /usr/local/bin/node-subtensor
+COPY --chmod=0755 ./scripts/docker_entrypoint.sh /entrypoint.sh
+
+EXPOSE 30333 9933 9944
+
+USER root
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["--base-path", "/data"]


### PR DESCRIPTION
## Summary

- route every PR-triggered Fireactions/FA runner selector to `fireactions-turbo`
- cover direct `runs-on` selectors plus e2e and try-runtime matrix selectors
- leave triggers, fork guards, job conditions, and steps unchanged

## Benchmark intent

This PR is intentionally workflow-only so its CI compares the new BHS Ryzen 9 9950X turbo runners against recent CI on the old Fireactions pools. The turbo pool has two replicas, so job execution time is the primary hardware metric; queue delay and total workflow duration should be reported separately.

Baseline Check Rust run: https://github.com/RaoFoundation/subtensor/actions/runs/29115141955

`sccache` is not activated by these workflows yet. The runner MMDS configuration alone does not set `RUSTC_WRAPPER`, so this is a hardware-only comparison using the existing cache behavior.