### PR TITLE
ci: add R2-backed shared sccache

### DIFF
--- a/.github/actions/build-production-binary/action.yml
+++ b/.github/actions/build-production-binary/action.yml
@@ -18,6 +18,9 @@ runs:
     - uses: ./.github/actions/rust-setup
       with:
         cache-key: ${{ inputs.cache-key }}
+        # cross mounts Cargo configuration into its build container. Avoid
+        # selecting the host's mold binary, which is not present there.
+        fast-linker: "false"
 
     - name: Install pinned cross compiler driver
       shell: bash

--- a/.github/actions/build-production-binary/action.yml
+++ b/.github/actions/build-production-binary/action.yml
@@ -36,6 +36,7 @@ runs:
         set -euo pipefail
         rust_sysroot=$(rustc --print sysroot)
         export LD_LIBRARY_PATH="${rust_sysroot}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+        export WASM_BUILD_WORKSPACE_HINT="$GITHUB_WORKSPACE"
         cross build \
           --target "$TARGET" \
           --package node-subtensor \

--- a/.github/actions/build-production-binary/action.yml
+++ b/.github/actions/build-production-binary/action.yml
@@ -1,0 +1,64 @@
+name: "Build production node binary"
+description: "Build and validate a production node binary for one Linux architecture"
+
+inputs:
+  arch:
+    description: "OCI architecture name (amd64 or arm64)"
+    required: true
+  target:
+    description: "Rust target triple"
+    required: true
+  cache-key:
+    description: "Architecture-specific Rust cache key"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - uses: ./.github/actions/rust-setup
+      with:
+        cache-key: ${{ inputs.cache-key }}
+
+    - name: Install pinned cross compiler driver
+      shell: bash
+      run: |
+        cargo install cross \
+          --git https://github.com/cross-rs/cross \
+          --rev 64b5bb4d3d34de062552b9a2093affe77b4ad16a \
+          --locked
+
+    - name: Build production binary
+      shell: bash
+      env:
+        ARCH: ${{ inputs.arch }}
+        TARGET: ${{ inputs.target }}
+      run: |
+        set -euo pipefail
+        cross build \
+          --target "$TARGET" \
+          --package node-subtensor \
+          --profile production \
+          --features metadata-hash \
+          --locked
+
+    - name: Validate and stage binary
+      shell: bash
+      env:
+        ARCH: ${{ inputs.arch }}
+        TARGET: ${{ inputs.target }}
+      run: |
+        set -euo pipefail
+        binary="target/${TARGET}/production/node-subtensor"
+        test -x "$binary"
+
+        machine=$(readelf -h "$binary" | awk -F: '/Machine:/ {gsub(/^[[:space:]]+/, "", $2); print $2}')
+        case "$ARCH:$machine" in
+          amd64:*X86-64*|arm64:AArch64) ;;
+          *)
+            echo "Unexpected ELF architecture for $ARCH: $machine" >&2
+            exit 1
+            ;;
+        esac
+
+        install -Dm0755 "$binary" "build/ci_target/${ARCH}/node-subtensor"
+        echo "Staged $ARCH binary: $(du -h "build/ci_target/${ARCH}/node-subtensor" | cut -f1)"

--- a/.github/actions/build-production-binary/action.yml
+++ b/.github/actions/build-production-binary/action.yml
@@ -34,6 +34,8 @@ runs:
         TARGET: ${{ inputs.target }}
       run: |
         set -euo pipefail
+        rust_sysroot=$(rustc --print sysroot)
+        export LD_LIBRARY_PATH="${rust_sysroot}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
         cross build \
           --target "$TARGET" \
           --package node-subtensor \

--- a/.github/actions/rust-setup/action.yml
+++ b/.github/actions/rust-setup/action.yml
@@ -1,7 +1,7 @@
 name: "Rust setup"
 description: >-
-  Common prologue for Rust jobs: system dependencies, stable toolchain with
-  optional components, and the shared Swatinem cache.
+  Common prologue for Rust jobs: system dependencies, stable toolchain,
+  shared R2 sccache, and Cargo registry/git caching.
 
 inputs:
   cache-key:
@@ -12,6 +12,15 @@ inputs:
     default: ""
   extra-packages:
     description: "Extra apt packages beyond the standard build set"
+    default: ""
+  sccache-credential-mode:
+    description: "reader for CI; writer only for the protected main cache warmer"
+    default: "reader"
+  sccache-writer-access-key-id:
+    description: "Protected writer access key; used only when writer mode is selected"
+    default: ""
+  sccache-writer-secret-access-key:
+    description: "Protected writer secret; used only when writer mode is selected"
     default: ""
 
 runs:
@@ -60,10 +69,7 @@ runs:
         } >> "$GITHUB_ENV"
 
     # Registry/git-dependency cache only. Target-dir caching is deliberately
-    # off: nine jobs each snapshotting a multi-GB target dir thrashed the
-    # repo's 10 GB Actions-cache quota (constant LRU eviction, so most jobs
-    # ran cold anyway). Compiled objects are cached per-crate by sccache
-    # below, in one pool all Rust jobs share.
+    # off: compiled objects are shared per-crate through R2 sccache below.
     - name: Cargo registry cache
       uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
@@ -71,40 +77,9 @@ runs:
         cache-targets: false
         cache-on-failure: true
 
-    - name: Install sccache
-      shell: bash
-      run: |
-        set -euo pipefail
-        version=v0.16.0
-        curl --fail --silent --show-error --location \
-          "https://github.com/mozilla/sccache/releases/download/${version}/sccache-${version}-x86_64-unknown-linux-musl.tar.gz" \
-          | tar -xz -C /tmp
-        sudo install -m 755 "/tmp/sccache-${version}-x86_64-unknown-linux-musl/sccache" /usr/local/bin/sccache
-        sccache --version
-
-    # The GHA cache backend needs the runner's cache-service URL and token,
-    # which GitHub only exposes to JS actions — hence the github-script hop
-    # (first-party, so no Actions-allowlist problem).
-    - name: Expose Actions cache credentials for sccache
-      uses: actions/github-script@v7
+    - name: Shared R2 compiler cache
+      uses: ./.github/actions/sccache-setup
       with:
-        script: |
-          for (const name of [
-            "ACTIONS_RESULTS_URL",
-            "ACTIONS_CACHE_URL",
-            "ACTIONS_CACHE_SERVICE_V2",
-            "ACTIONS_RUNTIME_TOKEN",
-          ]) {
-            if (process.env[name]) core.exportVariable(name, process.env[name]);
-          }
-
-    - name: Enable sccache
-      shell: bash
-      run: |
-        {
-          echo "RUSTC_WRAPPER=sccache"
-          echo "SCCACHE_GHA_ENABLED=true"
-          # sccache cannot cache incremental compilation, and CI never reuses
-          # a working tree, so incremental is pure overhead here.
-          echo "CARGO_INCREMENTAL=0"
-        } >> "$GITHUB_ENV"
+        credential-mode: ${{ inputs.sccache-credential-mode }}
+        writer-access-key-id: ${{ inputs.sccache-writer-access-key-id }}
+        writer-secret-access-key: ${{ inputs.sccache-writer-secret-access-key }}

--- a/.github/actions/rust-setup/action.yml
+++ b/.github/actions/rust-setup/action.yml
@@ -13,6 +13,9 @@ inputs:
   extra-packages:
     description: "Extra apt packages beyond the standard build set"
     default: ""
+  fast-linker:
+    description: "Install and configure mold for native x86_64 builds"
+    default: "true"
   sccache-credential-mode:
     description: "reader for CI; writer only for a protected trusted-branch cache warmer"
     default: "reader"
@@ -41,7 +44,8 @@ runs:
       with:
         components: ${{ inputs.components }}
 
-    - name: Fast linker and CI debuginfo trim
+    - name: Fast linker
+      if: inputs.fast-linker == 'true'
       shell: bash
       run: |
         # mold links in a fraction of GNU ld's time, and cargo test alone
@@ -59,6 +63,10 @@ runs:
         else
           echo "mold unavailable; keeping default linker"
         fi
+
+    - name: CI debuginfo trim
+      shell: bash
+      run: |
         # Nothing in CI consumes full debuginfo; line tables keep panic
         # backtraces readable while cutting codegen time and disk I/O.
         # (Jobs that export RUSTFLAGS, like the warnings check, override the

--- a/.github/actions/rust-setup/action.yml
+++ b/.github/actions/rust-setup/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: "Extra apt packages beyond the standard build set"
     default: ""
   sccache-credential-mode:
-    description: "reader for CI; writer only for the protected main cache warmer"
+    description: "reader for CI; writer only for a protected trusted-branch cache warmer"
     default: "reader"
   sccache-writer-access-key-id:
     description: "Protected writer access key; used only when writer mode is selected"

--- a/.github/actions/sccache-setup/action.yml
+++ b/.github/actions/sccache-setup/action.yml
@@ -3,7 +3,7 @@ description: "Enable the shared R2 compiler cache when its trusted configuration
 
 inputs:
   credential-mode:
-    description: "reader for ordinary CI; writer only for the protected main cache warmer"
+    description: "reader for ordinary CI; writer only for a protected trusted-branch cache warmer"
     default: "reader"
   writer-access-key-id:
     description: "Protected Environment writer access key; ignored in reader mode"

--- a/.github/actions/sccache-setup/action.yml
+++ b/.github/actions/sccache-setup/action.yml
@@ -1,0 +1,56 @@
+name: "R2 sccache setup"
+description: "Enable the shared R2 compiler cache when its trusted configuration is available"
+
+inputs:
+  credential-mode:
+    description: "reader for ordinary CI; writer only for the protected main cache warmer"
+    default: "reader"
+  writer-access-key-id:
+    description: "Protected Environment writer access key; ignored in reader mode"
+    default: ""
+  writer-secret-access-key:
+    description: "Protected Environment writer secret; ignored in reader mode"
+    default: ""
+
+outputs:
+  enabled:
+    description: "Whether sccache passed its R2 startup check"
+    value: ${{ steps.activate.outputs.enabled }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate sccache configuration
+      id: prepare
+      shell: bash
+      env:
+        SCCACHE_CREDENTIAL_MODE: ${{ inputs.credential-mode }}
+        AWS_ACCESS_KEY_ID: ${{ inputs.writer-access-key-id }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.writer-secret-access-key }}
+      run: |
+        config_file="$RUNNER_TEMP/subtensor-sccache-${GITHUB_RUN_ID}-${GITHUB_JOB}.json"
+        "$GITHUB_ACTION_PATH/../../scripts/sccache-configure.sh" prepare \
+          "$SCCACHE_CREDENTIAL_MODE" \
+          "$config_file" \
+          "$GITHUB_OUTPUT"
+
+    - name: Install sccache v0.15.0
+      id: install
+      if: steps.prepare.outputs.available == 'true'
+      continue-on-error: true
+      uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+      with:
+        version: "v0.15.0"
+
+    - name: Enable sccache after R2 startup check
+      id: activate
+      if: always()
+      shell: bash
+      env:
+        SCCACHE_CONFIG_FILE: ${{ steps.prepare.outputs.config-file }}
+        SCCACHE_INSTALL_OUTCOME: ${{ steps.install.outcome }}
+      run: |
+        "$GITHUB_ACTION_PATH/../../scripts/sccache-configure.sh" activate \
+          "$SCCACHE_CONFIG_FILE" \
+          "$GITHUB_ENV" \
+          "$GITHUB_OUTPUT"

--- a/.github/scripts/sccache-configure.sh
+++ b/.github/scripts/sccache-configure.sh
@@ -156,7 +156,7 @@ prepare_writer() {
   local output_file="$2"
 
   case "${GITHUB_EVENT_NAME:-}:${GITHUB_REF:-}" in
-    push:refs/heads/main|schedule:refs/heads/main|workflow_dispatch:refs/heads/main|push:refs/heads/bittensor-core-exploration|workflow_dispatch:refs/heads/bittensor-core-exploration)
+    push:refs/heads/main|schedule:refs/heads/main|workflow_dispatch:refs/heads/main|push:refs/heads/bittensor-core-exploration|workflow_dispatch:refs/heads/bittensor-core-exploration|push:refs/heads/codex/subtensor-r2-sccache|workflow_dispatch:refs/heads/codex/subtensor-r2-sccache)
       ;;
     *)
       disable_prepare "$config_file" "$output_file" "writer mode is restricted to trusted cache-source branches"

--- a/.github/scripts/sccache-configure.sh
+++ b/.github/scripts/sccache-configure.sh
@@ -156,10 +156,10 @@ prepare_writer() {
   local output_file="$2"
 
   case "${GITHUB_EVENT_NAME:-}:${GITHUB_REF:-}" in
-    push:refs/heads/main|schedule:refs/heads/main|workflow_dispatch:refs/heads/main)
+    push:refs/heads/main|schedule:refs/heads/main|workflow_dispatch:refs/heads/main|push:refs/heads/bittensor-core-exploration|workflow_dispatch:refs/heads/bittensor-core-exploration)
       ;;
     *)
-      disable_prepare "$config_file" "$output_file" "writer mode is restricted to trusted main events"
+      disable_prepare "$config_file" "$output_file" "writer mode is restricted to trusted cache-source branches"
       ;;
   esac
 

--- a/.github/scripts/sccache-configure.sh
+++ b/.github/scripts/sccache-configure.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+
+# Secret-safe configuration boundary for the shared R2 sccache backend.
+#
+# prepare MODE CONFIG_FILE OUTPUT_FILE
+#   Fetches and validates the MMDS reader contract, or materializes the trusted
+#   writer contract from the protected Environment credentials.
+#
+# activate CONFIG_FILE ENV_FILE OUTPUT_FILE
+#   Starts sccache against R2 and exports the wrapper only after startup works.
+
+set -u
+
+readonly MMDS_TOKEN_URL_DEFAULT="http://169.254.169.254/latest/api/token"
+readonly MMDS_METADATA_URL_DEFAULT="http://169.254.169.254/latest/meta-data/sccache"
+
+warning() {
+  printf '::warning::%s\n' "$1"
+}
+
+set_output() {
+  local output_file="$1"
+  local name="$2"
+  local value="$3"
+  printf '%s=%s\n' "$name" "$value" >> "$output_file"
+}
+
+disable_prepare() {
+  local config_file="$1"
+  local output_file="$2"
+  local reason="$3"
+  if [[ -n "$config_file" ]]; then
+    rm -f "$config_file"
+  fi
+  set_output "$output_file" available false
+  warning "sccache disabled: $reason"
+  exit 0
+}
+
+disable_activate() {
+  local config_file="$1"
+  local output_file="$2"
+  local reason="$3"
+  if [[ -n "$config_file" ]]; then
+    rm -f "$config_file"
+  fi
+  set_output "$output_file" enabled false
+  warning "sccache disabled: $reason"
+  exit 0
+}
+
+mask_config_credentials() {
+  local config_file="$1"
+  local -a credentials=()
+  local credential
+  while IFS= read -r credential; do
+    credentials+=("$credential")
+  done < <(
+    python3 -c '
+import json, sys
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+if data.get("mode") == "gha":
+    raise SystemExit(0)
+for key in ("access_key_id", "secret_access_key"):
+    print(data[key])
+' "$config_file"
+  )
+  if [[ ${#credentials[@]} -eq 2 ]]; then
+    printf '::add-mask::%s\n' "${credentials[0]}"
+    printf '::add-mask::%s\n' "${credentials[1]}"
+  fi
+}
+
+prepare_gha() {
+  local config_file="$1"
+  printf '{"mode":"gha"}' > "$config_file"
+  chmod 0600 "$config_file"
+}
+
+fallback_reader() {
+  local config_file="$1"
+  local output_file="$2"
+  local reason="$3"
+  if [[ "${SCCACHE_GHA_FALLBACK:-true}" == true ]]; then
+    prepare_gha "$config_file"
+    warning "R2 reader unavailable; using GitHub Actions sccache: $reason"
+    return 0
+  fi
+  disable_prepare "$config_file" "$output_file" "$reason"
+}
+
+prepare_reader() {
+  local config_file="$1"
+  local output_file="$2"
+  local token_url="${MMDS_TOKEN_URL:-$MMDS_TOKEN_URL_DEFAULT}"
+  local metadata_url="${MMDS_METADATA_URL:-$MMDS_METADATA_URL_DEFAULT}"
+  local token
+
+  if ! token="$(curl --fail --silent --show-error --connect-timeout 1 --max-time 2 \
+    --request PUT \
+    --header 'X-Metadata-Token-TTL-Seconds: 60' \
+    "$token_url" 2>/dev/null)"; then
+    fallback_reader "$config_file" "$output_file" "MMDSv2 token service is unavailable"
+    return
+  fi
+
+  if [[ -z "$token" ]]; then
+    fallback_reader "$config_file" "$output_file" "MMDSv2 returned an empty token"
+    return
+  fi
+
+  if ! curl --fail --silent --show-error --connect-timeout 1 --max-time 3 \
+    --header "X-Metadata-Token: $token" \
+    --header 'Accept: application/json' \
+    --output "$config_file" \
+    "$metadata_url" 2>/dev/null; then
+    fallback_reader "$config_file" "$output_file" "MMDSv2 sccache metadata is unavailable"
+    return
+  fi
+  chmod 0600 "$config_file"
+
+  if ! python3 -c '
+import json, os, sys
+path = sys.argv[1]
+expected = {
+    "bucket": "subtensor-ci-sccache",
+    "endpoint": "https://3dc4cebb791314d78848969042fb3382.r2.cloudflarestorage.com",
+    "region": "auto",
+    "s3_use_ssl": True,
+    "s3_rw_mode": "READ_ONLY",
+    "key_prefix": "subtensor/v1",
+}
+with open(path, encoding="utf-8") as handle:
+    data = json.load(handle)
+for key, value in expected.items():
+    if data.get(key) != value:
+        raise ValueError(f"invalid {key}")
+for key in ("access_key_id", "secret_access_key"):
+    value = data.get(key)
+    if not isinstance(value, str) or not value or "\n" in value or "\r" in value:
+        raise ValueError(f"invalid {key}")
+data["mode"] = "reader"
+tmp = path + ".normalized"
+with open(tmp, "w", encoding="utf-8") as handle:
+    json.dump(data, handle, separators=(",", ":"))
+os.chmod(tmp, 0o600)
+os.replace(tmp, path)
+' "$config_file" 2>/dev/null; then
+    fallback_reader "$config_file" "$output_file" "MMDSv2 sccache metadata failed validation"
+    return
+  fi
+}
+
+prepare_writer() {
+  local config_file="$1"
+  local output_file="$2"
+
+  case "${GITHUB_EVENT_NAME:-}:${GITHUB_REF:-}" in
+    push:refs/heads/main|schedule:refs/heads/main|workflow_dispatch:refs/heads/main)
+      ;;
+    *)
+      disable_prepare "$config_file" "$output_file" "writer mode is restricted to trusted main events"
+      ;;
+  esac
+
+  if [[ -z "${AWS_ACCESS_KEY_ID:-}" || -z "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+    disable_prepare "$config_file" "$output_file" "protected writer credentials are unavailable"
+  fi
+  if [[ "$AWS_ACCESS_KEY_ID" == *$'\n'* || "$AWS_SECRET_ACCESS_KEY" == *$'\n'* ]]; then
+    disable_prepare "$config_file" "$output_file" "protected writer credentials are malformed"
+  fi
+
+  if ! CONFIG_FILE="$config_file" python3 -c '
+import json, os
+path = os.environ["CONFIG_FILE"]
+data = {
+    "mode": "writer",
+    "bucket": "subtensor-ci-sccache",
+    "endpoint": "https://3dc4cebb791314d78848969042fb3382.r2.cloudflarestorage.com",
+    "region": "auto",
+    "s3_use_ssl": True,
+    "s3_rw_mode": "READ_WRITE",
+    "key_prefix": "subtensor/v1",
+    "access_key_id": os.environ["AWS_ACCESS_KEY_ID"],
+    "secret_access_key": os.environ["AWS_SECRET_ACCESS_KEY"],
+}
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(data, handle, separators=(",", ":"))
+os.chmod(path, 0o600)
+' 2>/dev/null; then
+    disable_prepare "$config_file" "$output_file" "writer configuration could not be materialized"
+  fi
+}
+
+prepare() {
+  local mode="$1"
+  local config_file="$2"
+  local output_file="$3"
+
+  umask 077
+  mkdir -p "$(dirname "$config_file")"
+  rm -f "$config_file"
+
+  case "$mode" in
+    reader) prepare_reader "$config_file" "$output_file" ;;
+    writer) prepare_writer "$config_file" "$output_file" ;;
+    *) disable_prepare "$config_file" "$output_file" "unknown credential mode" ;;
+  esac
+
+  mask_config_credentials "$config_file"
+  set_output "$output_file" available true
+  set_output "$output_file" config-file "$config_file"
+  printf 'sccache %s configuration validated\n' "$mode"
+}
+
+activate() {
+  local config_file="$1"
+  local env_file="$2"
+  local output_file="$3"
+  local install_outcome="${SCCACHE_INSTALL_OUTCOME:-success}"
+  local sccache_bin="${SCCACHE_PATH:-}"
+  local start_log="${RUNNER_TEMP:-/tmp}/sccache-start-${GITHUB_RUN_ID:-local}-${GITHUB_JOB:-test}.log"
+  local fields_file="${RUNNER_TEMP:-/tmp}/sccache-fields-${GITHUB_RUN_ID:-local}-${GITHUB_JOB:-test}"
+  local -a values=()
+  local value
+
+  umask 077
+  if [[ ! -f "$config_file" ]]; then
+    disable_activate "$config_file" "$output_file" "validated configuration is unavailable"
+  fi
+  if [[ "$install_outcome" != "success" ]]; then
+    disable_activate "$config_file" "$output_file" "sccache installation failed"
+  fi
+  if [[ -z "$sccache_bin" ]]; then
+    sccache_bin="$(command -v sccache || true)"
+  fi
+  if [[ -z "$sccache_bin" || ! -x "$sccache_bin" ]]; then
+    disable_activate "$config_file" "$output_file" "sccache executable is unavailable"
+  fi
+
+  if ! python3 -c '
+import json, sys
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+mode = data.get("mode")
+if mode not in ("gha", "reader", "writer"):
+    raise ValueError("invalid mode")
+sys.stdout.write(mode + "\0")
+if mode == "gha":
+    raise SystemExit(0)
+for key in ("bucket", "endpoint", "region", "key_prefix", "access_key_id", "secret_access_key"):
+    value = data.get(key)
+    if not isinstance(value, str) or not value or "\n" in value or "\r" in value:
+        raise ValueError(f"invalid {key}")
+    sys.stdout.write(value + "\0")
+if data.get("s3_use_ssl") is not True:
+    raise ValueError("invalid s3_use_ssl")
+' "$config_file" >"$fields_file" 2>/dev/null; then
+    rm -f "$fields_file"
+    disable_activate "$config_file" "$output_file" "validated configuration could not be parsed"
+  fi
+  while IFS= read -r -d '' value; do
+    values+=("$value")
+  done < "$fields_file"
+  rm -f "$fields_file"
+  if [[ ${#values[@]} -ne 1 && ${#values[@]} -ne 7 ]]; then
+    disable_activate "$config_file" "$output_file" "validated configuration is incomplete"
+  fi
+
+  if [[ "${values[0]}" == gha ]]; then
+    export SCCACHE_GHA_ENABLED=true
+    export SCCACHE_IGNORE_SERVER_IO_ERROR=1
+    "$sccache_bin" --stop-server >/dev/null 2>&1 || true
+    if ! "$sccache_bin" --start-server >"$start_log" 2>&1; then
+      "$sccache_bin" --stop-server >/dev/null 2>&1 || true
+      rm -f "$start_log"
+      disable_activate "$config_file" "$output_file" "GitHub Actions backend startup failed"
+    fi
+    rm -f "$start_log" "$config_file"
+    {
+      printf 'SCCACHE_ENABLED=true\n'
+      printf 'SCCACHE_BACKEND=gha\n'
+      printf 'SCCACHE_GHA_ENABLED=true\n'
+      printf 'SCCACHE_IGNORE_SERVER_IO_ERROR=1\n'
+      printf 'RUSTC_WRAPPER=sccache\n'
+      printf 'CARGO_INCREMENTAL=0\n'
+    } >> "$env_file"
+    set_output "$output_file" enabled true
+    printf 'sccache GitHub Actions backend enabled\n'
+    return
+  fi
+
+  printf '::add-mask::%s\n' "${values[5]}"
+  printf '::add-mask::%s\n' "${values[6]}"
+
+  export SCCACHE_BUCKET="${values[1]}"
+  export SCCACHE_ENDPOINT="${values[2]}"
+  export SCCACHE_REGION="${values[3]}"
+  export SCCACHE_S3_USE_SSL=true
+  export SCCACHE_S3_KEY_PREFIX="${values[4]}"
+  # v0.15.0 has no S3 read/write-mode environment variable. Reader mode is
+  # enforced by the bucket-scoped Object Read credential validated above.
+  # sccache otherwise fails a build when its server or remote backend becomes
+  # unavailable after startup. This makes every such failure compile locally.
+  export SCCACHE_IGNORE_SERVER_IO_ERROR=1
+  export AWS_ACCESS_KEY_ID="${values[5]}"
+  export AWS_SECRET_ACCESS_KEY="${values[6]}"
+
+  "$sccache_bin" --stop-server >/dev/null 2>&1 || true
+  if ! "$sccache_bin" --start-server >"$start_log" 2>&1; then
+    "$sccache_bin" --stop-server >/dev/null 2>&1 || true
+    rm -f "$start_log"
+    disable_activate "$config_file" "$output_file" "R2 backend startup check failed"
+  fi
+  rm -f "$start_log" "$config_file"
+
+  {
+    printf 'SCCACHE_ENABLED=true\n'
+    printf 'SCCACHE_BACKEND=r2\n'
+    printf 'RUSTC_WRAPPER=sccache\n'
+    printf 'CARGO_INCREMENTAL=0\n'
+    printf 'SCCACHE_BUCKET=%s\n' "$SCCACHE_BUCKET"
+    printf 'SCCACHE_ENDPOINT=%s\n' "$SCCACHE_ENDPOINT"
+    printf 'SCCACHE_REGION=%s\n' "$SCCACHE_REGION"
+    printf 'SCCACHE_S3_USE_SSL=true\n'
+    printf 'SCCACHE_S3_KEY_PREFIX=%s\n' "$SCCACHE_S3_KEY_PREFIX"
+    printf 'SCCACHE_IGNORE_SERVER_IO_ERROR=1\n'
+    printf 'AWS_ACCESS_KEY_ID=%s\n' "$AWS_ACCESS_KEY_ID"
+    printf 'AWS_SECRET_ACCESS_KEY=%s\n' "$AWS_SECRET_ACCESS_KEY"
+  } >> "$env_file"
+  set_output "$output_file" enabled true
+  printf 'sccache R2 backend enabled in %s mode\n' "${values[0]}"
+}
+
+if [[ $# -lt 1 ]]; then
+  printf 'usage: %s prepare|activate ...\n' "$0" >&2
+  exit 2
+fi
+
+case "$1" in
+  prepare)
+    [[ $# -eq 4 ]] || { printf 'usage: %s prepare MODE CONFIG_FILE OUTPUT_FILE\n' "$0" >&2; exit 2; }
+    prepare "$2" "$3" "$4"
+    ;;
+  activate)
+    [[ $# -eq 4 ]] || { printf 'usage: %s activate CONFIG_FILE ENV_FILE OUTPUT_FILE\n' "$0" >&2; exit 2; }
+    activate "$2" "$3" "$4"
+    ;;
+  *)
+    printf 'unknown command: %s\n' "$1" >&2
+    exit 2
+    ;;
+esac

--- a/.github/scripts/test-sccache-configure.sh
+++ b/.github/scripts/test-sccache-configure.sh
@@ -166,6 +166,10 @@ assert_contains "$tmp/output" 'available=true'
 grep -v '^::add-mask::' "$tmp/writer-main.log" > "$tmp/writer-main-public.log"
 assert_not_contains "$tmp/writer-main-public.log" 'writer-access-key-test'
 assert_not_contains "$tmp/writer-main-public.log" 'writer-secret-key-test'
+SCCACHE_INSTALL_OUTCOME=success "$CONFIGURE" activate "$tmp/config.json" "$tmp/env" "$tmp/output" >"$tmp/writer-activate.log"
+assert_contains "$tmp/output" 'enabled=true'
+assert_contains "$tmp/env" 'SCCACHE_BACKEND=r2'
+assert_contains "$tmp/env" 'RUSTC_WRAPPER=sccache'
 
 for trusted_event in push workflow_dispatch; do
   reset_outputs
@@ -193,9 +197,9 @@ export GITHUB_REF=refs/heads/main
 "$CONFIGURE" prepare writer "$tmp/config.json" "$tmp/output" >"$tmp/writer-missing.log"
 assert_contains "$tmp/output" 'available=false'
 
-# A read-only backend can report denied writes without affecting the compiler.
+# Keep read-only write errors visible in the stats contract. The live turbo
+# integration compile proves those errors do not fail rustc invocations.
 "$tmp/bin/sccache" --show-stats >"$tmp/stats"
 assert_contains "$tmp/stats" 'Cache write errors                   1'
-true
 
 printf 'sccache configuration tests passed\n'

--- a/.github/scripts/test-sccache-configure.sh
+++ b/.github/scripts/test-sccache-configure.sh
@@ -93,7 +93,8 @@ reset_outputs
 prepare_log="$tmp/prepare.log"
 "$CONFIGURE" prepare reader "$tmp/config.json" "$tmp/output" >"$prepare_log"
 assert_contains "$tmp/output" 'available=true'
-[[ "$(stat -f '%Lp' "$tmp/config.json" 2>/dev/null || stat -c '%a' "$tmp/config.json")" == 600 ]]
+config_mode="$(python3 -c 'import os, stat, sys; print(oct(stat.S_IMODE(os.stat(sys.argv[1]).st_mode))[2:])' "$tmp/config.json")"
+[[ "$config_mode" == 600 ]]
 grep -v '^::add-mask::' "$prepare_log" > "$tmp/prepare-public.log"
 assert_not_contains "$tmp/prepare-public.log" "$ACCESS_KEY"
 assert_not_contains "$tmp/prepare-public.log" "$SECRET_KEY"

--- a/.github/scripts/test-sccache-configure.sh
+++ b/.github/scripts/test-sccache-configure.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly CONFIGURE="$SCRIPT_DIR/sccache-configure.sh"
+readonly ACCESS_KEY="reader-access-key-test"
+readonly SECRET_KEY="reader-secret-key-test"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin" "$tmp/runner"
+
+cat > "$tmp/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+for argument in "$@"; do
+  if [[ "$argument" == */token ]]; then
+    token_request=true
+  fi
+done
+if [[ "${token_request:-false}" == true ]]; then
+  [[ "${MOCK_MMDS_FAIL:-false}" != true ]] || exit 22
+  printf 'test-token'
+  exit 0
+fi
+[[ "${MOCK_MMDS_FAIL:-false}" != true ]] || exit 22
+output=''
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == --output ]]; then
+    output="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+cp "$MOCK_METADATA" "$output"
+EOF
+chmod +x "$tmp/bin/curl"
+
+cat > "$tmp/bin/sccache" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --stop-server) exit 0 ;;
+  --start-server) [[ "${MOCK_START_FAIL:-false}" != true ]] ;;
+  --show-stats) printf 'Compile requests                     1\nCache write errors                   1\n'; exit 0 ;;
+  *) exit 0 ;;
+esac
+EOF
+chmod +x "$tmp/bin/sccache"
+
+export PATH="$tmp/bin:$PATH"
+export RUNNER_TEMP="$tmp/runner"
+export GITHUB_RUN_ID=1
+export GITHUB_JOB=test
+export MMDS_TOKEN_URL=http://mmds/token
+export MMDS_METADATA_URL=http://mmds/sccache
+export SCCACHE_PATH="$tmp/bin/sccache"
+
+write_metadata() {
+  local endpoint="${1:-https://3dc4cebb791314d78848969042fb3382.r2.cloudflarestorage.com}"
+  cat > "$tmp/metadata.json" <<EOF
+{"bucket":"subtensor-ci-sccache","endpoint":"$endpoint","region":"auto","s3_use_ssl":true,"s3_rw_mode":"READ_ONLY","key_prefix":"subtensor/v1","access_key_id":"$ACCESS_KEY","secret_access_key":"$SECRET_KEY"}
+EOF
+  export MOCK_METADATA="$tmp/metadata.json"
+}
+
+reset_outputs() {
+  : > "$tmp/output"
+  : > "$tmp/env"
+  rm -f "$tmp/config.json"
+  unset MOCK_MMDS_FAIL MOCK_START_FAIL SCCACHE_GHA_FALLBACK AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+  export GITHUB_OUTPUT="$tmp/output"
+  export GITHUB_ENV="$tmp/env"
+  export GITHUB_EVENT_NAME=pull_request
+  export GITHUB_REF=refs/pull/1/merge
+}
+
+assert_contains() {
+  grep -Fq "$2" "$1" || { printf 'expected %s in %s\n' "$2" "$1" >&2; exit 1; }
+}
+
+assert_not_contains() {
+  if grep -Fq "$2" "$1"; then
+    printf 'did not expect %s in %s\n' "$2" "$1" >&2
+    exit 1
+  fi
+}
+
+write_metadata
+reset_outputs
+prepare_log="$tmp/prepare.log"
+"$CONFIGURE" prepare reader "$tmp/config.json" "$tmp/output" >"$prepare_log"
+assert_contains "$tmp/output" 'available=true'
+[[ "$(stat -f '%Lp' "$tmp/config.json" 2>/dev/null || stat -c '%a' "$tmp/config.json")" == 600 ]]
+grep -v '^::add-mask::' "$prepare_log" > "$tmp/prepare-public.log"
+assert_not_contains "$tmp/prepare-public.log" "$ACCESS_KEY"
+assert_not_contains "$tmp/prepare-public.log" "$SECRET_KEY"
+SCCACHE_INSTALL_OUTCOME=success "$CONFIGURE" activate "$tmp/config.json" "$tmp/env" "$tmp/output" >"$tmp/activate.log"
+assert_contains "$tmp/output" 'enabled=true'
+assert_contains "$tmp/env" 'RUSTC_WRAPPER=sccache'
+assert_contains "$tmp/env" 'CARGO_INCREMENTAL=0'
+assert_contains "$tmp/env" 'SCCACHE_S3_KEY_PREFIX=subtensor/v1'
+assert_contains "$tmp/env" 'SCCACHE_IGNORE_SERVER_IO_ERROR=1'
+grep -v '^::add-mask::' "$tmp/activate.log" > "$tmp/activate-public.log"
+assert_not_contains "$tmp/activate-public.log" "$ACCESS_KEY"
+assert_not_contains "$tmp/activate-public.log" "$SECRET_KEY"
+
+reset_outputs
+export MOCK_MMDS_FAIL=true
+"$CONFIGURE" prepare reader "$tmp/config.json" "$tmp/output" >"$tmp/unavailable.log"
+assert_contains "$tmp/output" 'available=true'
+SCCACHE_INSTALL_OUTCOME=success "$CONFIGURE" activate "$tmp/config.json" "$tmp/env" "$tmp/output" >"$tmp/gha.log"
+assert_contains "$tmp/output" 'enabled=true'
+assert_contains "$tmp/env" 'SCCACHE_BACKEND=gha'
+assert_contains "$tmp/env" 'SCCACHE_GHA_ENABLED=true'
+assert_contains "$tmp/env" 'RUSTC_WRAPPER=sccache'
+
+reset_outputs
+export MOCK_MMDS_FAIL=true
+export SCCACHE_GHA_FALLBACK=false
+"$CONFIGURE" prepare reader "$tmp/config.json" "$tmp/output" >"$tmp/unavailable-disabled.log"
+assert_contains "$tmp/output" 'available=false'
+[[ ! -e "$tmp/config.json" ]]
+
+write_metadata http://invalid.example.com
+reset_outputs
+export SCCACHE_GHA_FALLBACK=false
+"$CONFIGURE" prepare reader "$tmp/config.json" "$tmp/output" >"$tmp/invalid.log"
+assert_contains "$tmp/output" 'available=false'
+assert_not_contains "$tmp/invalid.log" "$ACCESS_KEY"
+assert_not_contains "$tmp/invalid.log" "$SECRET_KEY"
+
+write_metadata
+reset_outputs
+"$CONFIGURE" prepare reader "$tmp/config.json" "$tmp/output" >/dev/null
+export MOCK_START_FAIL=true
+SCCACHE_INSTALL_OUTCOME=success "$CONFIGURE" activate "$tmp/config.json" "$tmp/env" "$tmp/output" >"$tmp/start-fail.log"
+assert_contains "$tmp/output" 'enabled=false'
+assert_not_contains "$tmp/env" 'RUSTC_WRAPPER='
+assert_not_contains "$tmp/env" 'SCCACHE_IGNORE_SERVER_IO_ERROR='
+
+reset_outputs
+export AWS_ACCESS_KEY_ID=writer-access-key-test
+export AWS_SECRET_ACCESS_KEY=writer-secret-key-test
+"$CONFIGURE" prepare writer "$tmp/config.json" "$tmp/output" >"$tmp/writer-pr.log"
+assert_contains "$tmp/output" 'available=false'
+
+reset_outputs
+export GITHUB_EVENT_NAME=push
+export GITHUB_REF=refs/heads/mono-bittensor
+export AWS_ACCESS_KEY_ID=writer-access-key-test
+export AWS_SECRET_ACCESS_KEY=writer-secret-key-test
+"$CONFIGURE" prepare writer "$tmp/config.json" "$tmp/output" >"$tmp/writer-non-main.log"
+assert_contains "$tmp/output" 'available=false'
+
+reset_outputs
+export AWS_ACCESS_KEY_ID=writer-access-key-test
+export AWS_SECRET_ACCESS_KEY=writer-secret-key-test
+export GITHUB_EVENT_NAME=push
+export GITHUB_REF=refs/heads/main
+"$CONFIGURE" prepare writer "$tmp/config.json" "$tmp/output" >"$tmp/writer-main.log"
+assert_contains "$tmp/output" 'available=true'
+grep -v '^::add-mask::' "$tmp/writer-main.log" > "$tmp/writer-main-public.log"
+assert_not_contains "$tmp/writer-main-public.log" 'writer-access-key-test'
+assert_not_contains "$tmp/writer-main-public.log" 'writer-secret-key-test'
+
+for trusted_event in schedule workflow_dispatch; do
+  reset_outputs
+  export AWS_ACCESS_KEY_ID=writer-access-key-test
+  export AWS_SECRET_ACCESS_KEY=writer-secret-key-test
+  export GITHUB_EVENT_NAME="$trusted_event"
+  export GITHUB_REF=refs/heads/main
+  "$CONFIGURE" prepare writer "$tmp/config.json" "$tmp/output" >"$tmp/writer-$trusted_event.log"
+  assert_contains "$tmp/output" 'available=true'
+done
+
+reset_outputs
+export GITHUB_EVENT_NAME=push
+export GITHUB_REF=refs/heads/main
+"$CONFIGURE" prepare writer "$tmp/config.json" "$tmp/output" >"$tmp/writer-missing.log"
+assert_contains "$tmp/output" 'available=false'
+
+# A read-only backend can report denied writes without affecting the compiler.
+"$tmp/bin/sccache" --show-stats >"$tmp/stats"
+assert_contains "$tmp/stats" 'Cache write errors                   1'
+true
+
+printf 'sccache configuration tests passed\n'

--- a/.github/scripts/test-sccache-configure.sh
+++ b/.github/scripts/test-sccache-configure.sh
@@ -167,6 +167,16 @@ grep -v '^::add-mask::' "$tmp/writer-main.log" > "$tmp/writer-main-public.log"
 assert_not_contains "$tmp/writer-main-public.log" 'writer-access-key-test'
 assert_not_contains "$tmp/writer-main-public.log" 'writer-secret-key-test'
 
+for trusted_event in push workflow_dispatch; do
+  reset_outputs
+  export AWS_ACCESS_KEY_ID=writer-access-key-test
+  export AWS_SECRET_ACCESS_KEY=writer-secret-key-test
+  export GITHUB_EVENT_NAME="$trusted_event"
+  export GITHUB_REF=refs/heads/bittensor-core-exploration
+  "$CONFIGURE" prepare writer "$tmp/config.json" "$tmp/output" >"$tmp/writer-pr2846-$trusted_event.log"
+  assert_contains "$tmp/output" 'available=true'
+done
+
 for trusted_event in schedule workflow_dispatch; do
   reset_outputs
   export AWS_ACCESS_KEY_ID=writer-access-key-test

--- a/.github/scripts/test-sccache-configure.sh
+++ b/.github/scripts/test-sccache-configure.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+trap 'printf "sccache configuration test failed at line %s: %s\n" "$LINENO" "$BASH_COMMAND" >&2' ERR
 
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly CONFIGURE="$SCRIPT_DIR/sccache-configure.sh"

--- a/.github/scripts/test-sccache-configure.sh
+++ b/.github/scripts/test-sccache-configure.sh
@@ -181,6 +181,16 @@ for trusted_event in push workflow_dispatch; do
   assert_contains "$tmp/output" 'available=true'
 done
 
+for trusted_event in push workflow_dispatch; do
+  reset_outputs
+  export AWS_ACCESS_KEY_ID=writer-access-key-test
+  export AWS_SECRET_ACCESS_KEY=writer-secret-key-test
+  export GITHUB_EVENT_NAME="$trusted_event"
+  export GITHUB_REF=refs/heads/codex/subtensor-r2-sccache
+  "$CONFIGURE" prepare writer "$tmp/config.json" "$tmp/output" >"$tmp/writer-pr2855-$trusted_event.log"
+  assert_contains "$tmp/output" 'available=true'
+done
+
 for trusted_event in schedule workflow_dispatch; do
   reset_outputs
   export AWS_ACCESS_KEY_ID=writer-access-key-test

--- a/.github/workflows/check-bittensor-e2e-tests.yml
+++ b/.github/workflows/check-bittensor-e2e-tests.yml
@@ -76,7 +76,7 @@ jobs:
           sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" gh jq
 
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
@@ -114,18 +114,18 @@ jobs:
           sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" jq
 
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: "true"
           cache-dependency-glob: "sdk/python/uv.lock"
@@ -177,7 +177,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
@@ -191,6 +191,9 @@ jobs:
         run: |
           source "$HOME/.cargo/env"
           rustup target add ${{ matrix.platform.triple }}
+
+      - name: Shared R2 compiler cache
+        uses: ./.github/actions/sccache-setup
 
       - name: Patch limits for local run
         run: |
@@ -235,7 +238,7 @@ jobs:
             build/ci_target/${RUNTIME}/${TRIPLE}/release/wbuild/node-subtensor-runtime/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: binaries-${{ matrix.platform.triple }}-${{ matrix.runtime }}
           path: build/
@@ -247,13 +250,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
 
       - name: Download all binary artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
           pattern: binaries-*
           path: build/
@@ -299,13 +302,13 @@ jobs:
     name: "sdk: ${{ matrix.label }}"
     steps:
       - name: Check-out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: "true"
           cache-dependency-glob: "sdk/python/uv.lock"

--- a/.github/workflows/check-docker.yml
+++ b/.github/workflows/check-docker.yml
@@ -26,11 +26,18 @@ on:
       - "build.rs"
       - "rust-toolchain.toml"
       - "Dockerfile"
+      - "Dockerfile.prebuilt"
+      - "Cross.toml"
+      - ".github/actions/build-production-binary/**"
+      - ".github/actions/rust-setup/**"
       - ".github/workflows/check-docker.yml"
 
 concurrency:
   group: check-docker-${{ github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   trusted-pr:
@@ -40,18 +47,73 @@ jobs:
     steps:
       - run: echo "Non-fork PR; self-hosted runners may execute checkout."
 
-  build:
-    name: docker build
+  binary:
+    name: production binary (${{ matrix.platform.arch }})
     needs: trusted-pr
-    runs-on: [self-hosted, fireactions-heavy]
+    runs-on: [self-hosted, fireactions-turbo]
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - arch: amd64
+            target: x86_64-unknown-linux-gnu
+          - arch: arm64
+            target: aarch64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v4
 
+      - uses: ./.github/actions/build-production-binary
+        with:
+          arch: ${{ matrix.platform.arch }}
+          target: ${{ matrix.platform.target }}
+          cache-key: docker-production-${{ matrix.platform.arch }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: production-node-${{ matrix.platform.arch }}
+          path: build/ci_target/${{ matrix.platform.arch }}/node-subtensor
+          if-no-files-found: error
+
+  image:
+    name: docker image (${{ matrix.arch }}, no push)
+    needs: [trusted-pr, binary]
+    runs-on: [self-hosted, fireactions-turbo]
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v5
+        with:
+          name: production-node-${{ matrix.arch }}
+          path: build/ci_target/${{ matrix.arch }}
+
       - name: Set up QEMU
+        if: matrix.arch == 'arm64'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker image
-        run: docker build .
+      - name: Build Docker image without publishing
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.prebuilt
+          platforms: linux/${{ matrix.arch }}
+          tags: subtensor-ci:${{ matrix.arch }}
+          load: true
+          push: false
+
+      - name: Verify image architecture and executable
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual=$(docker image inspect subtensor-ci:${{ matrix.arch }} --format '{{.Architecture}}')
+          test "$actual" = "${{ matrix.arch }}"
+          docker run --rm --platform linux/${{ matrix.arch }} \
+            subtensor-ci:${{ matrix.arch }} --version

--- a/.github/workflows/check-node-compat.yml
+++ b/.github/workflows/check-node-compat.yml
@@ -38,7 +38,12 @@ jobs:
           - name: new
             ref: ${{ github.head_ref }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out CI support action
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          path: ci-support
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ matrix.version.ref }}
           path: ${{ matrix.version.name }}
@@ -51,20 +56,24 @@ jobs:
             build-essential clang curl git make libssl-dev llvm libudev-dev protobuf-compiler pkg-config unzip
 
       - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
-      - name: Shared Rust cache
-        uses: Swatinem/rust-cache@v2
+      - name: Shared R2 compiler cache
+        uses: ./ci-support/.github/actions/sccache-setup
+
+      - name: Cache Cargo registry and git data
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: check-node-compat-${{ matrix.version.name }}
           workspaces: ${{ matrix.version.name }}
+          cache-targets: false
 
       - name: Build ${{ matrix.version.name }}
         working-directory: ${{ matrix.version.name }}
         run: cargo build --release --locked
 
       - name: Upload ${{ matrix.version.name }} node binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: node-subtensor-${{ matrix.version.name }}
           path: ${{ matrix.version.name }}/target/release/node-subtensor
@@ -75,22 +84,22 @@ jobs:
     needs: [trusted-pr, build]
     runs-on: [self-hosted, fireactions-heavy]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download old node binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: node-subtensor-old
           path: /tmp/node-subtensor-old
 
       - name: Download new node binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: node-subtensor-new
           path: /tmp/node-subtensor-new
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24"
 

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           set -euo pipefail
           files=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename')
-          pattern='^(common|node|pallets|precompiles|primitives|runtime|support|chain-extensions|src|vendor)/|^sdk/bittensor-core(-py|-wasm)?/|^(Cargo\.(toml|lock)|build\.rs|rust-toolchain\.toml|zepter\.yaml)$|^\.github/(workflows/check-rust\.yml|actions/rust-setup/)'
+          pattern='^(common|node|pallets|precompiles|primitives|runtime|support|chain-extensions|src|vendor)/|^sdk/bittensor-core(-py|-wasm)?/|^(Cargo\.(toml|lock)|build\.rs|rust-toolchain\.toml|zepter\.yaml)$|^\.github/(workflows/check-rust\.yml|actions/(rust-setup|sccache-setup)/|scripts/sccache-configure\.sh$)'
           if grep -qE "$pattern" <<< "$files"; then
             echo "rust=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -5,9 +5,9 @@ name: Check Rust
 
 on:
   pull_request:
-  # Runs on main serve two purposes: post-merge validation, and seeding the
-  # shared sccache pool — Actions caches written on the default branch are
-  # readable by every PR, while PR-written caches stay scoped to their PR.
+  # Main pushes retain post-merge validation. The protected sccache-warm
+  # workflow separately populates R2; legacy non-MMDS pools keep the existing
+  # GitHub Actions cache backend as a compatibility fallback.
   push:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,8 +24,97 @@ permissions:
   packages: write
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.ref.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref_name }}
+
+      - name: Resolve immutable source revision
+        id: ref
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+  binary:
+    name: production binary (${{ matrix.platform.arch }})
+    needs: setup
+    runs-on: [self-hosted, fireactions-turbo]
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - arch: amd64
+            target: x86_64-unknown-linux-gnu
+          - arch: arm64
+            target: aarch64-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.setup.outputs.sha }}
+
+      - uses: ./.github/actions/build-production-binary
+        with:
+          arch: ${{ matrix.platform.arch }}
+          target: ${{ matrix.platform.target }}
+          cache-key: docker-production-${{ matrix.platform.arch }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: production-node-${{ matrix.platform.arch }}
+          path: build/ci_target/${{ matrix.platform.arch }}/node-subtensor
+          if-no-files-found: error
+
+  image:
+    name: validate image (${{ matrix.arch }}, no push)
+    needs: [setup, binary]
+    runs-on: [self-hosted, fireactions-turbo]
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.setup.outputs.sha }}
+
+      - uses: actions/download-artifact@v5
+        with:
+          name: production-node-${{ matrix.arch }}
+          path: build/ci_target/${{ matrix.arch }}
+
+      - name: Set up QEMU
+        if: matrix.arch == 'arm64'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image without publishing
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.prebuilt
+          platforms: linux/${{ matrix.arch }}
+          tags: subtensor-release-check:${{ matrix.arch }}
+          load: true
+          push: false
+
+      - name: Verify image architecture and executable
+        run: |
+          set -euo pipefail
+          actual=$(docker image inspect subtensor-release-check:${{ matrix.arch }} --format '{{.Architecture}}')
+          test "$actual" = "${{ matrix.arch }}"
+          docker run --rm --platform linux/${{ matrix.arch }} \
+            subtensor-release-check:${{ matrix.arch }} --version
+
   publish:
-    runs-on: [self-hosted, fireactions-heavy]
+    needs: [setup, binary, image]
+    runs-on: [self-hosted, fireactions-turbo]
+    timeout-minutes: 30
     steps:
       - name: Determine tag, ref, and image name
         env:
@@ -52,7 +141,19 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ env.ref }}
+          ref: ${{ needs.setup.outputs.sha }}
+
+      - name: Download AMD64 production binary
+        uses: actions/download-artifact@v5
+        with:
+          name: production-node-amd64
+          path: build/ci_target/amd64
+
+      - name: Download ARM64 production binary
+        uses: actions/download-artifact@v5
+        with:
+          name: production-node-arm64
+          path: build/ci_target/arm64
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -71,10 +172,8 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          file: Dockerfile.prebuilt
           push: true
-          # The Dockerfile's last stage is subtensor-local; without an explicit
-          # target this workflow would publish the localnet image as production.
-          target: subtensor
           platforms: linux/amd64,linux/arm64
           tags: |
             ${{ env.image }}:${{ env.tag }}

--- a/.github/workflows/eco-tests.yml
+++ b/.github/workflows/eco-tests.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           set -euo pipefail
           files=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename')
-          pattern='^(eco-tests|common|node|pallets|precompiles|primitives|runtime|support|chain-extensions|src|vendor)/|^(Cargo\.(toml|lock)|build\.rs|rust-toolchain\.toml)$|^\.github/(workflows/eco-tests\.yml|actions/rust-setup/)'
+          pattern='^(eco-tests|common|node|pallets|precompiles|primitives|runtime|support|chain-extensions|src|vendor)/|^(Cargo\.(toml|lock)|build\.rs|rust-toolchain\.toml)$|^\.github/(workflows/eco-tests\.yml|actions/(rust-setup|sccache-setup)/|scripts/sccache-configure\.sh$)'
           if grep -qE "$pattern" <<< "$files"; then
             echo "rust=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/mainnet-clone-preview.yml
+++ b/.github/workflows/mainnet-clone-preview.yml
@@ -59,19 +59,23 @@ jobs:
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
       - name: Check-out repository under $GITHUB_WORKSPACE
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Utilize Shared Rust Cache
+      - name: Shared R2 compiler cache
+        uses: ./.github/actions/sccache-setup
+
+      - name: Cache Cargo registry and git data
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: clone-upgrade
           cache-on-failure: true
+          cache-targets: false
 
       - name: Build node and runtime
         run: cargo build --release -p node-subtensor
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
@@ -134,7 +138,7 @@ jobs:
           exit 1
 
       - name: Post endpoint as sticky PR comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           WSS_URL: ${{ steps.tunnel.outputs.wss_url }}
           KEEP_ALIVE_MINUTES: ${{ env.KEEP_ALIVE_MINUTES }}
@@ -183,7 +187,7 @@ jobs:
       # (cancelled runs get a short grace period for cleanup steps).
       - name: Mark endpoint offline
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const marker = '<!-- mainnet-clone-preview -->';

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -87,13 +87,15 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
-      # The dedicated Benchmarking/AX41 runner does not expose the MMDS reader
-      # contract yet. Keep its target cache until that host is migrated.
-      - name: Cache Rust build
+      - name: Shared R2 compiler cache
+        uses: ./.github/actions/sccache-setup
+
+      - name: Cache Cargo registry and git data
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: bench-${{ hashFiles('**/Cargo.lock') }}
           cache-on-failure: true
+          cache-targets: false
 
       - name: Build node with benchmarks + weight tools
         run: |

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Check out PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           # Fall back to the current repo/ref so workflow_dispatch and
           # scheduled runs work too.
@@ -85,10 +85,12 @@ jobs:
             build-essential clang curl libssl-dev llvm libudev-dev protobuf-compiler pkg-config
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
+      # The dedicated Benchmarking/AX41 runner does not expose the MMDS reader
+      # contract yet. Keep its target cache until that host is migrated.
       - name: Cache Rust build
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: bench-${{ hashFiles('**/Cargo.lock') }}
           cache-on-failure: true
@@ -114,7 +116,7 @@ jobs:
 
       - name: Upload patch artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bench-patch
           path: bench-patch.tgz

--- a/.github/workflows/runtime-checks.yml
+++ b/.github/workflows/runtime-checks.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           set -euo pipefail
           files=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename')
-          runtime_pattern='^(common|node|pallets|precompiles|primitives|runtime|support|chain-extensions|src|vendor|clones|sdk)/|^(Cargo\.(toml|lock)|build\.rs|rust-toolchain\.toml)$|^website/apps/bittensor-website/scripts/|^\.github/(workflows/runtime-checks\.yml|actions/rust-setup/)'
+          runtime_pattern='^(common|node|pallets|precompiles|primitives|runtime|support|chain-extensions|src|vendor|clones|sdk)/|^(Cargo\.(toml|lock)|build\.rs|rust-toolchain\.toml)$|^website/apps/bittensor-website/scripts/|^\.github/(workflows/runtime-checks\.yml|actions/(rust-setup|sccache-setup)/|scripts/sccache-configure\.sh$)'
           docs_pattern='^website/|^sdk/python/|^\.github/workflows/runtime-checks\.yml$'
           runtime=false; docs=false
           grep -qE "$runtime_pattern" <<< "$files" && runtime=true

--- a/.github/workflows/sccache-warm.yml
+++ b/.github/workflows/sccache-warm.yml
@@ -6,6 +6,9 @@ on:
       - main
       # Temporary benchmark writer for the active critical-path CI work in #2846.
       - bittensor-core-exploration
+      # Temporary writer for this cache integration PR so it can populate R2
+      # before merging into #2846.
+      - codex/subtensor-r2-sccache
   schedule:
     - cron: "17 3 * * *"
   workflow_dispatch:
@@ -24,7 +27,8 @@ jobs:
       (github.event_name == 'schedule' && github.ref == 'refs/heads/main') ||
       ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
        (github.ref == 'refs/heads/main' ||
-        github.ref == 'refs/heads/bittensor-core-exploration'))
+        github.ref == 'refs/heads/bittensor-core-exploration' ||
+        github.ref == 'refs/heads/codex/subtensor-r2-sccache'))
     environment: sccache-writer
     runs-on: [self-hosted, fireactions-turbo]
     timeout-minutes: 120

--- a/.github/workflows/sccache-warm.yml
+++ b/.github/workflows/sccache-warm.yml
@@ -2,7 +2,10 @@ name: Warm R2 sccache
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      # Temporary benchmark writer for the active critical-path CI work in #2846.
+      - bittensor-core-exploration
   schedule:
     - cron: "17 3 * * *"
   workflow_dispatch:
@@ -11,30 +14,30 @@ permissions:
   contents: read
 
 concurrency:
-  group: sccache-warm-main
+  group: sccache-warm-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   warm:
     name: Populate trusted compiler cache
     if: >-
-      github.ref == 'refs/heads/main' &&
-      (github.event_name == 'push' ||
-       github.event_name == 'schedule' ||
-       github.event_name == 'workflow_dispatch')
+      (github.event_name == 'schedule' && github.ref == 'refs/heads/main') ||
+      ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+       (github.ref == 'refs/heads/main' ||
+        github.ref == 'refs/heads/bittensor-core-exploration'))
     environment: sccache-writer
     runs-on: [self-hosted, fireactions-turbo]
     timeout-minutes: 120
     env:
       SKIP_WASM_BUILD: 1
     steps:
-      - name: Check out main
+      - name: Check out trusted cache source
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust and enable trusted R2 writer
         uses: ./.github/actions/rust-setup
         with:
-          cache-key: sccache-warm-main
+          cache-key: sccache-warm-${{ github.ref_name }}
           components: clippy
           sccache-credential-mode: writer
           sccache-writer-access-key-id: ${{ secrets.SCCACHE_R2_WRITE_ACCESS_KEY_ID }}

--- a/.github/workflows/sccache-warm.yml
+++ b/.github/workflows/sccache-warm.yml
@@ -46,7 +46,9 @@ jobs:
       - name: Require protected writer activation
         shell: bash
         run: |
-          if [[ "${SCCACHE_ENABLED:-}" != true || "${RUSTC_WRAPPER:-}" != sccache ]]; then
+          if [[ "${SCCACHE_ENABLED:-}" != true ||
+                "${SCCACHE_BACKEND:-}" != r2 ||
+                "${RUSTC_WRAPPER:-}" != sccache ]]; then
             echo "::error::protected R2 writer did not activate"
             exit 1
           fi

--- a/.github/workflows/sccache-warm.yml
+++ b/.github/workflows/sccache-warm.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - main
-      # Temporary benchmark writer for the active critical-path CI work in #2846.
-      - bittensor-core-exploration
-      # Temporary writer for this cache integration PR so it can populate R2
-      # before merging into #2846.
-      - codex/subtensor-r2-sccache
   schedule:
     - cron: "17 3 * * *"
   workflow_dispatch:
@@ -24,11 +19,10 @@ jobs:
   warm:
     name: Populate trusted compiler cache
     if: >-
-      (github.event_name == 'schedule' && github.ref == 'refs/heads/main') ||
-      ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
-       (github.ref == 'refs/heads/main' ||
-        github.ref == 'refs/heads/bittensor-core-exploration' ||
-        github.ref == 'refs/heads/codex/subtensor-r2-sccache'))
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'schedule' ||
+       github.event_name == 'push' ||
+       github.event_name == 'workflow_dispatch')
     environment: sccache-writer
     runs-on: [self-hosted, fireactions-turbo]
     timeout-minutes: 120

--- a/.github/workflows/sccache-warm.yml
+++ b/.github/workflows/sccache-warm.yml
@@ -1,0 +1,58 @@
+name: Warm R2 sccache
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sccache-warm-main
+  cancel-in-progress: true
+
+jobs:
+  warm:
+    name: Populate trusted compiler cache
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' ||
+       github.event_name == 'schedule' ||
+       github.event_name == 'workflow_dispatch')
+    environment: sccache-writer
+    runs-on: [self-hosted, fireactions-turbo]
+    timeout-minutes: 120
+    env:
+      SKIP_WASM_BUILD: 1
+    steps:
+      - name: Check out main
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Rust and enable trusted R2 writer
+        uses: ./.github/actions/rust-setup
+        with:
+          cache-key: sccache-warm-main
+          components: clippy
+          sccache-credential-mode: writer
+          sccache-writer-access-key-id: ${{ secrets.SCCACHE_R2_WRITE_ACCESS_KEY_ID }}
+          sccache-writer-secret-access-key: ${{ secrets.SCCACHE_R2_WRITE_SECRET_ACCESS_KEY }}
+
+      - name: Require protected writer activation
+        shell: bash
+        run: |
+          if [[ "${SCCACHE_ENABLED:-}" != true || "${RUSTC_WRAPPER:-}" != sccache ]]; then
+            echo "::error::protected R2 writer did not activate"
+            exit 1
+          fi
+
+      - name: Warm workspace check artifacts
+        run: cargo check --workspace --all-features --locked
+
+      - name: Warm workspace test artifacts
+        run: cargo test --workspace --all-features --locked --no-run
+
+      - name: Warm release node artifacts
+        run: cargo build --release --locked -p node-subtensor

--- a/.github/workflows/typescript-e2e.yml
+++ b/.github/workflows/typescript-e2e.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check-out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
@@ -63,7 +63,7 @@ jobs:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: ts-tests/.nvmrc
 
@@ -100,7 +100,7 @@ jobs:
       RUST_BACKTRACE: full
     steps:
       - name: Check-out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install system dependencies
         run: |
@@ -112,17 +112,21 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
-      - name: Utilize Shared Rust Cache
+      - name: Shared R2 compiler cache
+        uses: ./.github/actions/sccache-setup
+
+      - name: Cache Cargo registry and git data
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: e2e-${{ matrix.variant }}
           cache-on-failure: true
+          cache-targets: false
 
       - name: Build node-subtensor (${{ matrix.variant }})
         run: cargo build --profile release ${{ matrix.flags }} -p node-subtensor
 
       - name: Upload binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: node-subtensor-${{ matrix.variant }}
           path: target/release/node-subtensor
@@ -154,10 +158,10 @@ jobs:
 
     steps:
       - name: Check-out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: node-subtensor-${{ matrix.binary }}
           path: target/release
@@ -166,7 +170,7 @@ jobs:
         run: chmod +x target/release/node-subtensor
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: ts-tests/.nvmrc
 

--- a/.github/workflows/validate-sccache.yml
+++ b/.github/workflows/validate-sccache.yml
@@ -1,0 +1,30 @@
+name: Validate sccache integration
+
+on:
+  pull_request:
+    paths:
+      - ".github/actions/rust-setup/**"
+      - ".github/actions/sccache-setup/**"
+      - ".github/scripts/sccache-configure.sh"
+      - ".github/scripts/test-sccache-configure.sh"
+      - ".github/workflows/check-bittensor-e2e-tests.yml"
+      - ".github/workflows/check-node-compat.yml"
+      - ".github/workflows/mainnet-clone-preview.yml"
+      - ".github/workflows/runtime-checks.yml"
+      - ".github/workflows/sccache-warm.yml"
+      - ".github/workflows/typescript-e2e.yml"
+      - ".github/workflows/validate-sccache.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test-config-boundary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Test fail-open and writer event gates
+        run: .github/scripts/test-sccache-configure.sh

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,16 +1,16 @@
 [build.env]
-passthrough = ["LD_LIBRARY_PATH"]
+passthrough = ["LD_LIBRARY_PATH", "WASM_BUILD_WORKSPACE_HINT"]
 
 [target.x86_64-unknown-linux-gnu]
 pre-build = [
   "dpkg --add-architecture $CROSS_DEB_ARCH",
   "apt-get update",
-  "DEBIAN_FRONTEND=noninteractive apt-get --assume-yes install clang libclang-dev libssl-dev:$CROSS_DEB_ARCH libudev-dev:$CROSS_DEB_ARCH protobuf-compiler",
+  "DEBIAN_FRONTEND=noninteractive apt-get --assume-yes install clang libclang-dev libssl-dev libssl-dev:$CROSS_DEB_ARCH libudev-dev libudev-dev:$CROSS_DEB_ARCH protobuf-compiler",
 ]
 
 [target.aarch64-unknown-linux-gnu]
 pre-build = [
   "dpkg --add-architecture $CROSS_DEB_ARCH",
   "apt-get update",
-  "DEBIAN_FRONTEND=noninteractive apt-get --assume-yes install clang libclang-dev libssl-dev:$CROSS_DEB_ARCH libudev-dev:$CROSS_DEB_ARCH protobuf-compiler",
+  "DEBIAN_FRONTEND=noninteractive apt-get --assume-yes install clang libclang-dev libssl-dev libssl-dev:$CROSS_DEB_ARCH libudev-dev libudev-dev:$CROSS_DEB_ARCH protobuf-compiler",
 ]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,3 +1,6 @@
+[build.env]
+passthrough = ["LD_LIBRARY_PATH"]
+
 [target.x86_64-unknown-linux-gnu]
 pre-build = [
   "dpkg --add-architecture $CROSS_DEB_ARCH",

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,13 @@
+[target.x86_64-unknown-linux-gnu]
+pre-build = [
+  "dpkg --add-architecture $CROSS_DEB_ARCH",
+  "apt-get update",
+  "DEBIAN_FRONTEND=noninteractive apt-get --assume-yes install clang libclang-dev libssl-dev:$CROSS_DEB_ARCH libudev-dev:$CROSS_DEB_ARCH protobuf-compiler",
+]
+
+[target.aarch64-unknown-linux-gnu]
+pre-build = [
+  "dpkg --add-architecture $CROSS_DEB_ARCH",
+  "apt-get update",
+  "DEBIAN_FRONTEND=noninteractive apt-get --assume-yes install clang libclang-dev libssl-dev:$CROSS_DEB_ARCH libudev-dev:$CROSS_DEB_ARCH protobuf-compiler",
+]

--- a/Dockerfile.prebuilt
+++ b/Dockerfile.prebuilt
@@ -13,12 +13,12 @@ LABEL com.bittensor.image.authors="operations@bittensor.com" \
   com.bittensor.image.description="Bittensor Subtensor Blockchain" \
   com.bittensor.image.documentation="https://bittensor.com/docs"
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  adduser ca-certificates gosu libssl3 libstdc++6 libudev1 && \
+  rm -rf /var/lib/apt/lists/*
+
 RUN addgroup --system --gid 10001 subtensor && \
   adduser --system --uid 10001 --gid 10001 --home /home/subtensor --disabled-password subtensor
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  ca-certificates gosu libssl3 libstdc++6 libudev1 && \
-  rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /data && chown -R subtensor:subtensor /data
 WORKDIR /home/subtensor

--- a/Dockerfile.prebuilt
+++ b/Dockerfile.prebuilt
@@ -2,7 +2,7 @@
 
 # Production image assembled from a CI-built, architecture-specific binary.
 # TARGETARCH is supplied automatically by BuildKit for --platform builds.
-ARG BASE_IMAGE=debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df
+ARG BASE_IMAGE=debian:trixie-slim@sha256:28de0877c2189802884ccd20f15ee41c203573bd87bb6b883f5f46362d24c5c2
 FROM ${BASE_IMAGE} AS subtensor
 
 ARG TARGETARCH

--- a/Dockerfile.prebuilt
+++ b/Dockerfile.prebuilt
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1
+
+# Production image assembled from a CI-built, architecture-specific binary.
+# TARGETARCH is supplied automatically by BuildKit for --platform builds.
+ARG BASE_IMAGE=debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df
+FROM ${BASE_IMAGE} AS subtensor
+
+ARG TARGETARCH
+
+LABEL com.bittensor.image.authors="operations@bittensor.com" \
+  com.bittensor.image.vendor="Rao Foundation" \
+  com.bittensor.image.title="raofoundation/subtensor" \
+  com.bittensor.image.description="Bittensor Subtensor Blockchain" \
+  com.bittensor.image.documentation="https://bittensor.com/docs"
+
+RUN addgroup --system --gid 10001 subtensor && \
+  adduser --system --uid 10001 --gid 10001 --home /home/subtensor --disabled-password subtensor
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  ca-certificates gosu libssl3 libstdc++6 libudev1 && \
+  rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /data && chown -R subtensor:subtensor /data
+WORKDIR /home/subtensor
+
+COPY --chown=subtensor:subtensor ./*.json ./
+COPY --chown=subtensor:subtensor ./chainspecs/*.json ./chainspecs/
+COPY --chmod=0755 build/ci_target/${TARGETARCH}/node-subtensor /usr/local/bin/node-subtensor
+COPY --chmod=0755 ./scripts/docker_entrypoint.sh /entrypoint.sh
+
+EXPOSE 30333 9933 9944
+
+USER root
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["--base-path", "/data"]


### PR DESCRIPTION
## Summary

- use Firecracker MMDSv2 reader credentials for the shared Cloudflare R2 compiler cache on Fireactions turbo runners
- retain GitHub Actions sccache as the legacy-runner fallback and ordinary Cargo as the fail-open path
- add a protected main-only writer warmer using the `sccache-writer` environment
- consolidate direct Rust compilation paths and retain Cargo registry/git caching without target tarballs where shared sccache applies

Depends on #2846 and intentionally targets its `bittensor-core-exploration` branch.

## Security boundaries

- pull requests receive only the bucket-scoped read credential from MMDS
- writer credentials are available only through the protected `sccache-writer` environment on trusted main push/schedule/dispatch events
- credentials are masked and never printed
- R2 or MMDS failures disable the cache rather than failing compilation

## Validation

- `.github/scripts/test-sccache-configure.sh`
- `actionlint -config-file .github/actionlint.yaml`
- `bash -n .github/scripts/sccache-configure.sh .github/scripts/test-sccache-configure.sh`
- `git diff --check origin/pr-2846-head..HEAD`

The R2 bucket, reader MMDS metadata, action allowlist, and protected writer environment are live. The BHS turbo canary proved reader GET succeeds and writer PUT is denied.