### PR TITLE
ci: post-merge fixes — Vercel deploy cwd, try-runtime snapshots, gittensor indexer

### DIFF
--- a/.github/workflows/ai-review-index-gittensor.yml
+++ b/.github/workflows/ai-review-index-gittensor.yml
@@ -29,7 +29,8 @@ jobs:
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: '3.11'
+          # The pinned gittensor commit requires Python >= 3.12.
+          python-version: '3.12'
 
       - name: Install gittensor (pinned to immutable commit SHA)
         # Pin to a specific reviewed commit, never @main. Any update requires a

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -38,7 +38,10 @@ jobs:
         run: corepack enable
 
       - name: Build and deploy
-        working-directory: website
+        # Run from the repo root: the Vercel project's root directory is
+        # website/apps/bittensor-website relative to the repo root, and the
+        # CLI resolves it against the cwd (running from website/ doubles the
+        # path and fails with ENOENT).
         run: |
           npx --yes vercel pull --yes --environment=preview --token "$VERCEL_TOKEN"
           npx --yes vercel build --token "$VERCEL_TOKEN"

--- a/.github/workflows/refresh-mainnet-snapshot.yml
+++ b/.github/workflows/refresh-mainnet-snapshot.yml
@@ -156,9 +156,12 @@ jobs:
       - name: Create state snapshot
         run: |
           export RUST_LOG=remote-ext=debug
+          # The snapshot path must precede --uri: --uri is variadic in
+          # try-runtime-cli, so a trailing positional gets consumed as a
+          # second URI value and fails validation.
           "$TRY_RUNTIME_BIN" create-snapshot \
-            --uri "${{ matrix.network.uri }}" \
-            "${{ matrix.network.name }}.snap"
+            "${{ matrix.network.name }}.snap" \
+            --uri "${{ matrix.network.uri }}"
           ls -lh "${{ matrix.network.name }}.snap"
 
       - name: Upload snapshot artifact

--- a/.github/workflows/watch-mainnet-release.yml
+++ b/.github/workflows/watch-mainnet-release.yml
@@ -282,7 +282,8 @@ jobs:
         run: corepack enable
 
       - name: Deploy to Vercel (production)
-        working-directory: website
+        # Repo root, not website/: the Vercel root directory is resolved
+        # against the cwd (see deploy-docs.yml).
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
## Summary

Consolidated fixes for the CI breakages surfaced by the first post-merge runs on main:

- **Deploy Docs failed (ENOENT)**: `vercel build` ran from `website/`, but the Vercel project's root directory (`website/apps/bittensor-website`) is resolved against the CLI's cwd, doubling the path. Dropped `working-directory: website` from the staging deploy (`deploy-docs.yml`) and the production promotion (`watch-mainnet-release.yml`).
- **All three try-runtime snapshot jobs failed**: in `refresh-mainnet-snapshot.yml`, `create-snapshot --uri <ws> <name>.snap` fails because `--uri` is variadic and swallows the trailing snapshot path ("not a valid WS(S) url"). Moved the positional path before `--uri`. (The mainnet clone snapshot job in the same workflow succeeded and already published its artifact.)
- **ai-review-index-gittensor fails every scheduled run**: the pinned gittensor commit declares `requires-python >=3.12`; bumped the job's Python from 3.11 to 3.12 (pin unchanged).

Related cleanup handled outside this PR:
- #2845 closed as superseded — its prefetch.sh large-diff fallback and cargo-audit rework already landed on main via #2846.
- Benchmark weight drift needs no action — main already carries the reference-runner weights (5fc21c11a4).

## Test plan

- [ ] After merge, workflow_dispatch **Deploy Docs** → staging deploy succeeds
- [ ] After merge, workflow_dispatch **Refresh Mainnet Snapshot** → all four snapshot artifacts publish
- [ ] Next scheduled **ai-review-index-gittensor** run installs and indexes cleanly