### PR TITLE
sdk: declare readme and point Documentation at bittensor.com/docs

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -3,6 +3,13 @@
 A lean Python SDK and CLI for the Bittensor chain. One install gives you both a
 library (`import bittensor`) and a command line (`btcli`).
 
+**Documentation: [bittensor.com/docs](https://bittensor.com/docs)**
+
+This package supersedes the separate
+[`bittensor-cli`](https://pypi.org/project/bittensor-cli/) and
+[`bittensor-wallet`](https://pypi.org/project/bittensor-wallet/) packages:
+`btcli` and the wallet ship here.
+
 The design goal is a thin, unopinionated wrapper: easy, safe, and fast to do the
 core chain operations, with nothing hidden. It does **not** implement the neuron
 networking layer (axon/dendrite/synapse) — it is the layer that talks to the

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "hatchling.build"
 name = "bittensor"
 version = "11.0.0.dev0"
 description = "A lean Python SDK (import bittensor) and CLI (btcli) for the Bittensor chain."
+readme = "README.md"
 requires-python = ">=3.10,<3.14"
 license = { text = "Apache-2.0" }
 authors = [{ name = "RaoFoundation" }]
@@ -32,6 +33,10 @@ dependencies = [
 [project.optional-dependencies]
 evm = []
 cli = []
+
+[project.urls]
+Documentation = "https://bittensor.com/docs"
+Repository = "https://github.com/RaoFoundation/subtensor"
 
 [project.scripts]
 btcli = "bittensor.cli.main:main"


### PR DESCRIPTION
## Summary
- `sdk/python/pyproject.toml` never declared `readme`, so the first v11 upload would have rendered an **empty PyPI project page**; declare it.
- Add `Documentation` (https://bittensor.com/docs) and `Repository` project URLs so they appear in the PyPI sidebar.
- README now leads with the docs link and states that this package supersedes `bittensor-cli` and `bittensor-wallet` — those PyPI pages rank highly and need somewhere current to send people.

Docs/packaging metadata only; no code changes.

Made with [Cursor](https://cursor.com)