### PR TITLE
ci: fix first-run failures in the bittensor-core wheel matrix

### DIFF
--- a/.github/workflows/build-core-wheels.yml
+++ b/.github/workflows/build-core-wheels.yml
@@ -71,6 +71,11 @@ jobs:
       # that the CentOS-based manylinux images strip from their minimal perl;
       # the Ubuntu-based rust-cross images used for cross targets have a full
       # perl and take the no-op branch.
+      #
+      # manylinux 2_28 for the aarch64 cross build: the manylinux2014-cross
+      # image's gcc is too old for ring's ARMv8 assembly (#error "ARM
+      # assembler must define __ARM_ARCH"); the 2_28 image carries a modern
+      # gcc. x86_64 stays on auto (manylinux2014) for the wider glibc floor.
       - name: Build wheel (manylinux)
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
@@ -78,14 +83,24 @@ jobs:
           command: build
           args: --release --out ../../dist
           target: ${{ matrix.target }}
-          manylinux: auto
+          manylinux: ${{ matrix.target == 'aarch64' && '2_28' || 'auto' }}
           before-script-linux: |
             if command -v yum >/dev/null && ! perl -MIPC::Cmd -e 1 2>/dev/null; then
               yum install -y perl-core
             fi
 
       # The sdist is the fallback for platforms without a wheel; build it
-      # once, alongside the x86_64 wheel.
+      # once, alongside the x86_64 wheel. Unlike the wheel build (which runs
+      # inside the manylinux docker image), the sdist step runs on the bare
+      # runner, and the ephemeral fireactions VMs ship without rustup.
+      - name: Install rustup (host, sdist step only)
+        if: matrix.target == 'x86_64'
+        run: |
+          if ! command -v rustup >/dev/null; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          fi
+
       - name: Build sdist
         if: matrix.target == 'x86_64'
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1


### PR DESCRIPTION
## Summary
First real run of the rc wheel channel (release train run 29203488826) failed in both Linux jobs of `build-core-wheels.yml`:

- **aarch64**: `ring`'s ARMv8 assembly fails under the `manylinux: auto` (manylinux2014) cross image — its gcc predates `__ARM_ARCH`. Switch aarch64 to `manylinux: 2_28`, the same setting the btwallet wheel matrix publishes with. x86_64 stays on auto to keep the wider glibc floor.
- **x86_64 sdist**: the sdist step runs on the bare fireactions VM (the wheel build runs inside docker), and the VM ships without rustup. Install rustup with no default toolchain; `rust-toolchain.toml` still pins the version.

macOS jobs were already green.

## Test plan
- [ ] Fresh release train: `Build bittensor-core rc wheels` matrix green, rc published to PyPI.

Made with [Cursor](https://cursor.com)