### PR TITLE
ci: build the core sdist with uv instead of maturin-action

### DIFF
--- a/.github/workflows/build-core-wheels.yml
+++ b/.github/workflows/build-core-wheels.yml
@@ -90,24 +90,24 @@ jobs:
             fi
 
       # The sdist is the fallback for platforms without a wheel; build it
-      # once, alongside the x86_64 wheel. Unlike the wheel build (which runs
-      # inside the manylinux docker image), the sdist step runs on the bare
-      # runner, and the ephemeral fireactions VMs ship without rustup.
-      - name: Install rustup (host, sdist step only)
-        if: matrix.target == 'x86_64'
-        run: |
-          if ! command -v rustup >/dev/null; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
-            echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-          fi
-
+      # once, alongside the x86_64 wheel. Not via maturin-action: its native
+      # (non-docker) path pip-installs helpers into the system Python, which
+      # the runner's PEP 668 (externally-managed) Python refuses. uv runs
+      # maturin's PEP 517 sdist hook in an isolated env instead. maturin's
+      # sdist hook still shells out to `cargo metadata` (no compilation), so
+      # the pinned toolchain from rust-toolchain.toml is installed first.
       - name: Build sdist
         if: matrix.target == 'x86_64'
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
-        with:
-          working-directory: sdk/bittensor-core-py
-          command: sdist
-          args: --out ../../dist
+        working-directory: sdk/bittensor-core-py
+        run: |
+          if ! command -v cargo >/dev/null; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+            export PATH="$HOME/.cargo/bin:$PATH"
+            rustup toolchain install
+          fi
+          curl -LsSf https://astral.sh/uv/0.11.28/install.sh | sh
+          export PATH="$HOME/.local/bin:$PATH"
+          uv build --sdist --out-dir ../../dist
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
Second first-run failure mode in the core wheel matrix's sdist step (train run 29205459529): with rustup present, maturin-action's native path then does `python3 -m pip install cffi` / `patchelf` into the system interpreter, and the fireactions Ubuntu Python is PEP 668 externally-managed, so pip refuses. The aarch64 manylinux-2_28 fix from #2868 worked — that job went green.

Replace the maturin-action sdist step with `uv build --sdist` (isolated build env, same uv pin as the other workflows). rustup stays because maturin's sdist hook runs `cargo metadata` to resolve the workspace path dependencies. Verified locally: `uv build --sdist` in `sdk/bittensor-core-py` produces the sdist in ~4s.

## Test plan
- [ ] Fresh release train: all four wheel jobs + sdist green, rc published to PyPI.

Made with [Cursor](https://cursor.com)