### PR TITLE
ci: snapshot-cached runtime checks — split clone shards, required try-runtime snapshots, integrity manifests

### DIFF
--- a/.github/scripts/snapshot-artifact.sh
+++ b/.github/scripts/snapshot-artifact.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  snapshot-artifact.sh mode EVENT_NAME LABELS_JSON MANUAL_FRESH OUTPUT_FILE
+  snapshot-artifact.sh select ARTIFACT_NAME BRANCH REPOSITORY_ID MAX_AGE_HOURS OUTPUT_FILE [required|optional]
+  snapshot-artifact.sh download ARTIFACT_ID DIGEST DESTINATION
+  snapshot-artifact.sh validate MANIFEST_FILE SNAPSHOT_FILE NETWORK GENESIS_HASH CLI_VERSION
+
+For tests, set ARTIFACTS_JSON_FILE instead of calling the GitHub API,
+ARTIFACT_ZIP_FILE instead of downloading an artifact, and NOW_EPOCH to
+override the current time.
+EOF
+  exit 2
+}
+
+set_output() {
+  local output_file="$1"
+  local name="$2"
+  local value="$3"
+  printf '%s=%s\n' "$name" "$value" >> "$output_file"
+}
+
+file_size() {
+  stat -c '%s' "$1" 2>/dev/null || stat -f '%z' "$1"
+}
+
+resolve_mode() {
+  [[ $# -eq 4 ]] || usage
+  local event_name="$1"
+  local labels_json="$2"
+  local manual_fresh="$3"
+  local output_file="$4"
+  local fresh=false
+
+  [[ "$labels_json" != null ]] || labels_json='[]'
+  [[ "$manual_fresh" == true || "$manual_fresh" == false ]] || {
+    echo "invalid manual fresh-state value: $manual_fresh" >&2
+    exit 2
+  }
+  jq -e 'type == "array" and all(.[]; type == "string")' <<<"$labels_json" >/dev/null || {
+    echo "invalid labels JSON: $labels_json" >&2
+    exit 2
+  }
+
+  if [[ "$event_name" == pull_request ]] &&
+    jq -e 'index("fresh-try-runtime-state") != null' <<<"$labels_json" >/dev/null; then
+    fresh=true
+  elif [[ "$event_name" == workflow_dispatch && "$manual_fresh" == true ]]; then
+    fresh=true
+  fi
+
+  set_output "$output_file" fresh-state "$fresh"
+  if [[ "$fresh" == true ]]; then
+    echo "Explicit live-state bypass selected."
+  else
+    echo "Fail-closed cached-state mode selected."
+  fi
+}
+
+select_artifact() {
+  [[ $# -eq 6 ]] || usage
+  local artifact_name="$1"
+  local branch="$2"
+  local repository_id="$3"
+  local max_age_hours="$4"
+  local output_file="$5"
+  local requirement="$6"
+  local payload now candidate created_epoch age_seconds age_hours
+
+  [[ "$repository_id" =~ ^[0-9]+$ ]] || { echo "invalid repository id: $repository_id" >&2; exit 2; }
+  [[ "$max_age_hours" =~ ^[0-9]+$ ]] || { echo "invalid maximum age: $max_age_hours" >&2; exit 2; }
+  [[ "$requirement" == required || "$requirement" == optional ]] || usage
+
+  if [[ -n "${ARTIFACTS_JSON_FILE:-}" ]]; then
+    payload=$(<"$ARTIFACTS_JSON_FILE")
+  else
+    : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
+    payload=$(gh api \
+      "repos/$GITHUB_REPOSITORY/actions/artifacts?name=$artifact_name&per_page=100")
+  fi
+
+  now="${NOW_EPOCH:-$(date -u +%s)}"
+  [[ "$now" =~ ^[0-9]+$ ]] || { echo "invalid NOW_EPOCH: $now" >&2; exit 2; }
+
+  candidate=$(jq -cer \
+    --arg name "$artifact_name" \
+    --arg branch "$branch" \
+    --argjson repository_id "$repository_id" \
+    --argjson now "$now" \
+    --argjson max_age_seconds "$((max_age_hours * 3600))" '
+      [
+        .artifacts[]
+        | select(.name == $name)
+        | select(.expired == false)
+        | select(.workflow_run.head_branch == $branch)
+        | select(.workflow_run.repository_id == $repository_id)
+        | select(.workflow_run.head_repository_id == $repository_id)
+        | .created_epoch = (.created_at | fromdateiso8601)
+        | select(.created_epoch <= $now)
+        | select(($now - .created_epoch) <= $max_age_seconds)
+      ]
+      | sort_by(.created_epoch)
+      | last // empty
+    ' <<<"$payload" 2>/dev/null || true)
+
+  if [[ -z "$candidate" ]]; then
+    set_output "$output_file" found false
+    if [[ "$requirement" == optional ]]; then
+      echo "No usable $artifact_name artifact found; optional restore will be skipped."
+      return 0
+    fi
+    echo "::error::No non-expired $artifact_name artifact from $branch is at most ${max_age_hours}h old. Dispatch Refresh Mainnet Snapshot, or explicitly request fresh live state."
+    return 1
+  fi
+
+  created_epoch=$(jq -er '.created_epoch' <<<"$candidate")
+  age_seconds=$((now - created_epoch))
+  age_hours=$((age_seconds / 3600))
+
+  set_output "$output_file" found true
+  set_output "$output_file" artifact-id "$(jq -er '.id' <<<"$candidate")"
+  set_output "$output_file" run-id "$(jq -er '.workflow_run.id' <<<"$candidate")"
+  set_output "$output_file" created-at "$(jq -er '.created_at' <<<"$candidate")"
+  set_output "$output_file" age-hours "$age_hours"
+  set_output "$output_file" size-bytes "$(jq -er '.size_in_bytes' <<<"$candidate")"
+  set_output "$output_file" digest "$(jq -er '.digest // ""' <<<"$candidate")"
+
+  if ((age_seconds > 36 * 3600)); then
+    echo "::warning::$artifact_name is ${age_hours}h old; refresh is expected daily and this artifact becomes unusable after ${max_age_hours}h."
+  fi
+  echo "Selected $artifact_name artifact $(jq -er '.id' <<<"$candidate") from run $(jq -er '.workflow_run.id' <<<"$candidate") (${age_hours}h old)."
+}
+
+download_artifact() {
+  [[ $# -eq 3 ]] || usage
+  local artifact_id="$1"
+  local digest="$2"
+  local destination="$3"
+  local archive actual_digest
+
+  [[ "$artifact_id" =~ ^[0-9]+$ ]] || { echo "invalid artifact id: $artifact_id" >&2; exit 2; }
+  [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]] || { echo "invalid artifact digest: $digest" >&2; exit 2; }
+
+  archive=$(mktemp)
+  trap 'rm -f "$archive"' RETURN
+  if [[ -n "${ARTIFACT_ZIP_FILE:-}" ]]; then
+    cp "$ARTIFACT_ZIP_FILE" "$archive"
+  else
+    : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
+    gh api \
+      -H 'Accept: application/vnd.github+json' \
+      "repos/$GITHUB_REPOSITORY/actions/artifacts/$artifact_id/zip" > "$archive"
+  fi
+
+  actual_digest="sha256:$(sha256sum "$archive" | awk '{print $1}')"
+  [[ "$actual_digest" == "$digest" ]] || {
+    echo "artifact archive checksum mismatch: expected $digest, got $actual_digest" >&2
+    exit 1
+  }
+  mkdir -p "$destination"
+  unzip -q "$archive" -d "$destination"
+  rm -f "$archive"
+  trap - RETURN
+  echo "Downloaded and verified artifact $artifact_id."
+}
+
+validate_manifest() {
+  [[ $# -eq 5 ]] || usage
+  local manifest_file="$1"
+  local snapshot_file="$2"
+  local network="$3"
+  local genesis_hash="$4"
+  local cli_version="$5"
+  local expected_file expected_size expected_sha actual_size actual_sha
+
+  [[ -f "$manifest_file" ]] || { echo "missing snapshot manifest: $manifest_file" >&2; exit 1; }
+  [[ -f "$snapshot_file" ]] || { echo "missing snapshot file: $snapshot_file" >&2; exit 1; }
+
+  jq -e \
+    --arg network "$network" \
+    --arg genesis "$genesis_hash" \
+    --arg cli "$cli_version" '
+      .schema_version == 1 and
+      .kind == "try-runtime-state" and
+      .network == $network and
+      .genesis_hash == $genesis and
+      .try_runtime_cli_version == $cli and
+      (.finalized_block_hash | test("^0x[0-9a-f]{64}$")) and
+      (.finalized_block_number | type == "number") and
+      (.source_spec_name | type == "string" and length > 0) and
+      (.source_spec_version | type == "number") and
+      (.created_at | fromdateiso8601 | type == "number") and
+      (.producer_sha | test("^[0-9a-f]{40}$")) and
+      (.snapshot_file | type == "string" and length > 0) and
+      (.snapshot_size_bytes | type == "number") and
+      (.snapshot_sha256 | test("^[0-9a-f]{64}$"))
+    ' "$manifest_file" >/dev/null || {
+      echo "snapshot manifest contract validation failed: $manifest_file" >&2
+      exit 1
+    }
+
+  expected_file=$(jq -er '.snapshot_file' "$manifest_file")
+  [[ "$expected_file" == "$(basename "$snapshot_file")" ]] || {
+    echo "manifest expects $expected_file, downloaded $(basename "$snapshot_file")" >&2
+    exit 1
+  }
+
+  expected_size=$(jq -er '.snapshot_size_bytes' "$manifest_file")
+  actual_size=$(file_size "$snapshot_file")
+  [[ "$actual_size" == "$expected_size" ]] || {
+    echo "snapshot size mismatch: expected $expected_size, got $actual_size" >&2
+    exit 1
+  }
+
+  expected_sha=$(jq -er '.snapshot_sha256' "$manifest_file")
+  actual_sha=$(sha256sum "$snapshot_file" | awk '{print $1}')
+  [[ "$actual_sha" == "$expected_sha" ]] || {
+    echo "snapshot checksum mismatch: expected $expected_sha, got $actual_sha" >&2
+    exit 1
+  }
+
+  echo "Validated $network snapshot at block $(jq -er '.finalized_block_number' "$manifest_file") ($(jq -er '.finalized_block_hash' "$manifest_file"))."
+}
+
+command="${1:-}"
+shift || true
+case "$command" in
+  mode) resolve_mode "$@" ;;
+  select) select_artifact "$@" ;;
+  download) download_artifact "$@" ;;
+  validate) validate_manifest "$@" ;;
+  *) usage ;;
+esac

--- a/.github/scripts/test-snapshot-artifact.sh
+++ b/.github/scripts/test-snapshot-artifact.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+helper="$script_dir/snapshot-artifact.sh"
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+# Use jq's own timestamp conversion so boundary tests remain stable on both
+# GNU/Linux and macOS, whose jq builds differ in local-time handling.
+now=$(jq -nr '"2026-07-12T14:00:00Z" | fromdateiso8601')
+repo_id=608683796
+
+write_artifacts() {
+  jq -n --argjson artifacts "$1" '{artifacts: $artifacts}' > "$tmp/artifacts.json"
+}
+
+artifact() {
+  local id="$1" name="$2" created="$3" branch="$4" repository_id="$5" expired="$6" run_id="$7"
+  jq -nc \
+    --argjson id "$id" --arg name "$name" --arg created "$created" --arg branch "$branch" \
+    --argjson repository_id "$repository_id" --argjson expired "$expired" --argjson run_id "$run_id" '
+      {
+        id: $id,
+        name: $name,
+        size_in_bytes: 1234,
+        expired: $expired,
+        digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        created_at: $created,
+        workflow_run: {
+          id: $run_id,
+          repository_id: $repository_id,
+          head_repository_id: $repository_id,
+          head_branch: $branch
+        }
+      }
+    '
+}
+
+select_fixture() {
+  local requirement="${1:-required}"
+  local output="$tmp/output"
+  local status=0
+  : > "$output"
+  ARTIFACTS_JSON_FILE="$tmp/artifacts.json" NOW_EPOCH="$now" \
+    "$helper" select try-runtime-snap-v0.10.1-mainnet main "$repo_id" 72 "$output" "$requirement" || status=$?
+  cat "$output"
+  return "$status"
+}
+
+mode_fixture() {
+  local event_name="$1" labels_json="$2" manual_fresh="$3"
+  local output="$tmp/mode-output"
+  : > "$output"
+  "$helper" mode "$event_name" "$labels_json" "$manual_fresh" "$output" >/dev/null
+  cat "$output"
+}
+
+# Live state is reachable only through the established PR label or the manual
+# workflow input. All other event/input combinations stay fail-closed.
+grep -qx 'fresh-state=true' <<<"$(mode_fixture pull_request '["fresh-try-runtime-state"]' false)"
+grep -qx 'fresh-state=true' <<<"$(mode_fixture workflow_dispatch '[]' true)"
+grep -qx 'fresh-state=false' <<<"$(mode_fixture pull_request '[]' false)"
+grep -qx 'fresh-state=false' <<<"$(mode_fixture workflow_dispatch '[]' false)"
+grep -qx 'fresh-state=false' <<<"$(mode_fixture schedule null false)"
+
+# Newest valid main-branch artifact wins even though the artifact payload does
+# not expose (and therefore does not depend on) the producer run conclusion.
+valid_old=$(artifact 11 try-runtime-snap-v0.10.1-mainnet 2026-07-11T02:00:00Z main "$repo_id" false 101)
+# The artifacts API intentionally has no producer conclusion dependency. This
+# synthetic marker models an artifact uploaded before a sibling matrix job
+# failed; selection must still use the independently successful artifact.
+valid_new=$(artifact 12 try-runtime-snap-v0.10.1-mainnet 2026-07-12T02:00:00Z main "$repo_id" false 102 \
+  | jq -c '.producer_conclusion = "failure"')
+wrong_branch=$(artifact 13 try-runtime-snap-v0.10.1-mainnet 2026-07-12T13:00:00Z feature "$repo_id" false 103)
+wrong_repo=$(artifact 14 try-runtime-snap-v0.10.1-mainnet 2026-07-12T13:30:00Z main 999 false 104)
+expired=$(artifact 15 try-runtime-snap-v0.10.1-mainnet 2026-07-12T13:45:00Z main "$repo_id" true 105)
+write_artifacts "$(jq -nc --argjson a "$valid_old" --argjson b "$valid_new" --argjson c "$wrong_branch" --argjson d "$wrong_repo" --argjson e "$expired" '[ $a, $b, $c, $d, $e ]')"
+selected=$(select_fixture)
+grep -qx 'artifact-id=12' <<<"$selected"
+grep -qx 'run-id=102' <<<"$selected"
+
+# The selected immutable artifact ID is downloaded as its archive, verified
+# against the API digest, and only then extracted.
+mkdir -p "$tmp/archive-input"
+printf 'artifact payload' > "$tmp/archive-input/payload.txt"
+(cd "$tmp/archive-input" && zip -q "$tmp/artifact.zip" payload.txt)
+archive_digest="sha256:$(sha256sum "$tmp/artifact.zip" | awk '{print $1}')"
+ARTIFACT_ZIP_FILE="$tmp/artifact.zip" \
+  "$helper" download 12 "$archive_digest" "$tmp/downloaded" >/dev/null
+grep -qx 'artifact payload' "$tmp/downloaded/payload.txt"
+if ARTIFACT_ZIP_FILE="$tmp/artifact.zip" \
+  "$helper" download 12 sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
+    "$tmp/bad-download" >/dev/null 2>&1; then
+  echo "expected artifact archive checksum mismatch to fail" >&2
+  exit 1
+fi
+
+# Exactly 72 hours is accepted, one second older fails, and optional lookup
+# reports a miss. An artifact older than 36 hours remains usable with a warning.
+at_boundary=$(artifact 19 try-runtime-snap-v0.10.1-mainnet 2026-07-09T14:00:00Z main "$repo_id" false 199)
+write_artifacts "[$at_boundary]"
+boundary=$(select_fixture)
+grep -qx 'artifact-id=19' <<<"$boundary"
+
+warning_age=$(artifact 18 try-runtime-snap-v0.10.1-mainnet 2026-07-11T01:59:59Z main "$repo_id" false 198)
+write_artifacts "[$warning_age]"
+warning_output="$tmp/warning-output"
+: > "$warning_output"
+warning_log=$(ARTIFACTS_JSON_FILE="$tmp/artifacts.json" NOW_EPOCH="$now" \
+  "$helper" select try-runtime-snap-v0.10.1-mainnet main "$repo_id" 72 "$warning_output" required)
+grep -q '^::warning::' <<<"$warning_log"
+
+too_old=$(artifact 20 try-runtime-snap-v0.10.1-mainnet 2026-07-09T13:59:59Z main "$repo_id" false 200)
+write_artifacts "[$too_old]"
+if select_fixture required >/dev/null 2>&1; then
+  echo "expected required stale lookup to fail" >&2
+  exit 1
+fi
+optional=$(select_fixture optional)
+grep -qx 'found=false' <<<"$optional"
+
+# Validate a complete manifest, then prove identity, size, and checksum failures are rejected.
+printf 'snapshot payload' > "$tmp/mainnet.snap"
+size=$(stat -c '%s' "$tmp/mainnet.snap" 2>/dev/null || stat -f '%z' "$tmp/mainnet.snap")
+sha=$(sha256sum "$tmp/mainnet.snap" | awk '{print $1}')
+jq -n \
+  --arg sha "$sha" --argjson size "$size" '
+    {
+      schema_version: 1,
+      kind: "try-runtime-state",
+      network: "mainnet",
+      genesis_hash: "0x2f0555cc76fc2840a25a6ea3b9637146806f1f44b090c175ffde2a7e5ab36c03",
+      finalized_block_hash: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      finalized_block_number: 123,
+      source_spec_name: "node-subtensor",
+      source_spec_version: 428,
+      try_runtime_cli_version: "0.10.1",
+      created_at: "2026-07-12T02:00:00Z",
+      producer_sha: "647ca2b0493ed5c74399b73f2595643ba785c1b8",
+      snapshot_file: "mainnet.snap",
+      snapshot_size_bytes: $size,
+      snapshot_sha256: $sha
+    }
+  ' > "$tmp/mainnet.manifest.json"
+
+"$helper" validate "$tmp/mainnet.manifest.json" "$tmp/mainnet.snap" mainnet \
+  0x2f0555cc76fc2840a25a6ea3b9637146806f1f44b090c175ffde2a7e5ab36c03 0.10.1 >/dev/null
+
+if "$helper" validate "$tmp/mainnet.manifest.json" "$tmp/mainnet.snap" testnet \
+  0x2f0555cc76fc2840a25a6ea3b9637146806f1f44b090c175ffde2a7e5ab36c03 0.10.1 >/dev/null 2>&1; then
+  echo "expected network mismatch to fail" >&2
+  exit 1
+fi
+
+printf 'corrupt' >> "$tmp/mainnet.snap"
+if "$helper" validate "$tmp/mainnet.manifest.json" "$tmp/mainnet.snap" mainnet \
+  0x2f0555cc76fc2840a25a6ea3b9637146806f1f44b090c175ffde2a7e5ab36c03 0.10.1 >/dev/null 2>&1; then
+  echo "expected checksum/size mismatch to fail" >&2
+  exit 1
+fi
+
+echo "snapshot artifact helper tests passed"

--- a/.github/workflows/refresh-mainnet-snapshot.yml
+++ b/.github/workflows/refresh-mainnet-snapshot.yml
@@ -11,8 +11,8 @@ name: Refresh Mainnet Snapshot
 #     snap`, replacing each job's own 30-40 min `live --uri` scrape.
 #
 # Security: PR jobs only consume snapshots produced by runs of this workflow
-# on the default branch (schedule and dispatch both execute main's code), so a
-# PR can never feed a poisoned snapshot to another PR. Day-old network state
+# on the default branch, so a PR can never feed a poisoned snapshot to another
+# PR. Day-old network state
 # is just as representative for an upgrade test as live state — and a pinned
 # snapshot is more reproducible than a fresh scrape. A PR that changes the
 # spec-patching logic itself (node/src/clone_spec.rs) can apply the
@@ -22,6 +22,11 @@ on:
   schedule:
     - cron: "0 2 * * *"
   workflow_dispatch:
+    inputs:
+      try_runtime_only:
+        description: "Generate only try-runtime snapshots (measurement/debugging)"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -32,10 +37,12 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  TRY_RUNTIME_VERSION: "0.10.1"
 
 jobs:
   snapshot:
     name: scrape mainnet and publish snapshot
+    if: github.event_name != 'workflow_dispatch' || !inputs.try_runtime_only
     runs-on: [self-hosted, fireactions-turbo-8]
     environment:
       name: ${{ github.event_name == 'workflow_dispatch' && 'sccache-reader' || 'sccache-writer' }}
@@ -103,12 +110,12 @@ jobs:
           name: mainnet-snapshot
           path: mainnet-snapshot.tar.gz
           if-no-files-found: error
-          retention-days: 3
+          retention-days: 7
           # The tarball is already gzipped.
           compression-level: 0
 
-  # try-runtime state snapshots, one job per network so the scrapes run in
-  # parallel and one flaky endpoint doesn't sink the others. The .snap format
+  # try-runtime state snapshots, one job per network so one flaky endpoint
+  # doesn't prevent the others from publishing. The .snap format
   # is tied to the try-runtime-cli release, so this version must match the
   # consumer pin in runtime-checks.yml.
   try-runtime-snapshot:
@@ -117,57 +124,125 @@ jobs:
     timeout-minutes: 90
     strategy:
       fail-fast: false
+      # The shared pool has enough capacity for the three PR consumers. Keep
+      # the off-critical-path producer to one slot so a refresh cannot crowd
+      # those consumers out.
+      max-parallel: 1
       matrix:
         network:
           # Same endpoints and genesis-hash identity checks as the try-runtime
           # consumer jobs (the hostnames are misleading; see runtime-checks.yml).
-          - name: devnet
-            uri: wss://dev.chain.opentensor.ai:443
-            genesis: "0x077899043eb684c5277b6814a39161f4ce072b45e782e12c81a521c63fb4f3e5"
-          - name: testnet
-            uri: wss://archive.dev.opentensor.ai:8443
-            genesis: "0x8f9cf856bf558a14440e75569c9e58594757048d7b3a84b5d25f6bd978263105"
           - name: mainnet
             uri: wss://archive.dev.opentensor.ai:443
             genesis: "0x2f0555cc76fc2840a25a6ea3b9637146806f1f44b090c175ffde2a7e5ab36c03"
+          - name: testnet
+            uri: wss://archive.dev.opentensor.ai:8443
+            genesis: "0x8f9cf856bf558a14440e75569c9e58594757048d7b3a84b5d25f6bd978263105"
+          - name: devnet
+            uri: wss://dev.chain.opentensor.ai:443
+            genesis: "0x077899043eb684c5277b6814a39161f4ce072b45e782e12c81a521c63fb4f3e5"
     steps:
-      - name: Verify endpoint serves the expected network
+      - name: Resolve and verify finalized source state
+        id: source
         run: |
+          set -euo pipefail
           http_uri="${{ matrix.network.uri }}"
           http_uri="${http_uri/wss:/https:}"
-          genesis=$(curl -sS -m 30 -H 'Content-Type: application/json' \
-            -d '{"id":1,"jsonrpc":"2.0","method":"chain_getBlockHash","params":[0]}' \
-            "$http_uri" | sed -n 's/.*"result":"\(0x[0-9a-f]*\)".*/\1/p')
+          rpc() {
+            curl -fsS -m 30 -H 'Content-Type: application/json' -d "$1" "$http_uri"
+          }
+          genesis=$(rpc \
+            '{"id":1,"jsonrpc":"2.0","method":"chain_getBlockHash","params":[0]}' \
+            | jq -er '.result')
           echo "endpoint genesis: $genesis"
           if [ "$genesis" != "${{ matrix.network.genesis }}" ]; then
             echo "::error::${{ matrix.network.name }} endpoint $http_uri serves genesis $genesis, expected ${{ matrix.network.genesis }}"
             exit 1
           fi
 
-      - name: Download try-runtime-cli v0.10.1
+          finalized_hash=$(rpc \
+            '{"id":1,"jsonrpc":"2.0","method":"chain_getFinalizedHead","params":[]}' \
+            | jq -er '.result')
+          header=$(rpc \
+            "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"chain_getHeader\",\"params\":[\"$finalized_hash\"]}")
+          number_hex=$(jq -er '.result.number' <<< "$header")
+          finalized_number=$((16#${number_hex#0x}))
+          runtime_version=$(rpc \
+            "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"state_getRuntimeVersion\",\"params\":[\"$finalized_hash\"]}")
+          spec_name=$(jq -er '.result.specName' <<< "$runtime_version")
+          spec_version=$(jq -er '.result.specVersion' <<< "$runtime_version")
+
+          echo "finalized block: $finalized_number ($finalized_hash)"
+          echo "runtime: $spec_name/$spec_version"
+          {
+            echo "block-hash=$finalized_hash"
+            echo "block-number=$finalized_number"
+            echo "spec-name=$spec_name"
+            echo "spec-version=$spec_version"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Download try-runtime-cli v${{ env.TRY_RUNTIME_VERSION }}
         run: |
           TRY_RUNTIME_BIN="$RUNNER_TEMP/try-runtime"
           curl --fail --silent --show-error --location \
-            "https://github.com/paritytech/try-runtime-cli/releases/download/v0.10.1/try-runtime-x86_64-unknown-linux-musl" \
+            "https://github.com/paritytech/try-runtime-cli/releases/download/v${TRY_RUNTIME_VERSION}/try-runtime-x86_64-unknown-linux-musl" \
             --output "$TRY_RUNTIME_BIN"
           chmod +x "$TRY_RUNTIME_BIN"
           echo "TRY_RUNTIME_BIN=$TRY_RUNTIME_BIN" >> "$GITHUB_ENV"
 
       - name: Create state snapshot
         run: |
+          set -euo pipefail
           export RUST_LOG=remote-ext=debug
-          # The snapshot path must precede --uri: --uri is variadic in
-          # try-runtime-cli, so a trailing positional gets consumed as a
-          # second URI value and fails validation.
+          snapshot="${{ matrix.network.name }}.snap"
+          manifest="${{ matrix.network.name }}.manifest.json"
+          # The positional path must precede --uri because --uri is variadic.
           "$TRY_RUNTIME_BIN" create-snapshot \
-            "${{ matrix.network.name }}.snap" \
-            --uri "${{ matrix.network.uri }}"
-          ls -lh "${{ matrix.network.name }}.snap"
+            "$snapshot" \
+            --uri "${{ matrix.network.uri }}" \
+            --at "${{ steps.source.outputs.block-hash }}"
+
+          snapshot_size=$(stat -c '%s' "$snapshot")
+          snapshot_sha=$(sha256sum "$snapshot" | awk '{print $1}')
+          created_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          jq -n \
+            --arg network "${{ matrix.network.name }}" \
+            --arg genesis "${{ matrix.network.genesis }}" \
+            --arg block_hash "${{ steps.source.outputs.block-hash }}" \
+            --argjson block_number "${{ steps.source.outputs.block-number }}" \
+            --arg spec_name "${{ steps.source.outputs.spec-name }}" \
+            --argjson spec_version "${{ steps.source.outputs.spec-version }}" \
+            --arg cli_version "$TRY_RUNTIME_VERSION" \
+            --arg created_at "$created_at" \
+            --arg producer_sha "$GITHUB_SHA" \
+            --arg snapshot_file "$snapshot" \
+            --argjson snapshot_size "$snapshot_size" \
+            --arg snapshot_sha "$snapshot_sha" '
+              {
+                schema_version: 1,
+                kind: "try-runtime-state",
+                network: $network,
+                genesis_hash: $genesis,
+                finalized_block_hash: $block_hash,
+                finalized_block_number: $block_number,
+                source_spec_name: $spec_name,
+                source_spec_version: $spec_version,
+                try_runtime_cli_version: $cli_version,
+                created_at: $created_at,
+                producer_sha: $producer_sha,
+                snapshot_file: $snapshot_file,
+                snapshot_size_bytes: $snapshot_size,
+                snapshot_sha256: $snapshot_sha
+              }
+            ' > "$manifest"
+          ls -lh "$snapshot" "$manifest"
 
       - name: Upload snapshot artifact
         uses: actions/upload-artifact@v4
         with:
-          name: try-runtime-snap-${{ matrix.network.name }}
-          path: ${{ matrix.network.name }}.snap
+          name: try-runtime-snap-v${{ env.TRY_RUNTIME_VERSION }}-${{ matrix.network.name }}
+          path: |
+            ${{ matrix.network.name }}.snap
+            ${{ matrix.network.name }}.manifest.json
           if-no-files-found: error
-          retention-days: 3
+          retention-days: 7

--- a/.github/workflows/runtime-checks.yml
+++ b/.github/workflows/runtime-checks.yml
@@ -1,9 +1,9 @@
 name: Runtime Checks
 
-# Build-once, fan-out gate for every PR: one job compiles the runtime wasm and
-# the release node binary, then try-runtime (devnet/testnet/mainnet), the
-# spec-version comparison, and the mainnet clone-upgrade suite all consume the
-# artifacts instead of rebuilding. Consolidates the former try-runtime.yml,
+# Build-artifacts-once, fan-out gate for every PR: independent jobs compile the
+# runtime wasm and release node in parallel, then try-runtime
+# (devnet/testnet/mainnet), the spec-version comparison, and the mainnet
+# clone-upgrade suite consume the artifacts instead of rebuilding. Consolidates the former try-runtime.yml,
 # check-spec-version.yml, and check-clone-upgrade.yml (artifacts are scoped to
 # a single workflow run, so the fan-out jobs must live in one file).
 
@@ -11,6 +11,19 @@ on:
   pull_request:
     types: [labeled, unlabeled, synchronize, opened, reopened]
   workflow_dispatch:
+    inputs:
+      fresh_state:
+        description: "Bypass cached try-runtime snapshots and scrape all networks live"
+        type: boolean
+        default: false
+      snapshot_source_branch:
+        description: "Trusted snapshot artifact branch (manual measurement only)"
+        type: string
+        default: main
+      try_runtime_only:
+        description: "Run only the try-runtime build and cached network checks"
+        type: boolean
+        default: false
 
 concurrency:
   group: runtime-checks-${{ github.ref }}
@@ -20,6 +33,7 @@ env:
   CARGO_TERM_COLOR: always
   WS_ENDPOINT: ws://127.0.0.1:9944
   MAINNET_RPC: https://entrypoint-finney.opentensor.ai
+  TRY_RUNTIME_VERSION: "0.10.1"
 
 jobs:
   # Fork PRs must not run on self-hosted runners — checkout executes untrusted
@@ -46,6 +60,7 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
       python_sdk: ${{ steps.filter.outputs.python_sdk }}
       sdk_drift: ${{ steps.filter.outputs.sdk_drift }}
+      snapshot_ci: ${{ steps.filter.outputs.snapshot_ci }}
     steps:
       # Plain gh-api file listing instead of a marketplace action: the org's
       # Actions allowlist rejects unlisted third-party actions (startup_failure).
@@ -60,38 +75,45 @@ jobs:
           files=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[].filename')
           # SDK-only changes are covered by sdk-checks and the Rust SDK e2e
           # workflow; they should not force clone-upgrade or SDK drift.
-          runtime_pattern='^(common|node|pallets|precompiles|primitives|runtime|support|chain-extensions|src|vendor|clones)/|^(Cargo\.toml|build\.rs|rust-toolchain\.toml)$|^website/apps/bittensor-website/scripts/|^\.github/(workflows/runtime-checks\.yml|actions/(rust-setup|sccache-setup)/|scripts/sccache-configure\.sh$)'
+          runtime_pattern='^(common|node|pallets|precompiles|primitives|runtime|support|chain-extensions|src|vendor|clones)/|^(Cargo\.toml|build\.rs|rust-toolchain\.toml)$|^website/apps/bittensor-website/scripts/|^\.github/(workflows/(runtime-checks|refresh-mainnet-snapshot)\.yml|actions/(rust-setup|sccache-setup)/|scripts/(sccache-configure|snapshot-artifact|test-snapshot-artifact)\.sh$)'
           docs_pattern='^website/|^sdk/python/|^\.github/workflows/runtime-checks\.yml$'
           python_sdk_pattern='^sdk/(python|bittensor-core|bittensor-core-py|bittensor-core-wasm)/|^Cargo.lock$|^\.github/workflows/runtime-checks\.yml$'
           sdk_drift_pattern='^(common|node|pallets|precompiles|primitives|runtime|support|chain-extensions|src|vendor)/|^(Cargo\.toml|build\.rs|rust-toolchain\.toml)$'
-          runtime=false; docs=false; python_sdk=false; sdk_drift=false
+          snapshot_pattern='^\.github/(workflows/(runtime-checks|refresh-mainnet-snapshot)\.yml|scripts/(snapshot-artifact|test-snapshot-artifact)\.sh)$'
+          runtime=false; docs=false; python_sdk=false; sdk_drift=false; snapshot_ci=false
           grep -qE "$runtime_pattern" <<< "$files" && runtime=true
           grep -qE "$docs_pattern" <<< "$files" && docs=true
           grep -qE "$python_sdk_pattern" <<< "$files" && python_sdk=true
           grep -qE "$sdk_drift_pattern" <<< "$files" && sdk_drift=true
-          echo "runtime=$runtime, docs=$docs, python_sdk=$python_sdk, sdk_drift=$sdk_drift"
+          grep -qE "$snapshot_pattern" <<< "$files" && snapshot_ci=true
+          echo "runtime=$runtime, docs=$docs, python_sdk=$python_sdk, sdk_drift=$sdk_drift, snapshot_ci=$snapshot_ci"
           {
             echo "runtime=$runtime"
             echo "docs=$docs"
             echo "python_sdk=$python_sdk"
             echo "sdk_drift=$sdk_drift"
+            echo "snapshot_ci=$snapshot_ci"
           } >> "$GITHUB_OUTPUT"
 
-  # The single compile of this workflow. Two artifacts:
-  #   try-runtime-wasm — production profile + try-runtime feature, used by the
-  #     three try-runtime network checks.
-  #   node-release — release node binary + its wbuild runtime wasm, used by
-  #     the clone-upgrade suite (start-local-clone.sh expects the binary at
-  #     target/release/node-subtensor; update-runtime-with-alice.ts expects the
-  #     wasm at target/release/wbuild/node-subtensor-runtime/).
-  build:
-    name: build runtime artifacts
+  snapshot-artifact-tests:
+    name: snapshot artifact contract tests
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.snapshot_ci == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: .github/scripts/test-snapshot-artifact.sh
+
+  # Build the try-runtime wasm independently so its consumers do not wait for
+  # the unrelated release node build. The source check also makes the
+  # --disable-mbm-checks optimization self-disabling when MBMs are introduced.
+  build-try-runtime:
+    name: build try-runtime wasm
     needs: [trusted-pr, changes]
     if: github.event_name != 'pull_request' || needs.changes.outputs.runtime == 'true'
-    # Keep this build on the reserved 16-core turbo lane: it gates every
-    # try-runtime check and clone shard. General and background work uses the
-    # 8-core pool so it cannot consume this critical-path capacity.
     runs-on: [self-hosted, fireactions-turbo-16]
+    outputs:
+      mbm_args: ${{ steps.mbm.outputs.args }}
     environment:
       name: ${{ github.event_name == 'workflow_dispatch' && 'sccache-reader' || 'sccache-writer' }}
       deployment: false
@@ -113,11 +135,25 @@ jobs:
           rustup target add wasm32-unknown-unknown
           rustup component add rust-src
 
+      - name: Detect multi-block migration configuration
+        id: mbm
+        run: |
+          set -euo pipefail
+          definitions=$(grep -cE '^[[:space:]]*type MultiBlockMigrator[[:space:]]*=' runtime/src/lib.rs || true)
+          if [ "$definitions" -ne 1 ]; then
+            echo "::error::expected exactly one MultiBlockMigrator definition, found $definitions"
+            exit 1
+          fi
+          if grep -qE '^[[:space:]]*type MultiBlockMigrator[[:space:]]*=[[:space:]]*\(\)[[:space:]]*;' runtime/src/lib.rs; then
+            echo "args=--disable-mbm-checks" >> "$GITHUB_OUTPUT"
+            echo "No multi-block migrator configured; duplicate MBM state loading will be disabled."
+          else
+            echo "args=" >> "$GITHUB_OUTPUT"
+            echo "Multi-block migrator configured; retaining the full MBM execution path."
+          fi
+
       - name: Build runtime wasm (production, try-runtime feature)
         run: cargo build --profile production -p node-subtensor-runtime --features try-runtime -q --locked
-
-      - name: Build node-subtensor (release)
-        run: cargo build --release -p node-subtensor
 
       - name: Upload try-runtime wasm
         uses: actions/upload-artifact@v4
@@ -126,6 +162,40 @@ jobs:
           path: target/production/wbuild/node-subtensor-runtime/node_subtensor_runtime.compact.compressed.wasm
           if-no-files-found: error
           retention-days: 3
+
+  # Release node + its wbuild runtime wasm, used only by clone-upgrade.
+  # start-local-clone.sh expects the binary at target/release/node-subtensor;
+  # update-runtime-with-alice.ts expects the wasm under target/release/wbuild.
+  build-node-release:
+    name: build release node
+    needs: [trusted-pr, changes]
+    if: >-
+      (github.event_name != 'pull_request' || needs.changes.outputs.runtime == 'true') &&
+      !(github.event_name == 'workflow_dispatch' && inputs.try_runtime_only)
+    runs-on: [self-hosted, fireactions-turbo-8]
+    environment:
+      name: ${{ github.event_name == 'workflow_dispatch' && 'sccache-reader' || 'sccache-writer' }}
+      deployment: false
+    timeout-minutes: 60
+    env:
+      RUST_BACKTRACE: full
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/rust-setup
+        with:
+          cache-key: runtime-checks-node
+          sccache-credential-mode: auto
+          sccache-writer-access-key-id: ${{ secrets.SCCACHE_R2_WRITE_ACCESS_KEY_ID }}
+          sccache-writer-secret-access-key: ${{ secrets.SCCACHE_R2_WRITE_SECRET_ACCESS_KEY }}
+
+      - name: Add wasm target and rust-src
+        run: |
+          rustup target add wasm32-unknown-unknown
+          rustup component add rust-src
+
+      - name: Build node-subtensor (release)
+        run: cargo build --release -p node-subtensor
 
       - name: Upload release node + runtime wasm
         uses: actions/upload-artifact@v4
@@ -137,12 +207,12 @@ jobs:
           if-no-files-found: error
           retention-days: 3
 
-  # For every PR: run try-runtime's on-runtime-upgrade checks against the
-  # current state of each live network, using the shared wasm artifact and the
-  # prebuilt try-runtime-cli — no Rust toolchain on these runners.
+  # For every PR: run try-runtime's on-runtime-upgrade checks against a recent,
+  # finalized snapshot of each network. Live state is an explicit diagnostic
+  # bypass only; cached jobs never contact a network endpoint.
   try-runtime:
     name: try-runtime ${{ matrix.network.name }}
-    needs: build
+    needs: build-try-runtime
     runs-on: [self-hosted, fireactions-tryruntime]
     permissions:
       contents: read
@@ -170,7 +240,20 @@ jobs:
             uri: wss://archive.dev.opentensor.ai:443
             genesis: "0x2f0555cc76fc2840a25a6ea3b9637146806f1f44b090c175ffde2a7e5ab36c03"
     steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve cached or fresh state mode
+        id: state-mode
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          MANUAL_FRESH: ${{ inputs.fresh_state || false }}
+        run: |
+          .github/scripts/snapshot-artifact.sh mode \
+            "$EVENT_NAME" "$LABELS_JSON" "$MANUAL_FRESH" "$GITHUB_OUTPUT"
+
       - name: Verify endpoint serves the expected network
+        if: steps.state-mode.outputs.fresh-state == 'true'
         run: |
           http_uri="${{ matrix.network.uri }}"
           http_uri="${http_uri/wss:/https:}"
@@ -189,11 +272,11 @@ jobs:
           name: try-runtime-wasm
           path: runtime-blob
 
-      - name: Download try-runtime-cli v0.10.1
+      - name: Download try-runtime-cli v${{ env.TRY_RUNTIME_VERSION }}
         run: |
           TRY_RUNTIME_BIN="$RUNNER_TEMP/try-runtime"
           curl --fail --silent --show-error --location \
-            "https://github.com/paritytech/try-runtime-cli/releases/download/v0.10.1/try-runtime-x86_64-unknown-linux-musl" \
+            "https://github.com/paritytech/try-runtime-cli/releases/download/v${TRY_RUNTIME_VERSION}/try-runtime-x86_64-unknown-linux-musl" \
             --output "$TRY_RUNTIME_BIN"
           chmod +x "$TRY_RUNTIME_BIN"
           echo "TRY_RUNTIME_BIN=$TRY_RUNTIME_BIN" >> "$GITHUB_ENV"
@@ -204,46 +287,85 @@ jobs:
       # the clone snapshot: only artifacts produced on the default branch.
       # The .snap format is coupled to the try-runtime-cli release, so the
       # producer and this job must pin the same version.
-      - name: Restore try-runtime state snapshot
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'fresh-try-runtime-state') }}
+      - name: Select try-runtime state snapshot
+        id: snapshot
+        if: steps.state-mode.outputs.fresh-state != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          # gh api prints the JSON error body to stdout on 404, so validate
-          # the id shape rather than trusting non-empty output.
-          run_id=$(gh api \
-            "repos/$GITHUB_REPOSITORY/actions/workflows/refresh-mainnet-snapshot.yml/runs?branch=main&status=success&per_page=1" \
-            --jq '.workflow_runs[0].id // empty' 2>/dev/null || true)
-          if ! [[ "$run_id" =~ ^[0-9]+$ ]]; then
-            echo "No snapshot run available; falling back to a live scrape."
-            exit 0
-          fi
-          # No checkout in this job, so gh cannot infer the repository.
-          if ! gh run download "$run_id" -R "$GITHUB_REPOSITORY" -n "try-runtime-snap-${{ matrix.network.name }}" -D snap; then
-            echo "Snapshot download failed (expired or that network's scrape failed); falling back to a live scrape."
-            exit 0
-          fi
-          echo "Restored ${{ matrix.network.name }}.snap from run $run_id."
-          echo "TRY_RUNTIME_SNAP=snap/${{ matrix.network.name }}.snap" >> "$GITHUB_ENV"
+          .github/scripts/snapshot-artifact.sh select \
+            "try-runtime-snap-v${TRY_RUNTIME_VERSION}-${{ matrix.network.name }}" \
+            "${{ github.event_name == 'workflow_dispatch' && inputs.snapshot_source_branch || github.event.repository.default_branch }}" \
+            "${{ github.repository_id }}" \
+            72 "$GITHUB_OUTPUT" required
+
+      - name: Mark snapshot restore start
+        if: steps.state-mode.outputs.fresh-state != 'true'
+        run: echo "SNAPSHOT_RESTORE_STARTED=$(date -u +%s)" >> "$GITHUB_ENV"
+
+      - name: Download selected try-runtime state snapshot
+        if: steps.state-mode.outputs.fresh-state != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          .github/scripts/snapshot-artifact.sh download \
+            "${{ steps.snapshot.outputs.artifact-id }}" \
+            "${{ steps.snapshot.outputs.digest }}" \
+            snap
+
+      - name: Validate try-runtime state snapshot
+        if: steps.state-mode.outputs.fresh-state != 'true'
+        run: |
+          set -euo pipefail
+          snapshot="snap/${{ matrix.network.name }}.snap"
+          manifest="snap/${{ matrix.network.name }}.manifest.json"
+          .github/scripts/snapshot-artifact.sh validate \
+            "$manifest" "$snapshot" \
+            "${{ matrix.network.name }}" "${{ matrix.network.genesis }}" \
+            "$TRY_RUNTIME_VERSION"
+          echo "TRY_RUNTIME_SNAP=$snapshot" >> "$GITHUB_ENV"
+          restore_seconds=$(($(date -u +%s) - SNAPSHOT_RESTORE_STARTED))
+          block=$(jq -er '.finalized_block_number' "$manifest")
+          spec=$(jq -er '.source_spec_name + "/" + (.source_spec_version | tostring)' "$manifest")
+          {
+            echo "### ${{ matrix.network.name }} cached state"
+            echo "- Artifact: ${{ steps.snapshot.outputs.artifact-id }} (run ${{ steps.snapshot.outputs.run-id }})"
+            echo "- Age: ${{ steps.snapshot.outputs.age-hours }}h"
+            echo "- Finalized block: $block"
+            echo "- Runtime: $spec"
+            echo "- Restore and validation: ${restore_seconds}s"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Check migrations
         env:
           NODE_URI: ${{ matrix.network.uri }}
+          FRESH_STATE: ${{ steps.state-mode.outputs.fresh-state }}
+          MBM_ARGS: ${{ needs.build-try-runtime.outputs.mbm_args }}
         run: |
+          set -euo pipefail
           export RUST_LOG=remote-ext=debug,runtime=debug
-          if [ -n "${TRY_RUNTIME_SNAP:-}" ]; then
-            state=(snap --path "$TRY_RUNTIME_SNAP")
-          else
+          if [ "$FRESH_STATE" = true ]; then
             state=(live --uri "$NODE_URI")
+            state_mode=live
+          else
+            : "${TRY_RUNTIME_SNAP:?cached execution requires a validated snapshot}"
+            state=(snap --path "$TRY_RUNTIME_SNAP")
+            state_mode=cached
           fi
+          mbm=()
+          [ -z "$MBM_ARGS" ] || mbm+=("$MBM_ARGS")
+          started=$(date -u +%s)
           "$TRY_RUNTIME_BIN" \
             --runtime runtime-blob/node_subtensor_runtime.compact.compressed.wasm \
             on-runtime-upgrade \
             --checks=all \
             --blocktime 12000 \
             --disable-spec-version-check --no-weight-warnings \
+            "${mbm[@]}" \
             "${state[@]}"
+          elapsed=$(($(date -u +%s) - started))
+          echo "- Replay mode: $state_mode (${elapsed}s)" >> "$GITHUB_STEP_SUMMARY"
 
   # Runtime-affecting PRs must carry a spec_version newer than what mainnet is
   # running — otherwise the release train will build the merge and then no-op
@@ -254,7 +376,10 @@ jobs:
   spec-version:
     name: spec_version newer than mainnet
     needs: [trusted-pr, changes]
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-spec-version-bump') && (github.event_name != 'pull_request' || needs.changes.outputs.runtime == 'true') }}
+    if: >-
+      !contains(github.event.pull_request.labels.*.name, 'no-spec-version-bump') &&
+      (github.event_name != 'pull_request' || needs.changes.outputs.runtime == 'true') &&
+      !(github.event_name == 'workflow_dispatch' && inputs.try_runtime_only)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -286,7 +411,9 @@ jobs:
   sdk-checks:
     name: SDK offline checks
     needs: [trusted-pr, changes]
-    if: github.event_name != 'pull_request' || needs.changes.outputs.runtime == 'true' || needs.changes.outputs.python_sdk == 'true'
+    if: >-
+      (github.event_name != 'pull_request' || needs.changes.outputs.runtime == 'true' || needs.changes.outputs.python_sdk == 'true') &&
+      !(github.event_name == 'workflow_dispatch' && inputs.try_runtime_only)
     runs-on: [self-hosted, fireactions-turbo-8]
     timeout-minutes: 30
     steps:
@@ -315,7 +442,7 @@ jobs:
   # node-release artifact instead of building, and restores the nightly
   # mainnet-snapshot artifact instead of re-scraping mainnet state (falls back
   # to a live scrape when no snapshot exists or the `fresh-mainnet-clone`
-  # label is set). Auto-skips (via the `build` need) when the PR touches
+  # label is set). Auto-skips (via the `build-node-release` need) when the PR touches
   # nothing runtime-relevant.
   #
   # The regression tests are wall-clock-bound (they wait on 12-second blocks)
@@ -324,7 +451,7 @@ jobs:
   # subset, preserving the suite's original relative order within each shard.
   clone-upgrade:
     name: clone-upgrade (${{ matrix.shard.name }})
-    needs: [trusted-pr, changes, build]
+    needs: [trusted-pr, changes, build-node-release]
     runs-on: [self-hosted, fireactions-turbo-8]
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-clone-upgrade') }}
     timeout-minutes: 90
@@ -378,35 +505,57 @@ jobs:
         with:
           node-version: 20
 
-      - name: Restore mainnet snapshot
+      - name: Select mainnet clone snapshot
+        id: clone-snapshot
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'fresh-mainnet-clone') }}
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          # Only trust snapshots produced on the default branch — schedule and
-          # dispatch runs of refresh-mainnet-snapshot execute main's code, so
-          # a PR can never poison the snapshot another PR consumes.
-          # gh api prints the JSON error body to stdout on 404 (e.g. before
-          # the snapshot workflow ever ran on main), so validate the id shape
-          # rather than trusting non-empty output.
-          run_id=$(gh api \
-            "repos/$GITHUB_REPOSITORY/actions/workflows/refresh-mainnet-snapshot.yml/runs?branch=main&status=success&per_page=1" \
-            --jq '.workflow_runs[0].id // empty' 2>/dev/null || true)
-          if ! [[ "$run_id" =~ ^[0-9]+$ ]]; then
-            echo "No snapshot available; falling back to a live mainnet scrape."
-            exit 0
-          fi
-          if ! gh run download "$run_id" -n mainnet-snapshot -D /tmp/mainnet-snapshot; then
-            echo "Snapshot download failed (likely expired); falling back to a live scrape."
-            exit 0
-          fi
+          .github/scripts/snapshot-artifact.sh select \
+            mainnet-snapshot \
+            "${{ github.event_name == 'workflow_dispatch' && inputs.snapshot_source_branch || github.event.repository.default_branch }}" \
+            "${{ github.repository_id }}" \
+            168 "$GITHUB_OUTPUT" optional
+
+      - name: Download selected mainnet clone snapshot
+        id: download-clone-snapshot
+        if: steps.clone-snapshot.outputs.found == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          .github/scripts/snapshot-artifact.sh download \
+            "${{ steps.clone-snapshot.outputs.artifact-id }}" \
+            "${{ steps.clone-snapshot.outputs.digest }}" \
+            /tmp/mainnet-snapshot
+
+      - name: Restore mainnet clone snapshot
+        id: restore-clone-snapshot
+        if: steps.download-clone-snapshot.outcome == 'success'
+        continue-on-error: true
+        run: |
+          set -euo pipefail
           tar -xzf /tmp/mainnet-snapshot/mainnet-snapshot.tar.gz
           rm -rf /tmp/mainnet-snapshot
-          echo "Restored snapshot from run $run_id."
+          echo "Restored artifact ${{ steps.clone-snapshot.outputs.artifact-id }} from run ${{ steps.clone-snapshot.outputs.run-id }}."
           # Tells start-local-clone.sh to keep the pre-initialized database
           # instead of wiping it and re-running genesis init.
           echo "KEEP_CLONE_DATA=1" >> "$GITHUB_ENV"
+
+      - name: Fall back after an unusable clone snapshot
+        if: >-
+          steps.clone-snapshot.outputs.found == 'true' &&
+          (steps.download-clone-snapshot.outcome != 'success' ||
+           steps.restore-clone-snapshot.outcome != 'success')
+        run: |
+          echo "::warning::selected clone snapshot was unusable; falling back to a live mainnet scrape"
+          rm -rf /tmp/mainnet-snapshot clones/mainnet-clone clones/mainnet-clone-chainspec.json
+
+      - name: Fall back after clone snapshot lookup failure
+        if: steps.clone-snapshot.outcome == 'failure'
+        run: echo "::warning::clone snapshot lookup failed; falling back to a live mainnet scrape"
 
       - name: Create mainnet clone
         # No-op when the snapshot restored the chainspec; otherwise scrapes
@@ -514,7 +663,7 @@ jobs:
   # cascading into skipped shards — fails.
   clone-upgrade-gate:
     name: Sudo-upgrade mainnet clone and test
-    needs: [changes, build, clone-upgrade]
+    needs: [changes, build-node-release, clone-upgrade]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -522,7 +671,7 @@ jobs:
         env:
           CHANGES: ${{ needs.changes.result }}
           SHARDS: ${{ needs.clone-upgrade.result }}
-          BUILD: ${{ needs.build.result }}
+          BUILD: ${{ needs.build-node-release.result }}
           LABEL_SKIP: ${{ contains(github.event.pull_request.labels.*.name, 'skip-clone-upgrade') }}
         run: |
           echo "changes=$CHANGES shards=$SHARDS build=$BUILD label-skip=$LABEL_SKIP"

--- a/.github/workflows/runtime-checks.yml
+++ b/.github/workflows/runtime-checks.yml
@@ -350,10 +350,17 @@ jobs:
           - name: stake-sdk
             tests: >-
               test-hotkey-swap-and-proxy-stake.ts
-              test-net-tao-flow-emission-allocation.ts
-              test-total-issuance-trackers.ts
               test-alpha-deprecated-stake-histogram.ts
             sdk: true
+          # test-total-issuance-trackers legitimately waits ~6 min on chain
+          # state (see CLONE_REGRESSION_TIMEOUT_MS below), so the two
+          # emission/issuance tests get their own shard instead of
+          # serializing behind the stake-sdk pair.
+          - name: issuance
+            tests: >-
+              test-net-tao-flow-emission-allocation.ts
+              test-total-issuance-trackers.ts
+            sdk: false
     steps:
       - uses: actions/checkout@v4
 
@@ -465,7 +472,7 @@ jobs:
           # limit prunes a subnet and only emits NetworkAdded from on_idle
           # after the pruned subnet's chunked storage cleanup finishes
           # (~6 min on mainnet-scale state).
-          CLONE_REGRESSION_TIMEOUT_MS: ${{ matrix.shard.name == 'stake-sdk' && '1800000' || '900000' }}
+          CLONE_REGRESSION_TIMEOUT_MS: ${{ matrix.shard.name == 'issuance' && '1800000' || '900000' }}
         run: npm run test:clone-regressions
 
       - name: Install uv

--- a/.github/workflows/runtime-checks.yml
+++ b/.github/workflows/runtime-checks.yml
@@ -24,6 +24,10 @@ on:
         description: "Run only the try-runtime build and cached network checks"
         type: boolean
         default: false
+      skip_devnet:
+        description: "Skip devnet when measuring a partially completed producer run"
+        type: boolean
+        default: false
 
 concurrency:
   group: runtime-checks-${{ github.ref }}
@@ -221,24 +225,33 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        network:
+        selected: [devnet, testnet, mainnet]
+        exclude:
+          - selected: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_devnet && 'devnet' || '__none__' }}
+        include:
           # NOTE: the hostnames are misleading — archive.dev.opentensor.ai
           # serves the TESTNET archive on :8443 and the MAINNET archive on
           # :443 (verified by genesis hash; try-runtime wants archive nodes,
           # which is why we don't use the entrypoint hostnames). The
           # "Verify endpoint" step below enforces each URI's identity.
-          - name: devnet
-            uri: wss://dev.chain.opentensor.ai:443
-            genesis: "0x077899043eb684c5277b6814a39161f4ce072b45e782e12c81a521c63fb4f3e5"
-          - name: testnet
-            uri: wss://archive.dev.opentensor.ai:8443
-            genesis: "0x8f9cf856bf558a14440e75569c9e58594757048d7b3a84b5d25f6bd978263105"
+          - selected: devnet
+            network:
+              name: devnet
+              uri: wss://dev.chain.opentensor.ai:443
+              genesis: "0x077899043eb684c5277b6814a39161f4ce072b45e782e12c81a521c63fb4f3e5"
+          - selected: testnet
+            network:
+              name: testnet
+              uri: wss://archive.dev.opentensor.ai:8443
+              genesis: "0x8f9cf856bf558a14440e75569c9e58594757048d7b3a84b5d25f6bd978263105"
+          - selected: mainnet
+            network:
+              name: mainnet
+              uri: wss://archive.dev.opentensor.ai:443
+              genesis: "0x2f0555cc76fc2840a25a6ea3b9637146806f1f44b090c175ffde2a7e5ab36c03"
           # Keep endpoint-heavy checks near the archive RPCs. Measurements
           # from BHS showed materially higher per-request latency, which
           # compounds during try-runtime's state traversal.
-          - name: mainnet
-            uri: wss://archive.dev.opentensor.ai:443
-            genesis: "0x2f0555cc76fc2840a25a6ea3b9637146806f1f44b090c175ffde2a7e5ab36c03"
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

Two related speedups for Runtime Checks, which has been the long pole on every runtime-affecting PR.

**1. Split the stake-sdk clone shard** (fe6edda810)
- `stake-sdk` keeps the two SDK-facing tests plus the metadata drift gate; a new `issuance` shard takes `test-net-tao-flow-emission-allocation` + `test-total-issuance-trackers` (the ~6-min legitimate wait) along with the 30-minute timeout override. Removes ~10 min from the longest shard.

**2. Snapshot-cached try-runtime** (348420a309, ef43c28ad7 — authored by @UnArbosFive on `codex/try-runtime-snapshot-cache-test`, cherry-picked here onto current main; conflicts with #2867's workflow changes resolved)
- Producer (`refresh-mainnet-snapshot.yml`): snapshots pinned to a finalized block (`--at`), shipped with a sha256/spec-version manifest, versioned artifact names (`try-runtime-snap-v0.10.1-<network>`), 7-day retention, `max-parallel: 1` so refreshes cannot crowd PR jobs off the tryruntime runner pool.
- Consumer (`runtime-checks.yml`): try-runtime jobs now **require** a fresh (<72h) digest-verified snapshot instead of silently falling back to a 30-40 min live scrape; live state is an explicit label/dispatch bypass. Build split into `build-try-runtime` (16-core, gates try-runtime) and `build-node-release` (8-core, gates clone shards) so neither waits on the other. MBM detection auto-adds `--disable-mbm-checks` while the runtime has no multi-block migrator.
- New `.github/scripts/snapshot-artifact.sh` helper (select/download/validate) with contract tests wired in as a `snapshot-artifact-tests` job.

Conflict resolutions of note: kept main's `create-snapshot` arg-order fix semantics via UnArbosFive's superset version; merged the `changes` filter to keep both #2867's `python_sdk`/`sdk_drift` outputs and the new `snapshot_ci` output; `sdk-checks` keeps the `python_sdk` trigger and gains the `try_runtime_only` dispatch exclusion.

## Deploy note (important)

After this merges, **dispatch `refresh-mainnet-snapshot.yml` on main once**: the artifact names change and snapshots become required, so runtime PRs will fail try-runtime until the first green producer run publishes the v-named artifacts. Validated on the source branch: mainnet snapshot 27 min, testnet 3 min.

## Test plan

- [x] YAML lint on both workflows
- [x] `.github/scripts/test-snapshot-artifact.sh` passes locally
- [ ] All four clone shards (balancer, locks, stake-sdk, issuance) green; "Sudo-upgrade mainnet clone and test" gate passes
- [ ] Post-merge: producer dispatched, next runtime PR restores snapshots