### PR TITLE
feat(subtensor): add migration to clear orphan subnet identities

### DIFF
--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -179,7 +179,9 @@ mod hooks {
                 // Fix lock state left behind by subnet-scoped hotkey swaps.
                 .saturating_add(migrations::migrate_fix_subnet_hotkey_lock_swaps::migrate_fix_subnet_hotkey_lock_swaps::<T>())
                 // Populate reverse lookup index for EVM address associations.
-                .saturating_add(migrations::migrate_associated_evm_address_index::migrate_associated_evm_address_index::<T>());
+                .saturating_add(migrations::migrate_associated_evm_address_index::migrate_associated_evm_address_index::<T>())
+                // Remove orphan SubnetIdentitiesV3 entries left for recycled netuids.
+                .saturating_add(migrations::migrate_clear_orphan_subnet_identities_v3::migrate_clear_orphan_subnet_identities_v3::<T>());
             weight
         }
 

--- a/pallets/subtensor/src/migrations/migrate_clear_orphan_subnet_identities_v3.rs
+++ b/pallets/subtensor/src/migrations/migrate_clear_orphan_subnet_identities_v3.rs
@@ -1,0 +1,63 @@
+use crate::{Config, Event, HasMigrationRun, NetworksAdded, Pallet, SubnetIdentitiesV3, Weight};
+use frame_support::traits::Get;
+use scale_info::prelude::string::String;
+use sp_std::vec::Vec;
+use subtensor_runtime_common::NetUid;
+
+/// Remove `SubnetIdentitiesV3` entries that belong to netuids which are no
+/// longer registered networks (`!NetworksAdded`).
+///
+/// Such orphan identities accumulate when a subnet slot is recycled: a new
+/// owner registers a subnet in a previously-used netuid without supplying an
+/// identity, and the stale identity from the prior owner is left in place,
+/// misleading participants about what the subnet is. The registration path
+/// (`set_new_network_state`) only writes on `Some(identity)` and never clears a
+/// pre-existing entry, and the historical `migrate_subnet_identities_to_v3`
+/// migration copied V2 entries unconditionally.
+///
+/// This mirrors the identity-clear in `do_dissolve_network` as a one-shot
+/// upgrade migration: orphan entries are removed and a `SubnetIdentityRemoved`
+/// event is emitted for each; identities of live subnets are untouched.
+pub fn migrate_clear_orphan_subnet_identities_v3<T: Config>() -> Weight {
+    let migration_name = b"migrate_clear_orphan_subnet_identities_v3".to_vec();
+    let mut weight = T::DbWeight::get().reads(1);
+
+    if HasMigrationRun::<T>::get(&migration_name) {
+        log::info!(
+            target: "runtime",
+            "Migration '{}' already run - skipping.",
+            String::from_utf8_lossy(&migration_name)
+        );
+        return weight;
+    }
+
+    log::info!(
+        target: "runtime",
+        "Running migration '{}'",
+        String::from_utf8_lossy(&migration_name),
+    );
+
+    // Collect identity netuids that no longer correspond to a registered subnet.
+    let orphan_netuids: Vec<NetUid> = SubnetIdentitiesV3::<T>::iter_keys()
+        .filter(|netuid| !NetworksAdded::<T>::get(netuid))
+        .collect();
+    let removed = orphan_netuids.len() as u64;
+    weight = weight.saturating_add(T::DbWeight::get().reads(removed));
+
+    for netuid in orphan_netuids {
+        SubnetIdentitiesV3::<T>::remove(netuid);
+        Pallet::<T>::deposit_event(Event::SubnetIdentityRemoved(netuid));
+    }
+    weight = weight.saturating_add(T::DbWeight::get().writes(removed));
+
+    HasMigrationRun::<T>::insert(&migration_name, true);
+    weight = weight.saturating_add(T::DbWeight::get().writes(1));
+
+    log::info!(
+        target: "runtime",
+        "Migration '{}' completed.",
+        String::from_utf8_lossy(&migration_name),
+    );
+
+    weight
+}

--- a/pallets/subtensor/src/migrations/mod.rs
+++ b/pallets/subtensor/src/migrations/mod.rs
@@ -8,6 +8,7 @@ pub mod migrate_associated_evm_address_index;
 pub mod migrate_auto_stake_destination;
 pub mod migrate_cleanup_swap_v3;
 pub mod migrate_clear_deprecated_registration_maps;
+pub mod migrate_clear_orphan_subnet_identities_v3;
 pub mod migrate_coldkey_swap_scheduled;
 pub mod migrate_coldkey_swap_scheduled_to_announcements;
 pub mod migrate_commit_reveal_settings;

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -79,6 +79,51 @@ fn test_migrate_associated_evm_address_index() {
 }
 
 #[test]
+fn test_migrate_clear_orphan_subnet_identities_v3() {
+    new_test_ext(1).execute_with(|| {
+        let migration_name = b"migrate_clear_orphan_subnet_identities_v3".to_vec();
+        HasMigrationRun::<Test>::remove(&migration_name);
+
+        let orphan_netuid = NetUid::from(1);
+        let live_netuid = NetUid::from(2);
+
+        // live_netuid is a registered network; orphan_netuid is not.
+        NetworksAdded::<Test>::insert(live_netuid, true);
+
+        let orphan_identity = SubnetIdentityV3 {
+            subnet_name: b"orphan".to_vec(),
+            ..Default::default()
+        };
+        let live_identity = SubnetIdentityV3 {
+            subnet_name: b"live".to_vec(),
+            ..Default::default()
+        };
+
+        SubnetIdentitiesV3::<Test>::insert(orphan_netuid, orphan_identity);
+        SubnetIdentitiesV3::<Test>::insert(live_netuid, live_identity.clone());
+
+        crate::migrations::migrate_clear_orphan_subnet_identities_v3::migrate_clear_orphan_subnet_identities_v3::<Test>();
+
+        // The orphan identity is removed; the live subnet identity is preserved.
+        assert!(!SubnetIdentitiesV3::<Test>::contains_key(orphan_netuid));
+        assert_eq!(
+            SubnetIdentitiesV3::<Test>::get(live_netuid),
+            Some(live_identity.clone())
+        );
+
+        // Migration is marked as run.
+        assert!(HasMigrationRun::<Test>::get(&migration_name));
+
+        // Idempotent: re-running is a no-op (live identity still present).
+        crate::migrations::migrate_clear_orphan_subnet_identities_v3::migrate_clear_orphan_subnet_identities_v3::<Test>();
+        assert_eq!(
+            SubnetIdentitiesV3::<Test>::get(live_netuid),
+            Some(live_identity)
+        );
+    });
+}
+
+#[test]
 fn test_migrate_associated_evm_address_index_reconciles_over_cap_buckets() {
     new_test_ext(1).execute_with(|| {
         let migration_name = b"migrate_associated_evm_address_index".to_vec();

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -1299,6 +1299,7 @@ fn test_per_u16_encodes_identically_to_u16() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn test_migrate_last_tx_block_delegate_take() {
     new_test_ext(1).execute_with(|| {
         // ------------------------------

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 429,
+    spec_version: 432,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Hi! I am Loom Agent - an autonomous AI agent set up by my maintainer to help contribute to this repository. This pull request was prepared autonomously under human supervision. Feedback is very welcome - I will do my best to address review comments promptly.

## Release Notes
- Added a one-shot runtime migration that clears orphan `SubnetIdentitiesV3` entries left behind for netuids that are no longer registered subnets, so a recycled subnet slot no longer displays the previous owner's identity.

## Description
When a subnet slot is recycled, a new owner can register a subnet in a previously-used netuid without supplying an identity. The registration path (`set_new_network_state`) only writes `SubnetIdentitiesV3` on `Some(identity)` and never clears a pre-existing entry, and the historical `migrate_subnet_identities_to_v3` migration copied V2 entries unconditionally - so the stale identity from a prior owner persists and misrepresents what the subnet is (issue #2572). `do_dissolve_network` already clears identity on dissolve, so no new orphans are created today, but latent/historical ones remain.

This implements the migration shape requested by the maintainer in the #2572 / #2601 thread: `migrate_clear_orphan_subnet_identities_v3` iterates `SubnetIdentitiesV3`, removes entries whose netuid is not in `NetworksAdded`, emits a `SubnetIdentityRemoved` event per removal, and is guarded by `HasMigrationRun` (idempotent; runs once at upgrade). Identities of live subnets are untouched. It is wired into `on_runtime_upgrade` in `pallets/subtensor/src/macros/hooks.rs`.

## Related Issue(s)
- Closes #2572
- Builds on the approach discussed in #2601 (closed): use a one-shot cleanup migration rather than a registration-time check.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change
Non-breaking. One-shot storage cleanup of orphan entries only; live subnet identities and all dispatch interfaces are unchanged. `spec_version` is bumped 429 -> 432.

## Testing
Built and tested with the project's pinned Rust 1.89.0 toolchain (`rust-toolchain.toml`), `--all-features`, on the branch rebased onto current `main` (a9b329f88):

- `cargo fmt --all -- --check` -> clean (rc=0).
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` -> clean (rc=0).
- `cargo test -p pallet-subtensor --all-features` -> `test result: ok. 1349 passed; 0 failed; 9 ignored`.
- New regression `test_migrate_clear_orphan_subnet_identities_v3`: pre-seeds an orphan V3 identity (netuid not in `NetworksAdded`) and a live one, runs the migration, asserts the orphan is removed while the live identity is preserved, `HasMigrationRun` is set, and a second run is a no-op.

(`./scripts/fix_rust.sh` was not run verbatim because it auto-fixes and auto-commits; the equivalent `fmt`/`clippy`/`test` gates above were run read-only with the pinned toolchain.)

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation (no public API change)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional Notes
- **Lint prerequisite (commit 2):** `main`'s Check Rust workflow is currently red because the typed-units WIP marked the `LastTxBlockDelegateTake` storage map `#[deprecated]` while its legacy-migration test (`test_migrate_last_tx_block_delegate_take` in `pallets/subtensor/src/tests/migration.rs`) still references it, so `cargo clippy --workspace --all-targets -- -D warnings` fails on `main`. That test deliberately touches the deprecated legacy storage to verify migration off it, so commit 2 annotates the test fn with `#[allow(deprecated)]` (behavior-neutral). It is unrelated to #2572 and can be dropped or superseded if you prefer a different resolution for the `main` lint breakage.
- As discussed in #2601, this is intentionally a migration only - it does not change the registration path. If you also want belt-and-braces clearing of a stale identity when a new owner registers without one, that can be added to `set_new_network_state` as a follow-up, but the maintainer direction was to fix the data, not add a check.
