### PR TITLE
ci: idempotent PyPI publish re-runs; fix stale branch-strategy review docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,9 +3,9 @@
 You are reviewing code for a Substrate-based blockchain with a $4B market cap. Lives and livelihoods depend on the security and correctness of this code. Be thorough, precise, and uncompromising on safety.
 
 ## Branch Strategy
-* Unless this is a hotfix or deployment PR (`devnet` => `testnet`, or `testnet` => `mainnet`), all PRs must target `devnet`
-* Flag PRs targeting `mainnet` directly unless they are hotfixes
-* `testnet` and `mainnet` branches must only receive promotion merges from the branch directly upstream of them
+* All PRs target `main`. Deployment is automated, not PR-driven: merges to `main` ride the release train, which promotes devnet → testnet → mainnet via on-chain `setCode` (see `docs/internals/release-process.mdx`)
+* `devnet`, `testnet`, and `mainnet` are CI-managed mirror branches recording what each network currently runs; they are ruleset-locked and only the release train updates them
+* Flag any PR that targets `devnet`, `testnet`, or `mainnet` — those branches never receive merges
 
 ## CRITICAL: Runtime Safety (Chain-Bricking Prevention)
 The runtime CANNOT panic under any circumstances. A single panic can brick the entire chain.

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -360,10 +360,14 @@ jobs:
       - name: Build SDK wheel and sdist
         working-directory: sdk/python
         run: uv build --out-dir ../../dist
+      # --check-url makes a re-run after a partial upload idempotent: files
+      # already on the index are skipped instead of failing with a 400
+      # duplicate (e.g. the SDK wheel landed but bittensor-core didn't).
       - name: Publish to PyPI
         run: |
           ls -la dist
-          uv publish --trusted-publishing always dist/*
+          uv publish --trusted-publishing always \
+            --check-url https://pypi.org/simple/ dist/*
 
   # ------------------------------------------------------------------
   # Stage 3: mainnet — the human gate.

--- a/.github/workflows/watch-mainnet-release.yml
+++ b/.github/workflows/watch-mainnet-release.yml
@@ -221,10 +221,14 @@ jobs:
         working-directory: sdk/python
         run: uv build --out-dir ../../dist
 
+      # --check-url makes a re-run after a partial upload idempotent: files
+      # already on the index are skipped instead of failing with a 400
+      # duplicate (e.g. the SDK wheel landed but bittensor-core didn't).
       - name: Publish to PyPI
         run: |
           ls -la dist
-          uv publish --trusted-publishing always dist/*
+          uv publish --trusted-publishing always \
+            --check-url https://pypi.org/simple/ dist/*
 
   publish-crates:
     name: Publish Rust crates to crates.io


### PR DESCRIPTION
## Summary
Two seamlessness fixes from the first live run of the rc channel:

- **`uv publish --check-url`** in `release-train.yml` and `watch-mainnet-release.yml`: run 29222052755 uploaded `bittensor 11.0.0rc6` and then failed on `bittensor-core` (no trusted publisher for the not-yet-existing project). A plain re-run would 400 on the already-uploaded wheel; `--check-url` skips identical files already on the index, making publish re-runs resume instead of fail.
- **`copilot-instructions.md` branch strategy**: still described the pre-release-train world (\"all PRs must target `devnet`\"), which the AI auditor cited to block a routine PR against `main` (#2866). Rewritten to match `ai-review/common.md`: PRs target `main`; `devnet`/`testnet`/`mainnet` are ruleset-locked CI mirrors.

Related ops changes made directly (not in this diff): stale classic branch protections on `testnet` and `devnet` deleted — they predate the mirror ruleset and the testnet one blocked the deploy-key mirror push on the first real testnet deploy.

## Test plan
- [ ] Next train's publish job re-run (if any) skips existing files.
- [ ] Auditor no longer flags main-targeted PRs for branch policy.

Made with [Cursor](https://cursor.com)