### PR TITLE
chore: rao-release — spec_version 430, devnet endpoint, SDK version from metadata, e2e de-flake

### DIFF
--- a/docs/concepts/network.mdx
+++ b/docs/concepts/network.mdx
@@ -20,6 +20,7 @@ The SDK's network names resolve to public endpoints:
 
 - `finney` — mainnet, `wss://entrypoint-finney.opentensor.ai:443`
 - `test` — public testnet, `wss://test.finney.opentensor.ai:443`
+- `devnet` — the development chain, `wss://dev.chain.opentensor.ai:443`
 - `local` — a dev node at `ws://127.0.0.1:9944`
 
 Mainnet also has a public **lite** node at

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 429,
+    spec_version: 430,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/sdk/bittensor-core/tests/e2e.rs
+++ b/sdk/bittensor-core/tests/e2e.rs
@@ -9,6 +9,8 @@
 mod e2e_support;
 
 use std::collections::BTreeSet;
+use std::thread;
+use std::time::{Duration, Instant};
 
 use bittensor_core::client::{as_str, as_u128, field, value_bytes, variant_name};
 use bittensor_core::codec::Value;
@@ -262,11 +264,26 @@ fn test_policy_aggregates_spend_across_batch() {
 #[test]
 fn test_mev_shield_next_key_is_mlkem768() {
     let ctx = TestContext::new();
-    let key = ctx
-        .client
-        .query("MevShield", "NextKey", &[], None)
-        .expect("NextKey read");
-    assert_eq!(value_bytes(&key).expect("NextKey bytes").len(), 1_184);
+    // NextKey is None until every localnet authority has authored a block and
+    // announced its key (the rotation inherent kills NextKey whenever the
+    // next-next author has no AuthorKeys entry yet), so poll instead of
+    // reading once right after startup.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let key = loop {
+        let key = ctx
+            .client
+            .query("MevShield", "NextKey", &[], None)
+            .expect("NextKey read");
+        if let Some(bytes) = value_bytes(&key) {
+            break bytes;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "NextKey not announced within 30s"
+        );
+        thread::sleep(Duration::from_millis(250));
+    };
+    assert_eq!(key.len(), 1_184);
 }
 
 #[test]

--- a/sdk/python/bittensor/__init__.py
+++ b/sdk/python/bittensor/__init__.py
@@ -31,6 +31,7 @@ root logger, so it stays silent unless your application opts in:
     logging.getLogger("bittensor").setLevel(logging.DEBUG)    # just the SDK
 """
 
+import importlib.metadata as _importlib_metadata
 import logging as _logging
 
 from . import evm, http_auth, intents, reads, timelock, wallets
@@ -194,7 +195,13 @@ __all__ = [
     *sorted(_INTENT_EXPORTS),
 ]
 
-__version__ = "11.0.0.dev0"
+# The single source of truth for the version is pyproject.toml (which the
+# release workflows stamp with the rc/dev suffix at build time); read it from
+# the installed distribution so wheels report what they were published as.
+try:
+    __version__ = _importlib_metadata.version("bittensor")
+except _importlib_metadata.PackageNotFoundError:  # uninstalled source tree
+    __version__ = "0.0.0.dev0+unknown"
 
 # Removed v10 API names raise with a pointer to the replacement instead of a
 # bare AttributeError, so an un-migrated script fails with instructions

--- a/sdk/python/bittensor/settings.py
+++ b/sdk/python/bittensor/settings.py
@@ -34,6 +34,7 @@ NETWORKS = {
     "finney": "wss://entrypoint-finney.opentensor.ai:443",
     "test": "wss://test.finney.opentensor.ai:443",
     "archive": "wss://archive.chain.opentensor.ai:443",
+    "devnet": "wss://dev.chain.opentensor.ai:443",
     "local": os.getenv("BT_CHAIN_ENDPOINT") or "ws://127.0.0.1:9944",
 }
 


### PR DESCRIPTION
## Description

Release prep branch:

- **Runtime**: bump `spec_version` 429 → 430 for the next mainnet upgrade.
- **Python SDK**: add the `devnet` network endpoint (`wss://dev.chain.opentensor.ai:443`) to `settings.py` and the network docs; read `__version__` from installed package metadata (pyproject.toml is the single source of truth, so wheels report the version they were published as).
- **Tests**: de-flake `test_mev_shield_next_key_is_mlkem768` by polling `MevShield.NextKey` (up to 30s) instead of a single read right after localnet startup — `NextKey` is legitimately `None` until every authority has authored and announced its key.

## Related Issue(s)

- None

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Other (please describe):

## Breaking Change

None.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional Notes

The e2e flake fixed here failed twice in a row on run 29261997025 (`rust-e2e: test_mev_shield_next_key_is_mlkem768`); root cause analysis in the test comment.

Made with [Cursor](https://cursor.com)