### PR TITLE
Add one-command upgrade verification script for sudo signers

### DIFF
--- a/.github/scripts/deploy/README.md
+++ b/.github/scripts/deploy/README.md
@@ -83,18 +83,21 @@ Do not sign a WASM you were simply handed. srtool builds are deterministic:
 identical source at the same toolchain produces a byte-identical runtime. The
 pre-release tag *is* the code being deployed.
 
-The short version is one command (requires docker):
+The short version is one command (requires docker). Run it from a checkout
+you already trust — reviewed `main`, not the proposal tag, so the proposal
+cannot supply the verifier that vouches for it:
 
 ```
-git fetch origin && git checkout v<spec>
+git fetch origin && git checkout origin/main
 ./scripts/verify-upgrade.sh
 ```
 
-It downloads the release manifest and wasm, confirms your checkout is the
-proposal commit, runs the same srtool container CI used, byte-compares the
-result against the released runtime, runs `btcli upgrade check` against the
-chain if btcli is installed, and prints the `btcli upgrade sign` command
-pinned to your own build. It never submits anything.
+It downloads the release manifest and wasm, fetches the proposal commit and
+rebuilds it from a pristine clone in the same srtool container CI used,
+byte-compares the result against the released runtime, runs
+`btcli upgrade check` against the chain if btcli is installed, and prints
+the `btcli upgrade sign` command pinned to your own build. It never submits
+anything.
 
 The manual recipe, if you prefer to run each step yourself:
 

--- a/.github/scripts/deploy/README.md
+++ b/.github/scripts/deploy/README.md
@@ -81,7 +81,22 @@ btcli multisig pending -w <ms>  # pending sudo-multisig ops; also lists pending 
 
 Do not sign a WASM you were simply handed. srtool builds are deterministic:
 identical source at the same toolchain produces a byte-identical runtime. The
-pre-release tag *is* the code being deployed, so:
+pre-release tag *is* the code being deployed.
+
+The short version is one command (requires docker):
+
+```
+git fetch origin && git checkout v<spec>
+./scripts/verify-upgrade.sh
+```
+
+It downloads the release manifest and wasm, confirms your checkout is the
+proposal commit, runs the same srtool container CI used, byte-compares the
+result against the released runtime, runs `btcli upgrade check` against the
+chain if btcli is installed, and prints the `btcli upgrade sign` command
+pinned to your own build. It never submits anything.
+
+The manual recipe, if you prefer to run each step yourself:
 
 ```
 git fetch origin && git checkout v<spec>

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -567,18 +567,20 @@ jobs:
 
           ### Verify it independently (recommended)
 
-          Build the runtime from this tag with srtool and compare byte-for-byte
-          (see \`.github/scripts/deploy/README.md\` for the full recipe):
+          One command rebuilds the runtime from this tag with srtool,
+          byte-compares it against the released wasm, and prints the sign
+          command pinned to your own build (needs docker; see
+          \`.github/scripts/deploy/README.md\` for the manual recipe):
 
           \`\`\`
           git fetch origin && git checkout ${tag}
-          # srtool build, then:
-          btcli upgrade check --url ${url} --wasm <path/to/your-build.wasm>
+          ./scripts/verify-upgrade.sh
           \`\`\`
 
-          Without \`--wasm\`, \`btcli upgrade check --url ${url}\` still verifies
-          the published artifacts against each other and the chain, but trusts
-          the released wasm; a local srtool build closes that gap.
+          Signing without verifying trusts the released wasm: plain
+          \`btcli upgrade check --url ${url}\` still verifies the published
+          artifacts against each other and the chain, but only a local srtool
+          build proves the bytes came from this source.
 
           ### Proposal details
 

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -569,12 +569,13 @@ jobs:
 
           One command rebuilds the runtime from this tag with srtool,
           byte-compares it against the released wasm, and prints the sign
-          command pinned to your own build (needs docker; see
+          command pinned to your own build. Run it from a checkout you
+          already trust (reviewed main), not this tag (needs docker; see
           \`.github/scripts/deploy/README.md\` for the manual recipe):
 
           \`\`\`
-          git fetch origin && git checkout ${tag}
-          ./scripts/verify-upgrade.sh
+          git fetch origin && git checkout origin/main
+          ./scripts/verify-upgrade.sh --url ${url}
           \`\`\`
 
           Signing without verifying trusts the released wasm: plain

--- a/scripts/srtool/build-srtool-image.sh
+++ b/scripts/srtool/build-srtool-image.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 
-docker build --build-arg RUSTC_VERSION="1.89.0" -t srtool https://github.com/paritytech/srtool.git#refs/tags/v0.18.3
+# Pinned to the commit behind srtool v0.18.3 so the builder cannot change
+# under a re-used tag. Optional first argument overrides the image tag.
+IMAGE_TAG="${1:-srtool}"
+SRTOOL_COMMIT="0a446889c5e60abe92a41e426377276f5c7295e6"
+
+docker build --build-arg RUSTC_VERSION="1.89.0" -t "$IMAGE_TAG" "https://github.com/paritytech/srtool.git#${SRTOOL_COMMIT}"

--- a/scripts/verify-upgrade.sh
+++ b/scripts/verify-upgrade.sh
@@ -87,10 +87,15 @@ release_sha=$(shasum -a 256 "$work/release.wasm" | cut -d' ' -f1)
 ok "release wasm matches manifest sha256"
 
 # ----------------------------------------------------------------- source ---
-git fetch --quiet origin "refs/tags/${tag}:refs/tags/${tag}" 2>/dev/null \
-  || note "could not fetch tag ${tag}; assuming the proposal commit is already local"
-git cat-file -e "${commit}^{commit}" 2>/dev/null \
-  || die "proposal commit $commit not found after fetching origin — do not sign"
+git fetch --quiet --force origin "refs/tags/${tag}:refs/tags/${tag}" \
+  || die "could not fetch tag ${tag} from origin — do not sign"
+tag_commit=$(git rev-parse "refs/tags/${tag}^{commit}" 2>/dev/null) \
+  || die "tag ${tag} does not resolve to a commit — do not sign"
+# Bind the tag to the manifest: without this, a manifest could point the
+# build at any commit in the repository and still get a green verdict.
+[ "$tag_commit" = "$commit" ] \
+  || die "tag ${tag} points at $tag_commit but the manifest claims $commit — do not sign"
+ok "tag ${tag} resolves to the manifest commit"
 
 # Build from a pristine clone of the proposal commit, never the working
 # tree: local modifications, untracked files, and ignored inputs such as a

--- a/scripts/verify-upgrade.sh
+++ b/scripts/verify-upgrade.sh
@@ -127,6 +127,10 @@ note "building the pinned srtool builder image as ${verify_image} (cached after 
 DOCKER_DEFAULT_PLATFORM=linux/amd64 "$image_script" "$verify_image"
 
 note "running the deterministic srtool build (30+ min on Apple Silicon under emulation)"
+# A hostile proposal could commit a wasm at a path matching the output
+# search below; purge every candidate so anything found afterwards was
+# necessarily produced by this build.
+find "$src" -name 'node_subtensor_runtime.compact.compressed.wasm' -delete
 ( cd "$src/runtime" && { [ -L node-subtensor ] || ln -s . node-subtensor; } )
 # Fresh cargo home: a signer's ~/.cargo/config.toml could redirect registries
 # or patch sources, so the verification build must not see it.
@@ -142,8 +146,11 @@ docker run --rm --user root --platform=linux/amd64 \
     code=\$?; [ \$code -ne 0 ] && cat /build/runtime/node-subtensor/srtool-output.log && exit \$code; \
     exit 0"
 
-built_wasm=$(find "$src/runtime" -name 'node_subtensor_runtime.compact.compressed.wasm' -path '*srtool*' | head -n 1)
-[ -n "$built_wasm" ] || die "srtool build produced no compact.compressed.wasm"
+candidates=$(find "$src/runtime" -name 'node_subtensor_runtime.compact.compressed.wasm' -path '*/target/srtool/*')
+[ -n "$candidates" ] || die "srtool build produced no compact.compressed.wasm"
+[ "$(printf '%s\n' "$candidates" | wc -l)" -eq 1 ] \
+  || die "expected exactly one srtool output wasm, found:${candidates}"
+built_wasm="$candidates"
 # $work (and the wasm inside it) is deleted on exit; keep a copy beside the
 # repo so the printed sign command references a path that still exists.
 local_wasm="$repo_root/verified-${tag}.wasm"

--- a/scripts/verify-upgrade.sh
+++ b/scripts/verify-upgrade.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# One-command independent verification of a proposed runtime upgrade.
+#
+# For sudo-multisig (triumvirate) signers: rebuilds the runtime from the
+# source you have checked out, byte-compares it against the artifact CI
+# published in the proposal pre-release, and prints the exact sign command
+# pinned to YOUR build. Never signs anything itself.
+#
+# Usage:
+#   git clone <repo> && cd subtensor && git checkout v<spec>
+#   ./scripts/verify-upgrade.sh                  # infers release from the tag
+#   ./scripts/verify-upgrade.sh --url <release>  # explicit release URL
+#
+# Requires: docker, curl, jq, git. Uses btcli for the final chain check if
+# it is installed; prints the command to run manually otherwise.
+
+set -euo pipefail
+
+RED=$'\033[31m'; GREEN=$'\033[32m'; YELLOW=$'\033[33m'; RESET=$'\033[0m'
+die()  { echo "${RED}error:${RESET} $*" >&2; exit 1; }
+ok()   { echo "${GREEN}ok:${RESET} $*"; }
+note() { echo "${YELLOW}note:${RESET} $*"; }
+
+url=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --url) url="${2:?--url needs a value}"; shift 2 ;;
+    -h|--help) sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) die "unknown argument: $1 (only --url <release-url> is accepted)" ;;
+  esac
+done
+
+for cmd in docker curl jq git; do
+  command -v "$cmd" >/dev/null || die "$cmd is required"
+done
+docker info >/dev/null 2>&1 || die "docker daemon is not running"
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+# ---------------------------------------------------------------- release ---
+if [ -z "$url" ]; then
+  tag=$(git describe --tags --exact-match 2>/dev/null) \
+    || die "HEAD is not at a release tag; check out the proposal tag (git checkout v<spec>) or pass --url"
+  origin=$(git remote get-url origin)
+  slug=$(echo "$origin" | sed -E 's#(git@github.com:|https://github.com/)##; s#\.git$##')
+  url="https://github.com/${slug}/releases/tag/${tag}"
+fi
+case "$url" in
+  https://github.com/*/releases/tag/*) ;;
+  *) die "unrecognized release URL: $url" ;;
+esac
+slug=$(echo "$url" | sed -E 's#https://github.com/([^/]+/[^/]+)/releases/tag/.*#\1#')
+tag=${url##*/}
+dl="https://github.com/${slug}/releases/download/${tag}"
+
+work=$(mktemp -d /tmp/verify-upgrade.XXXXXX)
+trap 'rm -rf "$work"' EXIT
+
+echo "Verifying proposal ${tag} from ${url}"
+curl -fsSL "${dl}/upgrade-manifest.json" -o "$work/manifest.json" \
+  || die "could not download upgrade-manifest.json from the release"
+curl -fsSL "${dl}/subtensor.wasm" -o "$work/release.wasm" \
+  || die "could not download subtensor.wasm from the release"
+
+commit=$(jq -r '.commit' "$work/manifest.json")
+expected_sha=$(jq -r '.wasm_sha256' "$work/manifest.json" | sed 's/^0x//')
+spec=$(jq -r '.spec_version' "$work/manifest.json")
+rustc_line=$(jq -r '.srtool_rustc // empty' "$work/manifest.json")
+
+# The release wasm must itself match the manifest before we compare anything
+# against it.
+release_sha=$(shasum -a 256 "$work/release.wasm" | cut -d' ' -f1)
+[ "$release_sha" = "$expected_sha" ] \
+  || die "release asset subtensor.wasm (sha256 $release_sha) does not match manifest wasm_sha256 ($expected_sha) — do not sign"
+ok "release wasm matches manifest sha256"
+
+# ----------------------------------------------------------------- source ---
+head_commit=$(git rev-parse HEAD)
+[ "$head_commit" = "$commit" ] \
+  || die "HEAD ($head_commit) is not the proposal commit ($commit); run: git fetch origin && git checkout $tag"
+git diff --quiet HEAD -- runtime pallets Cargo.toml Cargo.lock \
+  || die "working tree has local modifications under runtime/, pallets/, or the cargo manifests; verify from a clean checkout"
+ok "HEAD is the proposal commit ${commit}"
+
+# ------------------------------------------------------------------ build ---
+pinned_rustc=$(grep -Eo 'RUSTC_VERSION="[0-9.]+"' scripts/srtool/build-srtool-image.sh | grep -Eo '[0-9.]+')
+if [ -n "$rustc_line" ]; then
+  echo "manifest toolchain: ${rustc_line}; local srtool pin: ${pinned_rustc}"
+fi
+if ! docker image inspect srtool >/dev/null 2>&1; then
+  note "srtool image not found locally; building it (one-time, ~10 min)"
+  DOCKER_DEFAULT_PLATFORM=linux/amd64 ./scripts/srtool/build-srtool-image.sh
+fi
+
+note "running the deterministic srtool build (30+ min on Apple Silicon under emulation)"
+( cd runtime && { [ -L node-subtensor ] || ln -s . node-subtensor; } )
+docker run --rm --user root --platform=linux/amd64 \
+  -e PACKAGE=node-subtensor-runtime \
+  -e BUILD_OPTS="--features=metadata-hash" \
+  -e PROFILE=production \
+  -v "$HOME/.cargo":/cargo-home \
+  -v "$repo_root":/build \
+  srtool bash -c "git config --global --add safe.directory /build && \
+    /srtool/build --app > /build/runtime/node-subtensor/srtool-output.log; \
+    code=\$?; [ \$code -ne 0 ] && cat /build/runtime/node-subtensor/srtool-output.log && exit \$code; \
+    exit 0"
+
+local_wasm=$(find runtime -name 'node_subtensor_runtime.compact.compressed.wasm' -path '*srtool*' | head -n 1)
+[ -n "$local_wasm" ] || die "srtool build produced no compact.compressed.wasm"
+
+# ---------------------------------------------------------------- compare ---
+local_sha=$(shasum -a 256 "$local_wasm" | cut -d' ' -f1)
+echo "your build:  sha256 $local_sha"
+echo "release:     sha256 $release_sha"
+if [ "$local_sha" != "$release_sha" ]; then
+  die "your srtool build does NOT match the released runtime — do not sign; check toolchain pin and report the mismatch"
+fi
+cmp -s "$local_wasm" "$work/release.wasm" \
+  || die "sha256 matched but bytes differ (should be impossible) — do not sign"
+ok "your build is byte-identical to the released runtime (spec ${spec})"
+
+# ------------------------------------------------------------ chain check ---
+if command -v btcli >/dev/null; then
+  echo
+  echo "Running btcli upgrade check against the chain..."
+  btcli upgrade check --url "$url" --wasm "$local_wasm"
+else
+  note "btcli not found; to also verify call data and on-chain state, install it and run:"
+  echo "  btcli upgrade check --url $url --wasm $local_wasm"
+fi
+
+echo
+echo "All verifications passed. To sign, pinning the call data to your own build:"
+echo
+echo "  btcli upgrade sign --url $url --wasm $local_wasm -w <your-wallet>"

--- a/scripts/verify-upgrade.sh
+++ b/scripts/verify-upgrade.sh
@@ -1,14 +1,19 @@
 #!/usr/bin/env bash
 # One-command independent verification of a proposed runtime upgrade.
 #
-# For sudo-multisig (triumvirate) signers: rebuilds the runtime from a
-# pristine export of the proposal commit, byte-compares it against the
-# artifact CI published in the proposal pre-release, and prints the exact
-# sign command pinned to YOUR build. Never signs anything itself.
+# For sudo-multisig (triumvirate) signers: fetches the proposal tag,
+# rebuilds the runtime from a pristine clone of the proposal commit,
+# byte-compares it against the artifact CI published in the proposal
+# pre-release, and prints the exact sign command pinned to YOUR build.
+# Never signs anything itself.
+#
+# Run this script from a checkout you already trust (reviewed main), NOT
+# from the proposal tag: a malicious proposal could otherwise supply the
+# very verifier that vouches for it.
 #
 # Usage:
-#   git clone <repo> && cd subtensor && git checkout v<spec>
-#   ./scripts/verify-upgrade.sh                  # infers release from the tag
+#   git fetch origin && git checkout origin/main
+#   ./scripts/verify-upgrade.sh                  # verifies the newest release
 #   ./scripts/verify-upgrade.sh --url <release>  # explicit release URL
 #
 # Requires: docker, curl, jq, git. Uses btcli for the final chain check if
@@ -25,7 +30,7 @@ url=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --url) url="${2:?--url needs a value}"; shift 2 ;;
-    -h|--help) sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -h|--help) sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
     *) die "unknown argument: $1 (only --url <release-url> is accepted)" ;;
   esac
 done
@@ -39,11 +44,12 @@ repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
 
 # ---------------------------------------------------------------- release ---
+origin=$(git remote get-url origin)
+slug=$(echo "$origin" | sed -E 's#(git@github.com:|https://github.com/)##; s#\.git$##')
 if [ -z "$url" ]; then
-  tag=$(git describe --tags --exact-match 2>/dev/null) \
-    || die "HEAD is not at a release tag; check out the proposal tag (git checkout v<spec>) or pass --url"
-  origin=$(git remote get-url origin)
-  slug=$(echo "$origin" | sed -E 's#(git@github.com:|https://github.com/)##; s#\.git$##')
+  tag=$(curl -fsSL "https://api.github.com/repos/${slug}/releases?per_page=1" \
+    | jq -r '.[0].tag_name // empty')
+  [ -n "$tag" ] || die "could not discover the newest release; pass --url <release-url>"
   url="https://github.com/${slug}/releases/tag/${tag}"
 fi
 # Strict allowlist: a URL that fails this cannot smuggle shell metacharacters
@@ -81,12 +87,10 @@ release_sha=$(shasum -a 256 "$work/release.wasm" | cut -d' ' -f1)
 ok "release wasm matches manifest sha256"
 
 # ----------------------------------------------------------------- source ---
-head_commit=$(git rev-parse HEAD)
-[ "$head_commit" = "$commit" ] \
-  || die "HEAD ($head_commit) is not the proposal commit ($commit); run: git fetch origin && git checkout $tag"
+git fetch --quiet origin "refs/tags/${tag}:refs/tags/${tag}" 2>/dev/null \
+  || note "could not fetch tag ${tag}; assuming the proposal commit is already local"
 git cat-file -e "${commit}^{commit}" 2>/dev/null \
-  || die "proposal commit $commit is not present locally; run: git fetch origin"
-ok "HEAD is the proposal commit ${commit}"
+  || die "proposal commit $commit not found after fetching origin — do not sign"
 
 # Build from a pristine clone of the proposal commit, never the working
 # tree: local modifications, untracked files, and ignored inputs such as a
@@ -97,10 +101,14 @@ src="$work/src"
 git clone --quiet "$repo_root" "$src"
 git -C "$src" checkout --quiet "$commit" \
   || die "could not check out $commit in the verification clone"
-ok "created pristine source clone at ${commit}"
+ok "created pristine source clone at proposal commit ${commit}"
 
 # ------------------------------------------------------------------ build ---
-pinned_rustc=$(grep -Eo 'RUSTC_VERSION="[0-9.]+"' "$src/scripts/srtool/build-srtool-image.sh" | grep -Eo '[0-9.]+')
+# The builder image recipe comes from the checkout this script runs in (the
+# signer's trusted checkout), never from the proposal commit: a malicious
+# proposal must not be able to swap out the toolchain that verifies it.
+image_script="$repo_root/scripts/srtool/build-srtool-image.sh"
+pinned_rustc=$(grep -Eo 'RUSTC_VERSION="[0-9.]+"' "$image_script" | grep -Eo '[0-9.]+')
 if [ -n "$rustc_line" ]; then
   echo "manifest toolchain: ${rustc_line}; local srtool pin: ${pinned_rustc}"
 fi
@@ -111,7 +119,7 @@ fi
 # fast; the first run takes ~10 min.
 verify_image="srtool-verify"
 note "building the pinned srtool builder image as ${verify_image} (cached after first run)"
-DOCKER_DEFAULT_PLATFORM=linux/amd64 "$src/scripts/srtool/build-srtool-image.sh" "$verify_image"
+DOCKER_DEFAULT_PLATFORM=linux/amd64 "$image_script" "$verify_image"
 
 note "running the deterministic srtool build (30+ min on Apple Silicon under emulation)"
 ( cd "$src/runtime" && { [ -L node-subtensor ] || ln -s . node-subtensor; } )

--- a/scripts/verify-upgrade.sh
+++ b/scripts/verify-upgrade.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # One-command independent verification of a proposed runtime upgrade.
 #
-# For sudo-multisig (triumvirate) signers: rebuilds the runtime from the
-# source you have checked out, byte-compares it against the artifact CI
-# published in the proposal pre-release, and prints the exact sign command
-# pinned to YOUR build. Never signs anything itself.
+# For sudo-multisig (triumvirate) signers: rebuilds the runtime from a
+# pristine export of the proposal commit, byte-compares it against the
+# artifact CI published in the proposal pre-release, and prints the exact
+# sign command pinned to YOUR build. Never signs anything itself.
 #
 # Usage:
 #   git clone <repo> && cd subtensor && git checkout v<spec>
@@ -46,10 +46,11 @@ if [ -z "$url" ]; then
   slug=$(echo "$origin" | sed -E 's#(git@github.com:|https://github.com/)##; s#\.git$##')
   url="https://github.com/${slug}/releases/tag/${tag}"
 fi
-case "$url" in
-  https://github.com/*/releases/tag/*) ;;
-  *) die "unrecognized release URL: $url" ;;
-esac
+# Strict allowlist: a URL that fails this cannot smuggle shell metacharacters
+# into anything we print or run below.
+printf '%s' "$url" | grep -Eq \
+  '^https://github\.com/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/releases/tag/[A-Za-z0-9._-]+$' \
+  || die "unrecognized release URL: $url"
 slug=$(echo "$url" | sed -E 's#https://github.com/([^/]+/[^/]+)/releases/tag/.*#\1#')
 tag=${url##*/}
 dl="https://github.com/${slug}/releases/download/${tag}"
@@ -63,10 +64,14 @@ curl -fsSL "${dl}/upgrade-manifest.json" -o "$work/manifest.json" \
 curl -fsSL "${dl}/subtensor.wasm" -o "$work/release.wasm" \
   || die "could not download subtensor.wasm from the release"
 
-commit=$(jq -r '.commit' "$work/manifest.json")
-expected_sha=$(jq -r '.wasm_sha256' "$work/manifest.json" | sed 's/^0x//')
-spec=$(jq -r '.spec_version' "$work/manifest.json")
+commit=$(jq -r '.commit // empty' "$work/manifest.json")
+expected_sha=$(jq -r '.wasm_sha256 // empty' "$work/manifest.json" | sed 's/^0x//')
+spec=$(jq -r '.spec_version // empty' "$work/manifest.json")
 rustc_line=$(jq -r '.srtool_rustc // empty' "$work/manifest.json")
+printf '%s' "$commit" | grep -Eq '^[0-9a-f]{40}$' \
+  || die "manifest has no valid commit hash — do not sign"
+printf '%s' "$expected_sha" | grep -Eq '^[0-9a-f]{64}$' \
+  || die "manifest has no valid wasm_sha256 — do not sign"
 
 # The release wasm must itself match the manifest before we compare anything
 # against it.
@@ -79,35 +84,57 @@ ok "release wasm matches manifest sha256"
 head_commit=$(git rev-parse HEAD)
 [ "$head_commit" = "$commit" ] \
   || die "HEAD ($head_commit) is not the proposal commit ($commit); run: git fetch origin && git checkout $tag"
-git diff --quiet HEAD -- runtime pallets Cargo.toml Cargo.lock \
-  || die "working tree has local modifications under runtime/, pallets/, or the cargo manifests; verify from a clean checkout"
+git cat-file -e "${commit}^{commit}" 2>/dev/null \
+  || die "proposal commit $commit is not present locally; run: git fetch origin"
 ok "HEAD is the proposal commit ${commit}"
 
+# Build from a pristine clone of the proposal commit, never the working
+# tree: local modifications, untracked files, and ignored inputs such as a
+# repo-level .cargo/ directory cannot influence the build or the verdict.
+# A clone (rather than an archive) keeps .git present, matching the CI
+# checkout the released artifact was built from.
+src="$work/src"
+git clone --quiet "$repo_root" "$src"
+git -C "$src" checkout --quiet "$commit" \
+  || die "could not check out $commit in the verification clone"
+ok "created pristine source clone at ${commit}"
+
 # ------------------------------------------------------------------ build ---
-pinned_rustc=$(grep -Eo 'RUSTC_VERSION="[0-9.]+"' scripts/srtool/build-srtool-image.sh | grep -Eo '[0-9.]+')
+pinned_rustc=$(grep -Eo 'RUSTC_VERSION="[0-9.]+"' "$src/scripts/srtool/build-srtool-image.sh" | grep -Eo '[0-9.]+')
 if [ -n "$rustc_line" ]; then
   echo "manifest toolchain: ${rustc_line}; local srtool pin: ${pinned_rustc}"
 fi
-if ! docker image inspect srtool >/dev/null 2>&1; then
-  note "srtool image not found locally; building it (one-time, ~10 min)"
-  DOCKER_DEFAULT_PLATFORM=linux/amd64 ./scripts/srtool/build-srtool-image.sh
-fi
+
+# Always (re)build the builder image from the commit-pinned srtool source
+# under a dedicated tag, so a stale or hostile pre-existing `srtool` image
+# cannot stand in as the verifier. With a warm docker layer cache this is
+# fast; the first run takes ~10 min.
+verify_image="srtool-verify"
+note "building the pinned srtool builder image as ${verify_image} (cached after first run)"
+DOCKER_DEFAULT_PLATFORM=linux/amd64 "$src/scripts/srtool/build-srtool-image.sh" "$verify_image"
 
 note "running the deterministic srtool build (30+ min on Apple Silicon under emulation)"
-( cd runtime && { [ -L node-subtensor ] || ln -s . node-subtensor; } )
+( cd "$src/runtime" && { [ -L node-subtensor ] || ln -s . node-subtensor; } )
+# Fresh cargo home: a signer's ~/.cargo/config.toml could redirect registries
+# or patch sources, so the verification build must not see it.
+mkdir -p "$work/cargo-home"
 docker run --rm --user root --platform=linux/amd64 \
   -e PACKAGE=node-subtensor-runtime \
   -e BUILD_OPTS="--features=metadata-hash" \
   -e PROFILE=production \
-  -v "$HOME/.cargo":/cargo-home \
-  -v "$repo_root":/build \
-  srtool bash -c "git config --global --add safe.directory /build && \
+  -v "$work/cargo-home":/cargo-home \
+  -v "$src":/build \
+  "$verify_image" bash -c "git config --global --add safe.directory /build && \
     /srtool/build --app > /build/runtime/node-subtensor/srtool-output.log; \
     code=\$?; [ \$code -ne 0 ] && cat /build/runtime/node-subtensor/srtool-output.log && exit \$code; \
     exit 0"
 
-local_wasm=$(find runtime -name 'node_subtensor_runtime.compact.compressed.wasm' -path '*srtool*' | head -n 1)
-[ -n "$local_wasm" ] || die "srtool build produced no compact.compressed.wasm"
+built_wasm=$(find "$src/runtime" -name 'node_subtensor_runtime.compact.compressed.wasm' -path '*srtool*' | head -n 1)
+[ -n "$built_wasm" ] || die "srtool build produced no compact.compressed.wasm"
+# $work (and the wasm inside it) is deleted on exit; keep a copy beside the
+# repo so the printed sign command references a path that still exists.
+local_wasm="$repo_root/verified-${tag}.wasm"
+cp "$built_wasm" "$local_wasm"
 
 # ---------------------------------------------------------------- compare ---
 local_sha=$(shasum -a 256 "$local_wasm" | cut -d' ' -f1)
@@ -127,10 +154,10 @@ if command -v btcli >/dev/null; then
   btcli upgrade check --url "$url" --wasm "$local_wasm"
 else
   note "btcli not found; to also verify call data and on-chain state, install it and run:"
-  echo "  btcli upgrade check --url $url --wasm $local_wasm"
+  printf '  btcli upgrade check --url %q --wasm %q\n' "$url" "$local_wasm"
 fi
 
 echo
 echo "All verifications passed. To sign, pinning the call data to your own build:"
 echo
-echo "  btcli upgrade sign --url $url --wasm $local_wasm -w <your-wallet>"
+printf '  btcli upgrade sign --url %q --wasm %q -w <your-wallet>\n' "$url" "$local_wasm"


### PR DESCRIPTION
## Summary
- Adds `scripts/verify-upgrade.sh`: signers check out the proposal tag and run one command. It downloads the release manifest and wasm, verifies the checkout is the proposal commit and the tree is clean, runs the same deterministic srtool container CI uses, byte-compares the result against the released runtime, runs `btcli upgrade check` if available, and prints the `btcli upgrade sign` command pinned to the signer's own build. It never submits anything.
- Release-train proposal pre-release notes now show the one-command flow instead of "srtool build, then:".
- Deploy README documents the script ahead of the manual recipe (which is kept).

## Test plan
- [x] `bash -n` and shellcheck clean
- [x] Front half exercised against the live v430 release with a docker stub: release-wasm/manifest sha match, commit pinning, toolchain report all pass; correctly dies when no build output exists
- [ ] Full end-to-end run doubles as the v430 verification currently running locally

Made with [Cursor](https://cursor.com)