### PR TITLE
fix: alias staging docs via the deployments API

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -63,6 +63,17 @@ jobs:
             npx --yes vercel build --token "$VERCEL_TOKEN"
             url=$(npx --yes vercel deploy --prebuilt --token "$VERCEL_TOKEN")
             echo "Deployed: $url"
-            npx --yes vercel alias set "$url" "staging.$DOCS_DOMAIN" --token "$VERCEL_TOKEN"
+            # `vercel alias set` only accepts domains in the team-level domain
+            # registry; staging.$DOCS_DOMAIN is attached (and verified) at the
+            # project level, so the CLI rejects it with "you don't have access
+            # to the domain". The deployments API honors project domains.
+            dep_id=$(curl -sf -H "Authorization: Bearer $VERCEL_TOKEN" \
+              "https://api.vercel.com/v13/deployments/${url#https://}?teamId=$VERCEL_ORG_ID" \
+              | node -pe 'JSON.parse(require("fs").readFileSync(0, "utf8")).id')
+            curl -sf -X POST \
+              -H "Authorization: Bearer $VERCEL_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "{\"alias\":\"staging.$DOCS_DOMAIN\"}" \
+              "https://api.vercel.com/v2/deployments/$dep_id/aliases?teamId=$VERCEL_ORG_ID" > /dev/null
             echo "Aliased to https://staging.$DOCS_DOMAIN" >> $GITHUB_STEP_SUMMARY
           fi


### PR DESCRIPTION
## Summary
- Every `Deploy Docs` run on main has failed at the final step with `Error: You don't have access to the domain staging.bittensor.com under rao-foundation`, because `vercel alias set` only accepts domains in the team-level domain registry while `staging.bittensor.com` is attached (and verified) at the project level.
- Replace the CLI alias with the Vercel deployments API (`GET /v13/deployments/<url>` to resolve the id, `POST /v2/deployments/<id>/aliases`), which honors project domains. `curl -sf` fails the step on any HTTP error.

## Test plan
- [x] Ran the exact resolve-and-alias pipeline locally against the latest deployment with the same token scope; the alias was applied and https://staging.bittensor.com serves it.
- [ ] After merge, confirm the `Deploy Docs` run goes green and staging.bittensor.com picks up the new deployment.

Made with [Cursor](https://cursor.com)