### PR TITLE
fix release page node upgrade guidance

### DIFF
--- a/website/apps/bittensor-website/src/app/(pages-without-footer)/releases/v431-upgrade/page.tsx
+++ b/website/apps/bittensor-website/src/app/(pages-without-footer)/releases/v431-upgrade/page.tsx
@@ -553,8 +553,9 @@ btcli tx transfer --dest 5F...dest --amount-tao 1 --signer extension`}
               every existing proxy configuration.
             </li>
             <li>
-              <strong>Node operators</strong> — nodes not yet running the spec 431 binary must
-              upgrade to continue syncing.
+              <strong>Node operators</strong> — no binary upgrade is required to continue
+              syncing. Nodes execute the upgraded on-chain Wasm runtime automatically; install
+              the latest node image when it is published to receive node-software updates.
             </li>
             <li>
               <strong>Indexers and SDK authors</strong> — chain metadata now carries typed


### PR DESCRIPTION
## What changed

Correct the v431 release page's node-operator guidance. The page now states that the runtime upgrade does not require a new node binary to continue syncing, while still recommending the latest image for node-software updates.

## Root cause

The release page originally described spec 430, including an unsupported claim that nodes needed a spec-matched binary to keep syncing. Commit `19a2c906` renamed the website release to v431, but no node or runtime compatibility change accompanied that rename.

## Compatibility evidence

- The official v424 and v430 runtime Wasm artifacts have identical import sets: 51 imports each, with no new host functions.
- The v424 and v430 node executors expose the same host-function tuple.
- Testnet is executing spec 430 successfully with the same authoring, transaction, state, and core runtime API versions reported by spec 424 on mainnet.
- The node uses `WasmExecutor`, so block import executes the on-chain runtime rather than requiring a native runtime with a matching spec version.
- The SDK crates are workspace members but are not dependencies of `node-subtensor`; SDK changes do not participate in block import.

## Operator impact

Operators do not need to perform an emergency binary upgrade to avoid a sync halt. They can install the latest image when published to receive node-software updates.

## Verification

- `yarn workspace @raofoundation/bittensor-website eslint 'src/app/(pages-without-footer)/releases/v431-upgrade/page.tsx'`
- `yarn workspace @raofoundation/bittensor-website tsc --noEmit`
- `yarn workspace @raofoundation/bittensor-website build`
- Confirmed the generated `/releases/v431-upgrade` HTML contains the corrected guidance.
- `git diff --check`

Note: whole-file Prettier check remains red because this newly added page has pre-existing formatting differences; this PR avoids unrelated formatting churn.
