### PR TITLE
Remove set_tempo extrinsic from SubtensorPallet

### DIFF
--- a/pallets/admin-utils/src/benchmarking.rs
+++ b/pallets/admin-utils/src/benchmarking.rs
@@ -348,28 +348,22 @@ mod benchmarks {
 		_(RawOrigin::Root, 1u16.into()/*netuid*/, true/*registration_allowed*/)/*sudo_set_network_registration_allowed*/;
     }
 
-    /*
-        benchmark_sudo_set_tempo {
-        let netuid = NetUid::from(1);
-        let tempo_default: u16 = 1; <------- unused?
-        let tempo: u16 = 15;
-        let modality: u16 = 0;
-
-        pallet_subtensor::Pallet::<T>::init_new_network(netuid, tempo);
-
-    }: sudo_set_tempo(RawOrigin::<AccountIdOf<T>>::Root, netuid, tempo)
-    */
     #[benchmark]
     fn sudo_set_tempo() {
+        let netuid = NetUid::from(1);
+        let owner: T::AccountId = account("owner", 0, 0);
+
         // disable admin freeze window
         pallet_subtensor::Pallet::<T>::set_admin_freeze_window(0);
-        pallet_subtensor::Pallet::<T>::init_new_network(
-            1u16.into(), /*netuid*/
-            1u16,        /*tempo*/
-        );
+        pallet_subtensor::Pallet::<T>::init_new_network(netuid, pallet_subtensor::MIN_TEMPO);
+        pallet_subtensor::SubnetOwner::<T>::insert(netuid, &owner);
 
         #[extrinsic_call]
-		_(RawOrigin::Root, 1u16.into()/*netuid*/, 1u16/*tempo*/)/*sudo_set_tempo*/;
+        _(
+            RawOrigin::Signed(owner),
+            netuid,
+            pallet_subtensor::MIN_TEMPO + 1,
+        );
     }
 
     #[benchmark]

--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -974,19 +974,43 @@ pub mod pallet {
             Ok(())
         }
 
-        /// The extrinsic sets the tempo for a subnet.
-        /// It is only callable by the root account.
-        /// The extrinsic will call the Subtensor pallet to set the tempo.
+        /// Sets the tempo for a subnet.
+        ///
+        /// Callable by root or the subnet owner. Subnet owners are constrained to
+        /// `[MinTempo, MaxTempo]` and a fixed `MinTempo`-block cooldown. Root bypasses
+        /// those owner restrictions. Both origins respect the admin freeze window.
         #[pallet::call_index(30)]
-        #[pallet::weight(<T as pallet::Config>::WeightInfo::sudo_set_tempo())]
+        #[pallet::weight(
+            <T as pallet::Config>::WeightInfo::sudo_set_tempo().max(
+                // Conservative floor from the retired owner-call benchmark, plus
+                // the additional subnet-existence read performed by this call.
+                Weight::from_parts(44_877_000, 4_498)
+                    .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(7_u64))
+                    .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(3_u64))
+            )
+        )]
         pub fn sudo_set_tempo(origin: OriginFor<T>, netuid: NetUid, tempo: u16) -> DispatchResult {
-            ensure_root(origin)?;
+            let tx = TransactionType::TempoUpdate;
+            let maybe_owner = pallet_subtensor::Pallet::<T>::ensure_sn_owner_or_root_with_limits(
+                origin,
+                netuid,
+                &[tx],
+            )?;
+
+            if maybe_owner.is_some() {
+                ensure!(
+                    (pallet_subtensor::MIN_TEMPO..=pallet_subtensor::MAX_TEMPO).contains(&tempo),
+                    pallet_subtensor::Error::<T>::TempoOutOfBounds
+                );
+            }
+
             pallet_subtensor::Pallet::<T>::ensure_admin_window_open(netuid)?;
             ensure!(
                 pallet_subtensor::Pallet::<T>::if_subnet_exist(netuid),
                 Error::<T>::SubnetDoesNotExist
             );
             pallet_subtensor::Pallet::<T>::apply_tempo_with_cycle_reset(netuid, tempo);
+            pallet_subtensor::Pallet::<T>::record_owner_rl(maybe_owner, netuid, &[tx]);
             log::debug!("TempoSet( netuid: {netuid:?} tempo: {tempo:?} ) ");
             Ok(())
         }

--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -68,6 +68,93 @@ fn test_sudo_set_serving_rate_limit() {
 }
 
 #[test]
+fn test_sudo_set_tempo() {
+    new_test_ext().execute_with(|| {
+        let netuid = NetUid::from(1);
+        let initial_tempo = 10;
+        let owner = U256::from(7);
+        let new_tempo = pallet_subtensor::MIN_TEMPO * 2;
+        add_network(netuid, initial_tempo);
+        SubnetOwner::<Test>::insert(netuid, owner);
+        SubtensorModule::set_admin_freeze_window(0);
+        System::set_block_number(42);
+
+        assert_noop!(
+            AdminUtils::sudo_set_tempo(RuntimeOrigin::signed(U256::from(1)), netuid, new_tempo),
+            DispatchError::BadOrigin
+        );
+        assert_eq!(Tempo::<Test>::get(netuid), initial_tempo);
+
+        assert_noop!(
+            AdminUtils::sudo_set_tempo(RuntimeOrigin::root(), netuid.next(), new_tempo),
+            Error::<Test>::SubnetDoesNotExist
+        );
+
+        assert_ok!(AdminUtils::sudo_set_tempo(
+            RuntimeOrigin::signed(owner),
+            netuid,
+            new_tempo
+        ));
+        assert_eq!(Tempo::<Test>::get(netuid), new_tempo);
+        assert_eq!(LastEpochBlock::<Test>::get(netuid), 42);
+
+        // Root bypasses owner bounds and the owner cooldown.
+        assert_ok!(AdminUtils::sudo_set_tempo(
+            RuntimeOrigin::root(),
+            netuid,
+            initial_tempo
+        ));
+        assert_eq!(Tempo::<Test>::get(netuid), initial_tempo);
+        assert_eq!(LastEpochBlock::<Test>::get(netuid), 42);
+    });
+}
+
+#[test]
+fn test_owner_set_tempo_enforces_bounds_and_fixed_rate_limit() {
+    new_test_ext().execute_with(|| {
+        let netuid = NetUid::from(1);
+        let owner = U256::from(7);
+        add_network(netuid, 10);
+        SubnetOwner::<Test>::insert(netuid, owner);
+        SubtensorModule::set_admin_freeze_window(0);
+        System::set_block_number(42);
+
+        assert_noop!(
+            AdminUtils::sudo_set_tempo(
+                RuntimeOrigin::signed(owner),
+                netuid,
+                pallet_subtensor::MIN_TEMPO - 1,
+            ),
+            SubtensorError::<Test>::TempoOutOfBounds
+        );
+
+        assert_ok!(AdminUtils::sudo_set_tempo(
+            RuntimeOrigin::signed(owner),
+            netuid,
+            pallet_subtensor::MIN_TEMPO
+        ));
+
+        System::set_block_number(42 + pallet_subtensor::MIN_TEMPO as u64 - 1);
+        assert_noop!(
+            AdminUtils::sudo_set_tempo(
+                RuntimeOrigin::signed(owner),
+                netuid,
+                pallet_subtensor::MIN_TEMPO + 1,
+            ),
+            SubtensorError::<Test>::TxRateLimitExceeded
+        );
+
+        System::set_block_number(42 + pallet_subtensor::MIN_TEMPO as u64);
+        assert_ok!(AdminUtils::sudo_set_tempo(
+            RuntimeOrigin::signed(owner),
+            netuid,
+            pallet_subtensor::MIN_TEMPO + 1,
+        ));
+        assert_eq!(Tempo::<Test>::get(netuid), pallet_subtensor::MIN_TEMPO + 1);
+    });
+}
+
+#[test]
 fn test_sudo_set_min_difficulty() {
     new_test_ext().execute_with(|| {
         let netuid = NetUid::from(1);

--- a/pallets/subtensor/src/benchmarks.rs
+++ b/pallets/subtensor/src/benchmarks.rs
@@ -2303,21 +2303,6 @@ mod pallet_benchmarks {
     }
 
     #[benchmark]
-    fn set_tempo() {
-        let netuid = NetUid::from(1);
-        let coldkey: T::AccountId = account("Owner", 0, 1);
-
-        Subtensor::<T>::init_new_network(netuid, 1u16);
-        SubnetOwner::<T>::insert(netuid, coldkey.clone());
-        SubtokenEnabled::<T>::insert(netuid, true);
-        Subtensor::<T>::set_commit_reveal_weights_enabled(netuid, false);
-        Subtensor::<T>::set_admin_freeze_window(0);
-
-        #[extrinsic_call]
-        _(RawOrigin::Signed(coldkey.clone()), netuid, MIN_TEMPO);
-    }
-
-    #[benchmark]
     fn set_activity_cutoff_factor() {
         let netuid = NetUid::from(1);
         let coldkey: T::AccountId = account("Owner", 0, 1);

--- a/pallets/subtensor/src/coinbase/tempo_control.rs
+++ b/pallets/subtensor/src/coinbase/tempo_control.rs
@@ -8,31 +8,6 @@ use crate::system::pallet_prelude::OriginFor;
 use crate::utils::rate_limiting::{Hyperparameter, TransactionType};
 
 impl<T: Config> Pallet<T> {
-    /// Owner-side `set_tempo` implementation.
-    pub fn do_set_tempo(origin: OriginFor<T>, netuid: NetUid, tempo: u16) -> DispatchResult {
-        let who = Self::ensure_subnet_owner(origin, netuid)?;
-
-        ensure!(
-            (MIN_TEMPO..=MAX_TEMPO).contains(&tempo),
-            Error::<T>::TempoOutOfBounds
-        );
-
-        Self::ensure_admin_window_open(netuid)?;
-
-        let tx = TransactionType::TempoUpdate;
-        ensure!(
-            tx.passes_rate_limit_on_subnet::<T>(&who, netuid),
-            Error::<T>::TxRateLimitExceeded
-        );
-
-        let now = Self::get_current_block_as_u64();
-
-        Self::apply_tempo_with_cycle_reset(netuid, tempo);
-
-        tx.set_last_block_on_subnet::<T>(&who, netuid, now);
-        Ok(())
-    }
-
     /// `set_activity_cutoff_factor` implementation. Callable by the subnet owner
     /// (subject to admin freeze window + rate limit) or by root (bypasses both).
     pub fn do_set_activity_cutoff_factor(

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -1830,9 +1830,9 @@ pub mod pallet {
     #[pallet::storage]
     pub type Tempo<T> = StorageMap<_, Identity, NetUid, u16, ValueQuery, DefaultTempo<T>>;
 
-    /// Lower bound for owner-set tempo. Also the fixed cooldown for `set_tempo`.
+    /// Lower bound for owner-set tempo. Also the fixed cooldown for tempo updates.
     pub const MIN_TEMPO: u16 = 360;
-    /// Upper bound for owner-set tempo (≈ 7 days at 12 s/block).
+    /// Upper bound for owner-set tempo and safety threshold for stalled subnet epochs.
     pub const MAX_TEMPO: u16 = 50_400;
     /// Lower bound for activity-cutoff factor (per-mille). 1_000 = one full tempo.
     pub const MIN_ACTIVITY_CUTOFF_FACTOR_MILLI: u32 = 1_000;
@@ -1851,7 +1851,7 @@ pub mod pallet {
     /// MAP ( netuid ) --> last epoch attempt block (consumed slot).
     /// Drives normal-cadence scheduling and the admin freeze window.
     /// Advances on every `should_run_epoch == true` slot — including consistency-skipped slots —
-    /// and on a successful `set_tempo` (cycle reset).
+    /// and when an administrative tempo update resets the cycle.
     #[pallet::storage]
     pub type LastEpochBlock<T> =
         StorageMap<_, Identity, NetUid, u64, ValueQuery, DefaultZeroU64<T>>;

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2337,15 +2337,6 @@ mod dispatches {
             Self::do_set_perpetual_lock(&coldkey, netuid, enabled)
         }
 
-        /// Owner-side `set_tempo`. Validates `[MinTempo, MaxTempo]`, applies a fixed
-        /// `MinTempo`-block cooldown via `TransactionType::TempoUpdate`, respects the admin
-        /// freeze window, and resets the cycle (`LastEpochBlock = current_block`) on success.
-        #[pallet::call_index(139)]
-        #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::set_tempo())]
-        pub fn set_tempo(origin: OriginFor<T>, netuid: NetUid, tempo: u16) -> DispatchResult {
-            Self::do_set_tempo(origin, netuid, tempo)
-        }
-
         /// `set_activity_cutoff_factor`. Per-mille (1/1000) units; `cutoff_blocks
         /// = (factor × tempo) / 1000`. Validates `[MinActivityCutoffFactorMilli,
         /// MaxActivityCutoffFactorMilli]`. Callable by the subnet owner (rate-limited

--- a/pallets/subtensor/src/migrations/migrate_dynamic_tempo.rs
+++ b/pallets/subtensor/src/migrations/migrate_dynamic_tempo.rs
@@ -12,10 +12,10 @@ use sp_std::collections::vec_deque::VecDeque;
 ///    `(block + netuid + 1) % (tempo + 1) == 0`. The new scheduler period is
 ///    `tempo` (next firing at `LastEpochBlock + tempo`).
 ///    Existing `Tempo[netuid]` values are preserved as-is regardless of whether
-///    they fall inside `[MIN_TEMPO, MAX_TEMPO]`. Owner-side `set_tempo` enforces
-///    the bounds for new updates; root-side `sudo_set_tempo` can still write any
-///    `u16`. Subnets with `Tempo == 0` are left as-is — the legacy short-circuit
-///    keeps them dormant and matches their pre-upgrade behaviour.
+///    they fall inside `[MIN_TEMPO, MAX_TEMPO]`. Owner-origin `AdminUtils::sudo_set_tempo`
+///    enforces the bounds for new updates; root can still write any `u16`. Subnets with
+///    `Tempo == 0` are left as-is — the legacy short-circuit keeps them dormant and matches
+///    their pre-upgrade behaviour.
 /// 2. Converts each subnet's existing `ActivityCutoff[netuid]` (absolute block count)
 ///    into `ActivityCutoffFactorMilli[netuid]` (per-mille of `tempo`) so that
 ///    `factor * tempo / 1000 ≈ old_cutoff` post-upgrade. Production defaults

--- a/pallets/subtensor/src/tests/tempo_control.rs
+++ b/pallets/subtensor/src/tests/tempo_control.rs
@@ -11,7 +11,6 @@ use crate::{
 };
 
 const DEFAULT_TEMPO: u16 = 360;
-const NEW_TEMPO: u16 = 720;
 
 fn setup_subnet(owner: U256) -> NetUid {
     let netuid = NetUid::from(1);
@@ -20,26 +19,6 @@ fn setup_subnet(owner: U256) -> NetUid {
     SubtokenEnabled::<Test>::insert(netuid, true);
     crate::Pallet::<Test>::set_admin_freeze_window(0);
     netuid
-}
-
-#[test]
-fn do_set_tempo_works_with_commit_reveal_enabled() {
-    new_test_ext(1).execute_with(|| {
-        let owner = U256::from(1);
-        let netuid = setup_subnet(owner);
-
-        // CR is enabled by default; `set_tempo` is no longer blocked for CR
-        // subnets — CR timing keys off the stateful `SubnetEpochIndex` counter.
-        assert!(CommitRevealWeightsEnabled::<Test>::get(netuid));
-
-        assert_ok!(crate::Pallet::<Test>::do_set_tempo(
-            <<Test as Config>::RuntimeOrigin>::signed(owner),
-            netuid,
-            NEW_TEMPO,
-        ));
-
-        assert_eq!(Tempo::<Test>::get(netuid), NEW_TEMPO);
-    });
 }
 
 #[test]
@@ -215,31 +194,6 @@ fn get_next_epoch_start_block_ignores_pending_when_auto_is_earlier() {
         assert_eq!(
             crate::Pallet::<Test>::get_next_epoch_start_block(netuid),
             Some(150)
-        );
-    });
-}
-
-#[test]
-fn get_next_epoch_start_block_reflects_set_tempo_cycle_reset() {
-    new_test_ext(1).execute_with(|| {
-        let owner = U256::from(1);
-        let netuid = setup_subnet(owner);
-
-        run_to_block(10);
-        let new_tempo: u16 = 720;
-
-        assert_ok!(crate::Pallet::<Test>::do_set_tempo(
-            <<Test as Config>::RuntimeOrigin>::signed(owner),
-            netuid,
-            new_tempo,
-        ));
-
-        let now = crate::Pallet::<Test>::get_current_block_as_u64();
-        // apply_tempo_with_cycle_reset sets LastEpochBlock = now;
-        // next fire is now + tempo.
-        assert_eq!(
-            crate::Pallet::<Test>::get_next_epoch_start_block(netuid),
-            Some(now + new_tempo as u64)
         );
     });
 }

--- a/pallets/subtensor/src/utils/misc.rs
+++ b/pallets/subtensor/src/utils/misc.rs
@@ -108,9 +108,8 @@ impl<T: Config> Pallet<T> {
     // ==== Global Setters ====
     // ========================
     /// Unchecked tempo write used by tests, precompiles, and internal helpers.
-    /// Does NOT reset `LastEpochBlock` — that is the responsibility of the owner-side
-    /// `set_tempo` extrinsic and `sudo_set_tempo` (root), both of which perform the cycle
-    /// reset explicitly.
+    /// Does NOT reset `LastEpochBlock`; `AdminUtils::sudo_set_tempo` performs the cycle reset
+    /// explicitly for owner and root updates.
     pub fn set_tempo_unchecked(netuid: NetUid, tempo: u16) {
         Tempo::<T>::insert(netuid, tempo);
         Self::deposit_event(Event::TempoSet(netuid, tempo));

--- a/pallets/subtensor/src/weights.rs
+++ b/pallets/subtensor/src/weights.rs
@@ -94,7 +94,6 @@ pub trait WeightInfo {
 	fn lock_stake() -> Weight;
 	fn move_lock() -> Weight;
 	fn associate_evm_key() -> Weight;
-	fn set_tempo() -> Weight;
 	fn set_activity_cutoff_factor() -> Weight;
 	fn trigger_epoch() -> Weight;
 	fn check_coldkey_swap_extension() -> Weight;
@@ -2468,27 +2467,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		Weight::from_parts(733_820_000, 4622)
 			.saturating_add(T::DbWeight::get().reads(5_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
-	}
-	/// Storage: `SubtensorModule::SubnetOwner` (r:1 w:0)
-	/// Proof: `SubtensorModule::SubnetOwner` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::Tempo` (r:1 w:1)
-	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::PendingEpochAt` (r:1 w:0)
-	/// Proof: `SubtensorModule::PendingEpochAt` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::LastEpochBlock` (r:1 w:1)
-	/// Proof: `SubtensorModule::LastEpochBlock` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::AdminFreezeWindow` (r:1 w:0)
-	/// Proof: `SubtensorModule::AdminFreezeWindow` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::TransactionKeyLastBlock` (r:1 w:1)
-	/// Proof: `SubtensorModule::TransactionKeyLastBlock` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	fn set_tempo() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `975`
-		//  Estimated: `4440`
-		// Minimum execution time: 43_154_000 picoseconds.
-		Weight::from_parts(44_877_000, 4440)
-			.saturating_add(T::DbWeight::get().reads(6_u64))
-			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
 	/// Storage: `SubtensorModule::SubnetOwner` (r:1 w:0)
 	/// Proof: `SubtensorModule::SubnetOwner` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -5006,27 +4984,6 @@ impl WeightInfo for () {
 		Weight::from_parts(733_820_000, 4622)
 			.saturating_add(RocksDbWeight::get().reads(5_u64))
 			.saturating_add(RocksDbWeight::get().writes(2_u64))
-	}
-	/// Storage: `SubtensorModule::SubnetOwner` (r:1 w:0)
-	/// Proof: `SubtensorModule::SubnetOwner` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::Tempo` (r:1 w:1)
-	/// Proof: `SubtensorModule::Tempo` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::PendingEpochAt` (r:1 w:0)
-	/// Proof: `SubtensorModule::PendingEpochAt` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::LastEpochBlock` (r:1 w:1)
-	/// Proof: `SubtensorModule::LastEpochBlock` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::AdminFreezeWindow` (r:1 w:0)
-	/// Proof: `SubtensorModule::AdminFreezeWindow` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
-	/// Storage: `SubtensorModule::TransactionKeyLastBlock` (r:1 w:1)
-	/// Proof: `SubtensorModule::TransactionKeyLastBlock` (`max_values`: None, `max_size`: None, mode: `Measured`)
-	fn set_tempo() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `975`
-		//  Estimated: `4440`
-		// Minimum execution time: 43_154_000 picoseconds.
-		Weight::from_parts(44_877_000, 4440)
-			.saturating_add(RocksDbWeight::get().reads(6_u64))
-			.saturating_add(RocksDbWeight::get().writes(3_u64))
 	}
 	/// Storage: `SubtensorModule::SubnetOwner` (r:1 w:0)
 	/// Proof: `SubtensorModule::SubnetOwner` (`max_values`: None, `max_size`: None, mode: `Measured`)

--- a/runtime/src/proxy_filters/call_groups.rs
+++ b/runtime/src/proxy_filters/call_groups.rs
@@ -471,7 +471,6 @@ call_filter_group!(
         RuntimeCall::SubtensorModule(SubtensorCall::sudo_set_min_childkey_take),
         RuntimeCall::SubtensorModule(SubtensorCall::sudo_set_max_childkey_take),
         RuntimeCall::SubtensorModule(SubtensorCall::terminate_lease),
-        RuntimeCall::SubtensorModule(SubtensorCall::set_tempo),
         RuntimeCall::SubtensorModule(SubtensorCall::set_activity_cutoff_factor),
         RuntimeCall::SubtensorModule(SubtensorCall::trigger_epoch),
         RuntimeCall::SubtensorModule(SubtensorCall::sudo_set_num_root_claims),
@@ -489,6 +488,7 @@ call_filter_group!(
     SubnetManagementCalls,
     [
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_serving_rate_limit),
+        RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_tempo),
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_max_difficulty),
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_weights_version_key),
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_adjustment_alpha),
@@ -545,7 +545,6 @@ call_filter_group!(
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_max_registrations_per_block),
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_subnet_owner_cut),
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_network_rate_limit),
-        RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_tempo),
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_total_issuance),
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_network_immunity_period),
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_network_min_lock_cost),

--- a/runtime/src/proxy_filters/mod.rs
+++ b/runtime/src/proxy_filters/mod.rs
@@ -414,9 +414,9 @@ mod tests {
         // Owner-settable subnet params + subnet identity.
         assert!(owner.contains("AdminUtils::sudo_set_serving_rate_limit"));
         assert!(owner.contains("AdminUtils::sudo_set_max_difficulty"));
+        assert!(owner.contains("AdminUtils::sudo_set_tempo"));
         assert!(owner.contains("SubtensorModule::set_subnet_identity"));
         // Root-only admin is not owner-settable (gated by `ensure_root`).
-        assert!(!owner.contains("AdminUtils::sudo_set_tempo"));
         assert!(!owner.contains("AdminUtils::sudo_set_kappa"));
         assert!(!owner.contains("AdminUtils::sudo_set_total_issuance"));
         assert!(!owner.contains("AdminUtils::swap_authorities"));

--- a/sdk/python/bittensor/_generated/calls.py
+++ b/sdk/python/bittensor/_generated/calls.py
@@ -481,11 +481,6 @@ class SubtensorModule:
         return Call('SubtensorModule', 'set_subnet_identity', {'netuid': netuid, 'subnet_name': subnet_name, 'github_repo': github_repo, 'subnet_contact': subnet_contact, 'subnet_url': subnet_url, 'discord': discord, 'description': description, 'logo_url': logo_url, 'additional': additional})
 
     @staticmethod
-    def set_tempo(netuid: 'NetUid', tempo: 'u16') -> Call:
-        'Owner-side `set_tempo`. Validates `[MinTempo, MaxTempo]`, applies a fixed `MinTempo`-block cooldown via `TransactionType::TempoUpdate`, respects the admin freeze window, and resets the cycle (`LastEpochBlock = current_block`) on success.'
-        return Call('SubtensorModule', 'set_tempo', {'netuid': netuid, 'tempo': tempo})
-
-    @staticmethod
     def set_weights(netuid: 'NetUid', dests: 'Any', weights: 'Any', version_key: 'u64') -> Call:
         'Sets the caller weights for the incentive mechanism. The call can be made from the hotkey account so is potentially insecure, however, the damage of changing weights is minimal if caught early. This function includes all the checks that the passed weights meet the requirements. Stored as u16s they represent rational values in the range [0,1] which sum to 1 and can be interpreted as probabilities. The specific weights determine how inflation propagates outward from this peer.  # Note The 16 bit integers weights should represent 1.0 as the max u16. However, the function normalizes all integers to u16_max anyway. This means that if the sum of all elements is larger or smaller than the amount of elements * u16_max, all elements will be corrected for this deviation.  # Arguments * `origin`: The caller, a hotkey who wishes to set their weights.  * `netuid`: The network uid we are setting these weights on.  * `dests`: The edge endpoint for the weight, i.e. j for w_ij.  * `weights`: The u16 integer encoded weights. Interpreted as rational values in the range [0,1]. They must sum to in32::MAX.  * `version_key`: The network version key to check if the validator is up to date.  # Events * `WeightsSet`: On successfully setting the weights on chain.  # Errors * `MechanismDoesNotExist`: Attempting to set weights on a non-existent network.  * `NotRegistered`: Attempting to set weights from a non registered account.  * `WeightVecNotEqualSize`: Attempting to set weights with uids not of same length.  * `DuplicateUids`: Attempting to set weights with duplicate uids.  * `UidsLengthExceedUidsInSubNet`: Attempting to set weights above the max allowed uids.  * `UidVecContainInvalidOne`: Attempting to set weights with invalid uids.  * `WeightVecLengthIsLow`: Attempting to set weights with fewer weights than min.  * `MaxWeightExceeded`: Attempting to set weights with max value exceeding limit.'
         return Call('SubtensorModule', 'set_weights', {'netuid': netuid, 'dests': dests, 'weights': weights, 'version_key': version_key})
@@ -1209,7 +1204,7 @@ class AdminUtils:
 
     @staticmethod
     def sudo_set_tempo(netuid: 'NetUid', tempo: 'u16') -> Call:
-        'The extrinsic sets the tempo for a subnet. It is only callable by the root account. The extrinsic will call the Subtensor pallet to set the tempo.'
+        'Sets the tempo for a subnet.  Callable by root or the subnet owner. Subnet owners are constrained to `[MinTempo, MaxTempo]` and a fixed `MinTempo`-block cooldown. Root bypasses those owner restrictions. Both origins respect the admin freeze window.'
         return Call('AdminUtils', 'sudo_set_tempo', {'netuid': netuid, 'tempo': tempo})
 
     @staticmethod
@@ -1582,5 +1577,3 @@ class LimitOrders:
     def set_pallet_status(enabled: 'bool') -> Call:
         'Set a status for the limit orders pallet  Must be called by root It allows disabling or enabling the pallet true means enabling, false means disabling'
         return Call('LimitOrders', 'set_pallet_status', {'enabled': enabled})
-
-

--- a/sdk/python/bittensor/_generated/calls.py
+++ b/sdk/python/bittensor/_generated/calls.py
@@ -1,7 +1,7 @@
 """Generated from runtime metadata by codegen. DO NOT EDIT BY HAND.
 
 Regenerate with: python -m codegen <ws-endpoint>
-Spec version: 429
+Spec version: 430
 """
 from typing import Any, NamedTuple
 
@@ -1577,3 +1577,5 @@ class LimitOrders:
     def set_pallet_status(enabled: 'bool') -> Call:
         'Set a status for the limit orders pallet  Must be called by root It allows disabling or enabling the pallet true means enabling, false means disabling'
         return Call('LimitOrders', 'set_pallet_status', {'enabled': enabled})
+
+

--- a/sdk/python/bittensor/_generated/constants.py
+++ b/sdk/python/bittensor/_generated/constants.py
@@ -1,7 +1,7 @@
 """Generated from runtime metadata by codegen. DO NOT EDIT BY HAND.
 
 Regenerate with: python -m codegen <ws-endpoint>
-Spec version: 429
+Spec version: 430
 
 Pallet constant descriptors: unpack into substrate.constant.
 """

--- a/sdk/python/bittensor/_generated/errors.py
+++ b/sdk/python/bittensor/_generated/errors.py
@@ -1,7 +1,7 @@
 """Generated from runtime metadata by codegen. DO NOT EDIT BY HAND.
 
 Regenerate with: python -m codegen <ws-endpoint>
-Spec version: 429
+Spec version: 430
 """
 from dataclasses import dataclass
 

--- a/sdk/python/bittensor/_generated/runtime_apis.py
+++ b/sdk/python/bittensor/_generated/runtime_apis.py
@@ -1,7 +1,7 @@
 """Generated from runtime metadata by codegen. DO NOT EDIT BY HAND.
 
 Regenerate with: python -m codegen <ws-endpoint>
-Spec version: 429
+Spec version: 430
 
 Runtime API method descriptors: unpack into substrate.runtime_call.
 """

--- a/sdk/python/bittensor/_generated/storage.py
+++ b/sdk/python/bittensor/_generated/storage.py
@@ -1,7 +1,7 @@
 """Generated from runtime metadata by codegen. DO NOT EDIT BY HAND.
 
 Regenerate with: python -m codegen <ws-endpoint>
-Spec version: 429
+Spec version: 430
 
 Storage item descriptors: unpack into substrate.query/query_map. Each carries its VALUE's type identity (value_type_ident) so normalization can key on the runtime's own type names without a node round-trip.
 """

--- a/sdk/python/codegen/check.py
+++ b/sdk/python/codegen/check.py
@@ -80,7 +80,6 @@ RAW_ONLY: dict[str, set[str]] = {
         "sudo_set_root_claim_threshold",
         "sudo_set_tx_childkey_take_rate_limit",
         "sudo_set_voting_power_ema_alpha",
-        "set_tempo",
         "trigger_epoch",
         "dissolve_network",
         "root_dissolve_network",


### PR DESCRIPTION
## Summary

- Remove the duplicate `SubtensorModule.set_tempo` extrinsic while leaving call index `139` vacant.
- Allow subnet owners to call `AdminUtils.sudo_set_tempo`.
- Preserve owner bounds validation, admin freeze-window checks, and the fixed `MIN_TEMPO` cooldown.
- Preserve root’s bounds and cooldown bypass.
- Move the call into the owner proxy allowlist.
- Update benchmarks, tests, weights, and generated Python SDK calls.

## Testing

- `cargo test -p pallet-admin-utils --lib`
- `cargo test -p pallet-subtensor tempo_control --lib`
- `cargo test -p node-subtensor-runtime proxy_filters --lib`
- `cargo test -p subtensor-precompiles --lib`
- Admin-utils runtime benchmark test
- Python SDK call coverage check