### PR TITLE
Restore devnet and testnet Docker image publishing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,13 +1,16 @@
 name: Publish Docker Image
 
-# Node images publish on runtime releases and on demand. Releases cut by
-# watch-mainnet-release.yml use the default GITHUB_TOKEN, which never emits
-# `release: published`; the watcher therefore dispatches this workflow
-# directly with the release tag. Release-version tags (vN) move :latest.
+# Node images publish when a network mirror moves, on runtime releases, and on
+# demand. Releases cut by watch-mainnet-release.yml use the default
+# GITHUB_TOKEN, which never emits `release: published`; the watcher therefore
+# dispatches this workflow directly with the release tag. Release-version tags
+# (vN) move :latest; network mirror tags do not.
 
 on:
   release:
     types: [published]
+  push:
+    branches: [devnet, testnet]
   workflow_dispatch:
     inputs:
       tag:
@@ -31,7 +34,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.tag || github.ref_name }}
+          # Push/release events carry the immutable promoted commit. Manual
+          # dispatches may override it with a branch or tag.
+          ref: ${{ github.event.inputs.tag || github.sha }}
 
       - name: Resolve immutable source revision
         id: ref
@@ -116,18 +121,15 @@ jobs:
     runs-on: [self-hosted, fireactions-turbo-8]
     timeout-minutes: 30
     steps:
-      - name: Determine tag, ref, and image name
+      - name: Determine tag and image name
         env:
           INPUT_TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
-          ref="$INPUT_TAG"
-          # `ref` is what we check out (a real branch/tag, may contain '/').
           # Docker tags cannot contain '/', so derive the tag by replacing any
           # disallowed characters — otherwise a ref like `feat/x` fails tag
           # validation at push time.
-          tag="${ref//[^a-zA-Z0-9._-]/-}"
+          tag="${INPUT_TAG//[^a-zA-Z0-9._-]/-}"
           echo "tag=$tag" >> $GITHUB_ENV
-          echo "ref=$ref" >> $GITHUB_ENV
           # Move :latest for release events and for dispatched release-version
           # tags (the watcher dispatches with tag=vN because its GITHUB_TOKEN
           # release cannot fire the `release` trigger).

--- a/docs/internals/release-process.mdx
+++ b/docs/internals/release-process.mdx
@@ -52,8 +52,11 @@ Human approval lives in GitHub **environment settings**, not workflow code:
 | mainnet | `mainnet` | environment reviewers **plus** the multisig ceremony below |
 
 Deploys to devnet and testnet are direct `setCode` transactions via the CI
-deploy key; each is followed by an on-chain `spec_version` verification and a
-smoke suite.
+deploy key. After the on-chain `spec_version` is verified, the train moves the
+corresponding network mirror branch. That branch push builds the exact deployed
+commit and updates `ghcr.io/raofoundation/subtensor:devnet` or `:testnet`; it
+does not move `:latest`. The smoke suite then validates the live network while
+the independent image build runs.
 
 ### The mainnet multisig ceremony
 
@@ -74,27 +77,19 @@ running your runtime with a public endpoint
 yet, it cuts the release train's artifacts:
 
 1. **GitHub release** `v<spec_version>`
-2. **Python SDK + bittensor-core wheels** to PyPI (trusted publishing)
-3. **Publishable Rust crates** to crates.io (auto-discovered; workspace crates
+2. **Production Docker images** tagged `v<spec_version>` and `latest`
+3. **Python SDK + bittensor-core wheels** to PyPI (trusted publishing)
+4. **Publishable Rust crates** to crates.io (auto-discovered; workspace crates
    are `publish = false` while they depend on the patched polkadot-sdk fork)
-4. **Production website/docs** to Vercel
+5. **Production website/docs** to Vercel
 
 This ordering means the release always reflects what is *actually running on
 mainnet*, not what was merged.
 
-### Known gap: Docker images don't publish on release
-
-`docker.yml` and `docker-localnet.yml` trigger on `release: published` and are
-what tag `ghcr.io` images (including `:latest`) for a mainnet release. However,
-the watcher creates the release with the default `GITHUB_TOKEN`, and **GitHub
-does not trigger workflows from events created by the default token** (a
-recursion guard). So the production node image is currently *not* published
-when a release is cut. Until fixed (use a PAT/app token for `gh release
-create`, or have the watcher call `gh workflow run docker.yml -f
-branch-or-tag=v<spec>`), publish manually via `docker.yml`'s
-`workflow_dispatch` with the release tag. Note the release also carries no
-attached artifacts — the srtool wasm/digest live only as 90-day workflow
-artifacts on the train run.
+The watcher explicitly dispatches `docker.yml` and `docker-localnet.yml`
+because releases created with the default `GITHUB_TOKEN` do not emit another
+workflow event. The production build publishes both the immutable release tag
+and `:latest`; the localnet build does the same in its separate package.
 
 ## Hotfixes
 


### PR DESCRIPTION
## Summary

- publish `ghcr.io/raofoundation/subtensor:devnet` when the `devnet` mirror branch moves
- publish `ghcr.io/raofoundation/subtensor:testnet` when the `testnet` mirror branch moves
- pin push and release builds to the immutable event SHA
- keep network-channel builds from moving `:latest`
- update the release-process documentation to describe the current mainnet and network-channel flows

## Why

The July release-flow consolidation retained the canonical `devnet` and
`testnet` mirror branches but removed their Docker push triggers. As a result,
deployments continued moving the network branches while the corresponding
container tags stopped updating.

The mirror branches are already the source of truth for the code running on
each network. Triggering Docker publication from those pushes restores the
previous behavior without coupling Docker orchestration to the release train.

## New flow

1. The release train deploys the runtime and verifies the on-chain `spec_version`.
2. It force-updates the matching `devnet` or `testnet` mirror branch to the deployed commit.
3. That push independently builds and publishes the matching Docker channel from the event SHA.
4. Smoke tests validate the live network in parallel.
5. Mainnet releases continue publishing `vN` and `:latest` through the release watcher.

## Validation

- YAML parsing for `docker.yml` and `release-train.yml`
- `git diff --check`
- event/ref/tag resolution checks for devnet, testnet, release, and manual-dispatch cases
- thermo-nuclear maintainability review
