### PR TITLE
Audit fixes for v431

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -35,7 +35,7 @@ jobs:
           sccache-writer-secret-access-key: ${{ secrets.SCCACHE_R2_WRITE_SECRET_ACCESS_KEY }}
 
       - name: Install cargo-audit
-        run: cargo install --force cargo-audit
+        run: cargo install --force --locked cargo-audit
 
       - name: cargo audit
         # Each ignore is a known, accepted advisory; revisit when bumping


### PR DESCRIPTION
## Summary

Stacked fixes for #2898 (`error-descriptions`). This draft is intentionally kept open for additional CI and review fixes.

Initial change:
- install `cargo-audit` with `--locked` so its published lockfile selects dependencies compatible with the repository's Rust 1.89 toolchain

## Root cause

The unlocked install resolved `kstring 2.0.3`, which requires Rust 1.96, and failed before `cargo audit` could run.

## Validation

- `cargo install --force --locked cargo-audit --root /tmp/subtensor-cargo-audit-locked`
- installed and ran `cargo-audit 0.22.2` successfully under Rust 1.89
- `git diff --check`
