### PR TITLE
fix(runtime): preserve deprecated tempo call indices

### DIFF
--- a/docs/migration.mdx
+++ b/docs/migration.mdx
@@ -580,8 +580,8 @@ the upgrade. Full narrative:
 - **Tempo and activity cutoff.** Owner (and root) set these through
   `AdminUtils::sudo_set_tempo` and `AdminUtils::sudo_set_activity_cutoff_factor`.
   `SubtensorModule` call indices 139 (`set_tempo`) and 140
-  (`set_activity_cutoff_factor`) are retired — retarget raw encodings and Owner
-  proxy prebuilds. The live inactivity window is
+  (`set_activity_cutoff_factor`) remain as deprecated compatibility entry points.
+  New integrations should use the AdminUtils calls. The live inactivity window is
   `activity_cutoff_factor` (per-mille of tempo); absolute `activity_cutoff` is
   derived / legacy. Set via `sub.SetHyperparameter` /
   `btcli sudo set --name activity_cutoff_factor|tempo`.

--- a/docs/migration.mdx
+++ b/docs/migration.mdx
@@ -580,8 +580,9 @@ the upgrade. Full narrative:
 - **Tempo and activity cutoff.** Owner (and root) set these through
   `AdminUtils::sudo_set_tempo` and `AdminUtils::sudo_set_activity_cutoff_factor`.
   `SubtensorModule` call indices 139 (`set_tempo`) and 140
-  (`set_activity_cutoff_factor`) remain as deprecated compatibility entry points.
-  New integrations should use the AdminUtils calls. The live inactivity window is
+  (`set_activity_cutoff_factor`) remain as deprecated no-op compatibility entry
+  points: they charge a fee and return success without changing state. Use the
+  AdminUtils calls to update these values. The live inactivity window is
   `activity_cutoff_factor` (per-mille of tempo); absolute `activity_cutoff` is
   derived / legacy. Set via `sub.SetHyperparameter` /
   `btcli sudo set --name activity_cutoff_factor|tempo`.

--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -1007,7 +1007,7 @@ pub mod pallet {
         #[pallet::call_index(30)]
         #[pallet::weight(
             <T as pallet::Config>::WeightInfo::sudo_set_tempo().max(
-                // Conservative floor from the deprecated compatibility call benchmark,
+                // Conservative floor from the original owner-call benchmark,
                 // plus the additional subnet-existence read performed by this call.
                 // Remove once weights are regenerated with the owner-path benchmark.
                 Weight::from_parts(44_877_000, 4_498)

--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -1007,7 +1007,7 @@ pub mod pallet {
         #[pallet::call_index(30)]
         #[pallet::weight(
             <T as pallet::Config>::WeightInfo::sudo_set_tempo().max(
-                // Conservative floor from the retired owner-call `set_tempo` benchmark,
+                // Conservative floor from the deprecated compatibility call benchmark,
                 // plus the additional subnet-existence read performed by this call.
                 // Remove once weights are regenerated with the owner-path benchmark.
                 Weight::from_parts(44_877_000, 4_498)

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2331,34 +2331,28 @@ mod dispatches {
             Self::do_set_perpetual_lock(&coldkey, netuid, enabled)
         }
 
-        /// Deprecated compatibility entry point for setting subnet tempo.
-        /// Use `AdminUtils::sudo_set_tempo` for new integrations.
+        /// Deprecated compatibility entry point retained for call-index stability.
+        /// This call charges a fee, returns success, and does not modify state.
+        /// Use `AdminUtils::sudo_set_tempo` to change subnet tempo.
         #[deprecated(note = "Use `AdminUtils::sudo_set_tempo` instead")]
         #[pallet::call_index(139)]
-        #[pallet::weight(
-            Weight::from_parts(44_877_000, 4_440)
-                .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(6_u64))
-                .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(3_u64))
-        )]
-        pub fn set_tempo(origin: OriginFor<T>, netuid: NetUid, tempo: u16) -> DispatchResult {
-            Self::do_set_tempo(origin, netuid, tempo)
+        #[pallet::weight((Weight::from_parts(0, 0), DispatchClass::Normal, Pays::Yes))]
+        pub fn set_tempo(_origin: OriginFor<T>, _netuid: NetUid, _tempo: u16) -> DispatchResult {
+            Ok(())
         }
 
-        /// Deprecated compatibility entry point for setting the activity-cutoff factor.
-        /// Use `AdminUtils::sudo_set_activity_cutoff_factor` for new integrations.
+        /// Deprecated compatibility entry point retained for call-index stability.
+        /// This call charges a fee, returns success, and does not modify state.
+        /// Use `AdminUtils::sudo_set_activity_cutoff_factor` to change the factor.
         #[deprecated(note = "Use `AdminUtils::sudo_set_activity_cutoff_factor` instead")]
         #[pallet::call_index(140)]
-        #[pallet::weight(
-            Weight::from_parts(37_446_000, 4_364)
-                .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(7_u64))
-                .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(2_u64))
-        )]
+        #[pallet::weight((Weight::from_parts(0, 0), DispatchClass::Normal, Pays::Yes))]
         pub fn set_activity_cutoff_factor(
-            origin: OriginFor<T>,
-            netuid: NetUid,
-            factor_milli: u32,
+            _origin: OriginFor<T>,
+            _netuid: NetUid,
+            _factor_milli: u32,
         ) -> DispatchResult {
-            Self::do_set_activity_cutoff_factor(origin, netuid, factor_milli)
+            Ok(())
         }
 
         /// Owner-side `trigger_epoch`. Schedules an epoch to fire after `AdminFreezeWindow`

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2331,10 +2331,35 @@ mod dispatches {
             Self::do_set_perpetual_lock(&coldkey, netuid, enabled)
         }
 
-        // Call indices 139 (`set_tempo`) and 140 (`set_activity_cutoff_factor`)
-        // are retired: both moved to the AdminUtils pallet (`sudo_set_tempo`,
-        // `sudo_set_activity_cutoff_factor`) where the other owner-settable
-        // hyperparameters live. Do not reuse these indices.
+        /// Deprecated compatibility entry point for setting subnet tempo.
+        /// Use `AdminUtils::sudo_set_tempo` for new integrations.
+        #[deprecated(note = "Use `AdminUtils::sudo_set_tempo` instead")]
+        #[pallet::call_index(139)]
+        #[pallet::weight(
+            Weight::from_parts(44_877_000, 4_440)
+                .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(6_u64))
+                .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(3_u64))
+        )]
+        pub fn set_tempo(origin: OriginFor<T>, netuid: NetUid, tempo: u16) -> DispatchResult {
+            Self::do_set_tempo(origin, netuid, tempo)
+        }
+
+        /// Deprecated compatibility entry point for setting the activity-cutoff factor.
+        /// Use `AdminUtils::sudo_set_activity_cutoff_factor` for new integrations.
+        #[deprecated(note = "Use `AdminUtils::sudo_set_activity_cutoff_factor` instead")]
+        #[pallet::call_index(140)]
+        #[pallet::weight(
+            Weight::from_parts(37_446_000, 4_364)
+                .saturating_add(<T as frame_system::Config>::DbWeight::get().reads(7_u64))
+                .saturating_add(<T as frame_system::Config>::DbWeight::get().writes(2_u64))
+        )]
+        pub fn set_activity_cutoff_factor(
+            origin: OriginFor<T>,
+            netuid: NetUid,
+            factor_milli: u32,
+        ) -> DispatchResult {
+            Self::do_set_activity_cutoff_factor(origin, netuid, factor_milli)
+        }
 
         /// Owner-side `trigger_epoch`. Schedules an epoch to fire after `AdminFreezeWindow`
         /// blocks. Rate-limited via the existing `OwnerHyperparamUpdate` pattern.

--- a/pallets/subtensor/src/tests/tempo_control.rs
+++ b/pallets/subtensor/src/tests/tempo_control.rs
@@ -1,7 +1,10 @@
 #![allow(clippy::expect_used)]
 #![allow(deprecated)]
 use codec::Encode;
-use frame_support::{assert_noop, assert_ok};
+use frame_support::{
+    assert_noop, assert_ok,
+    dispatch::{GetDispatchInfo, Pays},
+};
 use frame_system::Config;
 use sp_core::U256;
 use subtensor_runtime_common::NetUid;
@@ -29,27 +32,36 @@ fn deprecated_tempo_extrinsics_keep_their_call_indices() {
 
     assert_eq!(tempo_call.encode()[0], 139);
     assert_eq!(activity_call.encode()[0], 140);
+    assert_eq!(tempo_call.get_dispatch_info().pays_fee, Pays::Yes);
+    assert_eq!(activity_call.get_dispatch_info().pays_fee, Pays::Yes);
 }
 
 #[test]
-fn deprecated_tempo_extrinsics_forward_to_shared_logic() {
+fn deprecated_tempo_extrinsics_return_ok_without_changing_state() {
     new_test_ext(1).execute_with(|| {
         let owner = U256::from(1);
         let netuid = setup_subnet(owner);
+        let tempo_before = Tempo::<Test>::get(netuid);
+        let factor_before = ActivityCutoffFactorMilli::<Test>::get(netuid);
+        let last_epoch_before = LastEpochBlock::<Test>::get(netuid);
 
         assert_ok!(crate::Pallet::<Test>::set_tempo(
             <<Test as Config>::RuntimeOrigin>::signed(owner),
             netuid,
             NEW_TEMPO,
         ));
-        assert_eq!(Tempo::<Test>::get(netuid), NEW_TEMPO);
-
         assert_ok!(crate::Pallet::<Test>::set_activity_cutoff_factor(
             <<Test as Config>::RuntimeOrigin>::signed(owner),
             netuid,
             5_000,
         ));
-        assert_eq!(ActivityCutoffFactorMilli::<Test>::get(netuid), 5_000);
+
+        assert_eq!(Tempo::<Test>::get(netuid), tempo_before);
+        assert_eq!(
+            ActivityCutoffFactorMilli::<Test>::get(netuid),
+            factor_before
+        );
+        assert_eq!(LastEpochBlock::<Test>::get(netuid), last_epoch_before);
     });
 }
 

--- a/pallets/subtensor/src/tests/tempo_control.rs
+++ b/pallets/subtensor/src/tests/tempo_control.rs
@@ -1,4 +1,6 @@
 #![allow(clippy::expect_used)]
+#![allow(deprecated)]
+use codec::Encode;
 use frame_support::{assert_noop, assert_ok};
 use frame_system::Config;
 use sp_core::U256;
@@ -12,6 +14,44 @@ use crate::{
 
 const DEFAULT_TEMPO: u16 = 360;
 const NEW_TEMPO: u16 = 720;
+
+#[test]
+fn deprecated_tempo_extrinsics_keep_their_call_indices() {
+    let netuid = NetUid::from(1);
+    let tempo_call = crate::Call::<Test>::set_tempo {
+        netuid,
+        tempo: NEW_TEMPO,
+    };
+    let activity_call = crate::Call::<Test>::set_activity_cutoff_factor {
+        netuid,
+        factor_milli: 5_000,
+    };
+
+    assert_eq!(tempo_call.encode()[0], 139);
+    assert_eq!(activity_call.encode()[0], 140);
+}
+
+#[test]
+fn deprecated_tempo_extrinsics_forward_to_shared_logic() {
+    new_test_ext(1).execute_with(|| {
+        let owner = U256::from(1);
+        let netuid = setup_subnet(owner);
+
+        assert_ok!(crate::Pallet::<Test>::set_tempo(
+            <<Test as Config>::RuntimeOrigin>::signed(owner),
+            netuid,
+            NEW_TEMPO,
+        ));
+        assert_eq!(Tempo::<Test>::get(netuid), NEW_TEMPO);
+
+        assert_ok!(crate::Pallet::<Test>::set_activity_cutoff_factor(
+            <<Test as Config>::RuntimeOrigin>::signed(owner),
+            netuid,
+            5_000,
+        ));
+        assert_eq!(ActivityCutoffFactorMilli::<Test>::get(netuid), 5_000);
+    });
+}
 
 fn setup_subnet(owner: U256) -> NetUid {
     let netuid = NetUid::from(1);

--- a/runtime/src/proxy_filters/call_groups.rs
+++ b/runtime/src/proxy_filters/call_groups.rs
@@ -3,6 +3,9 @@
 //! Keep this file boring: one generated group per call-bearing runtime pallet.
 //! Proxy-specific policy belongs in `mod.rs`.
 
+// The Owner proxy keeps deprecated Subtensor tempo calls for encoded-call compatibility.
+#![allow(deprecated)]
+
 use frame_system::Call as SystemCall;
 use pallet_admin_utils::Call as AdminUtilsCall;
 use pallet_balances::Call as BalancesCall;
@@ -480,12 +483,14 @@ call_filter_group!(
     ]
 );
 
-// Subnet parameters a subnet owner may set directly (the admin-utils calls
-// guarded by `ensure_sn_owner_or_root`). These are the genuine owner/lease
-// management surface, as opposed to the root-only `RootConfigCalls`.
+// Subnet parameters a subnet owner may set directly. This includes deprecated
+// Subtensor compatibility calls plus AdminUtils calls guarded by
+// `ensure_sn_owner_or_root`, as opposed to the root-only `RootConfigCalls`.
 call_filter_group!(
     SubnetManagementCalls,
     [
+        RuntimeCall::SubtensorModule(SubtensorCall::set_tempo),
+        RuntimeCall::SubtensorModule(SubtensorCall::set_activity_cutoff_factor),
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_serving_rate_limit),
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_max_difficulty),
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_weights_version_key),
@@ -679,7 +684,7 @@ type SubtensorSplitCalls = (
     SubtensorCommonCalls,
 );
 
-// admin-utils, split for the Owner and SubnetLeaseBeneficiary proxies.
+// AdminUtils calls and deprecated owner-call shims, split for owner proxies.
 #[cfg(test)]
 type AdminUtilsSplitCalls = (SubnetManagementCalls, RootConfigCalls, OwnerKeyCalls);
 

--- a/runtime/src/proxy_filters/mod.rs
+++ b/runtime/src/proxy_filters/mod.rs
@@ -415,9 +415,12 @@ mod tests {
         assert!(owner.contains("AdminUtils::sudo_set_serving_rate_limit"));
         assert!(owner.contains("AdminUtils::sudo_set_max_difficulty"));
         assert!(owner.contains("SubtensorModule::set_subnet_identity"));
-        // Owner-or-root tempo control lives in AdminUtils.
+        // Canonical owner-or-root tempo control lives in AdminUtils; deprecated
+        // Subtensor entry points remain available for encoded-call compatibility.
         assert!(owner.contains("AdminUtils::sudo_set_tempo"));
         assert!(owner.contains("AdminUtils::sudo_set_activity_cutoff_factor"));
+        assert!(owner.contains("SubtensorModule::set_tempo"));
+        assert!(owner.contains("SubtensorModule::set_activity_cutoff_factor"));
         // Root-only admin is not owner-settable (gated by `ensure_root`).
         assert!(!owner.contains("AdminUtils::sudo_set_kappa"));
         assert!(!owner.contains("AdminUtils::sudo_set_total_issuance"));

--- a/sdk/python/bittensor/_generated/calls.py
+++ b/sdk/python/bittensor/_generated/calls.py
@@ -422,7 +422,7 @@ class SubtensorModule:
 
     @staticmethod
     def set_activity_cutoff_factor(netuid: 'NetUid', factor_milli: 'u32') -> Call:
-        'Deprecated compatibility entry point for setting the activity-cutoff factor. Use `AdminUtils::sudo_set_activity_cutoff_factor` for new integrations.'
+        'Deprecated compatibility entry point retained for call-index stability. This call charges a fee, returns success, and does not modify state. Use `AdminUtils::sudo_set_activity_cutoff_factor` to change the factor.'
         return Call('SubtensorModule', 'set_activity_cutoff_factor', {'netuid': netuid, 'factor_milli': factor_milli})
 
     @staticmethod
@@ -482,7 +482,7 @@ class SubtensorModule:
 
     @staticmethod
     def set_tempo(netuid: 'NetUid', tempo: 'u16') -> Call:
-        'Deprecated compatibility entry point for setting subnet tempo. Use `AdminUtils::sudo_set_tempo` for new integrations.'
+        'Deprecated compatibility entry point retained for call-index stability. This call charges a fee, returns success, and does not modify state. Use `AdminUtils::sudo_set_tempo` to change subnet tempo.'
         return Call('SubtensorModule', 'set_tempo', {'netuid': netuid, 'tempo': tempo})
 
     @staticmethod
@@ -1587,4 +1587,3 @@ class LimitOrders:
     def set_pallet_status(enabled: 'bool') -> Call:
         'Set a status for the limit orders pallet  Must be called by root It allows disabling or enabling the pallet true means enabling, false means disabling'
         return Call('LimitOrders', 'set_pallet_status', {'enabled': enabled})
-

--- a/sdk/python/bittensor/_generated/calls.py
+++ b/sdk/python/bittensor/_generated/calls.py
@@ -421,6 +421,11 @@ class SubtensorModule:
         return Call('SubtensorModule', 'serve_prometheus', {'netuid': netuid, 'version': version, 'ip': ip, 'port': port, 'ip_type': ip_type})
 
     @staticmethod
+    def set_activity_cutoff_factor(netuid: 'NetUid', factor_milli: 'u32') -> Call:
+        'Deprecated compatibility entry point for setting the activity-cutoff factor. Use `AdminUtils::sudo_set_activity_cutoff_factor` for new integrations.'
+        return Call('SubtensorModule', 'set_activity_cutoff_factor', {'netuid': netuid, 'factor_milli': factor_milli})
+
+    @staticmethod
     def set_auto_parent_delegation_enabled(hotkey: 'AccountId32', enabled: 'bool') -> Call:
         'Allows a root validator to toggle auto parent delegation for new subnets owner hotkey'
         return Call('SubtensorModule', 'set_auto_parent_delegation_enabled', {'hotkey': hotkey, 'enabled': enabled})
@@ -474,6 +479,11 @@ class SubtensorModule:
     def set_subnet_identity(netuid: 'NetUid', subnet_name: 'Any', github_repo: 'Any', subnet_contact: 'Any', subnet_url: 'Any', discord: 'Any', description: 'Any', logo_url: 'Any', additional: 'Any') -> Call:
         'Set the identity information for a subnet. # Arguments * `origin`: The signature of the calling coldkey, which must be the owner of the subnet.  * `netuid`: The unique network identifier of the subnet.  * `subnet_name`: The name of the subnet.  * `github_repo`: The GitHub repository associated with the subnet identity.  * `subnet_contact`: The contact information for the subnet.'
         return Call('SubtensorModule', 'set_subnet_identity', {'netuid': netuid, 'subnet_name': subnet_name, 'github_repo': github_repo, 'subnet_contact': subnet_contact, 'subnet_url': subnet_url, 'discord': discord, 'description': description, 'logo_url': logo_url, 'additional': additional})
+
+    @staticmethod
+    def set_tempo(netuid: 'NetUid', tempo: 'u16') -> Call:
+        'Deprecated compatibility entry point for setting subnet tempo. Use `AdminUtils::sudo_set_tempo` for new integrations.'
+        return Call('SubtensorModule', 'set_tempo', {'netuid': netuid, 'tempo': tempo})
 
     @staticmethod
     def set_weights(netuid: 'NetUid', dests: 'Any', weights: 'Any', version_key: 'u64') -> Call:
@@ -1577,5 +1587,4 @@ class LimitOrders:
     def set_pallet_status(enabled: 'bool') -> Call:
         'Set a status for the limit orders pallet  Must be called by root It allows disabling or enabling the pallet true means enabling, false means disabling'
         return Call('LimitOrders', 'set_pallet_status', {'enabled': enabled})
-
 


### PR DESCRIPTION
# Summary

- Preserve SubtensorModule call indices 139 and 140 as deprecated compatibility extrinsics.
- Make both deprecated calls no-ops that return success without changing runtime state.
- Mark both calls as Pays::Yes so submitted transactions still pay normal fees.
- Keep AdminUtils as the only functional interface for changing tempo and activity cutoff.
- Restore Python call builders and Owner proxy compatibility for existing encoded calls.
- Update migration documentation to explain the no-op behavior.

# Compatibility

The following deprecated calls remain decodable:

- SubtensorModule.set_tempo at index 139
- SubtensorModule.set_activity_cutoff_factor at index 140

Both calls:

- Return success
- Charge transaction fees
- Do not validate or use their arguments
- Do not modify tempo, activity cutoff, epoch, or rate-limit state

Functional updates must use:

- AdminUtils.sudo_set_tempo
- AdminUtils.sudo_set_activity_cutoff_factor

# Tests

- Verify SCALE call indices remain 139 and 140.
- Verify both calls use Pays::Yes.
- Verify both calls return success.
- Verify tempo, activity cutoff, and epoch state remain unchanged.
- All 12 tempo-control tests pass.
- The AdminUtils tempo owner/root test passes.
- Runtime-benchmark feature compilation passes.
- Rust formatting and diff validation pass.
- Python source compilation passes.