### PR TITLE
release-v441: bump spec and PyPI bases

### DIFF
--- a/.github/workflows/watch-mainnet-release.yml
+++ b/.github/workflows/watch-mainnet-release.yml
@@ -13,7 +13,8 @@ name: Watch Mainnet Release
 #      docker-localnet.yml (a release created with the default GITHUB_TOKEN
 #      does not emit `release: published`, so their `on: release` triggers
 #      never fire for releases cut by this workflow)
-#   3. Python SDK + bittensor-core wheels to PyPI
+#   3. Python SDK + bittensor-core wheels to PyPI when the tagged versions
+#      are not already published completely
 #   4. Publishable Rust crates to crates.io
 #   5. Production website/docs deployment on Vercel
 #   6. Before finalizing the GitHub release, the `mainnet` branch is
@@ -193,12 +194,13 @@ jobs:
               "$chain_spec" "$release_sha" "$chain_code_hash")
             : ${artifact_id:?no artifact matches the immutable tag and finalized runtime}
             echo "artifact_id=$artifact_id" >> "$GITHUB_OUTPUT"
-            python_needed=true
-          elif python3 .github/scripts/check-python-release.py \
+          fi
+
+          if python3 .github/scripts/check-python-release.py \
               --sdk-version "$sdk_version" \
               --core-version "$core_version" \
               --repository "$GITHUB_REPOSITORY"; then
-            echo "Stable Python packages are complete on PyPI."
+            echo "Stable Python packages are complete on PyPI; skipping Python publication."
             python_needed=false
           else
             python_status=$?

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 440,
+    spec_version: 441,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/proxy_filters/call_groups.rs
+++ b/runtime/src/proxy_filters/call_groups.rs
@@ -583,6 +583,8 @@ call_filter_group!(
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_tao_flow_normalization_exponent),
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_tao_flow_smoothing_factor),
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_net_tao_flow_enabled),
+        RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_emission_bar_quantile),
+        RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_emission_gate_exponent),
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_max_mechanism_count),
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_start_call_delay),
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_coldkey_swap_announcement_delay),

--- a/runtime/tests/claim_root_weight.rs
+++ b/runtime/tests/claim_root_weight.rs
@@ -34,10 +34,12 @@ fn claim_root_with_extensions_fits_normal_extrinsic_limit() {
 
     let mut dispatch_info = call.get_dispatch_info();
     dispatch_info.extension_weight = extensions.weight(&call);
-    let max_extrinsic = BlockWeights::get()
+    let Some(max_extrinsic) = BlockWeights::get()
         .get(DispatchClass::Normal)
         .max_extrinsic
-        .expect("normal extrinsics have a configured maximum");
+    else {
+        panic!("normal extrinsics have a configured maximum");
+    };
 
     assert!(
         dispatch_info.total_weight().all_lte(max_extrinsic),

--- a/sdk/bittensor-core-py/pyproject.toml
+++ b/sdk/bittensor-core-py/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 name = "bittensor-core"
 # Static (not read from Cargo.toml) so the release train can stamp PEP 440
 # rc/dev suffixes that cargo's semver would reject.
-version = "0.1.1"
+version = "0.1.2"
 description = "The chain-defined compute core for Bittensor clients: sp-core keys, keyfiles, drand timelock, ML-KEM, SCALE codec, and RFC-0078 metadata digest, built from the bittensor monorepo"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bittensor"
-version = "11.0.1.dev0"
+version = "11.0.2.dev0"
 description = "A lean Python SDK (import bittensor) and CLI (btcli) for the Bittensor chain."
 readme = "README.md"
 requires-python = ">=3.10,<3.15"


### PR DESCRIPTION
## Summary
- Bump runtime `spec_version` **440 → 441** so the release train can propose a new upgrade
- Bump Python package bases to unpublished versions: `bittensor` **11.0.2.dev0**, `bittensor-core` **0.1.2** (11.0.1 / 0.1.1 already on PyPI)
- Register the v440 emission-gate configuration calls in the root-only proxy call group to keep proxy filtering and metadata complete.

No release notes or feature changes — version pumps only so the train can cut a new stable after mainnet executes.

## Test plan
- [ ] CI green
- [ ] Release Train builds 441 and publishes SDK rc against free bases
- [ ] After mainnet 441 lands, watch-mainnet-release publishes stable `11.0.2` / `0.1.2`


Made with [Cursor](https://cursor.com)