### PR TITLE
fix: make release-v441 publication merge-ready

### DIFF
--- a/.github/scripts/python_rc_plan.py
+++ b/.github/scripts/python_rc_plan.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Plan SDK release-candidate publication from stable PyPI base availability."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+SDK_VERSION_RE = re.compile(
+    r'^version = "([0-9]+\.[0-9]+\.[0-9]+)\.dev0"$', re.MULTILINE
+)
+CORE_VERSION_RE = re.compile(r'^version = "([0-9]+\.[0-9]+\.[0-9]+)"$', re.MULTILINE)
+RUN_NUMBER_RE = re.compile(r"^[1-9][0-9]*$")
+
+
+class ApiError(RuntimeError):
+    """PyPI could not provide authoritative package-version state."""
+
+
+class InconsistentPackageState(RuntimeError):
+    """Only one of the SDK and core stable bases is published."""
+
+
+def base_versions(sdk_manifest: str, core_manifest: str) -> tuple[str, str]:
+    """Read the stable SDK and core bases from their project manifests."""
+    sdk_match = SDK_VERSION_RE.search(sdk_manifest)
+    if sdk_match is None:
+        raise ValueError("SDK project.version must be X.Y.Z.dev0")
+    core_match = CORE_VERSION_RE.search(core_manifest)
+    if core_match is None:
+        raise ValueError("core project.version must be X.Y.Z")
+    return sdk_match.group(1), core_match.group(1)
+
+
+def _fetch_status(url: str) -> int:
+    request = Request(
+        url,
+        headers={"User-Agent": "subtensor-release-train/1"},
+    )
+    try:
+        with urlopen(request, timeout=30) as response:
+            return response.status
+    except HTTPError as error:
+        return error.code
+    except (OSError, URLError) as error:
+        raise ApiError(f"could not fetch {url}: {error}") from error
+
+
+def version_is_published(
+    package: str,
+    version: str,
+    *,
+    base_url: str = "https://pypi.org",
+    fetch_status: Callable[[str], int] = _fetch_status,
+) -> bool:
+    """Return whether PyPI has reserved this exact package version."""
+    url = (
+        f"{base_url.rstrip('/')}/pypi/"
+        f"{quote(package, safe='')}/{quote(version, safe='')}/json"
+    )
+    status = fetch_status(url)
+    if status == 200:
+        return True
+    if status == 404:
+        return False
+    raise ApiError(f"{url} returned HTTP {status}")
+
+
+def publication_outputs(
+    sdk_base: str,
+    core_base: str,
+    run_number: str,
+    *,
+    is_published: Callable[[str, str], bool] = version_is_published,
+) -> list[str]:
+    """Return the GitHub job outputs for the consistent package state."""
+    if RUN_NUMBER_RE.fullmatch(run_number) is None:
+        raise ValueError("run number must be a positive integer")
+
+    sdk_published = is_published("bittensor", sdk_base)
+    core_published = is_published("bittensor-core", core_base)
+    if sdk_published != core_published:
+        raise InconsistentPackageState(
+            "one Python stable base is published and the other is available; "
+            "bump the published package base before publishing another rc"
+        )
+    if sdk_published:
+        return ["publish=false"]
+    return [
+        "publish=true",
+        f"sdk={sdk_base}rc{run_number}",
+        f"core={core_base}rc{run_number}",
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("sdk_manifest", type=Path)
+    parser.add_argument("core_manifest", type=Path)
+    parser.add_argument("--run-number", required=True)
+    parser.add_argument("--base-url", default="https://pypi.org")
+    arguments = parser.parse_args()
+    try:
+        sdk_base, core_base = base_versions(
+            arguments.sdk_manifest.read_text(),
+            arguments.core_manifest.read_text(),
+        )
+        outputs = publication_outputs(
+            sdk_base,
+            core_base,
+            arguments.run_number,
+            is_published=lambda package, version: version_is_published(
+                package,
+                version,
+                base_url=arguments.base_url,
+            ),
+        )
+    except (OSError, ApiError, InconsistentPackageState, ValueError) as error:
+        print(f"could not plan Python rc publication: {error}", file=sys.stderr)
+        return 1
+
+    if outputs == ["publish=false"]:
+        print(
+            f"Stable bittensor {sdk_base} and bittensor-core {core_base} "
+            "are already published; skipping SDK rc publication.",
+            file=sys.stderr,
+        )
+    print(*outputs, sep="\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_python_rc_plan.py
+++ b/.github/scripts/test_python_rc_plan.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import unittest
+
+from python_rc_plan import (
+    ApiError,
+    InconsistentPackageState,
+    base_versions,
+    publication_outputs,
+    version_is_published,
+)
+
+
+class PythonRcPlanTests(unittest.TestCase):
+    def test_reads_stable_bases_from_manifests(self) -> None:
+        self.assertEqual(
+            base_versions(
+                '[project]\nversion = "11.0.2.dev0"\n',
+                '[project]\nversion = "0.1.2"\n',
+            ),
+            ("11.0.2", "0.1.2"),
+        )
+
+    def test_rejects_non_release_manifest_versions(self) -> None:
+        with self.assertRaisesRegex(ValueError, "X.Y.Z.dev0"):
+            base_versions(
+                '[project]\nversion = "11.0.2"\n',
+                '[project]\nversion = "0.1.2"\n',
+            )
+
+    def test_publishes_when_both_stable_bases_are_available(self) -> None:
+        self.assertEqual(
+            publication_outputs(
+                "11.0.2",
+                "0.1.2",
+                "123",
+                is_published=lambda _package, _version: False,
+            ),
+            ["publish=true", "sdk=11.0.2rc123", "core=0.1.2rc123"],
+        )
+
+    def test_skips_when_both_stable_bases_are_published(self) -> None:
+        self.assertEqual(
+            publication_outputs(
+                "11.0.1",
+                "0.1.1",
+                "123",
+                is_published=lambda _package, _version: True,
+            ),
+            ["publish=false"],
+        )
+
+    def test_rejects_either_mixed_package_state(self) -> None:
+        for published_package in ("bittensor", "bittensor-core"):
+            with self.subTest(published_package=published_package):
+                with self.assertRaises(InconsistentPackageState):
+                    publication_outputs(
+                        "11.0.2",
+                        "0.1.2",
+                        "123",
+                        is_published=lambda package, _version: (
+                            package == published_package
+                        ),
+                    )
+
+    def test_maps_only_200_and_404_to_package_state(self) -> None:
+        self.assertTrue(
+            version_is_published(
+                "bittensor",
+                "11.0.2",
+                fetch_status=lambda _url: 200,
+            )
+        )
+        self.assertFalse(
+            version_is_published(
+                "bittensor",
+                "11.0.2",
+                fetch_status=lambda _url: 404,
+            )
+        )
+        with self.assertRaises(ApiError):
+            version_is_published(
+                "bittensor",
+                "11.0.2",
+                fetch_status=lambda _url: 503,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -318,42 +318,10 @@ jobs:
       - name: Decide whether to publish rc versions
         id: versions
         run: |
-          base=$(sed -n 's/^version = "\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' sdk/python/pyproject.toml | head -n 1)
-          : ${base:?could not parse base version from sdk/python/pyproject.toml}
-          core_base=$(sed -n 's/^version = "\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' sdk/bittensor-core-py/pyproject.toml | head -n 1)
-          : ${core_base:?could not parse base version from sdk/bittensor-core-py/pyproject.toml}
-
-          published=0
-          missing=0
-          for package_version in "bittensor:${base}" "bittensor-core:${core_base}"; do
-            package=${package_version%%:*}
-            version=${package_version#*:}
-            status=$(curl -sS --connect-timeout 10 --max-time 30 \
-              -o /dev/null -w '%{http_code}' \
-              "https://pypi.org/pypi/${package}/${version}/json")
-            case "$status" in
-              200) published=$((published + 1)) ;;
-              404) missing=$((missing + 1)) ;;
-              *)
-                echo "PyPI availability check for ${package} ${version} returned HTTP ${status}."
-                exit 1
-                ;;
-            esac
-          done
-
-          if [ "$missing" -eq 2 ]; then
-            echo "publish=true" >> "$GITHUB_OUTPUT"
-            echo "sdk=${base}rc${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
-            echo "core=${core_base}rc${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
-          elif [ "$published" -eq 2 ]; then
-            echo "Stable bittensor ${base} and bittensor-core ${core_base} are already published; skipping SDK rc publication."
-            echo "publish=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Python base versions are inconsistent: one is published and the other is available."
-            echo "Bump the published package base before publishing another rc."
-            exit 1
-          fi
-
+          python3 .github/scripts/python_rc_plan.py \
+            sdk/python/pyproject.toml \
+            sdk/bittensor-core-py/pyproject.toml \
+            --run-number "$GITHUB_RUN_NUMBER" >> "$GITHUB_OUTPUT"
 
   build-core-rc:
     name: Build bittensor-core rc wheels

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -6,7 +6,7 @@ name: Release Train
 #   push to main
 #     └─ build wasm once (srtool)
 #          └─ deploy devnet ── smoke-check devnet
-#               └─ deploy testnet ── smoke-check testnet ── publish SDK rc
+#               └─ deploy testnet ── smoke-check testnet ── publish SDK rc when needed
 #                    └─ propose mainnet upgrade (env gate + triumvirate multisig)
 #
 # Branch mirrors: after each successful deploy the `devnet`/`testnet` branch
@@ -297,8 +297,8 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm moonwall test smoke_testnet
 
-  # SDK rc channel rides the train: publish after testnet is green
-  # (replaces the publish-sdk-rc job in deploy-testnet.yml).
+  # SDK rc channel rides the train after testnet is green. Runtime-only trains
+  # whose stable SDK and core bases are already published skip this channel.
   #
   # Both packages get the same rcN suffix, computed once here so the wheel
   # matrix and the publish job stamp identical versions. The rc SDK pins
@@ -310,11 +310,12 @@ jobs:
     needs: check-testnet
     runs-on: [self-hosted, fireactions-turbo-8]
     outputs:
+      publish: ${{ steps.versions.outputs.publish }}
       sdk: ${{ steps.versions.outputs.sdk }}
       core: ${{ steps.versions.outputs.core }}
     steps:
       - uses: actions/checkout@v4
-      - name: Parse base versions and append rc suffix
+      - name: Decide whether to publish rc versions
         id: versions
         run: |
           base=$(sed -n 's/^version = "\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' sdk/python/pyproject.toml | head -n 1)
@@ -322,9 +323,8 @@ jobs:
           core_base=$(sed -n 's/^version = "\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' sdk/bittensor-core-py/pyproject.toml | head -n 1)
           : ${core_base:?could not parse base version from sdk/bittensor-core-py/pyproject.toml}
 
-          # PyPI versions are immutable. Reject an already-published stable
-          # base before producing more release candidates that can never be
-          # promoted to a final release.
+          published=0
+          missing=0
           for package_version in "bittensor:${base}" "bittensor-core:${core_base}"; do
             package=${package_version%%:*}
             version=${package_version#*:}
@@ -332,11 +332,8 @@ jobs:
               -o /dev/null -w '%{http_code}' \
               "https://pypi.org/pypi/${package}/${version}/json")
             case "$status" in
-              404) ;;
-              200)
-                echo "${package} ${version} is already published; bump the base version."
-                exit 1
-                ;;
+              200) published=$((published + 1)) ;;
+              404) missing=$((missing + 1)) ;;
               *)
                 echo "PyPI availability check for ${package} ${version} returned HTTP ${status}."
                 exit 1
@@ -344,12 +341,24 @@ jobs:
             esac
           done
 
-          echo "sdk=${base}rc${GITHUB_RUN_NUMBER}" >> $GITHUB_OUTPUT
-          echo "core=${core_base}rc${GITHUB_RUN_NUMBER}" >> $GITHUB_OUTPUT
+          if [ "$missing" -eq 2 ]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "sdk=${base}rc${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+            echo "core=${core_base}rc${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+          elif [ "$published" -eq 2 ]; then
+            echo "Stable bittensor ${base} and bittensor-core ${core_base} are already published; skipping SDK rc publication."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Python base versions are inconsistent: one is published and the other is available."
+            echo "Bump the published package base before publishing another rc."
+            exit 1
+          fi
+
 
   build-core-rc:
     name: Build bittensor-core rc wheels
     needs: rc-versions
+    if: needs.rc-versions.outputs.publish == 'true'
     uses: ./.github/workflows/build-core-wheels.yml
     with:
       version: ${{ needs.rc-versions.outputs.core }}
@@ -357,6 +366,7 @@ jobs:
   publish-sdk-rc:
     name: Publish SDK rc to PyPI
     needs: [rc-versions, build-core-rc]
+    if: needs.rc-versions.outputs.publish == 'true'
     runs-on: [self-hosted, fireactions-turbo-8]
     environment: testnet
     permissions:

--- a/.github/workflows/runtime-checks.yml
+++ b/.github/workflows/runtime-checks.yml
@@ -495,6 +495,7 @@ jobs:
         working-directory: sdk/python
         run: |
           python3 ../../.github/scripts/test_prepare_sdk_dist.py
+          python3 ../../.github/scripts/test_python_rc_plan.py
           uv sync --python 3.14 --locked --all-extras --dev
           uv run btcli --version
           uv run ruff check .

--- a/.github/workflows/watch-mainnet-release.yml
+++ b/.github/workflows/watch-mainnet-release.yml
@@ -13,8 +13,7 @@ name: Watch Mainnet Release
 #      docker-localnet.yml (a release created with the default GITHUB_TOKEN
 #      does not emit `release: published`, so their `on: release` triggers
 #      never fire for releases cut by this workflow)
-#   3. Python SDK + bittensor-core wheels to PyPI when the tagged versions
-#      are not already published completely
+#   3. Python SDK + bittensor-core wheels to PyPI
 #   4. Publishable Rust crates to crates.io
 #   5. Production website/docs deployment on Vercel
 #   6. Before finalizing the GitHub release, the `mainnet` branch is
@@ -194,13 +193,12 @@ jobs:
               "$chain_spec" "$release_sha" "$chain_code_hash")
             : ${artifact_id:?no artifact matches the immutable tag and finalized runtime}
             echo "artifact_id=$artifact_id" >> "$GITHUB_OUTPUT"
-          fi
-
-          if python3 .github/scripts/check-python-release.py \
+            python_needed=true
+          elif python3 .github/scripts/check-python-release.py \
               --sdk-version "$sdk_version" \
               --core-version "$core_version" \
               --repository "$GITHUB_REPOSITORY"; then
-            echo "Stable Python packages are complete on PyPI; skipping Python publication."
+            echo "Stable Python packages are complete on PyPI."
             python_needed=false
           else
             python_status=$?

--- a/docs/hyperparameters/index.mdx
+++ b/docs/hyperparameters/index.mdx
@@ -9,50 +9,50 @@ Read them with `btcli sudo get --netuid N` (the [`subnet_hyperparameters`](/docs
 
 | Hyperparameter | Unit | Owner-settable | What it controls | Source |
 | --- | --- | --- | --- | --- |
-| [`rho`](/docs/hyperparameters/rho) | integer | yes | trust curve steepness | [`Rho`](/code/pallets/subtensor/src/lib.rs#L2154) |
-| [`kappa`](/docs/hyperparameters/kappa) | fraction (u16, 65535 = 1.0) | root only | consensus majority-stake threshold | [`Kappa`](/code/pallets/subtensor/src/lib.rs#L2163) |
-| [`immunity_period`](/docs/hyperparameters/immunity-period) | blocks (12s) | yes | prune-immunity window for new neurons | [`ImmunityPeriod`](/code/pallets/subtensor/src/lib.rs#L2192) |
-| [`min_allowed_weights`](/docs/hyperparameters/min-allowed-weights) | integer | yes | minimum weights per submission | [`MinAllowedWeights`](/code/pallets/subtensor/src/lib.rs#L2218) |
-| [`max_weights_limit`](/docs/hyperparameters/max-weights-limit) | fraction (u16, 65535 = 1.0) | root only | cap on a single miner's weight | [`MaxWeightsLimit`](/code/pallets/subtensor/src/lib.rs#L2208) |
-| [`tempo`](/docs/hyperparameters/tempo) | blocks (12s) | yes | blocks per consensus epoch | [`Tempo`](/code/pallets/subtensor/src/lib.rs#L1982) |
-| [`min_difficulty`](/docs/hyperparameters/min-difficulty) | PoW difficulty (u64) | root only | PoW registration difficulty floor | [`MinDifficulty`](/code/pallets/subtensor/src/lib.rs#L2296) |
-| [`max_difficulty`](/docs/hyperparameters/max-difficulty) | PoW difficulty (u64) | yes | PoW registration difficulty ceiling | [`MaxDifficulty`](/code/pallets/subtensor/src/lib.rs#L2301) |
-| [`difficulty`](/docs/hyperparameters/difficulty) | PoW difficulty (u64) | root only | current PoW registration difficulty | [`Difficulty`](/code/pallets/subtensor/src/lib.rs#L2282) |
-| [`weights_version`](/docs/hyperparameters/weights-version) | integer | yes | minimum version key for set_weights | [`WeightsVersionKey`](/code/pallets/subtensor/src/lib.rs#L2213) |
-| [`weights_rate_limit`](/docs/hyperparameters/weights-rate-limit) | blocks (12s) | root only | wait between weight submissions | [`WeightsSetRateLimit`](/code/pallets/subtensor/src/lib.rs#L2248) |
-| [`adjustment_interval`](/docs/hyperparameters/adjustment-interval) | blocks (12s) | root only | difficulty/burn adjustment cadence | [`AdjustmentInterval`](/code/pallets/subtensor/src/lib.rs#L2228) |
-| [`activity_cutoff`](/docs/hyperparameters/activity-cutoff) | blocks (12s) | root only | no-weights window before inactive | [`ActivityCutoff`](/code/pallets/subtensor/src/lib.rs#L2198) |
-| [`activity_cutoff_factor`](/docs/hyperparameters/activity-cutoff-factor) | integer | yes | activity cutoff, per-mille of tempo | [`ActivityCutoffFactorMilli`](/code/pallets/subtensor/src/lib.rs#L2025) |
-| [`registration_allowed`](/docs/hyperparameters/registration-allowed) | flag | root only | new neuron registrations allowed | [`NetworkRegistrationAllowed`](/code/pallets/subtensor/src/lib.rs#L2063) |
-| [`network_pow_registration_allowed`](/docs/hyperparameters/network-pow-registration-allowed) | flag | yes | PoW registration toggle | [`NetworkPowRegistrationAllowed`](/code/pallets/subtensor/src/lib.rs#L2068) |
-| [`target_regs_per_interval`](/docs/hyperparameters/target-regs-per-interval) | integer | root only | registration-rate controller target | [`TargetRegistrationsPerInterval`](/code/pallets/subtensor/src/lib.rs#L2263) |
-| [`min_burn`](/docs/hyperparameters/min-burn) | TAO amount in rao | yes | burned-registration cost floor | [`MinBurn`](/code/pallets/subtensor/src/lib.rs#L2286) |
-| [`max_burn`](/docs/hyperparameters/max-burn) | TAO amount in rao | yes | burned-registration cost ceiling | [`MaxBurn`](/code/pallets/subtensor/src/lib.rs#L2291) |
-| [`bonds_moving_avg`](/docs/hyperparameters/bonds-moving-avg) | fraction (1,000,000 = 1.0) | yes | bonds EMA smoothing factor | [`BondsMovingAverage`](/code/pallets/subtensor/src/lib.rs#L2233) |
-| [`max_regs_per_block`](/docs/hyperparameters/max-regs-per-block) | integer | root only | per-block registration cap | [`MaxRegistrationsPerBlock`](/code/pallets/subtensor/src/lib.rs#L1898) |
-| [`serving_rate_limit`](/docs/hyperparameters/serving-rate-limit) | blocks (12s) | yes | cooldown between axon serve calls | [`ServingRateLimit`](/code/pallets/subtensor/src/lib.rs#L2149) |
-| [`max_validators`](/docs/hyperparameters/max-validators) | integer | root only | top-stake validator permit cap | [`MaxAllowedValidators`](/code/pallets/subtensor/src/lib.rs#L2223) |
-| [`adjustment_alpha`](/docs/hyperparameters/adjustment-alpha) | fraction (u64, u64::MAX = 1.0) | yes | difficulty/burn adjust smoothing | [`AdjustmentAlpha`](/code/pallets/subtensor/src/lib.rs#L2268) |
-| [`commit_reveal_period`](/docs/hyperparameters/commit-reveal-period) | epochs (tempos) | yes | weight commit-to-reveal delay | [`RevealPeriodEpochs`](/code/pallets/subtensor/src/lib.rs#L2710) |
-| [`commit_reveal_weights_enabled`](/docs/hyperparameters/commit-reveal-weights-enabled) | flag | yes | commit-reveal weights toggle | [`CommitRevealWeightsEnabled`](/code/pallets/subtensor/src/lib.rs#L2273) |
+| [`rho`](/docs/hyperparameters/rho) | integer | yes | trust curve steepness | [`Rho`](/code/pallets/subtensor/src/lib.rs#L2160) |
+| [`kappa`](/docs/hyperparameters/kappa) | fraction (u16, 65535 = 1.0) | root only | consensus majority-stake threshold | [`Kappa`](/code/pallets/subtensor/src/lib.rs#L2169) |
+| [`immunity_period`](/docs/hyperparameters/immunity-period) | blocks (12s) | yes | prune-immunity window for new neurons | [`ImmunityPeriod`](/code/pallets/subtensor/src/lib.rs#L2198) |
+| [`min_allowed_weights`](/docs/hyperparameters/min-allowed-weights) | integer | yes | minimum weights per submission | [`MinAllowedWeights`](/code/pallets/subtensor/src/lib.rs#L2224) |
+| [`max_weights_limit`](/docs/hyperparameters/max-weights-limit) | fraction (u16, 65535 = 1.0) | root only | cap on a single miner's weight | [`MaxWeightsLimit`](/code/pallets/subtensor/src/lib.rs#L2214) |
+| [`tempo`](/docs/hyperparameters/tempo) | blocks (12s) | yes | blocks per consensus epoch | [`Tempo`](/code/pallets/subtensor/src/lib.rs#L1988) |
+| [`min_difficulty`](/docs/hyperparameters/min-difficulty) | PoW difficulty (u64) | root only | PoW registration difficulty floor | [`MinDifficulty`](/code/pallets/subtensor/src/lib.rs#L2302) |
+| [`max_difficulty`](/docs/hyperparameters/max-difficulty) | PoW difficulty (u64) | yes | PoW registration difficulty ceiling | [`MaxDifficulty`](/code/pallets/subtensor/src/lib.rs#L2307) |
+| [`difficulty`](/docs/hyperparameters/difficulty) | PoW difficulty (u64) | root only | current PoW registration difficulty | [`Difficulty`](/code/pallets/subtensor/src/lib.rs#L2288) |
+| [`weights_version`](/docs/hyperparameters/weights-version) | integer | yes | minimum version key for set_weights | [`WeightsVersionKey`](/code/pallets/subtensor/src/lib.rs#L2219) |
+| [`weights_rate_limit`](/docs/hyperparameters/weights-rate-limit) | blocks (12s) | root only | wait between weight submissions | [`WeightsSetRateLimit`](/code/pallets/subtensor/src/lib.rs#L2254) |
+| [`adjustment_interval`](/docs/hyperparameters/adjustment-interval) | blocks (12s) | root only | difficulty/burn adjustment cadence | [`AdjustmentInterval`](/code/pallets/subtensor/src/lib.rs#L2234) |
+| [`activity_cutoff`](/docs/hyperparameters/activity-cutoff) | blocks (12s) | root only | no-weights window before inactive | [`ActivityCutoff`](/code/pallets/subtensor/src/lib.rs#L2204) |
+| [`activity_cutoff_factor`](/docs/hyperparameters/activity-cutoff-factor) | integer | yes | activity cutoff, per-mille of tempo | [`ActivityCutoffFactorMilli`](/code/pallets/subtensor/src/lib.rs#L2031) |
+| [`registration_allowed`](/docs/hyperparameters/registration-allowed) | flag | root only | new neuron registrations allowed | [`NetworkRegistrationAllowed`](/code/pallets/subtensor/src/lib.rs#L2069) |
+| [`network_pow_registration_allowed`](/docs/hyperparameters/network-pow-registration-allowed) | flag | yes | PoW registration toggle | [`NetworkPowRegistrationAllowed`](/code/pallets/subtensor/src/lib.rs#L2074) |
+| [`target_regs_per_interval`](/docs/hyperparameters/target-regs-per-interval) | integer | root only | registration-rate controller target | [`TargetRegistrationsPerInterval`](/code/pallets/subtensor/src/lib.rs#L2269) |
+| [`min_burn`](/docs/hyperparameters/min-burn) | TAO amount in rao | yes | burned-registration cost floor | [`MinBurn`](/code/pallets/subtensor/src/lib.rs#L2292) |
+| [`max_burn`](/docs/hyperparameters/max-burn) | TAO amount in rao | yes | burned-registration cost ceiling | [`MaxBurn`](/code/pallets/subtensor/src/lib.rs#L2297) |
+| [`bonds_moving_avg`](/docs/hyperparameters/bonds-moving-avg) | fraction (1,000,000 = 1.0) | yes | bonds EMA smoothing factor | [`BondsMovingAverage`](/code/pallets/subtensor/src/lib.rs#L2239) |
+| [`max_regs_per_block`](/docs/hyperparameters/max-regs-per-block) | integer | root only | per-block registration cap | [`MaxRegistrationsPerBlock`](/code/pallets/subtensor/src/lib.rs#L1904) |
+| [`serving_rate_limit`](/docs/hyperparameters/serving-rate-limit) | blocks (12s) | yes | cooldown between axon serve calls | [`ServingRateLimit`](/code/pallets/subtensor/src/lib.rs#L2155) |
+| [`max_validators`](/docs/hyperparameters/max-validators) | integer | root only | top-stake validator permit cap | [`MaxAllowedValidators`](/code/pallets/subtensor/src/lib.rs#L2229) |
+| [`adjustment_alpha`](/docs/hyperparameters/adjustment-alpha) | fraction (u64, u64::MAX = 1.0) | yes | difficulty/burn adjust smoothing | [`AdjustmentAlpha`](/code/pallets/subtensor/src/lib.rs#L2274) |
+| [`commit_reveal_period`](/docs/hyperparameters/commit-reveal-period) | epochs (tempos) | yes | weight commit-to-reveal delay | [`RevealPeriodEpochs`](/code/pallets/subtensor/src/lib.rs#L2716) |
+| [`commit_reveal_weights_enabled`](/docs/hyperparameters/commit-reveal-weights-enabled) | flag | yes | commit-reveal weights toggle | [`CommitRevealWeightsEnabled`](/code/pallets/subtensor/src/lib.rs#L2279) |
 | [`alpha_high`](/docs/hyperparameters/alpha-high) | fraction (u16, 65535 = 1.0) | yes | liquid-alpha smoothing upper bound | — |
 | [`alpha_low`](/docs/hyperparameters/alpha-low) | fraction (u16, 65535 = 1.0) | yes | liquid-alpha smoothing lower bound | — |
-| [`liquid_alpha_enabled`](/docs/hyperparameters/liquid-alpha-enabled) | flag | yes | per-weight bonds EMA (liquid alpha) | [`LiquidAlphaOn`](/code/pallets/subtensor/src/lib.rs#L2350) |
-| [`bonds_penalty`](/docs/hyperparameters/bonds-penalty) | fraction (u16, 65535 = 1.0) | yes | penalty on out-of-consensus bonds | [`BondsPenalty`](/code/pallets/subtensor/src/lib.rs#L2238) |
-| [`alpha_sigmoid_steepness`](/docs/hyperparameters/alpha-sigmoid-steepness) | integer | yes | liquid-alpha sigmoid steepness | [`AlphaSigmoidSteepness`](/code/pallets/subtensor/src/lib.rs#L2158) |
-| [`min_childkey_take`](/docs/hyperparameters/min-childkey-take) | fraction (u16, 65535 = 1.0) | yes | floor for childkey take | [`MinChildkeyTakePerSubnet`](/code/pallets/subtensor/src/lib.rs#L1342) |
-| [`owner_immune_neuron_limit`](/docs/hyperparameters/owner-immune-neuron-limit) | integer | yes | owner-designated prune-immune UIDs | [`ImmuneOwnerUidsLimit`](/code/pallets/subtensor/src/lib.rs#L2449) |
-| [`max_allowed_uids`](/docs/hyperparameters/max-allowed-uids) | integer | yes | neuron slot capacity before pruning | [`MaxAllowedUids`](/code/pallets/subtensor/src/lib.rs#L2187) |
-| [`burn_increase_mult`](/docs/hyperparameters/burn-increase-mult) | multiplier (U64F64 bits / 2^64) | yes | burn cost bump per registration | [`BurnIncreaseMult`](/code/pallets/subtensor/src/lib.rs#L2882) |
-| [`burn_half_life`](/docs/hyperparameters/burn-half-life) | blocks (12s) | yes | burn cost decay half-life | [`BurnHalfLife`](/code/pallets/subtensor/src/lib.rs#L2877) |
-| [`collateral_lock_share`](/docs/hyperparameters/collateral-lock-share) | fraction (u16, 65535 = 1.0) | yes | registration price share locked | [`CollateralLockShare`](/code/pallets/subtensor/src/lib.rs#L2891) |
-| [`collateral_drain_ratio`](/docs/hyperparameters/collateral-drain-ratio) | multiplier (U64F64 bits / 2^64) | yes | collateral released per α earned | [`CollateralDrainRatio`](/code/pallets/subtensor/src/lib.rs#L2900) |
-| [`yuma3_enabled`](/docs/hyperparameters/yuma3-enabled) | flag | yes | yuma3 consensus variant toggle | [`Yuma3On`](/code/pallets/subtensor/src/lib.rs#L2355) |
+| [`liquid_alpha_enabled`](/docs/hyperparameters/liquid-alpha-enabled) | flag | yes | per-weight bonds EMA (liquid alpha) | [`LiquidAlphaOn`](/code/pallets/subtensor/src/lib.rs#L2356) |
+| [`bonds_penalty`](/docs/hyperparameters/bonds-penalty) | fraction (u16, 65535 = 1.0) | yes | penalty on out-of-consensus bonds | [`BondsPenalty`](/code/pallets/subtensor/src/lib.rs#L2244) |
+| [`alpha_sigmoid_steepness`](/docs/hyperparameters/alpha-sigmoid-steepness) | integer | yes | liquid-alpha sigmoid steepness | [`AlphaSigmoidSteepness`](/code/pallets/subtensor/src/lib.rs#L2164) |
+| [`min_childkey_take`](/docs/hyperparameters/min-childkey-take) | fraction (u16, 65535 = 1.0) | yes | floor for childkey take | [`MinChildkeyTakePerSubnet`](/code/pallets/subtensor/src/lib.rs#L1348) |
+| [`owner_immune_neuron_limit`](/docs/hyperparameters/owner-immune-neuron-limit) | integer | yes | owner-designated prune-immune UIDs | [`ImmuneOwnerUidsLimit`](/code/pallets/subtensor/src/lib.rs#L2455) |
+| [`max_allowed_uids`](/docs/hyperparameters/max-allowed-uids) | integer | yes | neuron slot capacity before pruning | [`MaxAllowedUids`](/code/pallets/subtensor/src/lib.rs#L2193) |
+| [`burn_increase_mult`](/docs/hyperparameters/burn-increase-mult) | multiplier (U64F64 bits / 2^64) | yes | burn cost bump per registration | [`BurnIncreaseMult`](/code/pallets/subtensor/src/lib.rs#L2888) |
+| [`burn_half_life`](/docs/hyperparameters/burn-half-life) | blocks (12s) | yes | burn cost decay half-life | [`BurnHalfLife`](/code/pallets/subtensor/src/lib.rs#L2883) |
+| [`collateral_lock_share`](/docs/hyperparameters/collateral-lock-share) | fraction (u16, 65535 = 1.0) | yes | registration price share locked | [`CollateralLockShare`](/code/pallets/subtensor/src/lib.rs#L2897) |
+| [`collateral_drain_ratio`](/docs/hyperparameters/collateral-drain-ratio) | multiplier (U64F64 bits / 2^64) | yes | collateral released per α earned | [`CollateralDrainRatio`](/code/pallets/subtensor/src/lib.rs#L2906) |
+| [`yuma3_enabled`](/docs/hyperparameters/yuma3-enabled) | flag | yes | yuma3 consensus variant toggle | [`Yuma3On`](/code/pallets/subtensor/src/lib.rs#L2361) |
 | [`yuma_version`](/docs/hyperparameters/yuma-version) | integer | root only | epoch consensus variant (2 or 3) | — |
 | [`subnet_is_active`](/docs/hyperparameters/subnet-is-active) | flag | root only | subnet started (staking + emissions) | — |
-| [`subnet_emission_enabled`](/docs/hyperparameters/subnet-emission-enabled) | flag | root only | root switch for TAO emission share | [`SubnetEmissionEnabled`](/code/pallets/subtensor/src/lib.rs#L1515) |
+| [`subnet_emission_enabled`](/docs/hyperparameters/subnet-emission-enabled) | flag | root only | root switch for TAO emission share | [`SubnetEmissionEnabled`](/code/pallets/subtensor/src/lib.rs#L1521) |
 | [`user_liquidity_enabled`](/docs/hyperparameters/user-liquidity-enabled) | flag | root only | legacy user-LP flag (always false) | — |
-| [`bonds_reset_enabled`](/docs/hyperparameters/bonds-reset-enabled) | flag | yes | bonds reset on metadata commit | [`BondsResetOn`](/code/pallets/subtensor/src/lib.rs#L2243) |
-| [`transfers_enabled`](/docs/hyperparameters/transfers-enabled) | flag | yes | stake transfers between coldkeys | [`TransferToggle`](/code/pallets/subtensor/src/lib.rs#L1966) |
-| [`owner_cut_enabled`](/docs/hyperparameters/owner-cut-enabled) | flag | yes | owner emission cut toggle | [`OwnerCutEnabled`](/code/pallets/subtensor/src/lib.rs#L1941) |
-| [`owner_cut_auto_lock_enabled`](/docs/hyperparameters/owner-cut-auto-lock-enabled) | flag | yes | auto-lock the owner's emission cut | [`OwnerCutAutoLockEnabled`](/code/pallets/subtensor/src/lib.rs#L1758) |
+| [`bonds_reset_enabled`](/docs/hyperparameters/bonds-reset-enabled) | flag | yes | bonds reset on metadata commit | [`BondsResetOn`](/code/pallets/subtensor/src/lib.rs#L2249) |
+| [`transfers_enabled`](/docs/hyperparameters/transfers-enabled) | flag | yes | stake transfers between coldkeys | [`TransferToggle`](/code/pallets/subtensor/src/lib.rs#L1972) |
+| [`owner_cut_enabled`](/docs/hyperparameters/owner-cut-enabled) | flag | yes | owner emission cut toggle | [`OwnerCutEnabled`](/code/pallets/subtensor/src/lib.rs#L1947) |
+| [`owner_cut_auto_lock_enabled`](/docs/hyperparameters/owner-cut-auto-lock-enabled) | flag | yes | auto-lock the owner's emission cut | [`OwnerCutAutoLockEnabled`](/code/pallets/subtensor/src/lib.rs#L1764) |

--- a/docs/internals/contributing.mdx
+++ b/docs/internals/contributing.mdx
@@ -40,7 +40,7 @@ pipeline (full detail: [Release process](/docs/internals/release-process)):
 push to main
   └─ build wasm once (deterministic srtool build)
        └─ deploy devnet ── smoke-check devnet
-            └─ deploy testnet ── smoke-check testnet ── publish SDK rc
+            └─ deploy testnet ── smoke-check testnet ── publish SDK rc when needed
                  └─ propose mainnet upgrade (environment gate + triumvirate multisig)
 ```
 

--- a/docs/internals/release-process.mdx
+++ b/docs/internals/release-process.mdx
@@ -15,7 +15,7 @@ executes.
 push to main
   └─ srtool build (once per train)
        └─ deploy devnet ───── smoke-check devnet
-            └─ deploy testnet ── smoke-check testnet ── publish SDK rc to PyPI
+            └─ deploy testnet ── smoke-check testnet ── publish SDK rc when needed
                  └─ propose mainnet upgrade (multisig)
 ```
 
@@ -48,7 +48,7 @@ Human approval lives in GitHub **environment settings**, not workflow code:
 | Stage | Environment | Gate |
 |-------|-------------|------|
 | devnet | `devnet` | none — deploys automatically, then runs the devnet smoke suite |
-| testnet | `testnet` | environment reviewers (one-click approval), then smoke suite + SDK release candidate to PyPI |
+| testnet | `testnet` | environment reviewers (one-click approval), then smoke suite + SDK release candidate when the stable package bases are unpublished |
 | mainnet | `mainnet` | environment reviewers **plus** the multisig ceremony below |
 
 Deploys to devnet and testnet are direct `setCode` transactions via the CI
@@ -101,8 +101,10 @@ partial upload is retried on the next watcher run even if the GitHub release
 already exists or the release-train artifact has expired. Retries require the
 release target, immutable tag, protected `mainnet` mirror, and finalized
 runtime bytes to agree. The SDK's committed `X.Y.Z.dev0` version is stamped to
-`X.Y.Z` for this build. The release train rejects a base SDK or core version
-that already exists on PyPI before publishing release candidates. Releases
+`X.Y.Z` for this build. The release train publishes release candidates only
+when both stable package bases are unpublished. If both are already on PyPI,
+the train treats the change as runtime-only and skips the SDK RC channel; a
+mixed state fails because the package versions must move together. Releases
 through v432 predate automated stable Python publication and are handled as
 historical state.
 

--- a/docs/query/associated-evm-key.mdx
+++ b/docs/query/associated-evm-key.mdx
@@ -43,6 +43,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.AssociatedEvmAddress`](/code/pallets/subtensor/src/lib.rs#L2775)
+- Storage [`SubtensorModule.AssociatedEvmAddress`](/code/pallets/subtensor/src/lib.rs#L2781)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/auto-stake-all.mdx
+++ b/docs/query/auto-stake-all.mdx
@@ -43,6 +43,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.AutoStakeDestination`](/code/pallets/subtensor/src/lib.rs#L1564)
+- Storage [`SubtensorModule.AutoStakeDestination`](/code/pallets/subtensor/src/lib.rs#L1570)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/auto-stake.mdx
+++ b/docs/query/auto-stake.mdx
@@ -43,6 +43,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.AutoStakeDestination`](/code/pallets/subtensor/src/lib.rs#L1564)
+- Storage [`SubtensorModule.AutoStakeDestination`](/code/pallets/subtensor/src/lib.rs#L1570)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/blocks-since-last-step.mdx
+++ b/docs/query/blocks-since-last-step.mdx
@@ -42,6 +42,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.BlocksSinceLastStep`](/code/pallets/subtensor/src/lib.rs#L2124)
+- Storage [`SubtensorModule.BlocksSinceLastStep`](/code/pallets/subtensor/src/lib.rs#L2130)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/blocks-since-last-update.mdx
+++ b/docs/query/blocks-since-last-update.mdx
@@ -48,6 +48,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.LastUpdate`](/code/pallets/subtensor/src/lib.rs#L2507)
+- Storage [`SubtensorModule.LastUpdate`](/code/pallets/subtensor/src/lib.rs#L2513)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/bonds.mdx
+++ b/docs/query/bonds.mdx
@@ -46,6 +46,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.Bonds`](/code/pallets/subtensor/src/lib.rs#L2535)
+- Storage [`SubtensorModule.Bonds`](/code/pallets/subtensor/src/lib.rs#L2541)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/burn.mdx
+++ b/docs/query/burn.mdx
@@ -42,6 +42,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.Burn`](/code/pallets/subtensor/src/lib.rs#L2278)
+- Storage [`SubtensorModule.Burn`](/code/pallets/subtensor/src/lib.rs#L2284)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/children.mdx
+++ b/docs/query/children.mdx
@@ -44,6 +44,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.ChildKeys`](/code/pallets/subtensor/src/lib.rs#L1387)
+- Storage [`SubtensorModule.ChildKeys`](/code/pallets/subtensor/src/lib.rs#L1393)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/coldkey-lock.mdx
+++ b/docs/query/coldkey-lock.mdx
@@ -44,6 +44,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.Lock`](/code/pallets/subtensor/src/lib.rs#L1687)
+- Storage [`SubtensorModule.Lock`](/code/pallets/subtensor/src/lib.rs#L1693)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/coldkey-swap-announcement.mdx
+++ b/docs/query/coldkey-swap-announcement.mdx
@@ -43,7 +43,7 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.ColdkeySwapAnnouncements`](/code/pallets/subtensor/src/lib.rs#L1599)
-- Storage [`SubtensorModule.ColdkeySwapDisputes`](/code/pallets/subtensor/src/lib.rs#L1605)
+- Storage [`SubtensorModule.ColdkeySwapAnnouncements`](/code/pallets/subtensor/src/lib.rs#L1605)
+- Storage [`SubtensorModule.ColdkeySwapDisputes`](/code/pallets/subtensor/src/lib.rs#L1611)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/commit-reveal-enabled.mdx
+++ b/docs/query/commit-reveal-enabled.mdx
@@ -42,6 +42,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.CommitRevealWeightsEnabled`](/code/pallets/subtensor/src/lib.rs#L2273)
+- Storage [`SubtensorModule.CommitRevealWeightsEnabled`](/code/pallets/subtensor/src/lib.rs#L2279)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/delegate-take.mdx
+++ b/docs/query/delegate-take.mdx
@@ -43,8 +43,8 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.Delegates`](/code/pallets/subtensor/src/lib.rs#L1357)
-- Storage [`SubtensorModule.MinDelegateTake`](/code/pallets/subtensor/src/lib.rs#L1330)
-- Storage [`SubtensorModule.MaxDelegateTake`](/code/pallets/subtensor/src/lib.rs#L1326)
+- Storage [`SubtensorModule.Delegates`](/code/pallets/subtensor/src/lib.rs#L1363)
+- Storage [`SubtensorModule.MinDelegateTake`](/code/pallets/subtensor/src/lib.rs#L1336)
+- Storage [`SubtensorModule.MaxDelegateTake`](/code/pallets/subtensor/src/lib.rs#L1332)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/difficulty.mdx
+++ b/docs/query/difficulty.mdx
@@ -42,6 +42,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.Difficulty`](/code/pallets/subtensor/src/lib.rs#L2282)
+- Storage [`SubtensorModule.Difficulty`](/code/pallets/subtensor/src/lib.rs#L2288)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/epoch-status.mdx
+++ b/docs/query/epoch-status.mdx
@@ -45,11 +45,11 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.Tempo`](/code/pallets/subtensor/src/lib.rs#L1982)
-- Storage [`SubtensorModule.LastEpochBlock`](/code/pallets/subtensor/src/lib.rs#L2007)
-- Storage [`SubtensorModule.BlocksSinceLastStep`](/code/pallets/subtensor/src/lib.rs#L2124)
-- Storage [`SubtensorModule.PendingEpochAt`](/code/pallets/subtensor/src/lib.rs#L2013)
-- Storage [`SubtensorModule.SubnetEpochIndex`](/code/pallets/subtensor/src/lib.rs#L2019)
+- Storage [`SubtensorModule.Tempo`](/code/pallets/subtensor/src/lib.rs#L1988)
+- Storage [`SubtensorModule.LastEpochBlock`](/code/pallets/subtensor/src/lib.rs#L2013)
+- Storage [`SubtensorModule.BlocksSinceLastStep`](/code/pallets/subtensor/src/lib.rs#L2130)
+- Storage [`SubtensorModule.PendingEpochAt`](/code/pallets/subtensor/src/lib.rs#L2019)
+- Storage [`SubtensorModule.SubnetEpochIndex`](/code/pallets/subtensor/src/lib.rs#L2025)
 - Runtime API [`SubnetInfoRuntimeApi.get_next_epoch_start_block`](/code/pallets/subtensor/src/coinbase/run_coinbase.rs#L1196-L1210)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/hotkey-identities.mdx
+++ b/docs/query/hotkey-identities.mdx
@@ -42,7 +42,7 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.Owner`](/code/pallets/subtensor/src/lib.rs#L1347)
-- Storage [`SubtensorModule.IdentitiesV2`](/code/pallets/subtensor/src/lib.rs#L2597)
+- Storage [`SubtensorModule.Owner`](/code/pallets/subtensor/src/lib.rs#L1353)
+- Storage [`SubtensorModule.IdentitiesV2`](/code/pallets/subtensor/src/lib.rs#L2603)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/hotkey-owner.mdx
+++ b/docs/query/hotkey-owner.mdx
@@ -42,6 +42,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.Owner`](/code/pallets/subtensor/src/lib.rs#L1347)
+- Storage [`SubtensorModule.Owner`](/code/pallets/subtensor/src/lib.rs#L1353)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/identity.mdx
+++ b/docs/query/identity.mdx
@@ -42,6 +42,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.IdentitiesV2`](/code/pallets/subtensor/src/lib.rs#L2597)
+- Storage [`SubtensorModule.IdentitiesV2`](/code/pallets/subtensor/src/lib.rs#L2603)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/immunity-period.mdx
+++ b/docs/query/immunity-period.mdx
@@ -42,6 +42,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.ImmunityPeriod`](/code/pallets/subtensor/src/lib.rs#L2192)
+- Storage [`SubtensorModule.ImmunityPeriod`](/code/pallets/subtensor/src/lib.rs#L2198)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/lease.mdx
+++ b/docs/query/lease.mdx
@@ -43,6 +43,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.SubnetLeases`](/code/pallets/subtensor/src/lib.rs#L2793)
+- Storage [`SubtensorModule.SubnetLeases`](/code/pallets/subtensor/src/lib.rs#L2799)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/leases.mdx
+++ b/docs/query/leases.mdx
@@ -40,6 +40,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.SubnetLeases`](/code/pallets/subtensor/src/lib.rs#L2793)
+- Storage [`SubtensorModule.SubnetLeases`](/code/pallets/subtensor/src/lib.rs#L2799)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/locks-for-coldkey.mdx
+++ b/docs/query/locks-for-coldkey.mdx
@@ -42,6 +42,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.Lock`](/code/pallets/subtensor/src/lib.rs#L1687)
+- Storage [`SubtensorModule.Lock`](/code/pallets/subtensor/src/lib.rs#L1693)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/max-weight-limit.mdx
+++ b/docs/query/max-weight-limit.mdx
@@ -42,6 +42,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.MaxWeightsLimit`](/code/pallets/subtensor/src/lib.rs#L2208)
+- Storage [`SubtensorModule.MaxWeightsLimit`](/code/pallets/subtensor/src/lib.rs#L2214)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/mechanism-count.mdx
+++ b/docs/query/mechanism-count.mdx
@@ -42,6 +42,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.MechanismCountCurrent`](/code/pallets/subtensor/src/lib.rs#L2867)
+- Storage [`SubtensorModule.MechanismCountCurrent`](/code/pallets/subtensor/src/lib.rs#L2873)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/mechanism-emission-split.mdx
+++ b/docs/query/mechanism-emission-split.mdx
@@ -43,6 +43,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.MechanismEmissionSplit`](/code/pallets/subtensor/src/lib.rs#L2872)
+- Storage [`SubtensorModule.MechanismEmissionSplit`](/code/pallets/subtensor/src/lib.rs#L2878)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/min-allowed-weights.mdx
+++ b/docs/query/min-allowed-weights.mdx
@@ -42,6 +42,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.MinAllowedWeights`](/code/pallets/subtensor/src/lib.rs#L2218)
+- Storage [`SubtensorModule.MinAllowedWeights`](/code/pallets/subtensor/src/lib.rs#L2224)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/miner-collateral.mdx
+++ b/docs/query/miner-collateral.mdx
@@ -56,6 +56,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.Owner`](/code/pallets/subtensor/src/lib.rs#L1347)
+- Storage [`SubtensorModule.Owner`](/code/pallets/subtensor/src/lib.rs#L1353)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/netuids-for-hotkey.mdx
+++ b/docs/query/netuids-for-hotkey.mdx
@@ -42,6 +42,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.IsNetworkMember`](/code/pallets/subtensor/src/lib.rs#L2050)
+- Storage [`SubtensorModule.IsNetworkMember`](/code/pallets/subtensor/src/lib.rs#L2056)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/owned-hotkeys.mdx
+++ b/docs/query/owned-hotkeys.mdx
@@ -42,6 +42,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.OwnedHotkeys`](/code/pallets/subtensor/src/lib.rs#L1559)
+- Storage [`SubtensorModule.OwnedHotkeys`](/code/pallets/subtensor/src/lib.rs#L1565)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/parents.mdx
+++ b/docs/query/parents.mdx
@@ -44,6 +44,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.ParentKeys`](/code/pallets/subtensor/src/lib.rs#L1400)
+- Storage [`SubtensorModule.ParentKeys`](/code/pallets/subtensor/src/lib.rs#L1406)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/pending-children.mdx
+++ b/docs/query/pending-children.mdx
@@ -48,6 +48,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.PendingChildKeys`](/code/pallets/subtensor/src/lib.rs#L1374)
+- Storage [`SubtensorModule.PendingChildKeys`](/code/pallets/subtensor/src/lib.rs#L1380)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/reveal-period.mdx
+++ b/docs/query/reveal-period.mdx
@@ -42,6 +42,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.RevealPeriodEpochs`](/code/pallets/subtensor/src/lib.rs#L2710)
+- Storage [`SubtensorModule.RevealPeriodEpochs`](/code/pallets/subtensor/src/lib.rs#L2716)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/root-claim-type.mdx
+++ b/docs/query/root-claim-type.mdx
@@ -42,6 +42,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.RootClaimType`](/code/pallets/subtensor/src/lib.rs#L2752)
+- Storage [`SubtensorModule.RootClaimType`](/code/pallets/subtensor/src/lib.rs#L2758)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/staking-hotkeys.mdx
+++ b/docs/query/staking-hotkeys.mdx
@@ -43,6 +43,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.StakingHotkeys`](/code/pallets/subtensor/src/lib.rs#L1554)
+- Storage [`SubtensorModule.StakingHotkeys`](/code/pallets/subtensor/src/lib.rs#L1560)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/subnet-collateral.mdx
+++ b/docs/query/subnet-collateral.mdx
@@ -46,6 +46,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.Uids`](/code/pallets/subtensor/src/lib.rs#L2460)
+- Storage [`SubtensorModule.Uids`](/code/pallets/subtensor/src/lib.rs#L2466)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/subnet-convictions.mdx
+++ b/docs/query/subnet-convictions.mdx
@@ -49,14 +49,14 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.HotkeyLock`](/code/pallets/subtensor/src/lib.rs#L1713)
-- Storage [`SubtensorModule.DecayingHotkeyLock`](/code/pallets/subtensor/src/lib.rs#L1725)
-- Storage [`SubtensorModule.OwnerLock`](/code/pallets/subtensor/src/lib.rs#L1737)
-- Storage [`SubtensorModule.DecayingOwnerLock`](/code/pallets/subtensor/src/lib.rs#L1741)
-- Storage [`SubtensorModule.SubnetOwnerHotkey`](/code/pallets/subtensor/src/lib.rs#L2139)
-- Storage [`SubtensorModule.SubnetAlphaOut`](/code/pallets/subtensor/src/lib.rs#L1545)
-- Storage [`SubtensorModule.UnlockRate`](/code/pallets/subtensor/src/lib.rs#L1779)
-- Storage [`SubtensorModule.MaturityRate`](/code/pallets/subtensor/src/lib.rs#L1775)
-- Storage [`SubtensorModule.NetworkRegisteredAt`](/code/pallets/subtensor/src/lib.rs#L2073)
+- Storage [`SubtensorModule.HotkeyLock`](/code/pallets/subtensor/src/lib.rs#L1719)
+- Storage [`SubtensorModule.DecayingHotkeyLock`](/code/pallets/subtensor/src/lib.rs#L1731)
+- Storage [`SubtensorModule.OwnerLock`](/code/pallets/subtensor/src/lib.rs#L1743)
+- Storage [`SubtensorModule.DecayingOwnerLock`](/code/pallets/subtensor/src/lib.rs#L1747)
+- Storage [`SubtensorModule.SubnetOwnerHotkey`](/code/pallets/subtensor/src/lib.rs#L2145)
+- Storage [`SubtensorModule.SubnetAlphaOut`](/code/pallets/subtensor/src/lib.rs#L1551)
+- Storage [`SubtensorModule.UnlockRate`](/code/pallets/subtensor/src/lib.rs#L1785)
+- Storage [`SubtensorModule.MaturityRate`](/code/pallets/subtensor/src/lib.rs#L1781)
+- Storage [`SubtensorModule.NetworkRegisteredAt`](/code/pallets/subtensor/src/lib.rs#L2079)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/subnet-emission-enabled.mdx
+++ b/docs/query/subnet-emission-enabled.mdx
@@ -42,6 +42,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.SubnetEmissionEnabled`](/code/pallets/subtensor/src/lib.rs#L1515)
+- Storage [`SubtensorModule.SubnetEmissionEnabled`](/code/pallets/subtensor/src/lib.rs#L1521)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/subnet-identity.mdx
+++ b/docs/query/subnet-identity.mdx
@@ -42,6 +42,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.SubnetIdentitiesV3`](/code/pallets/subtensor/src/lib.rs#L2602)
+- Storage [`SubtensorModule.SubnetIdentitiesV3`](/code/pallets/subtensor/src/lib.rs#L2608)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/subnet-names.mdx
+++ b/docs/query/subnet-names.mdx
@@ -40,6 +40,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.SubnetIdentitiesV3`](/code/pallets/subtensor/src/lib.rs#L2602)
+- Storage [`SubtensorModule.SubnetIdentitiesV3`](/code/pallets/subtensor/src/lib.rs#L2608)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/subnet-start-schedule.mdx
+++ b/docs/query/subnet-start-schedule.mdx
@@ -43,7 +43,7 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.NetworkRegisteredAt`](/code/pallets/subtensor/src/lib.rs#L2073)
+- Storage [`SubtensorModule.NetworkRegisteredAt`](/code/pallets/subtensor/src/lib.rs#L2079)
 - Constant [`SubtensorModule.InitialStartCallDelay`](/code/runtime/src/lib.rs#L851)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/subnet.mdx
+++ b/docs/query/subnet.mdx
@@ -42,8 +42,8 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.Tempo`](/code/pallets/subtensor/src/lib.rs#L1982)
-- Storage [`SubtensorModule.Burn`](/code/pallets/subtensor/src/lib.rs#L2278)
-- Storage [`SubtensorModule.SubnetworkN`](/code/pallets/subtensor/src/lib.rs#L2041)
+- Storage [`SubtensorModule.Tempo`](/code/pallets/subtensor/src/lib.rs#L1988)
+- Storage [`SubtensorModule.Burn`](/code/pallets/subtensor/src/lib.rs#L2284)
+- Storage [`SubtensorModule.SubnetworkN`](/code/pallets/subtensor/src/lib.rs#L2047)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/subnets.mdx
+++ b/docs/query/subnets.mdx
@@ -40,9 +40,9 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.NetworksAdded`](/code/pallets/subtensor/src/lib.rs#L2045)
-- Storage [`SubtensorModule.Tempo`](/code/pallets/subtensor/src/lib.rs#L1982)
-- Storage [`SubtensorModule.Burn`](/code/pallets/subtensor/src/lib.rs#L2278)
-- Storage [`SubtensorModule.SubnetworkN`](/code/pallets/subtensor/src/lib.rs#L2041)
+- Storage [`SubtensorModule.NetworksAdded`](/code/pallets/subtensor/src/lib.rs#L2051)
+- Storage [`SubtensorModule.Tempo`](/code/pallets/subtensor/src/lib.rs#L1988)
+- Storage [`SubtensorModule.Burn`](/code/pallets/subtensor/src/lib.rs#L2284)
+- Storage [`SubtensorModule.SubnetworkN`](/code/pallets/subtensor/src/lib.rs#L2047)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/timelocked-weight-commits.mdx
+++ b/docs/query/timelocked-weight-commits.mdx
@@ -47,6 +47,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.TimelockedWeightCommits`](/code/pallets/subtensor/src/lib.rs#L2658)
+- Storage [`SubtensorModule.TimelockedWeightCommits`](/code/pallets/subtensor/src/lib.rs#L2664)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/token-symbols.mdx
+++ b/docs/query/token-symbols.mdx
@@ -42,6 +42,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.TokenSymbol`](/code/pallets/subtensor/src/lib.rs#L1793)
+- Storage [`SubtensorModule.TokenSymbol`](/code/pallets/subtensor/src/lib.rs#L1799)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/tx-rate-limit.mdx
+++ b/docs/query/tx-rate-limit.mdx
@@ -40,6 +40,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.TxRateLimit`](/code/pallets/subtensor/src/lib.rs#L2336)
+- Storage [`SubtensorModule.TxRateLimit`](/code/pallets/subtensor/src/lib.rs#L2342)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/uid.mdx
+++ b/docs/query/uid.mdx
@@ -43,6 +43,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.Uids`](/code/pallets/subtensor/src/lib.rs#L2460)
+- Storage [`SubtensorModule.Uids`](/code/pallets/subtensor/src/lib.rs#L2466)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/weights-rate-limit.mdx
+++ b/docs/query/weights-rate-limit.mdx
@@ -42,6 +42,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.WeightsSetRateLimit`](/code/pallets/subtensor/src/lib.rs#L2248)
+- Storage [`SubtensorModule.WeightsSetRateLimit`](/code/pallets/subtensor/src/lib.rs#L2254)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/query/weights.mdx
+++ b/docs/query/weights.mdx
@@ -47,6 +47,6 @@ Async is the same surface awaited: `async with bt.Subtensor() as client:`.
 
 ## On-chain implementation
 
-- Storage [`SubtensorModule.Weights`](/code/pallets/subtensor/src/lib.rs#L2522)
+- Storage [`SubtensorModule.Weights`](/code/pallets/subtensor/src/lib.rs#L2528)
 
 Every file is browsable under [/code](/code) exactly as built into the runtime.

--- a/docs/tx/add-collateral.mdx
+++ b/docs/tx/add-collateral.mdx
@@ -23,7 +23,7 @@ to clear unshielded at an unbounded AMM price.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.add_collateral`](/code/pallets/subtensor/src/macros/dispatches.rs#L2450-L2460) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.add_collateral`](/code/pallets/subtensor/src/macros/dispatches.rs#L2466-L2476) |
 
 ## Parameters
 
@@ -77,7 +77,7 @@ result = sub.execute_tool("add_collateral", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.add_collateral` — [`pallets/subtensor/src/macros/dispatches.rs#L2452`](/code/pallets/subtensor/src/macros/dispatches.rs#L2450-L2460):
+`SubtensorModule.add_collateral` — [`pallets/subtensor/src/macros/dispatches.rs#L2468`](/code/pallets/subtensor/src/macros/dispatches.rs#L2466-L2476):
 
 ```rust
 #[pallet::call_index(144)]

--- a/docs/tx/add-stake-limit.mdx
+++ b/docs/tx/add-stake-limit.mdx
@@ -15,7 +15,7 @@ for large amounts or thin pools, where the swap itself moves the price.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.add_stake_limit`](/code/pallets/subtensor/src/macros/dispatches.rs#L1392-L1411) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.add_stake_limit`](/code/pallets/subtensor/src/macros/dispatches.rs#L1393-L1412) |
 
 ## Parameters
 
@@ -74,7 +74,7 @@ result = sub.execute_tool("add_stake_limit", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.add_stake_limit` — [`pallets/subtensor/src/macros/dispatches.rs#L1394`](/code/pallets/subtensor/src/macros/dispatches.rs#L1392-L1411):
+`SubtensorModule.add_stake_limit` — [`pallets/subtensor/src/macros/dispatches.rs#L1395`](/code/pallets/subtensor/src/macros/dispatches.rs#L1393-L1412):
 
 ```rust
 #[pallet::call_index(88)]

--- a/docs/tx/add-stake.mdx
+++ b/docs/tx/add-stake.mdx
@@ -22,7 +22,7 @@ reserve (`InsufficientLiquidity`).
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.add_stake`](/code/pallets/subtensor/src/macros/dispatches.rs#L559-L568), [`SubtensorModule.add_stake_limit`](/code/pallets/subtensor/src/macros/dispatches.rs#L1392-L1411) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.add_stake`](/code/pallets/subtensor/src/macros/dispatches.rs#L560-L569), [`SubtensorModule.add_stake_limit`](/code/pallets/subtensor/src/macros/dispatches.rs#L1393-L1412) |
 
 ## Parameters
 
@@ -79,7 +79,7 @@ result = sub.execute_tool("add_stake", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.add_stake` — [`pallets/subtensor/src/macros/dispatches.rs#L561`](/code/pallets/subtensor/src/macros/dispatches.rs#L559-L568):
+`SubtensorModule.add_stake` — [`pallets/subtensor/src/macros/dispatches.rs#L562`](/code/pallets/subtensor/src/macros/dispatches.rs#L560-L569):
 
 ```rust
 #[pallet::call_index(2)]
@@ -96,7 +96,7 @@ pub fn add_stake(
 
 Delegates to [`do_add_stake`](/code/pallets/subtensor/src/staking/add_stake.rs#L30).
 
-`SubtensorModule.add_stake_limit` — [`pallets/subtensor/src/macros/dispatches.rs#L1394`](/code/pallets/subtensor/src/macros/dispatches.rs#L1392-L1411):
+`SubtensorModule.add_stake_limit` — [`pallets/subtensor/src/macros/dispatches.rs#L1395`](/code/pallets/subtensor/src/macros/dispatches.rs#L1393-L1412):
 
 ```rust
 #[pallet::call_index(88)]

--- a/docs/tx/announce-coldkey-swap.mdx
+++ b/docs/tx/announce-coldkey-swap.mdx
@@ -23,7 +23,7 @@ an unauthorized one with `dispute_coldkey_swap`.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.announce_coldkey_swap`](/code/pallets/subtensor/src/macros/dispatches.rs#L1986-L2014) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.announce_coldkey_swap`](/code/pallets/subtensor/src/macros/dispatches.rs#L2002-L2030) |
 
 ## Parameters
 
@@ -72,7 +72,7 @@ result = sub.execute_tool("announce_coldkey_swap", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.announce_coldkey_swap` — [`pallets/subtensor/src/macros/dispatches.rs#L1988`](/code/pallets/subtensor/src/macros/dispatches.rs#L1986-L2014):
+`SubtensorModule.announce_coldkey_swap` — [`pallets/subtensor/src/macros/dispatches.rs#L2004`](/code/pallets/subtensor/src/macros/dispatches.rs#L2002-L2030):
 
 ```rust
 #[pallet::call_index(125)]

--- a/docs/tx/associate-evm-key.mdx
+++ b/docs/tx/associate-evm-key.mdx
@@ -20,7 +20,7 @@ neuron.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `hotkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.associate_evm_key`](/code/pallets/subtensor/src/macros/dispatches.rs#L1574-L1588) |
+| `hotkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.associate_evm_key`](/code/pallets/subtensor/src/macros/dispatches.rs#L1575-L1589) |
 
 ## Parameters
 
@@ -78,7 +78,7 @@ result = sub.execute_tool("associate_evm_key", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.associate_evm_key` — [`pallets/subtensor/src/macros/dispatches.rs#L1580`](/code/pallets/subtensor/src/macros/dispatches.rs#L1574-L1588):
+`SubtensorModule.associate_evm_key` — [`pallets/subtensor/src/macros/dispatches.rs#L1581`](/code/pallets/subtensor/src/macros/dispatches.rs#L1575-L1589):
 
 ```rust
 #[pallet::call_index(93)]

--- a/docs/tx/associate-hotkey.mdx
+++ b/docs/tx/associate-hotkey.mdx
@@ -15,7 +15,7 @@ take over the hotkey.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.try_associate_hotkey`](/code/pallets/subtensor/src/macros/dispatches.rs#L1520-L1528) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.try_associate_hotkey`](/code/pallets/subtensor/src/macros/dispatches.rs#L1521-L1529) |
 
 ## Parameters
 
@@ -62,7 +62,7 @@ result = sub.execute_tool("associate_hotkey", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.try_associate_hotkey` — [`pallets/subtensor/src/macros/dispatches.rs#L1522`](/code/pallets/subtensor/src/macros/dispatches.rs#L1520-L1528):
+`SubtensorModule.try_associate_hotkey` — [`pallets/subtensor/src/macros/dispatches.rs#L1523`](/code/pallets/subtensor/src/macros/dispatches.rs#L1521-L1529):
 
 ```rust
 #[pallet::call_index(91)]

--- a/docs/tx/burned-register.mdx
+++ b/docs/tx/burned-register.mdx
@@ -21,7 +21,7 @@ period ends. Use `root_register` instead for the root network
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.burned_register`](/code/pallets/subtensor/src/macros/dispatches.rs#L816-L824) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.burned_register`](/code/pallets/subtensor/src/macros/dispatches.rs#L817-L825) |
 
 ## Parameters
 
@@ -71,7 +71,7 @@ result = sub.execute_tool("burned_register", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.burned_register` — [`pallets/subtensor/src/macros/dispatches.rs#L818`](/code/pallets/subtensor/src/macros/dispatches.rs#L816-L824):
+`SubtensorModule.burned_register` — [`pallets/subtensor/src/macros/dispatches.rs#L819`](/code/pallets/subtensor/src/macros/dispatches.rs#L817-L825):
 
 ```rust
 #[pallet::call_index(7)]

--- a/docs/tx/claim-root.mdx
+++ b/docs/tx/claim-root.mdx
@@ -17,7 +17,7 @@ deadline — but each call pays out only the subnets listed.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.claim_root`](/code/pallets/subtensor/src/macros/dispatches.rs#L1890-L1908) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.claim_root`](/code/pallets/subtensor/src/macros/dispatches.rs#L1892-L1924) |
 
 ## Parameters
 
@@ -66,11 +66,17 @@ result = sub.execute_tool("claim_root", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.claim_root` — [`pallets/subtensor/src/macros/dispatches.rs#L1892`](/code/pallets/subtensor/src/macros/dispatches.rs#L1890-L1908):
+`SubtensorModule.claim_root` — [`pallets/subtensor/src/macros/dispatches.rs#L1900`](/code/pallets/subtensor/src/macros/dispatches.rs#L1892-L1924):
 
 ```rust
 #[pallet::call_index(121)]
-#[pallet::weight(<T as crate::pallet::Config>::WeightInfo::claim_root())]
+// The benchmark covers one hotkey and one subnet. Manual claims bound both
+// dimensions below and refund unused weight after execution.
+#[pallet::weight(
+    <T as crate::pallet::Config>::WeightInfo::claim_root()
+        .saturating_mul(MAX_ROOT_CLAIM_HOTKEYS as u64)
+        .saturating_mul(MAX_SUBNET_CLAIMS as u64)
+)]
 pub fn claim_root(
     origin: OriginFor<T>,
     subnets: BTreeSet<NetUid>,
@@ -83,9 +89,17 @@ pub fn claim_root(
         Error::<T>::InvalidSubnetNumber
     );
 
+    let hotkey_count = StakingHotkeys::<T>::decode_len(&coldkey).unwrap_or_default();
+    ensure!(
+        hotkey_count <= MAX_ROOT_CLAIM_HOTKEYS,
+        Error::<T>::TooManyRootClaimHotkeys
+    );
+
     Self::maybe_add_coldkey_index(&coldkey);
 
-    let weight = Self::do_root_claim(coldkey, Some(subnets))?;
+    let weight = T::DbWeight::get()
+        .reads(1)
+        .saturating_add(Self::do_root_claim(coldkey, Some(subnets))?);
     Ok((Some(weight), Pays::Yes).into())
 }
 ```

--- a/docs/tx/clear-coldkey-swap-announcement.mdx
+++ b/docs/tx/clear-coldkey-swap-announcement.mdx
@@ -17,7 +17,7 @@ right call instead.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.clear_coldkey_swap_announcement`](/code/pallets/subtensor/src/macros/dispatches.rs#L2185-L2202) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.clear_coldkey_swap_announcement`](/code/pallets/subtensor/src/macros/dispatches.rs#L2201-L2218) |
 
 ## Parameters
 
@@ -62,7 +62,7 @@ result = sub.execute_tool("clear_coldkey_swap_announcement", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.clear_coldkey_swap_announcement` — [`pallets/subtensor/src/macros/dispatches.rs#L2187`](/code/pallets/subtensor/src/macros/dispatches.rs#L2185-L2202):
+`SubtensorModule.clear_coldkey_swap_announcement` — [`pallets/subtensor/src/macros/dispatches.rs#L2203`](/code/pallets/subtensor/src/macros/dispatches.rs#L2201-L2218):
 
 ```rust
 #[pallet::call_index(133)]

--- a/docs/tx/commit-weights.mdx
+++ b/docs/tx/commit-weights.mdx
@@ -16,7 +16,7 @@ commit-reveal setting.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `hotkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.commit_timelocked_mechanism_weights`](/code/pallets/subtensor/src/macros/dispatches.rs#L1851-L1869) |
+| `hotkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.commit_timelocked_mechanism_weights`](/code/pallets/subtensor/src/macros/dispatches.rs#L1852-L1870) |
 
 ## Parameters
 
@@ -70,7 +70,7 @@ result = sub.execute_tool("commit_weights", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.commit_timelocked_mechanism_weights` — [`pallets/subtensor/src/macros/dispatches.rs#L1853`](/code/pallets/subtensor/src/macros/dispatches.rs#L1851-L1869):
+`SubtensorModule.commit_timelocked_mechanism_weights` — [`pallets/subtensor/src/macros/dispatches.rs#L1854`](/code/pallets/subtensor/src/macros/dispatches.rs#L1852-L1870):
 
 ```rust
 #[pallet::call_index(118)]

--- a/docs/tx/decrease-take.mdx
+++ b/docs/tx/decrease-take.mdx
@@ -14,7 +14,7 @@ Use `set_take` to land on an absolute value without tracking direction.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.decrease_take`](/code/pallets/subtensor/src/macros/dispatches.rs#L490-L498) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.decrease_take`](/code/pallets/subtensor/src/macros/dispatches.rs#L491-L499) |
 
 ## Parameters
 
@@ -64,7 +64,7 @@ result = sub.execute_tool("decrease_take", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.decrease_take` — [`pallets/subtensor/src/macros/dispatches.rs#L492`](/code/pallets/subtensor/src/macros/dispatches.rs#L490-L498):
+`SubtensorModule.decrease_take` — [`pallets/subtensor/src/macros/dispatches.rs#L493`](/code/pallets/subtensor/src/macros/dispatches.rs#L491-L499):
 
 ```rust
 #[pallet::call_index(65)]

--- a/docs/tx/dispute-coldkey-swap.mdx
+++ b/docs/tx/dispute-coldkey-swap.mdx
@@ -18,7 +18,7 @@ you made yourself.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.dispute_coldkey_swap`](/code/pallets/subtensor/src/macros/dispatches.rs#L2055-L2074) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.dispute_coldkey_swap`](/code/pallets/subtensor/src/macros/dispatches.rs#L2071-L2090) |
 
 ## Parameters
 
@@ -63,7 +63,7 @@ result = sub.execute_tool("dispute_coldkey_swap", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.dispute_coldkey_swap` — [`pallets/subtensor/src/macros/dispatches.rs#L2057`](/code/pallets/subtensor/src/macros/dispatches.rs#L2055-L2074):
+`SubtensorModule.dispute_coldkey_swap` — [`pallets/subtensor/src/macros/dispatches.rs#L2073`](/code/pallets/subtensor/src/macros/dispatches.rs#L2071-L2090):
 
 ```rust
 #[pallet::call_index(127)]

--- a/docs/tx/increase-take.mdx
+++ b/docs/tx/increase-take.mdx
@@ -15,7 +15,7 @@ without tracking the direction yourself.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.increase_take`](/code/pallets/subtensor/src/macros/dispatches.rs#L523-L531) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.increase_take`](/code/pallets/subtensor/src/macros/dispatches.rs#L524-L532) |
 
 ## Parameters
 
@@ -65,7 +65,7 @@ result = sub.execute_tool("increase_take", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.increase_take` — [`pallets/subtensor/src/macros/dispatches.rs#L525`](/code/pallets/subtensor/src/macros/dispatches.rs#L523-L531):
+`SubtensorModule.increase_take` — [`pallets/subtensor/src/macros/dispatches.rs#L526`](/code/pallets/subtensor/src/macros/dispatches.rs#L524-L532):
 
 ```rust
 #[pallet::call_index(66)]

--- a/docs/tx/lock-stake.mdx
+++ b/docs/tx/lock-stake.mdx
@@ -21,7 +21,7 @@ persists is controlled per coldkey per subnet with
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.lock_stake`](/code/pallets/subtensor/src/macros/dispatches.rs#L2257-L2267) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.lock_stake`](/code/pallets/subtensor/src/macros/dispatches.rs#L2273-L2283) |
 
 ## Parameters
 
@@ -74,7 +74,7 @@ result = sub.execute_tool("lock_stake", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.lock_stake` — [`pallets/subtensor/src/macros/dispatches.rs#L2259`](/code/pallets/subtensor/src/macros/dispatches.rs#L2257-L2267):
+`SubtensorModule.lock_stake` — [`pallets/subtensor/src/macros/dispatches.rs#L2275`](/code/pallets/subtensor/src/macros/dispatches.rs#L2273-L2283):
 
 ```rust
 #[pallet::call_index(136)]

--- a/docs/tx/move-lock.mdx
+++ b/docs/tx/move-lock.mdx
@@ -16,7 +16,7 @@ existing lock on the subnet to move.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.move_lock`](/code/pallets/subtensor/src/macros/dispatches.rs#L2281-L2290) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.move_lock`](/code/pallets/subtensor/src/macros/dispatches.rs#L2297-L2306) |
 
 ## Parameters
 
@@ -68,7 +68,7 @@ result = sub.execute_tool("move_lock", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.move_lock` — [`pallets/subtensor/src/macros/dispatches.rs#L2283`](/code/pallets/subtensor/src/macros/dispatches.rs#L2281-L2290):
+`SubtensorModule.move_lock` — [`pallets/subtensor/src/macros/dispatches.rs#L2299`](/code/pallets/subtensor/src/macros/dispatches.rs#L2297-L2306):
 
 ```rust
 #[pallet::call_index(137)]

--- a/docs/tx/move-stake.mdx
+++ b/docs/tx/move-stake.mdx
@@ -16,7 +16,7 @@ changes.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.move_stake`](/code/pallets/subtensor/src/macros/dispatches.rs#L1256-L1274) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.move_stake`](/code/pallets/subtensor/src/macros/dispatches.rs#L1257-L1275) |
 
 ## Parameters
 
@@ -77,7 +77,7 @@ result = sub.execute_tool("move_stake", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.move_stake` — [`pallets/subtensor/src/macros/dispatches.rs#L1258`](/code/pallets/subtensor/src/macros/dispatches.rs#L1256-L1274):
+`SubtensorModule.move_stake` — [`pallets/subtensor/src/macros/dispatches.rs#L1259`](/code/pallets/subtensor/src/macros/dispatches.rs#L1257-L1275):
 
 ```rust
 #[pallet::call_index(85)]

--- a/docs/tx/register-leased-network.mdx
+++ b/docs/tx/register-leased-network.mdx
@@ -19,7 +19,7 @@ perpetual and ownership never transfers.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.register_leased_network`](/code/pallets/subtensor/src/macros/dispatches.rs#L1672-L1680) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.register_leased_network`](/code/pallets/subtensor/src/macros/dispatches.rs#L1673-L1681) |
 
 ## Parameters
 
@@ -69,7 +69,7 @@ result = sub.execute_tool("register_leased_network", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.register_leased_network` — [`pallets/subtensor/src/macros/dispatches.rs#L1674`](/code/pallets/subtensor/src/macros/dispatches.rs#L1672-L1680):
+`SubtensorModule.register_leased_network` — [`pallets/subtensor/src/macros/dispatches.rs#L1675`](/code/pallets/subtensor/src/macros/dispatches.rs#L1673-L1681):
 
 ```rust
 #[pallet::call_index(110)]

--- a/docs/tx/register-subnet.mdx
+++ b/docs/tx/register-subnet.mdx
@@ -27,7 +27,7 @@ current cost before sending.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.register_network`](/code/pallets/subtensor/src/macros/dispatches.rs#L1003-L1007) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.register_network`](/code/pallets/subtensor/src/macros/dispatches.rs#L1004-L1008) |
 
 ## Parameters
 
@@ -74,7 +74,7 @@ result = sub.execute_tool("register_subnet", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.register_network` — [`pallets/subtensor/src/macros/dispatches.rs#L1005`](/code/pallets/subtensor/src/macros/dispatches.rs#L1003-L1007):
+`SubtensorModule.register_network` — [`pallets/subtensor/src/macros/dispatches.rs#L1006`](/code/pallets/subtensor/src/macros/dispatches.rs#L1004-L1008):
 
 ```rust
 #[pallet::call_index(59)]

--- a/docs/tx/remove-stake-limit.mdx
+++ b/docs/tx/remove-stake-limit.mdx
@@ -16,7 +16,7 @@ this over plain `remove_stake` when exiting large positions.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.remove_stake_limit`](/code/pallets/subtensor/src/macros/dispatches.rs#L1445-L1463) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.remove_stake_limit`](/code/pallets/subtensor/src/macros/dispatches.rs#L1446-L1464) |
 
 ## Parameters
 
@@ -75,7 +75,7 @@ result = sub.execute_tool("remove_stake_limit", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.remove_stake_limit` — [`pallets/subtensor/src/macros/dispatches.rs#L1447`](/code/pallets/subtensor/src/macros/dispatches.rs#L1445-L1463):
+`SubtensorModule.remove_stake_limit` — [`pallets/subtensor/src/macros/dispatches.rs#L1448`](/code/pallets/subtensor/src/macros/dispatches.rs#L1446-L1464):
 
 ```rust
 #[pallet::call_index(89)]

--- a/docs/tx/remove-stake.mdx
+++ b/docs/tx/remove-stake.mdx
@@ -22,7 +22,7 @@ position instead of leaving dust (`AmountTooLow`).
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.remove_stake`](/code/pallets/subtensor/src/macros/dispatches.rs#L593-L602), [`SubtensorModule.remove_stake_limit`](/code/pallets/subtensor/src/macros/dispatches.rs#L1445-L1463) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.remove_stake`](/code/pallets/subtensor/src/macros/dispatches.rs#L594-L603), [`SubtensorModule.remove_stake_limit`](/code/pallets/subtensor/src/macros/dispatches.rs#L1446-L1464) |
 
 ## Parameters
 
@@ -79,7 +79,7 @@ result = sub.execute_tool("remove_stake", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.remove_stake` — [`pallets/subtensor/src/macros/dispatches.rs#L595`](/code/pallets/subtensor/src/macros/dispatches.rs#L593-L602):
+`SubtensorModule.remove_stake` — [`pallets/subtensor/src/macros/dispatches.rs#L596`](/code/pallets/subtensor/src/macros/dispatches.rs#L594-L603):
 
 ```rust
 #[pallet::call_index(3)]
@@ -96,7 +96,7 @@ pub fn remove_stake(
 
 Delegates to [`do_remove_stake`](/code/pallets/subtensor/src/staking/remove_stake.rs#L35).
 
-`SubtensorModule.remove_stake_limit` — [`pallets/subtensor/src/macros/dispatches.rs#L1447`](/code/pallets/subtensor/src/macros/dispatches.rs#L1445-L1463):
+`SubtensorModule.remove_stake_limit` — [`pallets/subtensor/src/macros/dispatches.rs#L1448`](/code/pallets/subtensor/src/macros/dispatches.rs#L1446-L1464):
 
 ```rust
 #[pallet::call_index(89)]

--- a/docs/tx/reset-axon.mdx
+++ b/docs/tx/reset-axon.mdx
@@ -13,7 +13,7 @@ is back up.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `hotkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.serve_axon`](/code/pallets/subtensor/src/macros/dispatches.rs#L640-L665) |
+| `hotkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.serve_axon`](/code/pallets/subtensor/src/macros/dispatches.rs#L641-L666) |
 
 ## Parameters
 
@@ -62,7 +62,7 @@ result = sub.execute_tool("reset_axon", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.serve_axon` — [`pallets/subtensor/src/macros/dispatches.rs#L642`](/code/pallets/subtensor/src/macros/dispatches.rs#L640-L665):
+`SubtensorModule.serve_axon` — [`pallets/subtensor/src/macros/dispatches.rs#L643`](/code/pallets/subtensor/src/macros/dispatches.rs#L641-L666):
 
 ```rust
 #[pallet::call_index(4)]

--- a/docs/tx/reveal-weights.mdx
+++ b/docs/tx/reveal-weights.mdx
@@ -18,7 +18,7 @@ salt-based commits — the timelocked path used by `set_weights` and
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `hotkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.reveal_weights`](/code/pallets/subtensor/src/macros/dispatches.rs#L275-L286) |
+| `hotkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.reveal_weights`](/code/pallets/subtensor/src/macros/dispatches.rs#L276-L287) |
 
 ## Parameters
 
@@ -77,7 +77,7 @@ result = sub.execute_tool("reveal_weights", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.reveal_weights` — [`pallets/subtensor/src/macros/dispatches.rs#L277`](/code/pallets/subtensor/src/macros/dispatches.rs#L275-L286):
+`SubtensorModule.reveal_weights` — [`pallets/subtensor/src/macros/dispatches.rs#L278`](/code/pallets/subtensor/src/macros/dispatches.rs#L276-L287):
 
 ```rust
 #[pallet::call_index(97)]

--- a/docs/tx/root-register.mdx
+++ b/docs/tx/root-register.mdx
@@ -17,7 +17,7 @@ hitting either cap fails until the window passes. Use
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.root_register`](/code/pallets/subtensor/src/macros/dispatches.rs#L809-L813) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.root_register`](/code/pallets/subtensor/src/macros/dispatches.rs#L810-L814) |
 
 ## Parameters
 
@@ -64,7 +64,7 @@ result = sub.execute_tool("root_register", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.root_register` — [`pallets/subtensor/src/macros/dispatches.rs#L811`](/code/pallets/subtensor/src/macros/dispatches.rs#L809-L813):
+`SubtensorModule.root_register` — [`pallets/subtensor/src/macros/dispatches.rs#L812`](/code/pallets/subtensor/src/macros/dispatches.rs#L810-L814):
 
 ```rust
 #[pallet::call_index(62)]

--- a/docs/tx/serve-axon-tls.mdx
+++ b/docs/tx/serve-axon-tls.mdx
@@ -15,7 +15,7 @@ the hotkey, which must be registered on the subnet. Use plain
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `hotkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.serve_axon_tls`](/code/pallets/subtensor/src/macros/dispatches.rs#L706-L732) |
+| `hotkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.serve_axon_tls`](/code/pallets/subtensor/src/macros/dispatches.rs#L707-L733) |
 
 ## Parameters
 
@@ -75,7 +75,7 @@ result = sub.execute_tool("serve_axon_tls", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.serve_axon_tls` — [`pallets/subtensor/src/macros/dispatches.rs#L708`](/code/pallets/subtensor/src/macros/dispatches.rs#L706-L732):
+`SubtensorModule.serve_axon_tls` — [`pallets/subtensor/src/macros/dispatches.rs#L709`](/code/pallets/subtensor/src/macros/dispatches.rs#L707-L733):
 
 ```rust
 #[pallet::call_index(40)]

--- a/docs/tx/serve-axon.mdx
+++ b/docs/tx/serve-axon.mdx
@@ -15,7 +15,7 @@ endpoint.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `hotkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.serve_axon`](/code/pallets/subtensor/src/macros/dispatches.rs#L640-L665) |
+| `hotkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.serve_axon`](/code/pallets/subtensor/src/macros/dispatches.rs#L641-L666) |
 
 ## Parameters
 
@@ -72,7 +72,7 @@ result = sub.execute_tool("serve_axon", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.serve_axon` — [`pallets/subtensor/src/macros/dispatches.rs#L642`](/code/pallets/subtensor/src/macros/dispatches.rs#L640-L665):
+`SubtensorModule.serve_axon` — [`pallets/subtensor/src/macros/dispatches.rs#L643`](/code/pallets/subtensor/src/macros/dispatches.rs#L641-L666):
 
 ```rust
 #[pallet::call_index(4)]

--- a/docs/tx/serve-prometheus.mdx
+++ b/docs/tx/serve-prometheus.mdx
@@ -13,7 +13,7 @@ data — running the metrics server is up to the caller.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `hotkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.serve_prometheus`](/code/pallets/subtensor/src/macros/dispatches.rs#L748-L759) |
+| `hotkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.serve_prometheus`](/code/pallets/subtensor/src/macros/dispatches.rs#L749-L760) |
 
 ## Parameters
 
@@ -69,7 +69,7 @@ result = sub.execute_tool("serve_prometheus", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.serve_prometheus` — [`pallets/subtensor/src/macros/dispatches.rs#L750`](/code/pallets/subtensor/src/macros/dispatches.rs#L748-L759):
+`SubtensorModule.serve_prometheus` — [`pallets/subtensor/src/macros/dispatches.rs#L751`](/code/pallets/subtensor/src/macros/dispatches.rs#L749-L760):
 
 ```rust
 #[pallet::call_index(5)]

--- a/docs/tx/set-auto-stake.mdx
+++ b/docs/tx/set-auto-stake.mdx
@@ -17,7 +17,7 @@ back with the `auto_stake` read.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.set_coldkey_auto_stake_hotkey`](/code/pallets/subtensor/src/macros/dispatches.rs#L1785-L1827) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.set_coldkey_auto_stake_hotkey`](/code/pallets/subtensor/src/macros/dispatches.rs#L1786-L1828) |
 
 ## Parameters
 
@@ -67,7 +67,7 @@ result = sub.execute_tool("set_auto_stake", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.set_coldkey_auto_stake_hotkey` — [`pallets/subtensor/src/macros/dispatches.rs#L1787`](/code/pallets/subtensor/src/macros/dispatches.rs#L1785-L1827):
+`SubtensorModule.set_coldkey_auto_stake_hotkey` — [`pallets/subtensor/src/macros/dispatches.rs#L1788`](/code/pallets/subtensor/src/macros/dispatches.rs#L1786-L1828):
 
 ```rust
 #[pallet::call_index(114)]

--- a/docs/tx/set-childkey-take.mdx
+++ b/docs/tx/set-childkey-take.mdx
@@ -14,7 +14,7 @@ minimum and maximum childkey take bounds, and rate-limits only increases
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.set_childkey_take`](/code/pallets/subtensor/src/macros/dispatches.rs#L926-L938) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.set_childkey_take`](/code/pallets/subtensor/src/macros/dispatches.rs#L927-L939) |
 
 ## Parameters
 
@@ -67,7 +67,7 @@ result = sub.execute_tool("set_childkey_take", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.set_childkey_take` — [`pallets/subtensor/src/macros/dispatches.rs#L928`](/code/pallets/subtensor/src/macros/dispatches.rs#L926-L938):
+`SubtensorModule.set_childkey_take` — [`pallets/subtensor/src/macros/dispatches.rs#L929`](/code/pallets/subtensor/src/macros/dispatches.rs#L927-L939):
 
 ```rust
 #[pallet::call_index(75)]

--- a/docs/tx/set-children.mdx
+++ b/docs/tx/set-children.mdx
@@ -26,7 +26,7 @@ is not yet enabled, where they apply immediately.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.set_children`](/code/pallets/subtensor/src/macros/dispatches.rs#L1078-L1088) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.set_children`](/code/pallets/subtensor/src/macros/dispatches.rs#L1079-L1089) |
 
 ## Parameters
 
@@ -79,7 +79,7 @@ result = sub.execute_tool("set_children", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.set_children` — [`pallets/subtensor/src/macros/dispatches.rs#L1080`](/code/pallets/subtensor/src/macros/dispatches.rs#L1078-L1088):
+`SubtensorModule.set_children` — [`pallets/subtensor/src/macros/dispatches.rs#L1081`](/code/pallets/subtensor/src/macros/dispatches.rs#L1079-L1089):
 
 ```rust
 #[pallet::call_index(67)]

--- a/docs/tx/set-identity.mdx
+++ b/docs/tx/set-identity.mdx
@@ -17,7 +17,7 @@ cosmetic: no effect on balances, stake, or permissions.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.set_identity`](/code/pallets/subtensor/src/macros/dispatches.rs#L1119-L1141) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.set_identity`](/code/pallets/subtensor/src/macros/dispatches.rs#L1120-L1142) |
 
 ## Parameters
 
@@ -72,7 +72,7 @@ result = sub.execute_tool("set_identity", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.set_identity` — [`pallets/subtensor/src/macros/dispatches.rs#L1121`](/code/pallets/subtensor/src/macros/dispatches.rs#L1119-L1141):
+`SubtensorModule.set_identity` — [`pallets/subtensor/src/macros/dispatches.rs#L1122`](/code/pallets/subtensor/src/macros/dispatches.rs#L1120-L1142):
 
 ```rust
 #[pallet::call_index(68)]

--- a/docs/tx/set-min-collateral.mdx
+++ b/docs/tx/set-min-collateral.mdx
@@ -15,7 +15,7 @@ immediately). Zero clears the floor and restores pure drain behavior.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.set_min_collateral`](/code/pallets/subtensor/src/macros/dispatches.rs#L2485-L2494) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.set_min_collateral`](/code/pallets/subtensor/src/macros/dispatches.rs#L2501-L2510) |
 
 ## Parameters
 
@@ -68,7 +68,7 @@ result = sub.execute_tool("set_min_collateral", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.set_min_collateral` — [`pallets/subtensor/src/macros/dispatches.rs#L2487`](/code/pallets/subtensor/src/macros/dispatches.rs#L2485-L2494):
+`SubtensorModule.set_min_collateral` — [`pallets/subtensor/src/macros/dispatches.rs#L2503`](/code/pallets/subtensor/src/macros/dispatches.rs#L2501-L2510):
 
 ```rust
 #[pallet::call_index(145)]

--- a/docs/tx/set-perpetual-lock.mdx
+++ b/docs/tx/set-perpetual-lock.mdx
@@ -15,7 +15,7 @@ illiquid until you switch back to decaying and the lock runs off.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.set_perpetual_lock`](/code/pallets/subtensor/src/macros/dispatches.rs#L2297-L2306) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.set_perpetual_lock`](/code/pallets/subtensor/src/macros/dispatches.rs#L2313-L2322) |
 
 ## Parameters
 
@@ -67,7 +67,7 @@ result = sub.execute_tool("set_perpetual_lock", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.set_perpetual_lock` — [`pallets/subtensor/src/macros/dispatches.rs#L2299`](/code/pallets/subtensor/src/macros/dispatches.rs#L2297-L2306):
+`SubtensorModule.set_perpetual_lock` — [`pallets/subtensor/src/macros/dispatches.rs#L2315`](/code/pallets/subtensor/src/macros/dispatches.rs#L2313-L2322):
 
 ```rust
 #[pallet::call_index(138)]

--- a/docs/tx/set-root-claim-type.mdx
+++ b/docs/tx/set-root-claim-type.mdx
@@ -14,7 +14,7 @@ already claimed. Read it back with the `root_claim_type` read.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.set_root_claim_type`](/code/pallets/subtensor/src/macros/dispatches.rs#L1917-L1933) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.set_root_claim_type`](/code/pallets/subtensor/src/macros/dispatches.rs#L1933-L1949) |
 
 ## Parameters
 
@@ -62,7 +62,7 @@ result = sub.execute_tool("set_root_claim_type", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.set_root_claim_type` — [`pallets/subtensor/src/macros/dispatches.rs#L1919`](/code/pallets/subtensor/src/macros/dispatches.rs#L1917-L1933):
+`SubtensorModule.set_root_claim_type` — [`pallets/subtensor/src/macros/dispatches.rs#L1935`](/code/pallets/subtensor/src/macros/dispatches.rs#L1933-L1949):
 
 ```rust
 #[pallet::call_index(122)]

--- a/docs/tx/set-subnet-identity.mdx
+++ b/docs/tx/set-subnet-identity.mdx
@@ -15,7 +15,7 @@ for economics use `set_hyperparameter`.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | subnet owner | SubtensorModule | [`SubtensorModule.set_subnet_identity`](/code/pallets/subtensor/src/macros/dispatches.rs#L1154-L1180) |
+| `coldkey` | subnet owner | SubtensorModule | [`SubtensorModule.set_subnet_identity`](/code/pallets/subtensor/src/macros/dispatches.rs#L1155-L1181) |
 
 ## Parameters
 
@@ -74,7 +74,7 @@ result = sub.execute_tool("set_subnet_identity", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.set_subnet_identity` — [`pallets/subtensor/src/macros/dispatches.rs#L1156`](/code/pallets/subtensor/src/macros/dispatches.rs#L1154-L1180):
+`SubtensorModule.set_subnet_identity` — [`pallets/subtensor/src/macros/dispatches.rs#L1157`](/code/pallets/subtensor/src/macros/dispatches.rs#L1155-L1181):
 
 ```rust
 #[pallet::call_index(78)]

--- a/docs/tx/set-take.mdx
+++ b/docs/tx/set-take.mdx
@@ -15,7 +15,7 @@ hotkey. If the move is upward it inherits the increase path's constraints
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.increase_take`](/code/pallets/subtensor/src/macros/dispatches.rs#L523-L531), [`SubtensorModule.decrease_take`](/code/pallets/subtensor/src/macros/dispatches.rs#L490-L498) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.increase_take`](/code/pallets/subtensor/src/macros/dispatches.rs#L524-L532), [`SubtensorModule.decrease_take`](/code/pallets/subtensor/src/macros/dispatches.rs#L491-L499) |
 
 ## Parameters
 
@@ -65,7 +65,7 @@ result = sub.execute_tool("set_take", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.increase_take` — [`pallets/subtensor/src/macros/dispatches.rs#L525`](/code/pallets/subtensor/src/macros/dispatches.rs#L523-L531):
+`SubtensorModule.increase_take` — [`pallets/subtensor/src/macros/dispatches.rs#L526`](/code/pallets/subtensor/src/macros/dispatches.rs#L524-L532):
 
 ```rust
 #[pallet::call_index(66)]
@@ -81,7 +81,7 @@ pub fn increase_take(
 
 Delegates to [`do_increase_take`](/code/pallets/subtensor/src/staking/increase_take.rs#L27).
 
-`SubtensorModule.decrease_take` — [`pallets/subtensor/src/macros/dispatches.rs#L492`](/code/pallets/subtensor/src/macros/dispatches.rs#L490-L498):
+`SubtensorModule.decrease_take` — [`pallets/subtensor/src/macros/dispatches.rs#L493`](/code/pallets/subtensor/src/macros/dispatches.rs#L491-L499):
 
 ```rust
 #[pallet::call_index(65)]

--- a/docs/tx/set-weights.mdx
+++ b/docs/tx/set-weights.mdx
@@ -22,7 +22,7 @@ unless you specifically need to force one path.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `hotkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.set_mechanism_weights`](/code/pallets/subtensor/src/macros/dispatches.rs#L128-L143), [`SubtensorModule.commit_timelocked_mechanism_weights`](/code/pallets/subtensor/src/macros/dispatches.rs#L1851-L1869) |
+| `hotkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.set_mechanism_weights`](/code/pallets/subtensor/src/macros/dispatches.rs#L129-L144), [`SubtensorModule.commit_timelocked_mechanism_weights`](/code/pallets/subtensor/src/macros/dispatches.rs#L1852-L1870) |
 
 ## Parameters
 
@@ -75,7 +75,7 @@ result = sub.execute_tool("set_weights", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.set_mechanism_weights` — [`pallets/subtensor/src/macros/dispatches.rs#L130`](/code/pallets/subtensor/src/macros/dispatches.rs#L128-L143):
+`SubtensorModule.set_mechanism_weights` — [`pallets/subtensor/src/macros/dispatches.rs#L131`](/code/pallets/subtensor/src/macros/dispatches.rs#L129-L144):
 
 ```rust
 #[pallet::call_index(119)]
@@ -98,7 +98,7 @@ pub fn set_mechanism_weights(
 
 Delegates to [`get_commit_reveal_weights_enabled`](/code/pallets/subtensor/src/utils/misc.rs#L607), [`do_set_mechanism_weights`](/code/pallets/subtensor/src/subnets/weights.rs#L916).
 
-`SubtensorModule.commit_timelocked_mechanism_weights` — [`pallets/subtensor/src/macros/dispatches.rs#L1853`](/code/pallets/subtensor/src/macros/dispatches.rs#L1851-L1869):
+`SubtensorModule.commit_timelocked_mechanism_weights` — [`pallets/subtensor/src/macros/dispatches.rs#L1854`](/code/pallets/subtensor/src/macros/dispatches.rs#L1852-L1870):
 
 ```rust
 #[pallet::call_index(118)]

--- a/docs/tx/stake-burn.mdx
+++ b/docs/tx/stake-burn.mdx
@@ -18,7 +18,7 @@ cap.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.add_stake_burn`](/code/pallets/subtensor/src/macros/dispatches.rs#L2169-L2179) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.add_stake_burn`](/code/pallets/subtensor/src/macros/dispatches.rs#L2185-L2195) |
 
 ## Parameters
 
@@ -74,7 +74,7 @@ result = sub.execute_tool("stake_burn", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.add_stake_burn` — [`pallets/subtensor/src/macros/dispatches.rs#L2171`](/code/pallets/subtensor/src/macros/dispatches.rs#L2169-L2179):
+`SubtensorModule.add_stake_burn` — [`pallets/subtensor/src/macros/dispatches.rs#L2187`](/code/pallets/subtensor/src/macros/dispatches.rs#L2185-L2195):
 
 ```rust
 #[pallet::call_index(132)]

--- a/docs/tx/start-call.mdx
+++ b/docs/tx/start-call.mdx
@@ -16,7 +16,7 @@ as soon as the delay allows.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | subnet owner | SubtensorModule | [`SubtensorModule.start_call`](/code/pallets/subtensor/src/macros/dispatches.rs#L1538-L1543) |
+| `coldkey` | subnet owner | SubtensorModule | [`SubtensorModule.start_call`](/code/pallets/subtensor/src/macros/dispatches.rs#L1539-L1544) |
 
 ## Parameters
 
@@ -65,7 +65,7 @@ result = sub.execute_tool("start_call", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.start_call` — [`pallets/subtensor/src/macros/dispatches.rs#L1540`](/code/pallets/subtensor/src/macros/dispatches.rs#L1538-L1543):
+`SubtensorModule.start_call` — [`pallets/subtensor/src/macros/dispatches.rs#L1541`](/code/pallets/subtensor/src/macros/dispatches.rs#L1539-L1544):
 
 ```rust
 #[pallet::call_index(92)]

--- a/docs/tx/swap-coldkey-announced.mdx
+++ b/docs/tx/swap-coldkey-announced.mdx
@@ -15,7 +15,7 @@ future operations sign with the new coldkey.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.swap_coldkey_announced`](/code/pallets/subtensor/src/macros/dispatches.rs#L2024-L2046) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.swap_coldkey_announced`](/code/pallets/subtensor/src/macros/dispatches.rs#L2040-L2062) |
 
 ## Parameters
 
@@ -64,7 +64,7 @@ result = sub.execute_tool("swap_coldkey_announced", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.swap_coldkey_announced` — [`pallets/subtensor/src/macros/dispatches.rs#L2026`](/code/pallets/subtensor/src/macros/dispatches.rs#L2024-L2046):
+`SubtensorModule.swap_coldkey_announced` — [`pallets/subtensor/src/macros/dispatches.rs#L2042`](/code/pallets/subtensor/src/macros/dispatches.rs#L2040-L2062):
 
 ```rust
 #[pallet::call_index(126)]

--- a/docs/tx/swap-hotkey.mdx
+++ b/docs/tx/swap-hotkey.mdx
@@ -23,7 +23,7 @@ instead.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.swap_hotkey`](/code/pallets/subtensor/src/macros/dispatches.rs#L836-L849) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.swap_hotkey`](/code/pallets/subtensor/src/macros/dispatches.rs#L837-L850) |
 
 ## Parameters
 
@@ -74,7 +74,7 @@ result = sub.execute_tool("swap_hotkey", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.swap_hotkey` — [`pallets/subtensor/src/macros/dispatches.rs#L842`](/code/pallets/subtensor/src/macros/dispatches.rs#L836-L849):
+`SubtensorModule.swap_hotkey` — [`pallets/subtensor/src/macros/dispatches.rs#L843`](/code/pallets/subtensor/src/macros/dispatches.rs#L837-L850):
 
 ```rust
 #[pallet::call_index(70)]

--- a/docs/tx/swap-stake.mdx
+++ b/docs/tx/swap-stake.mdx
@@ -18,7 +18,7 @@ only if you want to control each leg separately.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.swap_stake`](/code/pallets/subtensor/src/macros/dispatches.rs#L1342-L1358), [`SubtensorModule.swap_stake_limit`](/code/pallets/subtensor/src/macros/dispatches.rs#L1490-L1510) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.swap_stake`](/code/pallets/subtensor/src/macros/dispatches.rs#L1343-L1359), [`SubtensorModule.swap_stake_limit`](/code/pallets/subtensor/src/macros/dispatches.rs#L1491-L1511) |
 
 ## Parameters
 
@@ -78,7 +78,7 @@ result = sub.execute_tool("swap_stake", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.swap_stake` — [`pallets/subtensor/src/macros/dispatches.rs#L1344`](/code/pallets/subtensor/src/macros/dispatches.rs#L1342-L1358):
+`SubtensorModule.swap_stake` — [`pallets/subtensor/src/macros/dispatches.rs#L1345`](/code/pallets/subtensor/src/macros/dispatches.rs#L1343-L1359):
 
 ```rust
 #[pallet::call_index(87)]
@@ -102,7 +102,7 @@ pub fn swap_stake(
 
 Delegates to [`do_swap_stake`](/code/pallets/subtensor/src/staking/move_stake.rs#L260).
 
-`SubtensorModule.swap_stake_limit` — [`pallets/subtensor/src/macros/dispatches.rs#L1492`](/code/pallets/subtensor/src/macros/dispatches.rs#L1490-L1510):
+`SubtensorModule.swap_stake_limit` — [`pallets/subtensor/src/macros/dispatches.rs#L1493`](/code/pallets/subtensor/src/macros/dispatches.rs#L1491-L1511):
 
 ```rust
 #[pallet::call_index(90)]

--- a/docs/tx/terminate-lease.mdx
+++ b/docs/tx/terminate-lease.mdx
@@ -14,7 +14,7 @@ block with the `lease` read before calling.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.terminate_lease`](/code/pallets/subtensor/src/macros/dispatches.rs#L1695-L1703) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.terminate_lease`](/code/pallets/subtensor/src/macros/dispatches.rs#L1696-L1704) |
 
 ## Parameters
 
@@ -64,7 +64,7 @@ result = sub.execute_tool("terminate_lease", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.terminate_lease` — [`pallets/subtensor/src/macros/dispatches.rs#L1697`](/code/pallets/subtensor/src/macros/dispatches.rs#L1695-L1703):
+`SubtensorModule.terminate_lease` — [`pallets/subtensor/src/macros/dispatches.rs#L1698`](/code/pallets/subtensor/src/macros/dispatches.rs#L1696-L1704):
 
 ```rust
 #[pallet::call_index(111)]

--- a/docs/tx/transfer-stake.mdx
+++ b/docs/tx/transfer-stake.mdx
@@ -19,7 +19,7 @@ this as an unbounded spend and blocks it until the cap is raised. Use
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.transfer_stake`](/code/pallets/subtensor/src/macros/dispatches.rs#L1300-L1318), [`SubtensorModule.transfer_stake_and_hotkey`](/code/pallets/subtensor/src/macros/dispatches.rs#L2392-L2412) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.transfer_stake`](/code/pallets/subtensor/src/macros/dispatches.rs#L1301-L1319), [`SubtensorModule.transfer_stake_and_hotkey`](/code/pallets/subtensor/src/macros/dispatches.rs#L2408-L2428) |
 
 ## Parameters
 
@@ -81,7 +81,7 @@ result = sub.execute_tool("transfer_stake", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.transfer_stake` — [`pallets/subtensor/src/macros/dispatches.rs#L1302`](/code/pallets/subtensor/src/macros/dispatches.rs#L1300-L1318):
+`SubtensorModule.transfer_stake` — [`pallets/subtensor/src/macros/dispatches.rs#L1303`](/code/pallets/subtensor/src/macros/dispatches.rs#L1301-L1319):
 
 ```rust
 #[pallet::call_index(86)]
@@ -107,7 +107,7 @@ pub fn transfer_stake(
 
 Delegates to [`do_transfer_stake`](/code/pallets/subtensor/src/staking/move_stake.rs#L120).
 
-`SubtensorModule.transfer_stake_and_hotkey` — [`pallets/subtensor/src/macros/dispatches.rs#L2394`](/code/pallets/subtensor/src/macros/dispatches.rs#L2392-L2412):
+`SubtensorModule.transfer_stake_and_hotkey` — [`pallets/subtensor/src/macros/dispatches.rs#L2410`](/code/pallets/subtensor/src/macros/dispatches.rs#L2408-L2428):
 
 ```rust
 #[pallet::call_index(143)]

--- a/docs/tx/unstake-all-alpha.mdx
+++ b/docs/tx/unstake-all-alpha.mdx
@@ -16,7 +16,7 @@ incur slippage.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.unstake_all_alpha`](/code/pallets/subtensor/src/macros/dispatches.rs#L1235-L1239) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.unstake_all_alpha`](/code/pallets/subtensor/src/macros/dispatches.rs#L1236-L1240) |
 
 ## Parameters
 
@@ -65,7 +65,7 @@ result = sub.execute_tool("unstake_all_alpha", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.unstake_all_alpha` — [`pallets/subtensor/src/macros/dispatches.rs#L1237`](/code/pallets/subtensor/src/macros/dispatches.rs#L1235-L1239):
+`SubtensorModule.unstake_all_alpha` — [`pallets/subtensor/src/macros/dispatches.rs#L1238`](/code/pallets/subtensor/src/macros/dispatches.rs#L1236-L1240):
 
 ```rust
 #[pallet::call_index(84)]

--- a/docs/tx/unstake-all.mdx
+++ b/docs/tx/unstake-all.mdx
@@ -17,7 +17,7 @@ staked.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.unstake_all`](/code/pallets/subtensor/src/macros/dispatches.rs#L1211-L1215) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.unstake_all`](/code/pallets/subtensor/src/macros/dispatches.rs#L1212-L1216) |
 
 ## Parameters
 
@@ -66,7 +66,7 @@ result = sub.execute_tool("unstake_all", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.unstake_all` — [`pallets/subtensor/src/macros/dispatches.rs#L1213`](/code/pallets/subtensor/src/macros/dispatches.rs#L1211-L1215):
+`SubtensorModule.unstake_all` — [`pallets/subtensor/src/macros/dispatches.rs#L1214`](/code/pallets/subtensor/src/macros/dispatches.rs#L1212-L1216):
 
 ```rust
 #[pallet::call_index(83)]

--- a/docs/tx/update-symbol.mdx
+++ b/docs/tx/update-symbol.mdx
@@ -15,7 +15,7 @@ stake, and emissions are untouched.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | subnet owner | SubtensorModule | [`SubtensorModule.update_symbol`](/code/pallets/subtensor/src/macros/dispatches.rs#L1720-L1737) |
+| `coldkey` | subnet owner | SubtensorModule | [`SubtensorModule.update_symbol`](/code/pallets/subtensor/src/macros/dispatches.rs#L1721-L1738) |
 
 ## Parameters
 
@@ -67,7 +67,7 @@ result = sub.execute_tool("update_symbol", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.update_symbol` — [`pallets/subtensor/src/macros/dispatches.rs#L1722`](/code/pallets/subtensor/src/macros/dispatches.rs#L1720-L1737):
+`SubtensorModule.update_symbol` — [`pallets/subtensor/src/macros/dispatches.rs#L1723`](/code/pallets/subtensor/src/macros/dispatches.rs#L1721-L1738):
 
 ```rust
 #[pallet::call_index(112)]

--- a/runtime/tests/claim_root_weight.rs
+++ b/runtime/tests/claim_root_weight.rs
@@ -8,6 +8,10 @@ use std::collections::BTreeSet;
 use subtensor_runtime_common::{NetUid, TaoBalance};
 
 #[test]
+#[allow(
+    clippy::expect_used,
+    reason = "test asserts the runtime configures a normal extrinsic limit"
+)]
 fn claim_root_with_extensions_fits_normal_extrinsic_limit() {
     let call = RuntimeCall::SubtensorModule(pallet_subtensor::Call::claim_root {
         subnets: BTreeSet::from([NetUid::from(1)]),
@@ -34,12 +38,10 @@ fn claim_root_with_extensions_fits_normal_extrinsic_limit() {
 
     let mut dispatch_info = call.get_dispatch_info();
     dispatch_info.extension_weight = extensions.weight(&call);
-    let Some(max_extrinsic) = BlockWeights::get()
+    let max_extrinsic = BlockWeights::get()
         .get(DispatchClass::Normal)
         .max_extrinsic
-    else {
-        panic!("normal extrinsics have a configured maximum");
-    };
+        .expect("normal extrinsics have a configured maximum");
 
     assert!(
         dispatch_info.total_weight().all_lte(max_extrinsic),

--- a/runtime/tests/claim_root_weight.rs
+++ b/runtime/tests/claim_root_weight.rs
@@ -8,10 +8,6 @@ use std::collections::BTreeSet;
 use subtensor_runtime_common::{NetUid, TaoBalance};
 
 #[test]
-#[allow(
-    clippy::expect_used,
-    reason = "test asserts the runtime configures a normal extrinsic limit"
-)]
 fn claim_root_with_extensions_fits_normal_extrinsic_limit() {
     let call = RuntimeCall::SubtensorModule(pallet_subtensor::Call::claim_root {
         subnets: BTreeSet::from([NetUid::from(1)]),
@@ -38,10 +34,9 @@ fn claim_root_with_extensions_fits_normal_extrinsic_limit() {
 
     let mut dispatch_info = call.get_dispatch_info();
     dispatch_info.extension_weight = extensions.weight(&call);
-    let max_extrinsic = BlockWeights::get()
-        .get(DispatchClass::Normal)
-        .max_extrinsic
-        .expect("normal extrinsics have a configured maximum");
+    let Some(max_extrinsic) = BlockWeights::get().get(DispatchClass::Normal).max_extrinsic else {
+        panic!("normal extrinsics have a configured maximum");
+    };
 
     assert!(
         dispatch_info.total_weight().all_lte(max_extrinsic),

--- a/sdk/python/bittensor/_transport/utils/receipt.py
+++ b/sdk/python/bittensor/_transport/utils/receipt.py
@@ -210,17 +210,11 @@ def build_system_error_message(dispatch_error: dict) -> Optional[dict]:
         name = str(variant)
     elif "Arithmetic" in dispatch_error:
         variant = dispatch_error["Arithmetic"]
-        name = (
-            str(next(iter(variant)))
-            if isinstance(variant, dict) and variant
-            else "Arithmetic"
-        )
+        name = str(next(iter(variant))) if isinstance(variant, dict) and variant else "Arithmetic"
     elif "Transactional" in dispatch_error:
         variant = dispatch_error["Transactional"]
         name = (
-            str(next(iter(variant)))
-            if isinstance(variant, dict) and variant
-            else "Transactional"
+            str(next(iter(variant))) if isinstance(variant, dict) and variant else "Transactional"
         )
     elif "Exhausted" in dispatch_error:
         name = "Exhausted"

--- a/sdk/python/bittensor/result.py
+++ b/sdk/python/bittensor/result.py
@@ -312,8 +312,7 @@ _NAME_HELP_OVERRIDES: dict[str, str] = {
         "use the same new coldkey you announced"
     ),
     "Payment": (
-        "fund the signing account so it can cover fees (and tip); check with "
-        "`btcli wallet balance`"
+        "fund the signing account so it can cover fees (and tip); check with `btcli wallet balance`"
     ),
     "Future": (
         "the nonce is too high; wait for pending extrinsics or resubmit with "
@@ -326,8 +325,7 @@ _NAME_HELP_OVERRIDES: dict[str, str] = {
         "the command — if it keeps failing, use a local wallet or file a bug"
     ),
     "ZeroMaxAmount": (
-        "relax the price/slippage limit or wait for a better price so max_amount "
-        "is non-zero"
+        "relax the price/slippage limit or wait for a better price so max_amount is non-zero"
     ),
     "AmountTooLow": (
         "raise the amount above the chain minimum stake (after fees/slippage); "
@@ -631,9 +629,11 @@ def chain_error_from_dispatch(err: Any) -> ChainError:
             if wrapper not in err:
                 continue
             variant = err[wrapper]
-            if wrapper in ("Token", "Arithmetic", "Transactional") and isinstance(
-                variant, dict
-            ) and variant:
+            if (
+                wrapper in ("Token", "Arithmetic", "Transactional")
+                and isinstance(variant, dict)
+                and variant
+            ):
                 name = next(iter(variant))
             elif wrapper in ("BadOrigin", "CannotLookup", "Other"):
                 name = wrapper

--- a/sdk/python/codegen/check.py
+++ b/sdk/python/codegen/check.py
@@ -231,6 +231,9 @@ RAW_ONLY: dict[str, set[str]] = {
         "sudo_set_difficulty",
         "sudo_set_dissolve_network_schedule_duration",
         "sudo_set_ema_price_halving_period",
+        # root-only global emission-gate policy
+        "sudo_set_emission_bar_quantile",
+        "sudo_set_emission_gate_exponent",
         "sudo_set_evm_chain_id",
         "sudo_set_kappa",
         "sudo_set_lock_reduction_interval",

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -117,7 +117,7 @@ wheels = [
 
 [[package]]
 name = "bittensor"
-version = "11.0.1.dev0"
+version = "11.0.2.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "bittensor-core" },
@@ -165,7 +165,7 @@ dev = [
 
 [[package]]
 name = "bittensor-core"
-version = "0.1.1"
+version = "0.1.2"
 source = { directory = "../bittensor-core-py" }
 
 [[package]]

--- a/website/apps/bittensor-website/public/catalog/intents.json
+++ b/website/apps/bittensor-website/public/catalog/intents.json
@@ -56,9 +56,9 @@
         "pallet": "SubtensorModule",
         "call": "add_collateral",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2452,
-        "end_line": 2460,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2450-L2460",
+        "line": 2468,
+        "end_line": 2476,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2466-L2476",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -179,18 +179,18 @@
         "pallet": "SubtensorModule",
         "call": "add_stake",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 561,
-        "end_line": 568,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L559-L568",
+        "line": 562,
+        "end_line": 569,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L560-L569",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       },
       {
         "pallet": "SubtensorModule",
         "call": "add_stake_limit",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 1394,
-        "end_line": 1411,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1392-L1411",
+        "line": 1395,
+        "end_line": 1412,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1393-L1412",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -258,9 +258,9 @@
         "pallet": "SubtensorModule",
         "call": "add_stake_limit",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 1394,
-        "end_line": 1411,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1392-L1411",
+        "line": 1395,
+        "end_line": 1412,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1393-L1412",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -300,9 +300,9 @@
         "pallet": "SubtensorModule",
         "call": "announce_coldkey_swap",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 1988,
-        "end_line": 2014,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1986-L2014",
+        "line": 2004,
+        "end_line": 2030,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2002-L2030",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -357,9 +357,9 @@
         "pallet": "SubtensorModule",
         "call": "associate_evm_key",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 1580,
-        "end_line": 1588,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1574-L1588",
+        "line": 1581,
+        "end_line": 1589,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1575-L1589",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -397,9 +397,9 @@
         "pallet": "SubtensorModule",
         "call": "try_associate_hotkey",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 1522,
-        "end_line": 1528,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1520-L1528",
+        "line": 1523,
+        "end_line": 1529,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1521-L1529",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -485,9 +485,9 @@
         "pallet": "SubtensorModule",
         "call": "burned_register",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 818,
-        "end_line": 824,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L816-L824",
+        "line": 819,
+        "end_line": 825,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L817-L825",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -530,9 +530,9 @@
         "pallet": "SubtensorModule",
         "call": "claim_root",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 1892,
-        "end_line": 1908,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1890-L1908",
+        "line": 1900,
+        "end_line": 1924,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1892-L1924",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -565,9 +565,9 @@
         "pallet": "SubtensorModule",
         "call": "clear_coldkey_swap_announcement",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2187,
-        "end_line": 2202,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2185-L2202",
+        "line": 2203,
+        "end_line": 2218,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2201-L2218",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -633,9 +633,9 @@
         "pallet": "SubtensorModule",
         "call": "commit_timelocked_mechanism_weights",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 1853,
-        "end_line": 1869,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1851-L1869",
+        "line": 1854,
+        "end_line": 1870,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1852-L1870",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -879,9 +879,9 @@
         "pallet": "SubtensorModule",
         "call": "decrease_take",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 492,
-        "end_line": 498,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L490-L498",
+        "line": 493,
+        "end_line": 499,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L491-L499",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -914,9 +914,9 @@
         "pallet": "SubtensorModule",
         "call": "dispute_coldkey_swap",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2057,
-        "end_line": 2074,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2055-L2074",
+        "line": 2073,
+        "end_line": 2090,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2071-L2090",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -1200,9 +1200,9 @@
         "pallet": "SubtensorModule",
         "call": "increase_take",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 525,
-        "end_line": 531,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L523-L531",
+        "line": 526,
+        "end_line": 532,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L524-L532",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -1318,9 +1318,9 @@
         "pallet": "SubtensorModule",
         "call": "lock_stake",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2259,
-        "end_line": 2267,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2257-L2267",
+        "line": 2275,
+        "end_line": 2283,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2273-L2283",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -1365,9 +1365,9 @@
         "pallet": "SubtensorModule",
         "call": "move_lock",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2283,
-        "end_line": 2290,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2281-L2290",
+        "line": 2299,
+        "end_line": 2306,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2297-L2306",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -1436,9 +1436,9 @@
         "pallet": "SubtensorModule",
         "call": "move_stake",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 1258,
-        "end_line": 1274,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1256-L1274",
+        "line": 1259,
+        "end_line": 1275,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1257-L1275",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -1700,9 +1700,9 @@
         "pallet": "SubtensorModule",
         "call": "register_leased_network",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 1674,
-        "end_line": 1680,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1672-L1680",
+        "line": 1675,
+        "end_line": 1681,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1673-L1681",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -1740,9 +1740,9 @@
         "pallet": "SubtensorModule",
         "call": "register_network",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 1005,
-        "end_line": 1007,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1003-L1007",
+        "line": 1006,
+        "end_line": 1008,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1004-L1008",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -1904,18 +1904,18 @@
         "pallet": "SubtensorModule",
         "call": "remove_stake",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 595,
-        "end_line": 602,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L593-L602",
+        "line": 596,
+        "end_line": 603,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L594-L603",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       },
       {
         "pallet": "SubtensorModule",
         "call": "remove_stake_limit",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 1447,
-        "end_line": 1463,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1445-L1463",
+        "line": 1448,
+        "end_line": 1464,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1446-L1464",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -1989,9 +1989,9 @@
         "pallet": "SubtensorModule",
         "call": "remove_stake_limit",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 1447,
-        "end_line": 1463,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1445-L1463",
+        "line": 1448,
+        "end_line": 1464,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1446-L1464",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -2031,9 +2031,9 @@
         "pallet": "SubtensorModule",
         "call": "serve_axon",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 642,
-        "end_line": 665,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L640-L665",
+        "line": 643,
+        "end_line": 666,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L641-L666",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -2101,9 +2101,9 @@
         "pallet": "SubtensorModule",
         "call": "reveal_weights",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 277,
-        "end_line": 286,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L275-L286",
+        "line": 278,
+        "end_line": 287,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L276-L287",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -2141,9 +2141,9 @@
         "pallet": "SubtensorModule",
         "call": "root_register",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 811,
-        "end_line": 813,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L809-L813",
+        "line": 812,
+        "end_line": 814,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L810-L814",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -2201,9 +2201,9 @@
         "pallet": "SubtensorModule",
         "call": "serve_axon",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 642,
-        "end_line": 665,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L640-L665",
+        "line": 643,
+        "end_line": 666,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L641-L666",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -2266,9 +2266,9 @@
         "pallet": "SubtensorModule",
         "call": "serve_axon_tls",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 708,
-        "end_line": 732,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L706-L732",
+        "line": 709,
+        "end_line": 733,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L707-L733",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -2322,9 +2322,9 @@
         "pallet": "SubtensorModule",
         "call": "serve_prometheus",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 750,
-        "end_line": 759,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L748-L759",
+        "line": 751,
+        "end_line": 760,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L749-L760",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -2368,9 +2368,9 @@
         "pallet": "SubtensorModule",
         "call": "set_coldkey_auto_stake_hotkey",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 1787,
-        "end_line": 1827,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1785-L1827",
+        "line": 1788,
+        "end_line": 1828,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1786-L1828",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -2423,9 +2423,9 @@
         "pallet": "SubtensorModule",
         "call": "set_childkey_take",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 928,
-        "end_line": 938,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L926-L938",
+        "line": 929,
+        "end_line": 939,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L927-L939",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -2474,9 +2474,9 @@
         "pallet": "SubtensorModule",
         "call": "set_children",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 1080,
-        "end_line": 1088,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1078-L1088",
+        "line": 1081,
+        "end_line": 1089,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1079-L1089",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -3041,9 +3041,9 @@
         "pallet": "SubtensorModule",
         "call": "set_identity",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 1121,
-        "end_line": 1141,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1119-L1141",
+        "line": 1122,
+        "end_line": 1142,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1120-L1142",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -3148,9 +3148,9 @@
         "pallet": "SubtensorModule",
         "call": "set_min_collateral",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2487,
-        "end_line": 2494,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2485-L2494",
+        "line": 2503,
+        "end_line": 2510,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2501-L2510",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -3195,9 +3195,9 @@
         "pallet": "SubtensorModule",
         "call": "set_perpetual_lock",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2299,
-        "end_line": 2306,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2297-L2306",
+        "line": 2315,
+        "end_line": 2322,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2313-L2322",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -3239,9 +3239,9 @@
         "pallet": "SubtensorModule",
         "call": "set_root_claim_type",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 1919,
-        "end_line": 1933,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1917-L1933",
+        "line": 1935,
+        "end_line": 1949,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1933-L1949",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -3368,9 +3368,9 @@
         "pallet": "SubtensorModule",
         "call": "set_subnet_identity",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 1156,
-        "end_line": 1180,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1154-L1180",
+        "line": 1157,
+        "end_line": 1181,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1155-L1181",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -3422,18 +3422,18 @@
         "pallet": "SubtensorModule",
         "call": "increase_take",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 525,
-        "end_line": 531,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L523-L531",
+        "line": 526,
+        "end_line": 532,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L524-L532",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       },
       {
         "pallet": "SubtensorModule",
         "call": "decrease_take",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 492,
-        "end_line": 498,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L490-L498",
+        "line": 493,
+        "end_line": 499,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L491-L499",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -3499,18 +3499,18 @@
         "pallet": "SubtensorModule",
         "call": "set_mechanism_weights",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 130,
-        "end_line": 143,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L128-L143",
+        "line": 131,
+        "end_line": 144,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L129-L144",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       },
       {
         "pallet": "SubtensorModule",
         "call": "commit_timelocked_mechanism_weights",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 1853,
-        "end_line": 1869,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1851-L1869",
+        "line": 1854,
+        "end_line": 1870,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1852-L1870",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -3573,9 +3573,9 @@
         "pallet": "SubtensorModule",
         "call": "add_stake_burn",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2171,
-        "end_line": 2179,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2169-L2179",
+        "line": 2187,
+        "end_line": 2195,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2185-L2195",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -3615,9 +3615,9 @@
         "pallet": "SubtensorModule",
         "call": "start_call",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 1540,
-        "end_line": 1543,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1538-L1543",
+        "line": 1541,
+        "end_line": 1544,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1539-L1544",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -3657,9 +3657,9 @@
         "pallet": "SubtensorModule",
         "call": "swap_coldkey_announced",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2026,
-        "end_line": 2046,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2024-L2046",
+        "line": 2042,
+        "end_line": 2062,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2040-L2062",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -3707,9 +3707,9 @@
         "pallet": "SubtensorModule",
         "call": "swap_hotkey",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 842,
-        "end_line": 849,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L836-L849",
+        "line": 843,
+        "end_line": 850,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L837-L850",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -3785,18 +3785,18 @@
         "pallet": "SubtensorModule",
         "call": "swap_stake",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 1344,
-        "end_line": 1358,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1342-L1358",
+        "line": 1345,
+        "end_line": 1359,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1343-L1359",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       },
       {
         "pallet": "SubtensorModule",
         "call": "swap_stake_limit",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 1492,
-        "end_line": 1510,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1490-L1510",
+        "line": 1493,
+        "end_line": 1511,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1491-L1511",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -3840,9 +3840,9 @@
         "pallet": "SubtensorModule",
         "call": "terminate_lease",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 1697,
-        "end_line": 1703,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1695-L1703",
+        "line": 1698,
+        "end_line": 1704,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1696-L1704",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -4017,18 +4017,18 @@
         "pallet": "SubtensorModule",
         "call": "transfer_stake",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 1302,
-        "end_line": 1318,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1300-L1318",
+        "line": 1303,
+        "end_line": 1319,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1301-L1319",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       },
       {
         "pallet": "SubtensorModule",
         "call": "transfer_stake_and_hotkey",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2394,
-        "end_line": 2412,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2392-L2412",
+        "line": 2410,
+        "end_line": 2428,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2408-L2428",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -4115,9 +4115,9 @@
         "pallet": "SubtensorModule",
         "call": "unstake_all",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 1213,
-        "end_line": 1215,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1211-L1215",
+        "line": 1214,
+        "end_line": 1216,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1212-L1216",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -4157,9 +4157,9 @@
         "pallet": "SubtensorModule",
         "call": "unstake_all_alpha",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 1237,
-        "end_line": 1239,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1235-L1239",
+        "line": 1238,
+        "end_line": 1240,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1236-L1240",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -4363,9 +4363,9 @@
         "pallet": "SubtensorModule",
         "call": "update_symbol",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 1722,
-        "end_line": 1737,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1720-L1737",
+        "line": 1723,
+        "end_line": 1738,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L1721-L1738",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]

--- a/website/apps/bittensor-website/public/catalog/reads.json
+++ b/website/apps/bittensor-website/public/catalog/reads.json
@@ -71,8 +71,8 @@
         "container": "SubtensorModule",
         "name": "AssociatedEvmAddress",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2775,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2775",
+        "line": 2781,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2781",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -99,8 +99,8 @@
         "container": "SubtensorModule",
         "name": "AutoStakeDestination",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1564,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1564",
+        "line": 1570,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1570",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -125,8 +125,8 @@
         "container": "SubtensorModule",
         "name": "AutoStakeDestination",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1564,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1564",
+        "line": 1570,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1570",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -221,8 +221,8 @@
         "container": "SubtensorModule",
         "name": "BlocksSinceLastStep",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2124,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2124",
+        "line": 2130,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2130",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -249,8 +249,8 @@
         "container": "SubtensorModule",
         "name": "LastUpdate",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2507,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2507",
+        "line": 2513,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2513",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -304,8 +304,8 @@
         "container": "SubtensorModule",
         "name": "Bonds",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2535,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2535",
+        "line": 2541,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2541",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -330,8 +330,8 @@
         "container": "SubtensorModule",
         "name": "Burn",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2278,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2278",
+        "line": 2284,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2284",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -358,8 +358,8 @@
         "container": "SubtensorModule",
         "name": "ChildKeys",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1387,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1387",
+        "line": 1393,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1393",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -386,8 +386,8 @@
         "container": "SubtensorModule",
         "name": "Lock",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1687,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1687",
+        "line": 1693,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1693",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -412,8 +412,8 @@
         "container": "SubtensorModule",
         "name": "ColdkeySwapAnnouncements",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1599,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1599",
+        "line": 1605,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1605",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       },
       {
@@ -421,8 +421,8 @@
         "container": "SubtensorModule",
         "name": "ColdkeySwapDisputes",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1605,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1605",
+        "line": 1611,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1611",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -462,8 +462,8 @@
         "container": "SubtensorModule",
         "name": "CommitRevealWeightsEnabled",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2273,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2273",
+        "line": 2279,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2279",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -632,8 +632,8 @@
         "container": "SubtensorModule",
         "name": "Delegates",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1357,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1357",
+        "line": 1363,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1363",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       },
       {
@@ -641,8 +641,8 @@
         "container": "SubtensorModule",
         "name": "MinDelegateTake",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1330,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1330",
+        "line": 1336,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1336",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       },
       {
@@ -650,8 +650,8 @@
         "container": "SubtensorModule",
         "name": "MaxDelegateTake",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1326,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1326",
+        "line": 1332,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1332",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -726,8 +726,8 @@
         "container": "SubtensorModule",
         "name": "Difficulty",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2282,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2282",
+        "line": 2288,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2288",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -752,32 +752,14 @@
         "container": "SubtensorModule",
         "name": "Tempo",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1982,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1982",
+        "line": 1988,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1988",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       },
       {
         "kind": "storage",
         "container": "SubtensorModule",
         "name": "LastEpochBlock",
-        "path": "pallets/subtensor/src/lib.rs",
-        "line": 2007,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2007",
-        "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
-      },
-      {
-        "kind": "storage",
-        "container": "SubtensorModule",
-        "name": "BlocksSinceLastStep",
-        "path": "pallets/subtensor/src/lib.rs",
-        "line": 2124,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2124",
-        "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
-      },
-      {
-        "kind": "storage",
-        "container": "SubtensorModule",
-        "name": "PendingEpochAt",
         "path": "pallets/subtensor/src/lib.rs",
         "line": 2013,
         "url": "/code/pallets/subtensor/src/lib.rs#L2013",
@@ -786,10 +768,28 @@
       {
         "kind": "storage",
         "container": "SubtensorModule",
-        "name": "SubnetEpochIndex",
+        "name": "BlocksSinceLastStep",
+        "path": "pallets/subtensor/src/lib.rs",
+        "line": 2130,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2130",
+        "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
+      },
+      {
+        "kind": "storage",
+        "container": "SubtensorModule",
+        "name": "PendingEpochAt",
         "path": "pallets/subtensor/src/lib.rs",
         "line": 2019,
         "url": "/code/pallets/subtensor/src/lib.rs#L2019",
+        "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
+      },
+      {
+        "kind": "storage",
+        "container": "SubtensorModule",
+        "name": "SubnetEpochIndex",
+        "path": "pallets/subtensor/src/lib.rs",
+        "line": 2025,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2025",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       },
       {
@@ -875,8 +875,8 @@
         "container": "SubtensorModule",
         "name": "Owner",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1347,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1347",
+        "line": 1353,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1353",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       },
       {
@@ -884,8 +884,8 @@
         "container": "SubtensorModule",
         "name": "IdentitiesV2",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2597,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2597",
+        "line": 2603,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2603",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -910,8 +910,8 @@
         "container": "SubtensorModule",
         "name": "Owner",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1347,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1347",
+        "line": 1353,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1353",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -936,8 +936,8 @@
         "container": "SubtensorModule",
         "name": "IdentitiesV2",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2597,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2597",
+        "line": 2603,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2603",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -962,8 +962,8 @@
         "container": "SubtensorModule",
         "name": "ImmunityPeriod",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2192,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2192",
+        "line": 2198,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2198",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -1026,8 +1026,8 @@
         "container": "SubtensorModule",
         "name": "SubnetLeases",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2793,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2793",
+        "line": 2799,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2799",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -1048,8 +1048,8 @@
         "container": "SubtensorModule",
         "name": "SubnetLeases",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2793,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2793",
+        "line": 2799,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2799",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -1074,8 +1074,8 @@
         "container": "SubtensorModule",
         "name": "Lock",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1687,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1687",
+        "line": 1693,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1693",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -1100,8 +1100,8 @@
         "container": "SubtensorModule",
         "name": "MaxWeightsLimit",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2208,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2208",
+        "line": 2214,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2214",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -1126,8 +1126,8 @@
         "container": "SubtensorModule",
         "name": "MechanismCountCurrent",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2867,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2867",
+        "line": 2873,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2873",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -1152,8 +1152,8 @@
         "container": "SubtensorModule",
         "name": "MechanismEmissionSplit",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2872,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2872",
+        "line": 2878,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2878",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -1226,8 +1226,8 @@
         "container": "SubtensorModule",
         "name": "MinAllowedWeights",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2218,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2218",
+        "line": 2224,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2224",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -1256,8 +1256,8 @@
         "container": "SubtensorModule",
         "name": "Owner",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1347,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1347",
+        "line": 1353,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1353",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -1333,8 +1333,8 @@
         "container": "SubtensorModule",
         "name": "IsNetworkMember",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2050,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2050",
+        "line": 2056,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2056",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -1425,8 +1425,8 @@
         "container": "SubtensorModule",
         "name": "OwnedHotkeys",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1559,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1559",
+        "line": 1565,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1565",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -1453,8 +1453,8 @@
         "container": "SubtensorModule",
         "name": "ParentKeys",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1400,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1400",
+        "line": 1406,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1406",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -1481,8 +1481,8 @@
         "container": "SubtensorModule",
         "name": "PendingChildKeys",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1374,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1374",
+        "line": 1380,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1380",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -1591,8 +1591,8 @@
         "container": "SubtensorModule",
         "name": "RevealPeriodEpochs",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2710,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2710",
+        "line": 2716,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2716",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -1645,8 +1645,8 @@
         "container": "SubtensorModule",
         "name": "RootClaimType",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2752,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2752",
+        "line": 2758,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2758",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -1810,8 +1810,8 @@
         "container": "SubtensorModule",
         "name": "StakingHotkeys",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1554,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1554",
+        "line": 1560,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1560",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -1836,8 +1836,8 @@
         "container": "SubtensorModule",
         "name": "Tempo",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1982,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1982",
+        "line": 1988,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1988",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       },
       {
@@ -1845,8 +1845,8 @@
         "container": "SubtensorModule",
         "name": "Burn",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2278,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2278",
+        "line": 2284,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2284",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       },
       {
@@ -1854,8 +1854,8 @@
         "container": "SubtensorModule",
         "name": "SubnetworkN",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2041,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2041",
+        "line": 2047,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2047",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -1880,8 +1880,8 @@
         "container": "SubtensorModule",
         "name": "Uids",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2460,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2460",
+        "line": 2466,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2466",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -1906,8 +1906,8 @@
         "container": "SubtensorModule",
         "name": "HotkeyLock",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1713,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1713",
+        "line": 1719,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1719",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       },
       {
@@ -1915,8 +1915,8 @@
         "container": "SubtensorModule",
         "name": "DecayingHotkeyLock",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1725,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1725",
+        "line": 1731,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1731",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       },
       {
@@ -1924,8 +1924,8 @@
         "container": "SubtensorModule",
         "name": "OwnerLock",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1737,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1737",
+        "line": 1743,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1743",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       },
       {
@@ -1933,8 +1933,8 @@
         "container": "SubtensorModule",
         "name": "DecayingOwnerLock",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1741,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1741",
+        "line": 1747,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1747",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       },
       {
@@ -1942,8 +1942,8 @@
         "container": "SubtensorModule",
         "name": "SubnetOwnerHotkey",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2139,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2139",
+        "line": 2145,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2145",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       },
       {
@@ -1951,8 +1951,8 @@
         "container": "SubtensorModule",
         "name": "SubnetAlphaOut",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1545,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1545",
+        "line": 1551,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1551",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       },
       {
@@ -1960,8 +1960,8 @@
         "container": "SubtensorModule",
         "name": "UnlockRate",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1779,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1779",
+        "line": 1785,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1785",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       },
       {
@@ -1969,8 +1969,8 @@
         "container": "SubtensorModule",
         "name": "MaturityRate",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1775,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1775",
+        "line": 1781,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1781",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       },
       {
@@ -1978,8 +1978,8 @@
         "container": "SubtensorModule",
         "name": "NetworkRegisteredAt",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2073,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2073",
+        "line": 2079,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2079",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -2004,8 +2004,8 @@
         "container": "SubtensorModule",
         "name": "SubnetEmissionEnabled",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1515,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1515",
+        "line": 1521,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1521",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -2057,8 +2057,8 @@
         "container": "SubtensorModule",
         "name": "SubnetIdentitiesV3",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2602,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2602",
+        "line": 2608,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2608",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -2079,8 +2079,8 @@
         "container": "SubtensorModule",
         "name": "SubnetIdentitiesV3",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2602,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2602",
+        "line": 2608,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2608",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -2128,8 +2128,8 @@
         "container": "SubtensorModule",
         "name": "NetworkRegisteredAt",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2073,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2073",
+        "line": 2079,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2079",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       },
       {
@@ -2159,8 +2159,8 @@
         "container": "SubtensorModule",
         "name": "NetworksAdded",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2045,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2045",
+        "line": 2051,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2051",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       },
       {
@@ -2168,8 +2168,8 @@
         "container": "SubtensorModule",
         "name": "Tempo",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1982,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1982",
+        "line": 1988,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1988",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       },
       {
@@ -2177,8 +2177,8 @@
         "container": "SubtensorModule",
         "name": "Burn",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2278,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2278",
+        "line": 2284,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2284",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       },
       {
@@ -2186,8 +2186,8 @@
         "container": "SubtensorModule",
         "name": "SubnetworkN",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2041,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2041",
+        "line": 2047,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2047",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -2214,8 +2214,8 @@
         "container": "SubtensorModule",
         "name": "TimelockedWeightCommits",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2658,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2658",
+        "line": 2664,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2664",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -2247,8 +2247,8 @@
         "container": "SubtensorModule",
         "name": "TokenSymbol",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 1793,
-        "url": "/code/pallets/subtensor/src/lib.rs#L1793",
+        "line": 1799,
+        "url": "/code/pallets/subtensor/src/lib.rs#L1799",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -2269,8 +2269,8 @@
         "container": "SubtensorModule",
         "name": "TxRateLimit",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2336,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2336",
+        "line": 2342,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2342",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -2297,8 +2297,8 @@
         "container": "SubtensorModule",
         "name": "Uids",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2460,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2460",
+        "line": 2466,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2466",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -2325,8 +2325,8 @@
         "container": "SubtensorModule",
         "name": "Weights",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2522,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2522",
+        "line": 2528,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2528",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]
@@ -2351,8 +2351,8 @@
         "container": "SubtensorModule",
         "name": "WeightsSetRateLimit",
         "path": "pallets/subtensor/src/lib.rs",
-        "line": 2248,
-        "url": "/code/pallets/subtensor/src/lib.rs#L2248",
+        "line": 2254,
+        "url": "/code/pallets/subtensor/src/lib.rs#L2254",
         "raw_url": "/code/raw/pallets/subtensor/src/lib.rs"
       }
     ]


### PR DESCRIPTION
## Summary

- restore the mainnet watcher content-verification path
- skip redundant SDK release candidates through a tested PyPI-state planner
- refresh the SDK lockfile, Python formatting, raw-call coverage, and generated docs
- keep the claim-root weight assertion lint-clean without a function-wide exemption

## Why

The release train must preserve exact stable-artifact verification while avoiding RC publication after both stable Python package bases already exist. This consolidates the release quality-gate fixes into one merge-ready change targeting `release-v441`.

The planner publishes only when both bases are available, skips only when both are published, and fails closed for mixed or indeterminate PyPI state.

## Verification

- Python RC planner unit tests: 6 passed
- exact live PyPI planning command: passed
- workflow YAML parse: passed
- `uv sync --python 3.14 --locked --all-extras --dev`: passed
- Ruff check and format check: passed
- ty check: passed with no errors
- SDK tests: 984 passed, 1 skipped
- SDK codegen coverage and name checks: passed
- generated docs drift check: passed
- `uv lock --check`: passed
- `cargo fmt --all -- --check`: passed
- focused runtime Clippy with `-D warnings`: passed
- focused claim-root weight test: passed
- `git diff --check`: passed

## Scope

This PR supersedes #2996 by including its lockfile correction and the remaining release quality-gate fixes.