### PR TITLE
Reject deterministic failures before block inclusion

### DIFF
--- a/pallets/commitments/src/lib.rs
+++ b/pallets/commitments/src/lib.rs
@@ -211,7 +211,8 @@ pub mod pallet {
         /// Set the commitment for a given netuid
         #[pallet::call_index(0)]
         #[pallet::weight((
-            <T as pallet::Config>::WeightInfo::set_commitment(),
+            <T as pallet::Config>::WeightInfo::set_commitment()
+                .saturating_add(T::CanCommit::validation_weight()),
             DispatchClass::Normal,
             Pays::No
         ))]
@@ -221,10 +222,8 @@ pub mod pallet {
             info: Box<CommitmentInfo<T::MaxFields>>,
         ) -> DispatchResult {
             let who = ensure_signed(origin.clone())?;
-            ensure!(
-                T::CanCommit::can_commit(netuid, &who),
-                Error::<T>::AccountNotAllowedCommit
-            );
+            T::CanCommit::validate(netuid, &who)
+                .map_err(|_| Error::<T>::AccountNotAllowedCommit)?;
 
             let extra_fields = info.fields.len() as u32;
             ensure!(
@@ -356,12 +355,21 @@ pub mod pallet {
 
 // Interfaces to interact with other pallets
 pub trait CanCommit<AccountId> {
-    fn can_commit(netuid: NetUid, who: &AccountId) -> bool;
+    type Error;
+
+    fn validate(netuid: NetUid, who: &AccountId) -> Result<(), Self::Error>;
+    fn validation_weight() -> frame_support::weights::Weight;
 }
 
 impl<A> CanCommit<A> for () {
-    fn can_commit(_: NetUid, _: &A) -> bool {
-        false
+    type Error = ();
+
+    fn validate(_: NetUid, _: &A) -> Result<(), Self::Error> {
+        Err(())
+    }
+
+    fn validation_weight() -> frame_support::weights::Weight {
+        frame_support::weights::Weight::zero()
     }
 }
 

--- a/pallets/commitments/src/mock.rs
+++ b/pallets/commitments/src/mock.rs
@@ -90,8 +90,14 @@ impl TypeInfo for TestMaxFields {
 
 pub struct TestCanCommit;
 impl pallet_commitments::CanCommit<u64> for TestCanCommit {
-    fn can_commit(_netuid: NetUid, _who: &u64) -> bool {
-        true
+    type Error = ();
+
+    fn validate(_netuid: NetUid, _who: &u64) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn validation_weight() -> Weight {
+        Weight::zero()
     }
 }
 

--- a/pallets/subtensor/src/extensions/subtensor.rs
+++ b/pallets/subtensor/src/extensions/subtensor.rs
@@ -399,6 +399,39 @@ mod tests {
     }
 
     #[test]
+    fn timelocked_commits_with_zero_rate_limit_do_not_conflict_in_pool() {
+        new_test_ext(0).execute_with(|| {
+            let netuid = NetUid::from(1);
+            let hotkey = U256::from(1);
+            let coldkey = U256::from(2);
+
+            add_network(netuid, 1, 0);
+            setup_reserves(
+                netuid,
+                1_000_000_000_000_u64.into(),
+                1_000_000_000_000_u64.into(),
+            );
+            register_ok_neuron(netuid, hotkey, coldkey, 0);
+            SubtensorModule::set_stake_threshold(0);
+            SubtensorModule::set_weights_set_rate_limit(netuid, 0);
+
+            let call =
+                RuntimeCall::SubtensorModule(SubtensorCall::commit_timelocked_mechanism_weights {
+                    netuid,
+                    mecid: MechId::MAIN,
+                    commit: Default::default(),
+                    reveal_round: 1,
+                    commit_reveal_version: 4,
+                });
+
+            let first = validate_signed(hotkey, &call).unwrap();
+            let second = validate_signed(hotkey, &call).unwrap();
+            assert!(first.provides.is_empty());
+            assert!(second.provides.is_empty());
+        });
+    }
+
+    #[test]
     fn weight_matches_top_level_dispatch_extension_checks() {
         new_test_ext(1).execute_with(|| {
             let extension = SubtensorTransactionExtension::<Test>::new();

--- a/pallets/subtensor/src/extensions/subtensor.rs
+++ b/pallets/subtensor/src/extensions/subtensor.rs
@@ -1,11 +1,11 @@
 use crate::{
     Call, CheckColdkeySwap, CheckDelegateTake, CheckEvmKeyAssociation, CheckRateLimits,
-    CheckServingEndpoints, CheckWeights, Config, Error, guards::applicable_call,
+    CheckServingEndpoints, CheckWeights, Config, Error, Pallet, guards::applicable_call,
 };
 use codec::{Decode, DecodeWithMemTracking, Encode};
 use frame_support::{
     dispatch::{DispatchExtension, DispatchInfo, PostDispatchInfo},
-    traits::{IsSubType, OriginTrait},
+    traits::{Get, IsSubType, OriginTrait},
     weights::Weight,
 };
 use scale_info::TypeInfo;
@@ -14,7 +14,7 @@ use sp_runtime::traits::{
 };
 use sp_runtime::{
     impl_tx_ext_default,
-    transaction_validity::{TransactionSource, TransactionValidityError},
+    transaction_validity::{TransactionSource, TransactionValidityError, ValidTransaction},
 };
 use sp_std::marker::PhantomData;
 use subtensor_macros::freeze_struct;
@@ -77,9 +77,10 @@ impl<T: Config + Send + Sync + TypeInfo> SubtensorTransactionExtension<T> {
 
     fn check(origin: &OriginOf<T>, call: &CallOf<T>) -> Result<(), Error<T>>
     where
-        T: pallet_shield::Config,
+        T: pallet_commitments::Config + pallet_shield::Config,
         CallOf<T>: Dispatchable<RuntimeOrigin = OriginOf<T>>
             + IsSubType<Call<T>>
+            + IsSubType<pallet_commitments::Call<T>>
             + IsSubType<pallet_shield::Call<T>>,
         OriginOf<T>: OriginTrait<AccountId = T::AccountId>,
     {
@@ -88,6 +89,16 @@ impl<T: Config + Send + Sync + TypeInfo> SubtensorTransactionExtension<T> {
         };
 
         CheckColdkeySwap::<T>::check(who, call)?;
+
+        let commitment_call: Option<&pallet_commitments::Call<T>> = call.is_sub_type();
+        if let Some(pallet_commitments::Call::set_commitment { netuid, .. }) = commitment_call {
+            if !Pallet::<T>::if_subnet_exist(*netuid) {
+                return Err(Error::<T>::SubnetNotExists);
+            }
+            if !Pallet::<T>::is_hotkey_registered_on_network(*netuid, who) {
+                return Err(Error::<T>::HotKeyNotRegisteredInSubNet);
+            }
+        }
 
         if let Some(call) = applicable_call(call, CheckWeights::<T>::applies_to) {
             CheckWeights::<T>::check(who, call)?;
@@ -107,13 +118,30 @@ impl<T: Config + Send + Sync + TypeInfo> SubtensorTransactionExtension<T> {
 
         Ok(())
     }
+
+    fn commitment_weight(call: &CallOf<T>) -> Weight
+    where
+        T: pallet_commitments::Config,
+        CallOf<T>: IsSubType<pallet_commitments::Call<T>>,
+    {
+        let commitment_call: Option<&pallet_commitments::Call<T>> = call.is_sub_type();
+        if matches!(
+            commitment_call,
+            Some(pallet_commitments::Call::set_commitment { .. })
+        ) {
+            T::DbWeight::get().reads(2)
+        } else {
+            Weight::zero()
+        }
+    }
 }
 
 impl<T> TransactionExtension<CallOf<T>> for SubtensorTransactionExtension<T>
 where
-    T: Config + pallet_shield::Config + Send + Sync + TypeInfo,
+    T: Config + pallet_commitments::Config + pallet_shield::Config + Send + Sync + TypeInfo,
     CallOf<T>: Dispatchable<RuntimeOrigin = OriginOf<T>, Info = DispatchInfo, PostInfo = PostDispatchInfo>
         + IsSubType<Call<T>>
+        + IsSubType<pallet_commitments::Call<T>>
         + IsSubType<pallet_shield::Call<T>>,
     OriginOf<T>: Clone + OriginTrait<AccountId = T::AccountId>,
 {
@@ -131,6 +159,7 @@ where
             .saturating_add(<CheckDelegateTake<T> as DE<CallOf<T>>>::weight(call))
             .saturating_add(<CheckServingEndpoints<T> as DE<CallOf<T>>>::weight(call))
             .saturating_add(<CheckEvmKeyAssociation<T> as DE<CallOf<T>>>::weight(call))
+            .saturating_add(Self::commitment_weight(call))
     }
 
     fn validate(
@@ -144,7 +173,17 @@ where
         _source: TransactionSource,
     ) -> ValidateResult<Self::Val, CallOf<T>> {
         Self::check(&origin, call)
-            .map(|()| (Default::default(), (), origin))
+            .map(|()| {
+                let mut validity = ValidTransaction::default();
+                if let Some(who) = origin.as_signer()
+                    && let Some(call) = applicable_call(call, CheckRateLimits::<T>::applies_to)
+                {
+                    validity
+                        .provides
+                        .extend(CheckRateLimits::<T>::provides_tags(who, call));
+                }
+                (validity, (), origin)
+            })
             .map_err(|error| TransactionValidityError::from(CustomTransactionError::from(error)))
     }
 
@@ -204,6 +243,9 @@ mod tests {
                 call,
             ))
             .saturating_add(<CheckEvmKeyAssociation<Test> as DE<RuntimeCall>>::weight(
+                call,
+            ))
+            .saturating_add(SubtensorTransactionExtension::<Test>::commitment_weight(
                 call,
             ))
     }
@@ -279,6 +321,84 @@ mod tests {
     }
 
     #[test]
+    fn validate_rejects_ineligible_metadata_commitment() {
+        new_test_ext(0).execute_with(|| {
+            let netuid = NetUid::from(1);
+            let hotkey = U256::from(1);
+            let coldkey = U256::from(2);
+            let commitment_call = || {
+                RuntimeCall::Commitments(pallet_commitments::Call::set_commitment {
+                    netuid,
+                    info: Box::new(pallet_commitments::CommitmentInfo {
+                        fields: frame_support::BoundedVec::default(),
+                    }),
+                })
+            };
+
+            assert_eq!(
+                validate_signed(hotkey, &commitment_call()).unwrap_err(),
+                CustomTransactionError::SubnetNotExists.into()
+            );
+
+            add_network(netuid, 1, 0);
+            assert_eq!(
+                validate_signed(hotkey, &commitment_call()).unwrap_err(),
+                CustomTransactionError::UidNotFound.into()
+            );
+
+            setup_reserves(
+                netuid,
+                1_000_000_000_000_u64.into(),
+                1_000_000_000_000_u64.into(),
+            );
+            register_ok_neuron(netuid, hotkey, coldkey, 0);
+            assert_ok!(validate_signed(hotkey, &commitment_call()));
+        });
+    }
+
+    #[test]
+    fn timelocked_commits_reject_at_validity_and_conflict_in_pool() {
+        new_test_ext(0).execute_with(|| {
+            let netuid = NetUid::from(1);
+            let hotkey = U256::from(1);
+            let coldkey = U256::from(2);
+
+            add_network(netuid, 1, 0);
+            setup_reserves(
+                netuid,
+                1_000_000_000_000_u64.into(),
+                1_000_000_000_000_u64.into(),
+            );
+            register_ok_neuron(netuid, hotkey, coldkey, 0);
+            SubtensorModule::set_stake_threshold(0);
+            SubtensorModule::set_weights_set_rate_limit(netuid, 100);
+            System::set_block_number(10_u64);
+            let uid = SubtensorModule::get_uid_for_net_and_hotkey(netuid, &hotkey).unwrap();
+            let netuid_index = SubtensorModule::get_mechanism_storage_index(netuid, MechId::MAIN);
+            SubtensorModule::set_last_update_for_uid(netuid_index, uid, 10);
+
+            let call =
+                RuntimeCall::SubtensorModule(SubtensorCall::commit_timelocked_mechanism_weights {
+                    netuid,
+                    mecid: MechId::MAIN,
+                    commit: Default::default(),
+                    reveal_round: 1,
+                    commit_reveal_version: 4,
+                });
+            assert_eq!(
+                validate_signed(hotkey, &call).unwrap_err(),
+                CustomTransactionError::RateLimitExceeded.into()
+            );
+
+            System::set_block_number(200_u64);
+            let first = validate_signed(hotkey, &call).unwrap();
+            let second = validate_signed(hotkey, &call).unwrap();
+            assert_eq!(first.provides.len(), 1);
+            assert_eq!(first.provides, second.provides);
+        });
+    }
+
+    #[test]
     fn weight_matches_top_level_dispatch_extension_checks() {
         new_test_ext(1).execute_with(|| {
             let extension = SubtensorTransactionExtension::<Test>::new();
@@ -292,6 +412,12 @@ mod tests {
                 }),
                 RuntimeCall::SubtensorModule(SubtensorCall::register_network {
                     hotkey: U256::from(9),
+                }),
+                RuntimeCall::Commitments(pallet_commitments::Call::set_commitment {
+                    netuid: NetUid::from(1),
+                    info: Box::new(pallet_commitments::CommitmentInfo {
+                        fields: frame_support::BoundedVec::default(),
+                    }),
                 }),
             ];
 

--- a/pallets/subtensor/src/extensions/subtensor.rs
+++ b/pallets/subtensor/src/extensions/subtensor.rs
@@ -1,13 +1,14 @@
 use crate::{
     Call, CheckColdkeySwap, CheckDelegateTake, CheckEvmKeyAssociation, CheckRateLimits,
-    CheckServingEndpoints, CheckWeights, Config, Error, Pallet, guards::applicable_call,
+    CheckServingEndpoints, CheckWeights, Config, Error, guards::applicable_call,
 };
 use codec::{Decode, DecodeWithMemTracking, Encode};
 use frame_support::{
     dispatch::{DispatchExtension, DispatchInfo, PostDispatchInfo},
-    traits::{Get, IsSubType, OriginTrait},
+    traits::{IsSubType, OriginTrait},
     weights::Weight,
 };
+use pallet_commitments::CanCommit;
 use scale_info::TypeInfo;
 use sp_runtime::traits::{
     DispatchInfoOf, Dispatchable, Implication, TransactionExtension, ValidateResult,
@@ -22,6 +23,7 @@ use subtensor_runtime_common::CustomTransactionError;
 
 type CallOf<T> = <T as frame_system::Config>::RuntimeCall;
 type OriginOf<T> = <T as frame_system::Config>::RuntimeOrigin;
+type CommitmentPolicy<T> = <T as pallet_commitments::Config>::CanCommit;
 
 #[allow(deprecated)]
 impl<T: Config> From<Error<T>> for CustomTransactionError {
@@ -83,6 +85,7 @@ impl<T: Config + Send + Sync + TypeInfo> SubtensorTransactionExtension<T> {
             + IsSubType<pallet_commitments::Call<T>>
             + IsSubType<pallet_shield::Call<T>>,
         OriginOf<T>: OriginTrait<AccountId = T::AccountId>,
+        CommitmentPolicy<T>: CanCommit<T::AccountId, Error = Error<T>>,
     {
         let Some(who) = origin.as_signer() else {
             return Ok(());
@@ -92,12 +95,7 @@ impl<T: Config + Send + Sync + TypeInfo> SubtensorTransactionExtension<T> {
 
         let commitment_call: Option<&pallet_commitments::Call<T>> = call.is_sub_type();
         if let Some(pallet_commitments::Call::set_commitment { netuid, .. }) = commitment_call {
-            if !Pallet::<T>::if_subnet_exist(*netuid) {
-                return Err(Error::<T>::SubnetNotExists);
-            }
-            if !Pallet::<T>::is_hotkey_registered_on_network(*netuid, who) {
-                return Err(Error::<T>::HotKeyNotRegisteredInSubNet);
-            }
+            CommitmentPolicy::<T>::validate(*netuid, who)?;
         }
 
         if let Some(call) = applicable_call(call, CheckWeights::<T>::applies_to) {
@@ -129,7 +127,7 @@ impl<T: Config + Send + Sync + TypeInfo> SubtensorTransactionExtension<T> {
             commitment_call,
             Some(pallet_commitments::Call::set_commitment { .. })
         ) {
-            T::DbWeight::get().reads(2)
+            CommitmentPolicy::<T>::validation_weight()
         } else {
             Weight::zero()
         }
@@ -144,6 +142,7 @@ where
         + IsSubType<pallet_commitments::Call<T>>
         + IsSubType<pallet_shield::Call<T>>,
     OriginOf<T>: Clone + OriginTrait<AccountId = T::AccountId>,
+    CommitmentPolicy<T>: CanCommit<T::AccountId, Error = Error<T>>,
 {
     const IDENTIFIER: &'static str = "SubtensorTransactionExtension";
 

--- a/pallets/subtensor/src/guards/check_rate_limits.rs
+++ b/pallets/subtensor/src/guards/check_rate_limits.rs
@@ -1,13 +1,14 @@
 use super::{CallOf, DispatchableOriginOf, applicable_call};
 use crate::weights::WeightInfo;
 use crate::{Call, Config, Error, Pallet, TransactionType};
+use codec::Encode;
 use frame_support::{
     dispatch::{DispatchErrorWithPostInfo, DispatchExtension, DispatchInfo, PostDispatchInfo},
     pallet_prelude::*,
     traits::{IsSubType, OriginTrait},
 };
 use sp_runtime::traits::Dispatchable;
-use sp_std::marker::PhantomData;
+use sp_std::{marker::PhantomData, vec, vec::Vec};
 use subtensor_runtime_common::{NetUid, NetUidStorageIndex};
 
 /// Dispatch extension for rate-limit checks that are safe to reject before dispatch.
@@ -22,6 +23,9 @@ impl<T: Config> CheckRateLimits<T> {
             call,
             Call::commit_weights { .. }
                 | Call::commit_mechanism_weights { .. }
+                | Call::commit_timelocked_weights { .. }
+                | Call::commit_timelocked_mechanism_weights { .. }
+                | Call::commit_crv3_mechanism_weights { .. }
                 | Call::set_weights { .. }
                 | Call::set_mechanism_weights { .. }
                 | Call::register_network { .. }
@@ -60,6 +64,21 @@ impl<T: Config> CheckRateLimits<T> {
                 Pallet::<T>::get_mechanism_storage_index(*netuid, *mecid),
                 Error::<T>::CommittingWeightsTooFast,
             ),
+            Call::commit_timelocked_weights { netuid, .. } => Self::check_weights_rate_limit(
+                who,
+                *netuid,
+                NetUidStorageIndex::from(*netuid),
+                Error::<T>::CommittingWeightsTooFast,
+            ),
+            Call::commit_timelocked_mechanism_weights { netuid, mecid, .. }
+            | Call::commit_crv3_mechanism_weights { netuid, mecid, .. } => {
+                Self::check_weights_rate_limit(
+                    who,
+                    *netuid,
+                    Pallet::<T>::get_mechanism_storage_index(*netuid, *mecid),
+                    Error::<T>::CommittingWeightsTooFast,
+                )
+            }
             Call::set_weights { netuid, .. }
                 if !Pallet::<T>::get_commit_reveal_weights_enabled(*netuid) =>
             {
@@ -87,6 +106,24 @@ impl<T: Config> CheckRateLimits<T> {
             }
             _ => Ok(()),
         }
+    }
+
+    /// One pending commit per hotkey and mechanism. Calls sharing this tag also share the same
+    /// on-chain rate limit, so the pool keeps only one candidate instead of landing the rest as
+    /// deterministic `CommittingWeightsTooFast` failures.
+    pub(crate) fn provides_tags(who: &T::AccountId, call: &Call<T>) -> Vec<Vec<u8>> {
+        let netuid_index = match call {
+            Call::commit_weights { netuid, .. }
+            | Call::commit_timelocked_weights { netuid, .. } => NetUidStorageIndex::from(*netuid),
+            Call::commit_mechanism_weights { netuid, mecid, .. }
+            | Call::commit_timelocked_mechanism_weights { netuid, mecid, .. }
+            | Call::commit_crv3_mechanism_weights { netuid, mecid, .. } => {
+                Pallet::<T>::get_mechanism_storage_index(*netuid, *mecid)
+            }
+            _ => return Vec::new(),
+        };
+
+        vec![(b"weight-commit", who, netuid_index).encode()]
     }
 }
 
@@ -190,6 +227,25 @@ mod tests {
                 netuid,
                 mecid: MechId::MAIN,
                 commit_hash: sp_core::H256::zero(),
+            }),
+            RuntimeCall::SubtensorModule(SubtensorCall::commit_timelocked_weights {
+                netuid,
+                commit: Default::default(),
+                reveal_round: 1,
+                commit_reveal_version: 4,
+            }),
+            RuntimeCall::SubtensorModule(SubtensorCall::commit_timelocked_mechanism_weights {
+                netuid,
+                mecid: MechId::MAIN,
+                commit: Default::default(),
+                reveal_round: 1,
+                commit_reveal_version: 4,
+            }),
+            RuntimeCall::SubtensorModule(SubtensorCall::commit_crv3_mechanism_weights {
+                netuid,
+                mecid: MechId::MAIN,
+                commit: Default::default(),
+                reveal_round: 1,
             }),
             set_weights_call(netuid, 0),
             RuntimeCall::SubtensorModule(SubtensorCall::set_mechanism_weights {

--- a/pallets/subtensor/src/guards/check_rate_limits.rs
+++ b/pallets/subtensor/src/guards/check_rate_limits.rs
@@ -108,20 +108,27 @@ impl<T: Config> CheckRateLimits<T> {
         }
     }
 
-    /// One pending commit per hotkey and mechanism. Calls sharing this tag also share the same
-    /// on-chain rate limit, so the pool keeps only one candidate instead of landing the rest as
-    /// deterministic `CommittingWeightsTooFast` failures.
+    /// One pending commit per hotkey and mechanism when commits are rate limited. Calls sharing
+    /// this tag also share the same on-chain rate limit, so the pool keeps only one candidate
+    /// instead of landing the rest as deterministic `CommittingWeightsTooFast` failures.
     pub(crate) fn provides_tags(who: &T::AccountId, call: &Call<T>) -> Vec<Vec<u8>> {
-        let netuid_index = match call {
+        let (netuid, netuid_index) = match call {
             Call::commit_weights { netuid, .. }
-            | Call::commit_timelocked_weights { netuid, .. } => NetUidStorageIndex::from(*netuid),
+            | Call::commit_timelocked_weights { netuid, .. } => {
+                (*netuid, NetUidStorageIndex::from(*netuid))
+            }
             Call::commit_mechanism_weights { netuid, mecid, .. }
             | Call::commit_timelocked_mechanism_weights { netuid, mecid, .. }
-            | Call::commit_crv3_mechanism_weights { netuid, mecid, .. } => {
-                Pallet::<T>::get_mechanism_storage_index(*netuid, *mecid)
-            }
+            | Call::commit_crv3_mechanism_weights { netuid, mecid, .. } => (
+                *netuid,
+                Pallet::<T>::get_mechanism_storage_index(*netuid, *mecid),
+            ),
             _ => return Vec::new(),
         };
+
+        if Pallet::<T>::get_weights_set_rate_limit(netuid) == 0 {
+            return Vec::new();
+        }
 
         vec![(b"weight-commit", who, netuid_index).encode()]
     }

--- a/pallets/subtensor/src/tests/mock.rs
+++ b/pallets/subtensor/src/tests/mock.rs
@@ -52,8 +52,20 @@ impl Get<u32> for TestMaxFields {
 
 pub struct TestCanCommit;
 impl pallet_commitments::CanCommit<U256> for TestCanCommit {
-    fn can_commit(_netuid: NetUid, _who: &U256) -> bool {
-        true
+    type Error = crate::Error<Test>;
+
+    fn validate(netuid: NetUid, who: &U256) -> Result<(), Self::Error> {
+        if !SubtensorModule::if_subnet_exist(netuid) {
+            return Err(crate::Error::<Test>::SubnetNotExists);
+        }
+        if !SubtensorModule::is_hotkey_registered_on_network(netuid, who) {
+            return Err(crate::Error::<Test>::HotKeyNotRegisteredInSubNet);
+        }
+        Ok(())
+    }
+
+    fn validation_weight() -> Weight {
+        <Test as frame_system::Config>::DbWeight::get().reads(2)
     }
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -712,15 +712,34 @@ impl Get<u32> for MaxCommitFields {
 #[subtensor_macros::freeze_struct("c39297f5eb97ee82")]
 pub struct AllowCommitments;
 impl CanCommit<AccountId> for AllowCommitments {
+    type Error = pallet_subtensor::Error<Runtime>;
+
     #[cfg(not(feature = "runtime-benchmarks"))]
-    fn can_commit(netuid: NetUid, address: &AccountId) -> bool {
-        SubtensorModule::if_subnet_exist(netuid)
-            && SubtensorModule::is_hotkey_registered_on_network(netuid, address)
+    fn validate(netuid: NetUid, address: &AccountId) -> Result<(), Self::Error> {
+        if !SubtensorModule::if_subnet_exist(netuid) {
+            return Err(pallet_subtensor::Error::<Runtime>::SubnetNotExists);
+        }
+        if !SubtensorModule::is_hotkey_registered_on_network(netuid, address) {
+            return Err(pallet_subtensor::Error::<Runtime>::HotKeyNotRegisteredInSubNet);
+        }
+        Ok(())
     }
 
     #[cfg(feature = "runtime-benchmarks")]
-    fn can_commit(_: NetUid, _: &AccountId) -> bool {
-        true
+    fn validate(_: NetUid, _: &AccountId) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn validation_weight() -> frame_support::weights::Weight {
+        #[cfg(not(feature = "runtime-benchmarks"))]
+        {
+            <Runtime as frame_system::Config>::DbWeight::get().reads(2)
+        }
+
+        #[cfg(feature = "runtime-benchmarks")]
+        {
+            frame_support::weights::Weight::zero()
+        }
     }
 }
 


### PR DESCRIPTION
## Value

This change prevents the two largest deterministic extrinsic failure classes before block inclusion.

| Failure prevented | Last 30 days | Validation added |
|---|---:|---|
| `CommittingWeightsTooFast` | 448,600 failures | Check the signer’s commit rate limit for the correct subnet/mechanism lane |
| `AccountNotAllowedCommit` | 156,220 failures | Check that the subnet exists and the signer is registered on it |
| **Total** | **604,820 failures** | **Reject invalid transactions before dispatch** |

## Validation changes

- `set_commitment`
  - Reject if the subnet does not exist.
  - Reject if the signer is not registered on the subnet.
  - Account for both validation storage reads.

- Weight commits
  - Apply the existing commit-rate check to:
    - `commit_timelocked_weights`
    - `commit_timelocked_mechanism_weights`
    - `commit_crv3_mechanism_weights`
  - Resolve mechanism commits to their mechanism-specific rate-limit lane.
  - Add a transaction-pool `provides` tag keyed by signer and subnet/mechanism so competing commits cannot coexist in the pool.

Successful commitment behavior and the runtime transaction format remain unchanged.