### PR TITLE
feat(cli): treat saved multisig names as -w wallets

### DIFF
--- a/docs/guides/multisig.mdx
+++ b/docs/guides/multisig.mdx
@@ -138,12 +138,40 @@ btcli wallet regen-coldkeypub -w team-treasury --ss58 5Fmulti...sigAddress
 btcli wallet balance team-treasury
 ```
 
-## Step 4 — spend: open the operation
+## Step 4 — spend: treat the multisig like a wallet
 
-Alice proposes paying 10 TAO out of the treasury. The inner call is an intent
-spec — `{"op": <intent name>, ...args}`, same shape as a batch child — with
-fully explicit arguments. As always, `--dry-run` previews fee and effects
-without submitting:
+Once the signer set is saved (`btcli multisig add`), pass the **multisig name**
+as `-w`. Any coldkey-signed command — transfer, stake, raw `call`, … — detects
+the book entry, picks a local member coldkey to sign, and opens or completes the
+approval round. Co-signers re-run the **same** command; the CLI fills the
+pending timepoint automatically:
+
+```bash
+# Alice (has the alice coldkey locally)
+btcli wallet transfer --dest 5DevPayee... --amount-tao 10 -w team-treasury
+
+# Bob (has the bob coldkey locally) — identical command
+btcli wallet transfer --dest 5DevPayee... --amount-tao 10 -w team-treasury
+```
+
+Works the same for intents and the raw-call escape hatch:
+
+```bash
+btcli tx add-stake --netuid 1 --amount-tao 5 -w team-treasury
+btcli call Balances.transfer_keep_alive \
+  --args '{"dest":"5DevPayee...","value":10000000000}' \
+  -w team-treasury
+```
+
+If several member coldkeys are present locally, the CLI prompts which one
+signs (or pass `-w alice --multisig team-treasury` to pin one). Each member
+still needs a little free TAO for fees and the opener's deposit.
+
+### Manual approval round (optional)
+
+You can still drive the round explicitly with intent specs — useful when you
+want to paste exact co-signer commands. `--other-signatories` lists every
+member *except* the signer:
 
 ```bash
 btcli tx multisig-execute \
@@ -159,16 +187,10 @@ btcli tx multisig-execute \
   -w alice
 ```
 
-`--other-signatories` lists every member *except* the signer; the CLI adds
-Alice's coldkey and sorts the set. Since no timepoint was passed, this opens
-the operation: Alice's deposit is reserved, and nothing executes yet.
-
 After submission the CLI prints the operation's `call_hash`, `call_data`, the
 opening `timepoint`, and **ready-to-run commands for each remaining
-co-signer** — copy-paste them to Bob and Carol over your team channel. The
-opening extrinsic embeds the full call, so co-signers can also recover
-everything from chain state alone (next step); no out-of-band call data is
-required.
+co-signer**. The opening extrinsic embeds the full call, so co-signers can also
+recover everything from chain state alone (next step).
 
 ## Step 5 — view pending operations
 
@@ -199,9 +221,13 @@ compromised — don't co-sign, and rotate that member out.
 
 ## Step 6 — approve and execute
 
-Bob was handed a ready-to-run command by `pending` (or by Alice). Because his
-approval is the one that reaches the threshold, it must be
-`multisig-execute` with the full call — the chain needs the call to run it.
+Prefer the short form from step 4: Bob runs the same `btcli wallet transfer
+-w team-treasury ...` (or whatever command Alice opened). The CLI finds the
+pending operation by call hash and supplies the timepoint.
+
+For the explicit path, Bob was handed a ready-to-run command by `pending` (or
+by Alice). Because his approval is the one that reaches the threshold, it must
+be `multisig-execute` with the full call — the chain needs the call to run it.
 The timepoint identifies the pending operation:
 
 ```bash

--- a/sdk/python/bittensor/cli/call.py
+++ b/sdk/python/bittensor/cli/call.py
@@ -193,22 +193,42 @@ def call(
         signatories=signatories,
         other_signatories=other_signatories,
         signer=signer,
+        wallet_default=app_ctx.wallet_name,
     )
     builder = _resolve_builder(target)
     params = _load_params(args, args_file)
     if proxy_for is not None:
         proxy_for = app_ctx.resolve_address("proxy_for", proxy_for)
     proxy_type_value = force_proxy_type.value if force_proxy_type else None
-    signing = app_ctx.signer(signer)
-    label = target + (" via Sudo.sudo" if sudo else "")
-    if proxy_for:
-        label += f" as {proxy_for} via proxy"
     via_multisig = threshold is not None
     if via_multisig and len(sigs) < threshold:
         raise typer.BadParameter(
             f"need at least {threshold} signatories, got {len(sigs)}",
             param_hint="--signatories",
         )
+    # ``-w <multisig>`` (no separate signatory wallet): pick a local member.
+    if via_multisig:
+        signer_ss58 = None
+        try:
+            signer_ss58 = app_ctx.wallet().coldkeypub.ss58_address
+        except Exception:
+            signer_ss58 = None
+        if signer_ss58 not in sigs:
+            try:
+                member_name, _ss58 = ms_helpers.pick_local_signatory(
+                    app_ctx,
+                    preset=preset or app_ctx.wallet_name,
+                    signatories=sigs,
+                )
+            except ValueError as error:
+                raise typer.BadParameter(str(error), param_hint="--wallet") from error
+            app_ctx.multisig_wallet_name = preset or app_ctx.wallet_name
+            app_ctx.wallet_name = member_name
+            app_ctx.wallet_given = True
+    signing = app_ctx.signer(signer)
+    label = target + (" via Sudo.sudo" if sudo else "")
+    if proxy_for:
+        label += f" as {proxy_for} via proxy"
 
     async def prepare(client):
         """Build the call against live metadata, nesting the wrappers inside-out:

--- a/sdk/python/bittensor/cli/commands/wallet.py
+++ b/sdk/python/bittensor/cli/commands/wallet.py
@@ -72,6 +72,13 @@ _SEED_HELP = (
     "line (it leaks to shell history and the process list)."
 )
 
+_PRIVATE_KEY_HELP = (
+    "64-byte hex private key as stored in a decrypted coldkey/hotkey keyfile "
+    "(128 hex characters, optional 0x prefix). This is not the same as --seed: "
+    "the first 32 bytes of an sr25519 private key are not a usable seed. Avoid "
+    "passing on the command line (it leaks to shell history and the process list)."
+)
+
 _N_WORDS_HELP = (
     "Number of words in the generated mnemonic: 12, 15, 18, 21, or 24. "
     "More words means more entropy."
@@ -98,50 +105,74 @@ _JSON_PASSWORD_HELP = (
 )
 
 _SEED_RE = re.compile(r"(0x)?[0-9a-fA-F]{64}")
+_PRIVATE_KEY_RE = re.compile(r"(0x)?[0-9a-fA-F]{128}")
 
 
 def _resolve_key_secret(
-    app_ctx: AppContext, kind: str, mnemonic: Optional[str], seed: Optional[str]
-) -> tuple[Optional[str], Optional[str]]:
-    """Settle the (mnemonic, seed) pair for a regen command: exactly one of the
-    two, prompted for securely when neither was passed (btcli-style, the answer
-    is auto-detected — a 64-hex-char token is a seed, anything else a mnemonic)."""
-    if mnemonic and seed:
-        app_ctx.output.error("pass only one of `--mnemonic` or `--seed`")
+    app_ctx: AppContext,
+    kind: str,
+    mnemonic: Optional[str],
+    seed: Optional[str],
+    private_key: Optional[str] = None,
+) -> tuple[Optional[str], Optional[str], Optional[str]]:
+    """Settle mnemonic / seed / private_key for a regen command.
+
+    Exactly one source. When none are passed, prompt securely and auto-detect:
+    128 hex chars → private key, 64 hex chars → seed, anything else → mnemonic.
+    """
+    provided = sum(bool(value) for value in (mnemonic, seed, private_key))
+    if provided > 1:
+        app_ctx.output.error("pass only one of `--mnemonic`, `--seed`, or `--private-key`")
         raise typer.Exit(2)
+    if private_key is not None:
+        if not _PRIVATE_KEY_RE.fullmatch(private_key):
+            app_ctx.output.error(
+                "private key must be 64 bytes of hex "
+                "(128 hex characters, optional 0x prefix)"
+            )
+            raise typer.Exit(2)
+        return None, None, private_key
     if seed is not None:
         # Validate here: the wallet lib panics (rust) on malformed hex.
         if not _SEED_RE.fullmatch(seed):
             app_ctx.output.error(
-                "seed must be 32 bytes of hex (64 hex characters, optional 0x prefix)"
+                "seed must be 32 bytes of hex (64 hex characters, optional 0x prefix); "
+                "for a 64-byte keyfile privateKey use --private-key"
             )
             raise typer.Exit(2)
-        return None, seed
+        return None, seed, None
     if mnemonic is not None:
-        return mnemonic, None
+        return mnemonic, None, None
     if not interactive(app_ctx):
         app_ctx.output.error(
-            "missing required option: `--mnemonic` or `--seed`",
+            "missing required option: `--mnemonic`, `--seed`, or `--private-key`",
             help="pass one explicitly, or run on a terminal to be prompted",
         )
         raise typer.Exit(2)
-    answer = typer.prompt(f"{kind} mnemonic or hex seed", hide_input=True).strip()
+    answer = typer.prompt(
+        f"{kind} mnemonic, hex seed, or private key", hide_input=True
+    ).strip()
+    if _PRIVATE_KEY_RE.fullmatch(answer):
+        return None, None, answer
     if _SEED_RE.fullmatch(answer):
-        return None, answer
-    return answer, None
+        return None, answer, None
+    return answer, None, None
 
 
 def _resolve_coldkey_source(
     app_ctx: AppContext,
     mnemonic: Optional[str],
     seed: Optional[str],
+    private_key: Optional[str],
     json_path: Optional[str],
     json_password: Optional[str],
-) -> tuple[Optional[str], Optional[str], Optional[tuple[str, str]]]:
-    """Resolve exactly one coldkey source: mnemonic, seed, or encrypted JSON."""
-    provided = sum(bool(value) for value in (mnemonic, seed, json_path))
+) -> tuple[Optional[str], Optional[str], Optional[str], Optional[tuple[str, str]]]:
+    """Resolve exactly one coldkey source: mnemonic, seed, private key, or JSON."""
+    provided = sum(bool(value) for value in (mnemonic, seed, private_key, json_path))
     if provided > 1:
-        app_ctx.output.error("pass only one of `--mnemonic`, `--seed`, or `--json-path`")
+        app_ctx.output.error(
+            "pass only one of `--mnemonic`, `--seed`, `--private-key`, or `--json-path`"
+        )
         raise typer.Exit(2)
 
     if json_path:
@@ -165,10 +196,12 @@ def _resolve_coldkey_source(
         if not json_password:
             app_ctx.output.error("JSON keystore password cannot be empty")
             raise typer.Exit(2)
-        return None, None, (json_data, json_password)
+        return None, None, None, (json_data, json_password)
 
-    mnemonic, seed = _resolve_key_secret(app_ctx, "Coldkey", mnemonic, seed)
-    return mnemonic, seed, None
+    mnemonic, seed, private_key = _resolve_key_secret(
+        app_ctx, "Coldkey", mnemonic, seed, private_key
+    )
+    return mnemonic, seed, private_key, None
 
 
 def _resolve_crypto_type(app_ctx: AppContext, value: str) -> int:
@@ -372,6 +405,7 @@ def regen_coldkey(
         "the command line (it leaks to shell history and the process list).",
     ),
     seed: str = typer.Option(None, "--seed", help=_SEED_HELP),
+    private_key: str = typer.Option(None, "--private-key", help=_PRIVATE_KEY_HELP),
     json_path: str | None = typer.Option(
         None,
         "--json-path",
@@ -387,19 +421,21 @@ def regen_coldkey(
     overwrite: bool = typer.Option(False, "--overwrite", help=_OVERWRITE_HELP),
     crypto_type: str = typer.Option("sr25519", "--crypto-type", help=_CRYPTO_TYPE_HELP),
 ):
-    """Regenerate a coldkey from a mnemonic, hex seed, or encrypted JSON keystore.
+    """Regenerate a coldkey from a mnemonic, seed, private key, or JSON keystore.
 
-    Pass exactly one of --mnemonic, --seed, or --json-path; if none are given you
-    are prompted securely on the terminal. Rewrites the wallet's coldkey files on
-    disk and prompts for a new encryption password unless --no-password is given.
-    When importing from JSON, the key type is read from the keystore; --crypto-type
-    applies only to mnemonic/seed regeneration.
+    Pass exactly one of --mnemonic, --seed, --private-key, or --json-path; if
+    none are given you are prompted securely on the terminal (128-hex → private
+    key, 64-hex → seed, otherwise mnemonic). Rewrites the wallet's coldkey
+    files on disk and prompts for a new encryption password unless --no-password
+    is given. When importing from JSON, the key type is read from the keystore;
+    --crypto-type applies only to mnemonic/seed/private-key regeneration.
     """
     app_ctx: AppContext = ctx_of(ctx)
-    mnemonic, seed, json_keystore = _resolve_coldkey_source(
+    mnemonic, seed, private_key, json_keystore = _resolve_coldkey_source(
         app_ctx,
         mnemonic,
         seed,
+        private_key,
         json_path,
         json_password,
     )
@@ -409,6 +445,7 @@ def regen_coldkey(
         wallet = wallets.regen_coldkey(
             mnemonic=mnemonic,
             seed=seed,
+            private_key=private_key,
             json=json_keystore,
             name=app_ctx.wallet_name,
             path=app_ctx.wallet_path,
@@ -441,19 +478,22 @@ def regen_hotkey(
         help="Hotkey mnemonic. Prompted for securely if omitted.",
     ),
     seed: str = typer.Option(None, "--seed", help=_SEED_HELP),
+    private_key: str = typer.Option(None, "--private-key", help=_PRIVATE_KEY_HELP),
     overwrite: bool = typer.Option(False, "--overwrite", help=_OVERWRITE_HELP),
     crypto_type: str = typer.Option("sr25519", "--crypto-type", help=_CRYPTO_TYPE_HELP),
 ):
-    """Regenerate a hotkey from a mnemonic or hex seed.
+    """Regenerate a hotkey from a mnemonic, hex seed, or private key.
 
-    Pass exactly one of --mnemonic or --seed; if neither is given you are
-    prompted securely on the terminal. Rewrites the hotkey file (stored
-    unencrypted) under the wallet path. The crypto type must match the one
-    the key was created with, or the regenerated key will have a different
-    address.
+    Pass exactly one of --mnemonic, --seed, or --private-key; if none are given
+    you are prompted securely on the terminal (128-hex → private key, 64-hex →
+    seed, otherwise mnemonic). Rewrites the hotkey file (stored unencrypted)
+    under the wallet path. The crypto type must match the one the key was
+    created with, or the regenerated key will have a different address.
     """
     app_ctx: AppContext = ctx_of(ctx)
-    mnemonic, seed = _resolve_key_secret(app_ctx, "Hotkey", mnemonic, seed)
+    mnemonic, seed, private_key = _resolve_key_secret(
+        app_ctx, "Hotkey", mnemonic, seed, private_key
+    )
     confirm_wallet(
         app_ctx,
         help_text="Wallet to regenerate the hotkey in.",
@@ -465,6 +505,7 @@ def regen_hotkey(
     wallet = wallets.regen_hotkey(
         mnemonic=mnemonic,
         seed=seed,
+        private_key=private_key,
         name=app_ctx.wallet_name,
         hotkey=app_ctx.hotkey_name,
         path=app_ctx.wallet_path,

--- a/sdk/python/bittensor/cli/commands/wallet.py
+++ b/sdk/python/bittensor/cli/commands/wallet.py
@@ -929,8 +929,8 @@ def wallet_balance(
     ctx: typer.Context,
     address: Optional[str] = typer.Argument(
         None,
-        help="Coldkey ss58 address or a local wallet name. "
-        "Defaults to the configured wallet's coldkey.",
+        help="Coldkey ss58 address, a local wallet name, or an address-book / "
+        "saved multisig name. Defaults to the configured wallet's coldkey.",
     ),
     all_wallets: bool = typer.Option(
         False, "--all", "-a", help="Show balances for every wallet under --wallet-path."
@@ -1015,7 +1015,14 @@ def wallet_balance(
         return
 
     resolved = app_ctx.resolve_address("coldkey_ss58", address)
-    row = app_ctx.run(lambda client: wallet_balance_row(client, app_ctx.wallet_name, resolved))
+    # Label the row with the name that was actually queried, not the configured
+    # wallet, when a positional name (wallet, book, or multisig) was given.
+    label = (
+        address
+        if address is not None and not wallets.is_bittensor_address(address)
+        else app_ctx.wallet_name
+    )
+    row = app_ctx.run(lambda client: wallet_balance_row(client, label, resolved))
     app_ctx.output.detail(None, human_balance_fields(row), json_fields=row)
 
 

--- a/sdk/python/bittensor/cli/context.py
+++ b/sdk/python/bittensor/cli/context.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import sys
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from types import SimpleNamespace
 from typing import Awaitable, Callable, Optional, TypeVar
 
@@ -69,7 +69,9 @@ def ss58_param_help(param: str) -> str:
         if param == "hotkey_ss58":
             text += " Defaults to your wallet's hotkey."
     else:
-        text = f"ss58 address, {book}or a local wallet name (uses its coldkey)."
+        text = (
+            f"ss58 address, {book}saved multisig name, or a local wallet name (uses its coldkey)."
+        )
         if param == "coldkey_ss58":
             text += " Defaults to your wallet's coldkey."
     return text
@@ -122,6 +124,9 @@ class AppContext:
     _extension_bridge_ws_url: Optional[str] = None
     _ledger_signer: Optional[object] = None
     _vault_signer: Optional[VaultSigner] = None
+    # Multisig names currently being derived by ``resolve_address`` — breaks
+    # the recursion when a saved multisig lists itself among its signatories.
+    _resolving_multisigs: set = field(default_factory=set)
 
     def reset_extension_session(self) -> None:
         self._extension_selection = None
@@ -308,15 +313,19 @@ class AppContext:
     def resolve_address(self, param: str, value: Optional[str]) -> Optional[str]:
         """Resolve an address-typed CLI value (any ``*_ss58`` param) to an ss58 address.
 
-        Five accepted forms:
+        Six accepted forms:
         - a raw ss58 address: used as-is;
         - an address-book name (``btcli addresses NAME SS58``);
         - a proxy-book name (``btcli proxy book add``);
+        - a saved multisig name (``btcli multisig add``), coldkey params only:
+          resolved to the derived multisig account address, so a multisig
+          behaves like a wallet for read-only queries;
         - a local key reference: hotkey params take ``HOTKEY`` (in the configured
           wallet) or ``WALLET/HOTKEY``; coldkey params take a ``WALLET`` name
           (resolved to its coldkey);
         - omitted: only the canonical ``hotkey_ss58`` / ``coldkey_ss58`` params
-          fall back to the configured wallet's own key. Destination-style params
+          fall back to the configured wallet's own key (or its multisig address
+          when ``-w`` names a saved multisig). Destination-style params
           (``--dest``, ``--destination-hotkey``, ...) never default.
         """
         kind = "hotkey" if "hotkey" in param else "coldkey"
@@ -350,6 +359,12 @@ class AppContext:
                 self.output.name_address(proxied, value)
                 self.output.classify_address(proxied, kind)
                 return proxied
+            if kind == "coldkey":
+                derived = self._saved_multisig_address(value)
+                if derived:
+                    self.output.name_address(derived, value)
+                    self.output.classify_address(derived, kind)
+                    return derived
         try:
             if value is None:
                 if param == "hotkey_ss58":
@@ -358,6 +373,13 @@ class AppContext:
                     self.output.classify_address(address, "hotkey")
                     return address
                 if param == "coldkey_ss58":
+                    # Same precedence as the write path: `-w <multisig>` means
+                    # the multisig account, even if a wallet dir shares the name.
+                    derived = self._saved_multisig_address(self.wallet_name)
+                    if derived:
+                        self.output.name_address(derived, self.wallet_name)
+                        self.output.classify_address(derived, "coldkey")
+                        return derived
                     address = self.wallet().coldkeypub.ss58_address
                     self.output.name_address(address, self.wallet_name)
                     self.output.classify_address(address, "coldkey")
@@ -379,6 +401,30 @@ class AppContext:
             shown = value if value is not None else f"{self.wallet_name}/{self.hotkey_name}"
             self.output.error(f"cannot resolve {address_cli_name(param)} {shown!r}: {error}")
             raise typer.Exit(1)
+
+    def _saved_multisig_address(self, name: Optional[str]) -> Optional[str]:
+        """Derived ss58 for a saved multisig ``name``, or None when not in the book.
+
+        The derivation runs offline from the resolved signer set and threshold
+        (the same account-id derivation the chain uses), so read paths can
+        treat a multisig book name like a wallet without a connection.
+        """
+        if not name or cfg.get_multisig(name) is None:
+            return None
+        if name in self._resolving_multisigs:
+            self.output.error(
+                f"multisig {name!r} refers to itself through its signatories",
+                help=f"fix the signer set with `btcli multisig add {name} --overwrite`",
+            )
+            raise typer.Exit(2)
+        self._resolving_multisigs.add(name)
+        try:
+            return ms_helpers.derive_saved_multisig_address(self, name)
+        except ValueError as error:
+            self.output.error(f"cannot resolve multisig {name!r}: {error}")
+            raise typer.Exit(2)
+        finally:
+            self._resolving_multisigs.discard(name)
 
     def resolve_signatory_list(self, raw: str) -> list[str]:
         """Resolve comma-separated signatory refs (ss58, address-book name, wallet)."""

--- a/sdk/python/bittensor/cli/context.py
+++ b/sdk/python/bittensor/cli/context.py
@@ -95,6 +95,10 @@ class AppContext:
     # Same for --wallet-hotkey/-H (or BT_WALLET_HOTKEY): hotkey-scoped commands
     # confirm the hotkey name when it was only defaulted.
     hotkey_given: bool = False
+    # When ``-w`` named a saved multisig and submit rewrote the intent, the
+    # multisig book name lives here while ``wallet_name`` is the local member
+    # coldkey that actually signs.
+    multisig_wallet_name: Optional[str] = None
     # Diagnostic log verbosity (-v count); kept so per-command --quiet/--verbose
     # overrides can reconfigure logging without losing the root-level setting.
     verbosity: int = 0
@@ -448,6 +452,15 @@ class AppContext:
                     f"[dim]dispatching via configured proxy_for {configured!r} "
                     "— pass `--proxy-for self` to sign directly[/dim]"
                 )
+
+        # ``-w <multisig>``: rewrite any coldkey intent as a multisig approval
+        # signed by a local member. Must run before confirm_wallet / wallet()
+        # because the multisig name is not a coldkey directory.
+        try:
+            intent = ms_helpers.wrap_intent_for_multisig_wallet(self, intent)
+        except ValueError as error:
+            self.output.error(str(error))
+            raise typer.Exit(2) from error
 
         # MEV shielding: explicit flag > persistent config > the intent's own
         # default. `forced` distinguishes "the user asked for shielding" (hard

--- a/sdk/python/bittensor/cli/multisig_helpers.py
+++ b/sdk/python/bittensor/cli/multisig_helpers.py
@@ -11,6 +11,7 @@ from typing import Any, Optional
 from .. import config as cfg
 from .. import wallets
 from .._generated import storage as st
+from .._transport.codec import multisig_account
 from ..result import ChainError, ExtrinsicResult
 from ..wallets import is_bittensor_address
 
@@ -243,6 +244,21 @@ def resolve_multisig(
     else:
         raise ValueError("with --multisig-threshold, pass --signatories or --other-signatories")
     return threshold, sigs, None, refs
+
+
+def derive_saved_multisig_address(app_ctx, name: str) -> Optional[str]:
+    """Derived ss58 of the saved multisig ``name``, or None when not in the book.
+
+    Fully offline: signatory refs (ss58, book names, wallet names) resolve
+    locally and the account id derivation is deterministic, so read-only
+    commands can treat a multisig book name like any other address without a
+    chain connection.
+    """
+    entry = cfg.get_multisig(name)
+    if entry is None:
+        return None
+    signatories = _resolve_stored_signatories(app_ctx, list(entry["signatories"]))
+    return multisig_account(signatories, int(entry["threshold"])).ss58_address
 
 
 def resolve_multisig_preset(app_ctx, name: str) -> tuple[int, list[str], list[str]]:

--- a/sdk/python/bittensor/cli/multisig_helpers.py
+++ b/sdk/python/bittensor/cli/multisig_helpers.py
@@ -165,14 +165,17 @@ def build_replay_command(
         if force_proxy_type:
             parts.append(f"--force-proxy-type {shlex.quote(force_proxy_type)}")
     if preset:
-        parts.append(f"--multisig {shlex.quote(preset)}")
+        # ``-w <multisig>`` auto-picks a local member and wraps the call; each
+        # co-signer can paste the same command on their machine.
+        parts.append(f"-w {shlex.quote(preset)}")
     elif other_signatory_labels:
         parts.append(f"--multisig-threshold {threshold}")
         parts.append(f"--other-signatories {shlex.quote(','.join(other_signatory_labels))}")
+        parts.append(f"-w {shlex.quote(wallet_label)}")
     else:
         parts.append(f"--multisig-threshold {threshold}")
         parts.append(f"--signatories {shlex.quote(','.join(signatories))}")
-    parts.append(f"-w {shlex.quote(wallet_label)}")
+        parts.append(f"-w {shlex.quote(wallet_label)}")
     if signer_role != "coldkey":
         parts.append(f"--signer {signer_role}")
     return " ".join(parts)
@@ -248,6 +251,180 @@ def resolve_multisig_preset(app_ctx, name: str) -> tuple[int, list[str], list[st
     if threshold is None:
         raise ValueError(f"unknown multisig {name!r}")
     return threshold, signatories, refs
+
+
+_MULTISIG_OPS = frozenset(
+    {
+        "multisig_approve",
+        "multisig_cancel",
+        "multisig_execute",
+        "multisig_threshold_1",
+    }
+)
+
+
+def local_signatory_wallets(app_ctx, signatories: list[str]) -> list[tuple[str, str]]:
+    """Local coldkey wallets whose ss58 is in ``signatories``: ``(name, ss58)``."""
+    wanted = set(signatories)
+    found: list[tuple[str, str]] = []
+    try:
+        for coldkey in wallets.list_wallets_detailed(app_ctx.wallet_path):
+            if coldkey.ss58 in wanted:
+                found.append((coldkey.name, coldkey.ss58))
+    except Exception:
+        return []
+    # Stable order matching the resolved signatory list.
+    order = {ss58: index for index, ss58 in enumerate(signatories)}
+    found.sort(key=lambda item: order.get(item[1], len(order)))
+    return found
+
+
+def pick_local_signatory(app_ctx, *, preset: str, signatories: list[str]) -> tuple[str, str]:
+    """Choose which local member coldkey signs for a saved multisig.
+
+    Returns ``(wallet_name, ss58)``. Auto-selects when exactly one member is
+    present locally; prompts when several are; errors when none are.
+    """
+    from .prompt import PromptSpec, fill_missing, interactive
+
+    locals_ = local_signatory_wallets(app_ctx, signatories)
+    if not locals_:
+        raise ValueError(
+            f"no local signatory wallet for multisig {preset!r}; "
+            "install one of its member coldkeys under --wallet-path, or pass "
+            f"`--multisig {preset} -w <signatory>`"
+        )
+    if len(locals_) == 1:
+        name, ss58 = locals_[0]
+        app_ctx.output.message(
+            f"[dim]signing as local member {format_signatory_display(ss58, name)} "
+            f"for multisig {preset}[/dim]"
+        )
+        return name, ss58
+
+    by_name = {name: ss58 for name, ss58 in locals_}
+    if app_ctx.assume_yes or not interactive(app_ctx):
+        raise ValueError(
+            f"multisig {preset!r} has {len(locals_)} local member wallets "
+            f"({', '.join(by_name)}); pass `-w <signatory>` (with "
+            f"`--multisig {preset}`) to choose one non-interactively"
+        )
+
+    def _parse(app_ctx_, raw: str) -> str:
+        if raw not in by_name:
+            known = ", ".join(sorted(by_name))
+            raise ValueError(f"unknown local signatory {raw!r}; choose one of: {known}")
+        return raw
+
+    answers: dict = {}
+    fill_missing(
+        app_ctx,
+        [
+            PromptSpec(
+                field="signatory_wallet",
+                flag="--wallet",
+                help=f"Which local member of multisig {preset!r} signs this approval.",
+                parse=_parse,
+                default=locals_[0][0],
+            )
+        ],
+        answers,
+    )
+    name = answers["signatory_wallet"]
+    return name, by_name[name]
+
+
+async def pending_timepoint_for_call(
+    client,
+    *,
+    signatories: list[str],
+    threshold: int,
+    call_hash: str,
+    signer_ss58: str,
+) -> Optional[dict[str, int]]:
+    """Return the opening timepoint for a pending op matching ``call_hash``.
+
+    Errors if this signer already approved. Returns ``None`` when nothing is
+    pending (caller should open a new operation).
+    """
+    ms = await client.multisig(signatories, threshold)
+    wanted = hex_bytes(call_hash)
+    for row in await list_pending_multisig_ops(client, ms.address):
+        if row["call_hash"] != wanted:
+            continue
+        if signer_ss58 in row.get("approvals") or []:
+            raise ValueError(
+                f"this signatory already approved pending call {wanted}; "
+                "wait for another member, or cancel the operation"
+            )
+        return dict(row["timepoint"])
+    return None
+
+
+def wrap_intent_for_multisig_wallet(app_ctx, intent):
+    """If ``-w`` names a saved multisig, rewrite ``intent`` as a multisig approval.
+
+    Picks a local member coldkey to sign, converts the original intent into a
+    ``multisig_execute`` / ``multisig_threshold_1`` wrapper (same shape as
+    ``btcli call --multisig``), and auto-fills the opening ``timepoint`` when a
+    matching pending operation already exists — so every co-signer can re-run
+    the same ``btcli wallet transfer -w <multisig> ...`` command.
+
+    Raises ``ValueError`` when the preset or local signatory set is unusable.
+    """
+    from ..intents.multisig import MultisigExecute, MultisigThreshold1, _compose_inner
+
+    if getattr(intent, "signer", None) != "coldkey":
+        return intent
+    if getattr(intent, "op", None) in _MULTISIG_OPS:
+        return intent
+    preset = app_ctx.wallet_name
+    if not preset or cfg.get_multisig(preset) is None:
+        return intent
+
+    threshold, signatories, _refs = resolve_multisig_preset(app_ctx, preset)
+    member_name, signer_ss58 = pick_local_signatory(
+        app_ctx, preset=preset, signatories=signatories
+    )
+
+    # Remember the multisig account name for summaries; the signing wallet is
+    # the local member that actually unlocks a coldkey.
+    app_ctx.multisig_wallet_name = preset
+    app_ctx.wallet_name = member_name
+    app_ctx.wallet_given = True
+
+    others = [ss58 for ss58 in signatories if ss58 != signer_ss58]
+    call_dict = intent.to_dict()
+
+    if threshold == 1:
+        app_ctx.output.message(
+            f"[dim]dispatching via 1-of-{len(signatories)} multisig {preset}[/dim]"
+        )
+        return MultisigThreshold1(other_signatories=others, call=call_dict)
+
+    async def _timepoint(client):
+        wallet = wallets.open_wallet(member_name, path=app_ctx.wallet_path)
+        inner = await _compose_inner(client._substrate, wallet, call_dict)
+        return await pending_timepoint_for_call(
+            client,
+            signatories=signatories,
+            threshold=threshold,
+            call_hash=inner.call_hash,
+            signer_ss58=signer_ss58,
+        )
+
+    timepoint = app_ctx.run(_timepoint)
+    action = "approving" if timepoint else "opening"
+    app_ctx.output.message(
+        f"[dim]{action} via {threshold}-of-{len(signatories)} multisig {preset} "
+        f"as {format_signatory_display(signer_ss58, member_name)}[/dim]"
+    )
+    return MultisigExecute(
+        threshold=threshold,
+        other_signatories=others,
+        call=call_dict,
+        timepoint=timepoint,
+    )
 
 
 async def multisig_list_records(

--- a/sdk/python/bittensor/cli/prompt.py
+++ b/sdk/python/bittensor/cli/prompt.py
@@ -37,6 +37,7 @@ except ImportError:  # older typer uses the external click package
         exceptions as click_exceptions,
     )
 
+from .. import config as cfg
 from .. import wallets
 from .context import AppContext
 from .output import STYLE_COMMAND, STYLE_HINT
@@ -172,11 +173,21 @@ def _parse_wallet(app_ctx: AppContext, raw: str, *, require_coldkey: bool = True
 
     A bad name re-prompts with the wallets that *are* available. The coldkey is
     only demanded when it is the signing key (hotkey-signed intents may use a
-    coldkey-less wallet dir).
+    coldkey-less wallet dir). Saved multisig book names are also accepted —
+    ``AppContext.submit`` rewrites the intent to a multisig approval signed by
+    a local member.
     """
     known = wallets.list_wallets(app_ctx.wallet_path)
     if raw not in known:
-        raise _unknown_name_error("wallet", raw, sorted(known))
+        if cfg.get_multisig(raw) is not None:
+            app_ctx.wallet_name = raw
+            app_ctx.wallet_given = True
+            return raw
+        suggestions = sorted(
+            set(known)
+            | {str(entry["name"]) for entry in cfg.load_multisigs() if entry.get("name")}
+        )
+        raise _unknown_name_error("wallet", raw, suggestions)
     try:
         address = wallets.open_wallet(
             raw, app_ctx.hotkey_name, app_ctx.wallet_path

--- a/sdk/python/bittensor/wallet.py
+++ b/sdk/python/bittensor/wallet.py
@@ -222,6 +222,7 @@ class Wallet:
         self,
         mnemonic: str | None = None,
         seed: str | bytes | None = None,
+        private_key: str | None = None,
         json: tuple[str, str] | None = None,
         use_password: bool = True,
         overwrite: bool = False,
@@ -235,6 +236,10 @@ class Wallet:
             if not suppress:
                 print(f"Regenerating coldkey from mnemonic\nMnemonic: {mnemonic}")
             keypair = Keypair.create_from_mnemonic(mnemonic, crypto_type)
+        elif private_key is not None:
+            if not suppress:
+                print("Regenerating coldkey from private key")
+            keypair = Keypair.create_from_private_key(private_key, crypto_type)
         elif seed is not None:
             keypair = Keypair.create_from_seed(_seed_bytes(seed), crypto_type)
         elif json is not None:
@@ -247,7 +252,7 @@ class Wallet:
                 print("Regenerating coldkey from encrypted JSON keystore")
             keypair = Keypair.create_from_encrypted_json(json_data, passphrase)
         else:
-            raise ValueError("either mnemonic, seed, or json must be provided")
+            raise ValueError("either mnemonic, seed, private_key, or json must be provided")
 
         if coldkey_password is not None:
             use_password = True
@@ -265,6 +270,7 @@ class Wallet:
         self,
         mnemonic: str | None = None,
         seed: str | bytes | None = None,
+        private_key: str | None = None,
         use_password: bool = False,
         overwrite: bool = False,
         suppress: bool = False,
@@ -277,10 +283,14 @@ class Wallet:
             if not suppress:
                 print(f"Regenerating hotkey from mnemonic\nMnemonic: {mnemonic}")
             keypair = Keypair.create_from_mnemonic(mnemonic, crypto_type)
+        elif private_key is not None:
+            if not suppress:
+                print("Regenerating hotkey from private key")
+            keypair = Keypair.create_from_private_key(private_key, crypto_type)
         elif seed is not None:
             keypair = Keypair.create_from_seed(_seed_bytes(seed), crypto_type)
         else:
-            raise ValueError("either mnemonic or seed must be provided")
+            raise ValueError("either mnemonic, seed, or private_key must be provided")
 
         if hotkey_password is not None:
             use_password = True

--- a/sdk/python/bittensor/wallets.py
+++ b/sdk/python/bittensor/wallets.py
@@ -244,18 +244,20 @@ def regen_coldkey(
     path: str = DEFAULT_WALLET_PATH,
     *,
     seed: str | None = None,
+    private_key: str | None = None,
     json: tuple[str, str] | None = None,
     use_password: bool = True,
     overwrite: bool = False,
     crypto_type: int = DEFAULT_CRYPTO_TYPE,
 ) -> Wallet:
-    """Regenerate a coldkey from a mnemonic, 32-byte hex seed, or encrypted JSON."""
+    """Regenerate a coldkey from a mnemonic, seed, private key, or encrypted JSON."""
     wallet = Wallet(name=name, path=path)
     # suppress=True stops the wallet lib from echoing the mnemonic back to stdout;
     # the caller already supplied it, so reprinting only widens secret exposure.
     wallet.regenerate_coldkey(
         mnemonic=mnemonic,
         seed=seed,
+        private_key=private_key,
         json=json,
         use_password=use_password,
         overwrite=overwrite,
@@ -272,14 +274,16 @@ def regen_hotkey(
     path: str = DEFAULT_WALLET_PATH,
     *,
     seed: str | None = None,
+    private_key: str | None = None,
     overwrite: bool = False,
     crypto_type: int = DEFAULT_CRYPTO_TYPE,
 ) -> Wallet:
-    """Regenerate a hotkey from a mnemonic or a 32-byte hex seed (exactly one)."""
+    """Regenerate a hotkey from a mnemonic, 32-byte hex seed, or 64-byte private key."""
     wallet = Wallet(name=name, hotkey=hotkey, path=path)
     wallet.regenerate_hotkey(
         mnemonic=mnemonic,
         seed=seed,
+        private_key=private_key,
         use_password=False,
         overwrite=overwrite,
         suppress=True,


### PR DESCRIPTION
## Summary
- Passing `-w <multisig>` (a name from `btcli multisig add`) on any coldkey-signed command (`wallet transfer`, `tx *`, `call`, …) auto-detects the book entry, picks a local member coldkey to sign, and wraps the operation as a multisig approval.
- Matching pending ops are found by call hash so co-signers re-run the **same** command; the CLI fills the timepoint.
- Co-signer replay commands now use `-w <multisig>` when a preset is known. Docs updated for the short path.

## Example
```bash
btcli wallet transfer --dest izzi --amount-tao 0.1 -w guard-ms
# co-signer, identical:
btcli wallet transfer --dest izzi --amount-tao 0.1 -w guard-ms
```

## Test plan
- [ ] `btcli multisig add` a 2-of-3 with two local member wallets
- [ ] Fund one member with fee TAO; run `btcli wallet transfer --dest <addr> --amount-tao 0.1 -w <multisig>`
- [ ] Confirm opener prints pending / co-signer hint
- [ ] On the second member (or same machine with the other key selected), re-run the identical transfer command and confirm execution
- [ ] `btcli call Balances.transfer_keep_alive ... -w <multisig>` works without `--multisig`
- [ ] Explicit `btcli call ... --multisig X -w <member>` still works unchanged
- [ ] Non-multisig `-w` transfer unchanged


Made with [Cursor](https://cursor.com)