### PR TITLE
btcli stake UX: free balance + 'all', paste any target hotkey, stake burn

### DIFF
--- a/docs/tx/add-collateral.mdx
+++ b/docs/tx/add-collateral.mdx
@@ -23,7 +23,7 @@ to clear unshielded at an unbounded AMM price.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.add_collateral`](/code/pallets/subtensor/src/macros/dispatches.rs#L2524-L2534) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.add_collateral`](/code/pallets/subtensor/src/macros/dispatches.rs#L2529-L2539) |
 
 ## Parameters
 
@@ -77,7 +77,7 @@ result = sub.execute_tool("add_collateral", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.add_collateral` — [`pallets/subtensor/src/macros/dispatches.rs#L2526`](/code/pallets/subtensor/src/macros/dispatches.rs#L2524-L2534):
+`SubtensorModule.add_collateral` — [`pallets/subtensor/src/macros/dispatches.rs#L2531`](/code/pallets/subtensor/src/macros/dispatches.rs#L2529-L2539):
 
 ```rust
 #[pallet::call_index(144)]

--- a/docs/tx/add-stake.mdx
+++ b/docs/tx/add-stake.mdx
@@ -14,11 +14,12 @@ than `rate_tolerance` (5%) above the price at submission — raise the
 tolerance or set `slippage_protection` to False to execute at any price,
 or use `add_stake_limit` to set an explicit limit price. The position's
 value then follows the pool price and the validator's performance, and can
-be exited later with `remove_stake`. Fails if the coldkey's free balance
-cannot cover the amount plus the transaction fee, and with `AmountTooLow`
-when the amount is below the chain minimum of 0.002 TAO plus the swap fee.
-Dynamic subnets also reject a single swap larger than 1000x the pool's TAO
-reserve (`InsufficientLiquidity`).
+be exited later with `remove_stake`. Pass `all` to stake the whole free
+balance minus the existential deposit and a small fee headroom. Fails if
+the coldkey's free balance cannot cover the amount plus the transaction
+fee, and with `AmountTooLow` when the amount is below the chain minimum
+of 0.002 TAO plus the swap fee. Dynamic subnets also reject a single swap
+larger than 1000x the pool's TAO reserve (`InsufficientLiquidity`).
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
@@ -30,7 +31,7 @@ reserve (`InsufficientLiquidity`).
 | --- | --- | --- | --- |
 | `hotkey_ss58` | string | yes | Hotkey the stake is added to (the validator you are backing). |
 | `netuid` | integer | yes | Subnet the stake lives on (netuid 0 is the root network). |
-| `amount_tao` | number \| `"all"` | yes | How much of the coldkey's free balance to stake. |
+| `amount_tao` | number \| `"all"` | yes | How much of the coldkey's free balance to stake, or `all` (everything minus the existential deposit and fee headroom). |
 | `slippage_protection` | boolean | no | Bound the price the swap may execute at (on by default): the call fails (`SlippageTooHigh`) instead of filling once the pool price moves more than `rate_tolerance` from the price at submission. Disable to execute at any price. |
 | `rate_tolerance` | number | no | Maximum price move slippage protection accepts, as a fraction (0.05 = 5%). Ignored when slippage protection is disabled. |
 

--- a/docs/tx/announce-coldkey-swap.mdx
+++ b/docs/tx/announce-coldkey-swap.mdx
@@ -23,7 +23,7 @@ an unauthorized one with `dispute_coldkey_swap`.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.announce_coldkey_swap`](/code/pallets/subtensor/src/macros/dispatches.rs#L2060-L2088) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.announce_coldkey_swap`](/code/pallets/subtensor/src/macros/dispatches.rs#L2065-L2093) |
 
 ## Parameters
 
@@ -72,7 +72,7 @@ result = sub.execute_tool("announce_coldkey_swap", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.announce_coldkey_swap` — [`pallets/subtensor/src/macros/dispatches.rs#L2062`](/code/pallets/subtensor/src/macros/dispatches.rs#L2060-L2088):
+`SubtensorModule.announce_coldkey_swap` — [`pallets/subtensor/src/macros/dispatches.rs#L2067`](/code/pallets/subtensor/src/macros/dispatches.rs#L2065-L2093):
 
 ```rust
 #[pallet::call_index(125)]

--- a/docs/tx/clear-coldkey-swap-announcement.mdx
+++ b/docs/tx/clear-coldkey-swap-announcement.mdx
@@ -17,7 +17,7 @@ right call instead.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.clear_coldkey_swap_announcement`](/code/pallets/subtensor/src/macros/dispatches.rs#L2259-L2276) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.clear_coldkey_swap_announcement`](/code/pallets/subtensor/src/macros/dispatches.rs#L2264-L2281) |
 
 ## Parameters
 
@@ -62,7 +62,7 @@ result = sub.execute_tool("clear_coldkey_swap_announcement", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.clear_coldkey_swap_announcement` — [`pallets/subtensor/src/macros/dispatches.rs#L2261`](/code/pallets/subtensor/src/macros/dispatches.rs#L2259-L2276):
+`SubtensorModule.clear_coldkey_swap_announcement` — [`pallets/subtensor/src/macros/dispatches.rs#L2266`](/code/pallets/subtensor/src/macros/dispatches.rs#L2264-L2281):
 
 ```rust
 #[pallet::call_index(133)]

--- a/docs/tx/dispute-coldkey-swap.mdx
+++ b/docs/tx/dispute-coldkey-swap.mdx
@@ -18,7 +18,7 @@ you made yourself.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.dispute_coldkey_swap`](/code/pallets/subtensor/src/macros/dispatches.rs#L2129-L2148) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.dispute_coldkey_swap`](/code/pallets/subtensor/src/macros/dispatches.rs#L2134-L2153) |
 
 ## Parameters
 
@@ -63,7 +63,7 @@ result = sub.execute_tool("dispute_coldkey_swap", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.dispute_coldkey_swap` — [`pallets/subtensor/src/macros/dispatches.rs#L2131`](/code/pallets/subtensor/src/macros/dispatches.rs#L2129-L2148):
+`SubtensorModule.dispute_coldkey_swap` — [`pallets/subtensor/src/macros/dispatches.rs#L2136`](/code/pallets/subtensor/src/macros/dispatches.rs#L2134-L2153):
 
 ```rust
 #[pallet::call_index(127)]

--- a/docs/tx/lock-stake.mdx
+++ b/docs/tx/lock-stake.mdx
@@ -21,7 +21,7 @@ persists is controlled per coldkey per subnet with
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.lock_stake`](/code/pallets/subtensor/src/macros/dispatches.rs#L2331-L2341) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.lock_stake`](/code/pallets/subtensor/src/macros/dispatches.rs#L2336-L2346) |
 
 ## Parameters
 
@@ -74,7 +74,7 @@ result = sub.execute_tool("lock_stake", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.lock_stake` — [`pallets/subtensor/src/macros/dispatches.rs#L2333`](/code/pallets/subtensor/src/macros/dispatches.rs#L2331-L2341):
+`SubtensorModule.lock_stake` — [`pallets/subtensor/src/macros/dispatches.rs#L2338`](/code/pallets/subtensor/src/macros/dispatches.rs#L2336-L2346):
 
 ```rust
 #[pallet::call_index(136)]

--- a/docs/tx/move-lock.mdx
+++ b/docs/tx/move-lock.mdx
@@ -16,7 +16,7 @@ existing lock on the subnet to move.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.move_lock`](/code/pallets/subtensor/src/macros/dispatches.rs#L2355-L2364) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.move_lock`](/code/pallets/subtensor/src/macros/dispatches.rs#L2360-L2369) |
 
 ## Parameters
 
@@ -68,7 +68,7 @@ result = sub.execute_tool("move_lock", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.move_lock` — [`pallets/subtensor/src/macros/dispatches.rs#L2357`](/code/pallets/subtensor/src/macros/dispatches.rs#L2355-L2364):
+`SubtensorModule.move_lock` — [`pallets/subtensor/src/macros/dispatches.rs#L2362`](/code/pallets/subtensor/src/macros/dispatches.rs#L2360-L2369):
 
 ```rust
 #[pallet::call_index(137)]

--- a/docs/tx/set-min-collateral.mdx
+++ b/docs/tx/set-min-collateral.mdx
@@ -15,7 +15,7 @@ immediately). Zero clears the floor and restores pure drain behavior.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.set_min_collateral`](/code/pallets/subtensor/src/macros/dispatches.rs#L2559-L2568) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.set_min_collateral`](/code/pallets/subtensor/src/macros/dispatches.rs#L2564-L2573) |
 
 ## Parameters
 
@@ -68,7 +68,7 @@ result = sub.execute_tool("set_min_collateral", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.set_min_collateral` — [`pallets/subtensor/src/macros/dispatches.rs#L2561`](/code/pallets/subtensor/src/macros/dispatches.rs#L2559-L2568):
+`SubtensorModule.set_min_collateral` — [`pallets/subtensor/src/macros/dispatches.rs#L2566`](/code/pallets/subtensor/src/macros/dispatches.rs#L2564-L2573):
 
 ```rust
 #[pallet::call_index(145)]

--- a/docs/tx/set-perpetual-lock.mdx
+++ b/docs/tx/set-perpetual-lock.mdx
@@ -15,7 +15,7 @@ illiquid until you switch back to decaying and the lock runs off.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.set_perpetual_lock`](/code/pallets/subtensor/src/macros/dispatches.rs#L2371-L2380) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.set_perpetual_lock`](/code/pallets/subtensor/src/macros/dispatches.rs#L2376-L2385) |
 
 ## Parameters
 
@@ -67,7 +67,7 @@ result = sub.execute_tool("set_perpetual_lock", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.set_perpetual_lock` — [`pallets/subtensor/src/macros/dispatches.rs#L2373`](/code/pallets/subtensor/src/macros/dispatches.rs#L2371-L2380):
+`SubtensorModule.set_perpetual_lock` — [`pallets/subtensor/src/macros/dispatches.rs#L2378`](/code/pallets/subtensor/src/macros/dispatches.rs#L2376-L2385):
 
 ```rust
 #[pallet::call_index(138)]

--- a/docs/tx/set-root-claim-threshold.mdx
+++ b/docs/tx/set-root-claim-threshold.mdx
@@ -19,7 +19,7 @@ effect afterwards with the `root_claim_threshold` read.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | root (chain sudo) | SubtensorModule | [`SubtensorModule.sudo_set_root_claim_threshold`](/code/pallets/subtensor/src/macros/dispatches.rs#L2023-L2044), `Sudo.sudo` |
+| `coldkey` | root (chain sudo) | SubtensorModule | [`SubtensorModule.sudo_set_root_claim_threshold`](/code/pallets/subtensor/src/macros/dispatches.rs#L2028-L2049), `Sudo.sudo` |
 
 ## Verify
 
@@ -77,7 +77,7 @@ result = sub.execute_tool("set_root_claim_threshold", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.sudo_set_root_claim_threshold` — [`pallets/subtensor/src/macros/dispatches.rs#L2025`](/code/pallets/subtensor/src/macros/dispatches.rs#L2023-L2044):
+`SubtensorModule.sudo_set_root_claim_threshold` — [`pallets/subtensor/src/macros/dispatches.rs#L2030`](/code/pallets/subtensor/src/macros/dispatches.rs#L2028-L2049):
 
 ```rust
 #[pallet::call_index(124)]

--- a/docs/tx/stake-burn.mdx
+++ b/docs/tx/stake-burn.mdx
@@ -11,14 +11,15 @@ signer's stake. The TAO is spent permanently — nothing lands in your stake,
 so this is not an investment call; use a regular add-stake intent to
 acquire a position. Fails on the root subnet
 (`CannotBurnOrRecycleOnRootSubnet`). The chain accepts an optional
-limit (omitted = market order), but this intent always requires
-`limit_price` and executes all-or-nothing: the swap fails instead of
-partially filling at a worse rate. Counts against a configured spend
-cap.
+limit (omitted = market order), but this intent always submits one and
+executes all-or-nothing: the swap fails instead of partially filling at
+a worse rate. When `limit_price` is omitted, the limit is derived from
+the current pool price plus `rate_tolerance` (5% by default). Counts
+against a configured spend cap.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.add_stake_burn`](/code/pallets/subtensor/src/macros/dispatches.rs#L2243-L2253) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.add_stake_burn`](/code/pallets/subtensor/src/macros/dispatches.rs#L2248-L2258) |
 
 ## Parameters
 
@@ -26,7 +27,8 @@ cap.
 | --- | --- | --- | --- |
 | `netuid` | integer | yes | Subnet whose alpha is bought and burned. |
 | `amount_tao` | number \| `"all"` | yes | Spent from the coldkey to buy alpha that is then burned. |
-| `limit_price` | integer | yes | Worst acceptable price in rao per alpha; the call fails rather than filling beyond it. |
+| `limit_price` | integer | no | Worst acceptable price in rao per alpha; the call fails rather than filling beyond it. Defaults to the current pool price plus `rate_tolerance`. |
+| `rate_tolerance` | number | no | Maximum price move accepted when `limit_price` is omitted, as a fraction (0.05 = 5%). Ignored when `limit_price` is given. |
 | `hotkey_ss58` | string | no | Hotkey the burn is routed through; defaults to the wallet's hotkey. |
 
 Address parameters (`--hotkey`, `--coldkey`, `--dest`, ...) accept a raw ss58
@@ -40,12 +42,10 @@ submitting), then submit:
 ```bash
 btcli tx stake-burn \
   --netuid <int> \
-  --amount-tao <amount|all> \
-  --limit-price <int> --dry-run
+  --amount-tao <amount|all> --dry-run
 btcli tx stake-burn \
   --netuid <int> \
-  --amount-tao <amount|all> \
-  --limit-price <int> -w my_coldkey
+  --amount-tao <amount|all> -w my_coldkey
 ```
 
 ## Python
@@ -55,7 +55,7 @@ import bittensor as bt
 from bittensor.wallet import Wallet
 
 wallet = Wallet(name="my_coldkey", hotkey="my_hotkey")
-intent = bt.StakeBurn(netuid=1, amount_tao=1.0, limit_price=0)
+intent = bt.StakeBurn(netuid=1, amount_tao=1.0)
 
 sub = bt.Subtensor()
 plan = sub.plan(intent, wallet)   # fee, effects, policy — no submission
@@ -74,7 +74,7 @@ result = sub.execute_tool("stake_burn", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.add_stake_burn` — [`pallets/subtensor/src/macros/dispatches.rs#L2245`](/code/pallets/subtensor/src/macros/dispatches.rs#L2243-L2253):
+`SubtensorModule.add_stake_burn` — [`pallets/subtensor/src/macros/dispatches.rs#L2250`](/code/pallets/subtensor/src/macros/dispatches.rs#L2248-L2258):
 
 ```rust
 #[pallet::call_index(132)]

--- a/docs/tx/swap-coldkey-announced.mdx
+++ b/docs/tx/swap-coldkey-announced.mdx
@@ -15,7 +15,7 @@ future operations sign with the new coldkey.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.swap_coldkey_announced`](/code/pallets/subtensor/src/macros/dispatches.rs#L2098-L2120) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.swap_coldkey_announced`](/code/pallets/subtensor/src/macros/dispatches.rs#L2103-L2125) |
 
 ## Parameters
 
@@ -64,7 +64,7 @@ result = sub.execute_tool("swap_coldkey_announced", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.swap_coldkey_announced` — [`pallets/subtensor/src/macros/dispatches.rs#L2100`](/code/pallets/subtensor/src/macros/dispatches.rs#L2098-L2120):
+`SubtensorModule.swap_coldkey_announced` — [`pallets/subtensor/src/macros/dispatches.rs#L2105`](/code/pallets/subtensor/src/macros/dispatches.rs#L2103-L2125):
 
 ```rust
 #[pallet::call_index(126)]

--- a/docs/tx/transfer-stake.mdx
+++ b/docs/tx/transfer-stake.mdx
@@ -32,7 +32,7 @@ owners.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.transfer_stake`](/code/pallets/subtensor/src/macros/dispatches.rs#L1324-L1342), [`SubtensorModule.transfer_stake_and_hotkey`](/code/pallets/subtensor/src/macros/dispatches.rs#L2466-L2486) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.transfer_stake`](/code/pallets/subtensor/src/macros/dispatches.rs#L1324-L1342), [`SubtensorModule.transfer_stake_and_hotkey`](/code/pallets/subtensor/src/macros/dispatches.rs#L2471-L2491) |
 
 ## Parameters
 
@@ -120,7 +120,7 @@ pub fn transfer_stake(
 
 Delegates to [`do_transfer_stake`](/code/pallets/subtensor/src/staking/move_stake.rs#L120).
 
-`SubtensorModule.transfer_stake_and_hotkey` — [`pallets/subtensor/src/macros/dispatches.rs#L2468`](/code/pallets/subtensor/src/macros/dispatches.rs#L2466-L2486):
+`SubtensorModule.transfer_stake_and_hotkey` — [`pallets/subtensor/src/macros/dispatches.rs#L2473`](/code/pallets/subtensor/src/macros/dispatches.rs#L2471-L2491):
 
 ```rust
 #[pallet::call_index(143)]

--- a/sdk/python/bittensor/cli/commands/stake.py
+++ b/sdk/python/bittensor/cli/commands/stake.py
@@ -44,6 +44,7 @@ for _alias, _op in (
     ("move", "move_stake"),
     ("transfer", "transfer_stake"),
     ("swap", "swap_stake"),
+    ("burn", "stake_burn"),
     ("unstake-all", "unstake_all"),
     ("unstake-all-alpha", "unstake_all_alpha"),
 ):

--- a/sdk/python/bittensor/cli/context.py
+++ b/sdk/python/bittensor/cli/context.py
@@ -321,11 +321,15 @@ class AppContext:
             # top-level import here would be circular.
             from .prompt import confirm_wallet
 
-            confirm_wallet(
+            # These keys are command *targets*, never signers, so a pasted ss58
+            # or address-book name is accepted and used directly (the key does
+            # not have to exist locally).
+            value = confirm_wallet(
                 self,
                 help_text=f"Wallet whose {kind} this command targets.",
                 require_coldkey=param == "coldkey_ss58",
                 hotkey_help=("Hotkey this command targets." if param == "hotkey_ss58" else None),
+                accept_address=True,
             )
         if value is not None and is_bittensor_address(value):
             booked = next(

--- a/sdk/python/bittensor/cli/prompt.py
+++ b/sdk/python/bittensor/cli/prompt.py
@@ -222,6 +222,49 @@ def _parse_hotkey(app_ctx: AppContext, raw: str) -> str:
     return raw
 
 
+def _parse_target_hotkey(app_ctx: AppContext, raw: str) -> str:
+    """Parse a *target* hotkey: local names keep the normal path, but a pasted
+    ss58 address, an address-book name, or ``WALLET/HOTKEY`` also work — the
+    target of a command never has to exist locally (only signers do)."""
+    known = wallets.list_wallets(app_ctx.wallet_path).get(app_ctx.wallet_name, [])
+    if raw in known:
+        return _parse_hotkey(app_ctx, raw)
+    if wallets.is_bittensor_address(raw):
+        return raw
+    booked = cfg.get_address(raw)
+    if booked:
+        app_ctx.output.name_address(booked, raw)
+        return booked
+    if "/" in raw:
+        wallet_name, _, hotkey = raw.rpartition("/")
+        try:
+            handle = wallets.open_wallet(
+                wallet_name or app_ctx.wallet_name, hotkey, app_ctx.wallet_path
+            )
+            address = handle.hotkey.ss58_address
+        except Exception as error:
+            raise ValueError(f"cannot open hotkey {raw!r}: {error}")
+        app_ctx.output.name_address(address, raw)
+        return address
+    error = _unknown_name_error(f"hotkey in wallet {app_ctx.wallet_name!r}", raw, sorted(known))
+    raise ValueError(f"{error} — or paste an ss58 address / address-book name")
+
+
+def _parse_target_wallet(app_ctx: AppContext, raw: str, *, require_coldkey: bool = True) -> str:
+    """Parse a *target* coldkey: a local wallet name as usual, but a pasted
+    ss58 address or address-book name also works (no signature needed)."""
+    if wallets.is_bittensor_address(raw):
+        return raw
+    booked = cfg.get_address(raw)
+    if booked:
+        app_ctx.output.name_address(booked, raw)
+        return booked
+    try:
+        return _parse_wallet(app_ctx, raw, require_coldkey=require_coldkey)
+    except ValueError as error:
+        raise ValueError(f"{error} — or paste an ss58 address / address-book name")
+
+
 def confirm_wallet(
     app_ctx: AppContext,
     *,
@@ -230,7 +273,8 @@ def confirm_wallet(
     must_exist: bool = True,
     hotkey_help: Optional[str] = None,
     hotkey_must_exist: bool = True,
-) -> None:
+    accept_address: bool = False,
+) -> Optional[str]:
     """Confirm the target wallet (and optionally hotkey) when only defaulted.
 
     Wallet-scoped commands call this so a bare invocation doesn't silently act
@@ -244,12 +288,24 @@ def confirm_wallet(
     Hotkey-scoped commands additionally pass ``hotkey_help`` so the hotkey
     name is confirmed in the same round (skipped by ``--wallet-hotkey``/``-H``
     or ``BT_WALLET_HOTKEY``); ``hotkey_must_exist=False`` accepts any name.
+
+    With ``accept_address`` (used when the key being confirmed is a command
+    *target*, not a signer) a pasted ss58 address or address-book name is also
+    accepted — the key doesn't have to exist locally. The pasted address is
+    returned so the caller can use it directly; local selections return None.
     """
     skip = app_ctx.assume_yes or app_ctx.uses_external_signer()
     specs: list[PromptSpec] = []
     if not app_ctx.wallet_given and not skip:
+        # A paste is only meaningful at the last prompt of the round: with a
+        # hotkey prompt following, the wallet answer selects whose hotkeys are
+        # on offer and stays a local name.
+        wallet_is_target = accept_address and hotkey_help is None
         parse: Parser = (
-            functools.partial(_parse_wallet, require_coldkey=require_coldkey)
+            functools.partial(
+                _parse_target_wallet if wallet_is_target else _parse_wallet,
+                require_coldkey=require_coldkey,
+            )
             if must_exist
             else _parse_wallet_name
         )
@@ -263,22 +319,47 @@ def confirm_wallet(
             )
         )
     if hotkey_help is not None and not app_ctx.hotkey_given and not skip:
+        if accept_address:
+            known = sorted(wallets.list_wallets(app_ctx.wallet_path).get(app_ctx.wallet_name, []))
+            if known:
+                listing = ", ".join(known[:8]) + (", …" if len(known) > 8 else "")
+                hotkey_help += (
+                    f" A local hotkey ({listing}), a pasted ss58 address, "
+                    "or an address-book name."
+                )
+            else:
+                hotkey_help += (
+                    f" Wallet {app_ctx.wallet_name!r} has no local hotkeys — paste the "
+                    "hotkey's ss58 address or an address-book name."
+                )
+            hotkey_parse: Parser = _parse_target_hotkey
+            hotkey_default = app_ctx.hotkey_name if app_ctx.hotkey_name in known else None
+        else:
+            hotkey_parse = _parse_hotkey if hotkey_must_exist else _parse_hotkey_name
+            hotkey_default = app_ctx.hotkey_name
         specs.append(
             PromptSpec(
                 field="wallet_hotkey",
                 flag="--wallet-hotkey",
                 help=hotkey_help,
-                parse=_parse_hotkey if hotkey_must_exist else _parse_hotkey_name,
-                default=app_ctx.hotkey_name,
+                parse=hotkey_parse,
+                default=hotkey_default,
             )
         )
+    answers: dict[str, Any] = {}
     if specs:
-        fill_missing(app_ctx, specs, {})
+        fill_missing(app_ctx, specs, answers)
     # Confirmed (or silently kept in a non-interactive session) — later
     # default fallbacks in the same invocation must not ask again.
     app_ctx.wallet_given = True
     if hotkey_help is not None:
         app_ctx.hotkey_given = True
+    if accept_address:
+        for key in ("wallet_hotkey", "wallet"):
+            answer = answers.get(key)
+            if isinstance(answer, str) and wallets.is_bittensor_address(answer):
+                return answer
+    return None
 
 
 def signer_specs(

--- a/sdk/python/bittensor/cli/stake_picker.py
+++ b/sdk/python/bittensor/cli/stake_picker.py
@@ -12,19 +12,20 @@ stake are offered — so the position list covers just that subnet.
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Callable, Optional
 
 import typer
 from rich.console import Console
 from rich.text import Text
 
+from .. import wallets
 from ..balance import Balance
 from ..reads import StakePosition, StakeValuation
 from .context import AppContext, address_cli_name
 from .helpers import chain_identity_names, local_address_names
 from .output import STYLE_COMMAND, STYLE_HINT, STYLE_KEY, STYLE_NAME, Output
-from .prompt import PromptSpec
+from .prompt import PromptSpec, _ask
 
 # Positions whose spot value is below this are dust: hidden from the pickers
 # (unless everything is dust) but still selectable by typing the netuid/hotkey.
@@ -41,6 +42,139 @@ STAKE_SOURCE_FIELDS: dict[str, tuple[str, Optional[str]]] = {
     "transfer_stake": ("hotkey_ss58", "origin_netuid"),
     "move_stake": ("origin_hotkey_ss58", "origin_netuid"),
 }
+
+# op -> hotkey field naming the *destination* validator. Unlike the source
+# picker above, this hotkey need not be local or hold stake: the wallet's own
+# hotkeys are offered for convenience, but any pasted ss58 / address-book name
+# works (staking to a validator does not require its keyfile).
+STAKE_TARGET_FIELDS: dict[str, str] = {
+    "add_stake": "hotkey_ss58",
+    "add_stake_limit": "hotkey_ss58",
+}
+
+# op -> money field whose interactive prompt should lead with the coldkey's
+# free balance (the amount these ops spend comes straight out of it).
+FREE_BALANCE_AMOUNT_FIELDS: dict[str, str] = {
+    "add_stake": "amount_tao",
+    "add_stake_limit": "amount_tao",
+    "stake_burn": "amount_tao",
+}
+
+
+def stake_target_spec(hotkey_field: str) -> PromptSpec:
+    """A PromptSpec whose custom flow picks the destination hotkey to stake to."""
+    return PromptSpec(
+        field=hotkey_field,
+        flag=address_cli_name(hotkey_field),
+        help=None,
+        parse=lambda _app_ctx, raw: raw,  # unused: the custom flow does everything
+        custom=lambda console, app_ctx, kwargs: _pick_target(
+            console, app_ctx, kwargs, hotkey_field
+        ),
+    )
+
+
+def _pick_target(
+    console: Console,
+    app_ctx: AppContext,
+    kwargs: dict,
+    hotkey_field: str,
+) -> list[str]:
+    """List the wallet's local hotkeys and ask which validator to stake to.
+
+    Any answer the flag form would take also works: a list number, a local
+    hotkey name (or ``WALLET/HOTKEY``), an address-book name, or a pasted
+    ss58 — the target does not have to exist locally.
+    """
+    local = next(
+        (
+            ck.hotkeys
+            for ck in wallets.list_wallets_detailed(app_ctx.wallet_path)
+            if ck.name == app_ctx.wallet_name
+        ),
+        [],
+    )
+    local = [hk for hk in local if hk.ss58]
+    flag = address_cli_name(hotkey_field)
+
+    hint = Text("  ")
+    hint.append(flag, style=STYLE_COMMAND)
+    hint.append("  ")
+    hint.append(
+        "Validator hotkey the stake goes to — it does not have to be a local key.",
+        style=STYLE_HINT,
+    )
+    console.print(hint)
+    if local:
+        labels = [f"{app_ctx.wallet_name}/{hk.name}" for hk in local]
+        label_width = max(len(label) for label in labels)
+        number_width = len(str(len(local)))
+        for index, (hk, label) in enumerate(zip(local, labels), start=1):
+            line = Text("    ", overflow="ignore", no_wrap=True)
+            line.append(str(index).rjust(number_width), style=STYLE_COMMAND)
+            line.append("  ")
+            line.append(label.ljust(label_width), style=STYLE_NAME)
+            line.append(f"  {hk.ss58}", style="dim")
+            console.print(line, soft_wrap=True)
+        console.print(
+            "  [dim]a number above, or any hotkey: ss58 address, address-book name, "
+            "or WALLET/HOTKEY[/dim]"
+        )
+    else:
+        console.print(
+            f"  [dim]wallet {app_ctx.wallet_name!r} has no local hotkeys — paste the "
+            "validator's ss58 address or an address-book name[/dim]"
+        )
+
+    prompt = Text("  ")
+    prompt.append(flag.lstrip("-"), style=STYLE_COMMAND)
+    prompt.append(": ", style=STYLE_COMMAND)
+    while True:
+        try:
+            raw = console.input(prompt).strip()
+        except (KeyboardInterrupt, EOFError):
+            console.print()
+            app_ctx.output.message("aborted.")
+            raise typer.Exit(130)
+        if not raw:
+            console.print("  a value is required", style=STYLE_HINT)
+            continue
+        if raw.isdigit() and local:
+            index = int(raw)
+            if 1 <= index <= len(local):
+                chosen = local[index - 1]
+                app_ctx.output.name_address(chosen.ss58, f"{app_ctx.wallet_name}/{chosen.name}")
+                kwargs[hotkey_field] = chosen.ss58
+                return [flag, chosen.ss58]
+            console.print(f"  enter a number between 1 and {len(local)}", style=STYLE_HINT)
+            continue
+        try:
+            address = app_ctx.resolve_address(hotkey_field, raw)
+        except typer.Exit:
+            continue  # the resolver already printed its own error
+        kwargs[hotkey_field] = address
+        return [flag, address]
+
+
+def with_free_balance(spec: PromptSpec) -> PromptSpec:
+    """Wrap an amount PromptSpec so the prompt leads with the free balance.
+
+    The amount these ops spend comes straight out of the coldkey's free
+    balance, so it is read (from the proxied account with --proxy-for,
+    otherwise the signing wallet) and shown before asking. Parsing and the
+    skip-the-prompts hint stay exactly as the plain spec would have them.
+    """
+
+    def _flow(console: Console, app_ctx: AppContext, kwargs: dict) -> list[str]:
+        owner, owner_label = _stake_owner(app_ctx, kwargs)
+        with console.status("[dim]reading balance…[/dim]"):
+            balance = app_ctx.run(lambda c: c.read("balance", coldkey_ss58=owner))
+        console.print(f"  [dim]free balance of {owner_label}: {balance}[/dim]")
+        value, raw = _ask(console, app_ctx, replace(spec, custom=None))
+        kwargs[spec.field] = value
+        return [spec.flag, raw]
+
+    return replace(spec, custom=_flow)
 
 
 def stake_source_spec(hotkey_field: str, netuid_field: Optional[str]) -> PromptSpec:

--- a/sdk/python/bittensor/cli/tx.py
+++ b/sdk/python/bittensor/cli/tx.py
@@ -29,7 +29,14 @@ from . import globals as g
 from .context import AppContext, address_cli_name, ctx_of, ss58_param_help
 from .prompt import PromptSpec, fill_missing, interactive, signer_specs
 from .root_helpers import claim_root_source_spec
-from .stake_picker import STAKE_SOURCE_FIELDS, stake_source_spec
+from .stake_picker import (
+    FREE_BALANCE_AMOUNT_FIELDS,
+    STAKE_SOURCE_FIELDS,
+    STAKE_TARGET_FIELDS,
+    stake_source_spec,
+    stake_target_spec,
+    with_free_balance,
+)
 
 # Field annotation (as a string, under PEP 563) -> the Python type Typer should
 # parse the option as. List/complex fields are taken as strings and parsed in the
@@ -266,6 +273,29 @@ def _make_command(intent_cls: type[Intent]):
         ):
             missing = [spec for spec in missing if spec.field != "hotkey_ss58"]
             missing.insert(0, claim_root_source_spec("hotkey_ss58"))
+        # Stake-destination ops (add_stake & co) pick their target hotkey from
+        # the wallet's own hotkeys — but any pasted ss58 / address-book name
+        # works, since the destination never has to exist locally — and their
+        # amount prompt leads with the coldkey's free balance so the answer
+        # (including `all`) can be an informed one.
+        prompts_ok = (
+            not app_ctx.assume_yes and not app_ctx.uses_extension_signer() and interactive(app_ctx)
+        )
+        target_field = STAKE_TARGET_FIELDS.get(intent_cls.op)
+        balance_field = FREE_BALANCE_AMOUNT_FIELDS.get(intent_cls.op)
+        if target_field is not None and kwargs.get(target_field) is None and prompts_ok:
+            # The picker slots in just before the amount, so the prompt order
+            # narrows down naturally: subnet, then validator, then how much.
+            index = next(
+                (i for i, spec in enumerate(missing) if spec.field == balance_field),
+                len(missing),
+            )
+            missing.insert(index, stake_target_spec(target_field))
+        if balance_field is not None and prompts_ok:
+            missing = [
+                with_free_balance(spec) if spec.field == balance_field else spec
+                for spec in missing
+            ]
         # The signing wallet is confirmed too (Enter accepts the configured
         # default); --yes and the extension signer keep the flag-only flow.
         if not app_ctx.assume_yes and not app_ctx.uses_extension_signer():

--- a/sdk/python/bittensor/intents/governance.py
+++ b/sdk/python/bittensor/intents/governance.py
@@ -9,6 +9,7 @@ from .._generated import calls
 from ._money import Money, Spend, tao_amount
 from .base import Intent
 from .registry import register
+from .staking import DEFAULT_RATE_TOLERANCE, _alpha_price_rao, _check_rate_tolerance
 
 
 @register
@@ -63,25 +64,35 @@ class StakeBurn(Intent):
     so this is not an investment call; use a regular add-stake intent to
     acquire a position. Fails on the root subnet
     (``CannotBurnOrRecycleOnRootSubnet``). The chain accepts an optional
-    limit (omitted = market order), but this intent always requires
-    ``limit_price`` and executes all-or-nothing: the swap fails instead of
-    partially filling at a worse rate. Counts against a configured spend
-    cap.
+    limit (omitted = market order), but this intent always submits one and
+    executes all-or-nothing: the swap fails instead of partially filling at
+    a worse rate. When ``limit_price`` is omitted, the limit is derived from
+    the current pool price plus ``rate_tolerance`` (5% by default). Counts
+    against a configured spend cap.
     """
 
     op = "stake_burn"
     signer = "coldkey"
     wraps = (("SubtensorModule", "add_stake_burn"),)
+    mev_shield_default = True
 
     netuid: int = field(metadata={"help": "Subnet whose alpha is bought and burned."})
     amount_tao: Money = field(
         metadata={"help": "Spent from the coldkey to buy alpha that is then burned."}
     )
-    limit_price: int = field(
+    limit_price: Optional[int] = field(
+        default=None,
         metadata={
             "help": "Worst acceptable price in rao per alpha; the call fails rather than "
-            "filling beyond it."
-        }
+            "filling beyond it. Defaults to the current pool price plus `rate_tolerance`."
+        },
+    )
+    rate_tolerance: float = field(
+        default=DEFAULT_RATE_TOLERANCE,
+        metadata={
+            "help": "Maximum price move accepted when `limit_price` is omitted, as a "
+            "fraction (0.05 = 5%). Ignored when `limit_price` is given."
+        },
     )
     hotkey_ss58: Optional[str] = field(
         default=None,
@@ -90,15 +101,21 @@ class StakeBurn(Intent):
 
     def __post_init__(self):
         self.amount_tao = tao_amount(self.amount_tao)
+        _check_rate_tolerance(self.rate_tolerance)
 
     async def build(self, substrate, wallet: Any):
         hotkey = self.hotkey_address(wallet, self.hotkey_ss58)
+        if self.limit_price is not None:
+            limit = self.limit_price
+        else:
+            price = await _alpha_price_rao(substrate, self.netuid)
+            limit = int(price * (1 + self.rate_tolerance))
         return await substrate.compose(
             calls.SubtensorModule.add_stake_burn(
                 hotkey=hotkey,
                 netuid=self.netuid,
                 amount=self.amount_tao.rao,
-                limit=self.limit_price,
+                limit=limit,
             )
         )
 

--- a/sdk/python/bittensor/intents/staking.py
+++ b/sdk/python/bittensor/intents/staking.py
@@ -6,7 +6,7 @@ import asyncio
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, Optional
 
-from .._generated import calls
+from .._generated import calls, constants
 from .._generated import storage as st
 from .._generated.runtime_apis import BetaBasketRuntimeApi, StakeInfoRuntimeApi, SwapRuntimeApi
 from ..balance import Balance
@@ -72,6 +72,30 @@ async def _alpha_price_rao(substrate, netuid: int) -> int:
             "limit; retry, or disable slippage protection to submit without a bound"
         )
     return int(price)
+
+
+# Reserved on top of the existential deposit when staking ``all``, so the
+# transaction fee never makes the build unaffordable (typical fees are ~τ0.000125).
+_ALL_STAKE_FEE_HEADROOM_RAO = 500_000  # τ0.0005
+
+
+async def _stakeable_rao(substrate, wallet: Any) -> int:
+    """The coldkey's free balance minus the existential deposit and a fee headroom.
+
+    Resolves an ``amount = "all"`` for ``add_stake`` at build time; refuses to
+    build when the remainder is nothing.
+    """
+    coldkey = public_view(wallet, "coldkey").ss58_address
+    account = await substrate.query(*st.System.Account, [coldkey])
+    free = int(((account or {}).get("data") or {}).get("free") or 0)
+    deposit = int(await substrate.constant(*constants.Balances.ExistentialDeposit))
+    rao = free - deposit - _ALL_STAKE_FEE_HEADROOM_RAO
+    if rao <= 0:
+        raise BittensorError(
+            f"nothing to stake: free balance {Balance.from_rao(free)} does not cover "
+            "the existential deposit plus the transaction fee"
+        )
+    return rao
 
 
 async def _staked_rao(substrate, wallet: Any, hotkey_ss58: str, netuid: int) -> int:
@@ -154,23 +178,30 @@ class AddStake(Intent):
     tolerance or set ``slippage_protection`` to False to execute at any price,
     or use ``add_stake_limit`` to set an explicit limit price. The position's
     value then follows the pool price and the validator's performance, and can
-    be exited later with ``remove_stake``. Fails if the coldkey's free balance
-    cannot cover the amount plus the transaction fee, and with ``AmountTooLow``
-    when the amount is below the chain minimum of 0.002 TAO plus the swap fee.
-    Dynamic subnets also reject a single swap larger than 1000x the pool's TAO
-    reserve (``InsufficientLiquidity``).
+    be exited later with ``remove_stake``. Pass ``all`` to stake the whole free
+    balance minus the existential deposit and a small fee headroom. Fails if
+    the coldkey's free balance cannot cover the amount plus the transaction
+    fee, and with ``AmountTooLow`` when the amount is below the chain minimum
+    of 0.002 TAO plus the swap fee. Dynamic subnets also reject a single swap
+    larger than 1000x the pool's TAO reserve (``InsufficientLiquidity``).
     """
 
     op = "add_stake"
     signer = "coldkey"
     wraps = (("SubtensorModule", "add_stake"), ("SubtensorModule", "add_stake_limit"))
     mev_shield_default = True
+    all_amount_fields: ClassVar[tuple[str, ...]] = ("amount_tao",)
 
     hotkey_ss58: str = field(
         metadata={"help": "Hotkey the stake is added to (the validator you are backing)."}
     )
     netuid: int = field(metadata={"help": NETUID_HELP})
-    amount_tao: Money = field(metadata={"help": "How much of the coldkey's free balance to stake."})
+    amount_tao: Money = field(
+        metadata={
+            "help": "How much of the coldkey's free balance to stake, or `all` "
+            "(everything minus the existential deposit and fee headroom)."
+        }
+    )
     slippage_protection: bool = field(default=True, metadata={"help": SLIPPAGE_PROTECTION_HELP})
     rate_tolerance: float = field(
         default=DEFAULT_RATE_TOLERANCE, metadata={"help": RATE_TOLERANCE_HELP}
@@ -178,18 +209,22 @@ class AddStake(Intent):
 
     def __post_init__(self):
         self.amount_tao = call_amount(
-            self.amount_tao, self.wraps[0], "amount_staked", netuid=self.netuid
+            self.amount_tao, self.wraps[0], "amount_staked", netuid=self.netuid, allow_all=True
         )
         _check_rate_tolerance(self.rate_tolerance)
 
     async def build(self, substrate, wallet: Any):
+        if self.amount_tao == ALL:
+            rao = await _stakeable_rao(substrate, wallet)
+        else:
+            rao = self.amount_tao.rao
         if self.slippage_protection:
             price = await _alpha_price_rao(substrate, self.netuid)
             return await substrate.compose(
                 calls.SubtensorModule.add_stake_limit(
                     hotkey=self.hotkey_ss58,
                     netuid=self.netuid,
-                    amount_staked=self.amount_tao.rao,
+                    amount_staked=rao,
                     limit_price=int(price * (1 + self.rate_tolerance)),
                     allow_partial=False,
                 )
@@ -198,19 +233,31 @@ class AddStake(Intent):
             calls.SubtensorModule.add_stake(
                 hotkey=self.hotkey_ss58,
                 netuid=self.netuid,
-                amount_staked=self.amount_tao.rao,
+                amount_staked=rao,
             )
         )
 
     def summary(self) -> str:
+        amount = "ALL free TAO" if self.amount_tao == ALL else str(self.amount_tao)
         note = (
             f" (fails if price moves >{self.rate_tolerance:.2%})"
             if self.slippage_protection
             else " (no slippage protection)"
         )
-        return f"stake {self.amount_tao} to {self.hotkey_ss58} on netuid {self.netuid}{note}"
+        return f"stake {amount} to {self.hotkey_ss58} on netuid {self.netuid}{note}"
+
+    async def warnings(self, substrate, signer_address: str) -> list[str]:
+        if self.amount_tao == ALL:
+            return [
+                "stakes the entire free balance (minus the existential deposit "
+                "and fee headroom)"
+            ]
+        return []
 
     def spend(self) -> Spend:
+        if self.amount_tao == ALL:
+            # Unbounded: a max_spend policy should block draining the whole account.
+            return UNBOUNDED
         return self.amount_tao
 
 

--- a/website/apps/bittensor-website/public/catalog/intents.json
+++ b/website/apps/bittensor-website/public/catalog/intents.json
@@ -56,9 +56,9 @@
         "pallet": "SubtensorModule",
         "call": "add_collateral",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2526,
-        "end_line": 2534,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2524-L2534",
+        "line": 2531,
+        "end_line": 2539,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2529-L2539",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -116,7 +116,7 @@
   {
     "name": "add_stake",
     "summary": "Stake TAO from the coldkey onto a hotkey.",
-    "description": "Stake TAO from the coldkey onto a hotkey.\n\nSwaps TAO from the coldkey's free balance into the subnet's alpha at the\ncurrent pool price and credits the result to your stake on the hotkey; on\nnetuid 0 (root) the stake stays TAO-denominated. The swap moves the pool,\nso large amounts incur slippage. By default the call is slippage-protected:\nit fails (`SlippageTooHigh`) instead of filling once the price rises more\nthan `rate_tolerance` (5%) above the price at submission \u2014 raise the\ntolerance or set `slippage_protection` to False to execute at any price,\nor use `add_stake_limit` to set an explicit limit price. The position's\nvalue then follows the pool price and the validator's performance, and can\nbe exited later with `remove_stake`. Fails if the coldkey's free balance\ncannot cover the amount plus the transaction fee, and with `AmountTooLow`\nwhen the amount is below the chain minimum of 0.002 TAO plus the swap fee.\nDynamic subnets also reject a single swap larger than 1000x the pool's TAO\nreserve (`InsufficientLiquidity`).",
+    "description": "Stake TAO from the coldkey onto a hotkey.\n\nSwaps TAO from the coldkey's free balance into the subnet's alpha at the\ncurrent pool price and credits the result to your stake on the hotkey; on\nnetuid 0 (root) the stake stays TAO-denominated. The swap moves the pool,\nso large amounts incur slippage. By default the call is slippage-protected:\nit fails (`SlippageTooHigh`) instead of filling once the price rises more\nthan `rate_tolerance` (5%) above the price at submission \u2014 raise the\ntolerance or set `slippage_protection` to False to execute at any price,\nor use `add_stake_limit` to set an explicit limit price. The position's\nvalue then follows the pool price and the validator's performance, and can\nbe exited later with `remove_stake`. Pass `all` to stake the whole free\nbalance minus the existential deposit and a small fee headroom. Fails if\nthe coldkey's free balance cannot cover the amount plus the transaction\nfee, and with `AmountTooLow` when the amount is below the chain minimum\nof 0.002 TAO plus the swap fee. Dynamic subnets also reject a single swap\nlarger than 1000x the pool's TAO reserve (`InsufficientLiquidity`).",
     "signer": "coldkey",
     "origin": "signed",
     "verify": null,
@@ -151,9 +151,15 @@
               "type": "string",
               "pattern": "^\\d+(\\.\\d+)?$",
               "description": "decimal string, for amounts too large for an exact float"
+            },
+            {
+              "type": "string",
+              "enum": [
+                "all"
+              ]
             }
           ],
-          "description": "How much of the coldkey's free balance to stake."
+          "description": "How much of the coldkey's free balance to stake, or `all` (everything minus the existential deposit and fee headroom)."
         },
         "slippage_protection": {
           "type": "boolean",
@@ -300,9 +306,9 @@
         "pallet": "SubtensorModule",
         "call": "announce_coldkey_swap",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2062,
-        "end_line": 2088,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2060-L2088",
+        "line": 2067,
+        "end_line": 2093,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2065-L2093",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -605,9 +611,9 @@
         "pallet": "SubtensorModule",
         "call": "clear_coldkey_swap_announcement",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2261,
-        "end_line": 2276,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2259-L2276",
+        "line": 2266,
+        "end_line": 2281,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2264-L2281",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -954,9 +960,9 @@
         "pallet": "SubtensorModule",
         "call": "dispute_coldkey_swap",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2131,
-        "end_line": 2148,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2129-L2148",
+        "line": 2136,
+        "end_line": 2153,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2134-L2153",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -1358,9 +1364,9 @@
         "pallet": "SubtensorModule",
         "call": "lock_stake",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2333,
-        "end_line": 2341,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2331-L2341",
+        "line": 2338,
+        "end_line": 2346,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2336-L2346",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -1405,9 +1411,9 @@
         "pallet": "SubtensorModule",
         "call": "move_lock",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2357,
-        "end_line": 2364,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2355-L2364",
+        "line": 2362,
+        "end_line": 2369,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2360-L2369",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -3188,9 +3194,9 @@
         "pallet": "SubtensorModule",
         "call": "set_min_collateral",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2561,
-        "end_line": 2568,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2559-L2568",
+        "line": 2566,
+        "end_line": 2573,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2564-L2573",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -3235,9 +3241,9 @@
         "pallet": "SubtensorModule",
         "call": "set_perpetual_lock",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2373,
-        "end_line": 2380,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2371-L2380",
+        "line": 2378,
+        "end_line": 2385,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2376-L2385",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -3290,9 +3296,9 @@
         "pallet": "SubtensorModule",
         "call": "sudo_set_root_claim_threshold",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2025,
-        "end_line": 2044,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2023-L2044",
+        "line": 2030,
+        "end_line": 2049,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2028-L2049",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -3619,7 +3625,7 @@
   {
     "name": "stake_burn",
     "summary": "Buy back / burn stake via the stake-burn extrinsic.",
-    "description": "Buy back / burn stake via the stake-burn extrinsic.\n\nSpends TAO from the signing coldkey to buy the subnet's alpha and burn it,\nreducing alpha supply (a buyback-and-burn) rather than adding to the\nsigner's stake. The TAO is spent permanently \u2014 nothing lands in your stake,\nso this is not an investment call; use a regular add-stake intent to\nacquire a position. Fails on the root subnet\n(`CannotBurnOrRecycleOnRootSubnet`). The chain accepts an optional\nlimit (omitted = market order), but this intent always requires\n`limit_price` and executes all-or-nothing: the swap fails instead of\npartially filling at a worse rate. Counts against a configured spend\ncap.",
+    "description": "Buy back / burn stake via the stake-burn extrinsic.\n\nSpends TAO from the signing coldkey to buy the subnet's alpha and burn it,\nreducing alpha supply (a buyback-and-burn) rather than adding to the\nsigner's stake. The TAO is spent permanently \u2014 nothing lands in your stake,\nso this is not an investment call; use a regular add-stake intent to\nacquire a position. Fails on the root subnet\n(`CannotBurnOrRecycleOnRootSubnet`). The chain accepts an optional\nlimit (omitted = market order), but this intent always submits one and\nexecutes all-or-nothing: the swap fails instead of partially filling at\na worse rate. When `limit_price` is omitted, the limit is derived from\nthe current pool price plus `rate_tolerance` (5% by default). Counts\nagainst a configured spend cap.",
     "signer": "coldkey",
     "origin": "signed",
     "verify": null,
@@ -3652,7 +3658,11 @@
         },
         "limit_price": {
           "type": "integer",
-          "description": "Worst acceptable price in rao per alpha; the call fails rather than filling beyond it."
+          "description": "Worst acceptable price in rao per alpha; the call fails rather than filling beyond it. Defaults to the current pool price plus `rate_tolerance`."
+        },
+        "rate_tolerance": {
+          "type": "number",
+          "description": "Maximum price move accepted when `limit_price` is omitted, as a fraction (0.05 = 5%). Ignored when `limit_price` is given."
         },
         "hotkey_ss58": {
           "type": "string",
@@ -3661,12 +3671,11 @@
       },
       "required": [
         "netuid",
-        "amount_tao",
-        "limit_price"
+        "amount_tao"
       ],
       "additionalProperties": false
     },
-    "cli": "btcli tx stake-burn --netuid <int> --amount-tao <amount|all> --limit-price <int>",
+    "cli": "btcli tx stake-burn --netuid <int> --amount-tao <amount|all>",
     "python_class": "StakeBurn",
     "markdown_url": "/llms.mdx/docs/tx/stake-burn/content.md",
     "sources": [
@@ -3674,9 +3683,9 @@
         "pallet": "SubtensorModule",
         "call": "add_stake_burn",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2245,
-        "end_line": 2253,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2243-L2253",
+        "line": 2250,
+        "end_line": 2258,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2248-L2258",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -3758,9 +3767,9 @@
         "pallet": "SubtensorModule",
         "call": "swap_coldkey_announced",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2100,
-        "end_line": 2120,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2098-L2120",
+        "line": 2105,
+        "end_line": 2125,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2103-L2125",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -4127,9 +4136,9 @@
         "pallet": "SubtensorModule",
         "call": "transfer_stake_and_hotkey",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2468,
-        "end_line": 2486,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2466-L2486",
+        "line": 2473,
+        "end_line": 2491,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2471-L2491",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]


### PR DESCRIPTION
## Summary

Fixes the `btcli stake add` flow that currently dead-ends when the validator hotkey isn't a local keyfile ("no hotkey in wallet '…' named '5FTV…' (available: none)"), and rounds out the staking UX:

- **`stake add` shows your free balance before asking how much to stake**, and the amount now accepts **`all`** — everything minus the existential deposit and a small fee headroom (resolved from chain state at build time; treated as an unbounded spend by spend-cap policies).
- **`stake add` offers the wallet's local hotkeys as a numbered picker** for the target validator, and **any pasted ss58 address, address-book name, or `WALLET/HOTKEY` is accepted** — staking to a validator never required its keyfile, now the CLI agrees.
- **Every prompted target hotkey/coldkey now accepts a pasted ss58 / address-book name** (e.g. `stake show`, `stake set-auto`, `stake child get`). Signer prompts stay strict: only keys that actually sign must exist locally.
- **`btcli stake burn`** mounts the existing `stake_burn` intent (buyback-and-burn via `add_stake_burn`) in the stake group. Its `limit_price` is now optional, defaulting to the current pool price plus a 5% `rate_tolerance` (same pattern as `add_stake`'s slippage protection), and it's MEV-shielded by default like the other pool-trading intents.

Docs under `docs/tx/` are regenerated from the registries (includes pre-existing Rust line-number drift in a few unrelated pages, since the generator links current `dispatches.rs` line ranges).

## Test plan

- [x] `pytest tests/unit` (1069 passed)
- [x] `codegen.check --coverage/--units/--names` green
- [x] `scripts/generate.py --check` green
- [x] Interactive pty run: `st add -w <wallet-with-hotkeys>` shows picker + free balance, accepts `all`, plan warns and summarizes "stake ALL free TAO…" (aborted at confirm)
- [x] Interactive pty run: `st add -w <wallet-without-hotkeys>` prompts for a pasted ss58 and proceeds
- [x] Interactive pty run: `stake show` accepts a pasted validator ss58 at the `--wallet-hotkey` prompt
- [x] `AddStake(amount_tao="all")` and `StakeBurn(limit_price=None)` build real calls against finney

Made with [Cursor](https://cursor.com)