### PR TITLE
feat(cli): machine-readable dry-run plans with spend, args, and replay command

### DIFF
--- a/sdk/python/bittensor/cli/call.py
+++ b/sdk/python/bittensor/cli/call.py
@@ -56,6 +56,7 @@ from ..intents.proxy import ProxyTypeChoice
 from . import multisig_helpers as ms_helpers
 from .context import ctx_of
 from .globals import with_tx_globals
+from .prompt import replay_command
 
 _MAX_SHOWN = 80  # truncate long param values (e.g. a wasm blob) in dry-run output
 
@@ -250,6 +251,7 @@ def call(
                 fields["multisig_preset"] = preset
         else:
             app_ctx.run(lambda client: _compose_only(client, prepare))
+        fields["command"] = replay_command()
         app_ctx.output.detail("dry run: raw call", fields)
         return
 

--- a/sdk/python/bittensor/cli/context.py
+++ b/sdk/python/bittensor/cli/context.py
@@ -436,7 +436,7 @@ class AppContext:
         """
         # Inline import: prompt.py imports AppContext from this module, so a
         # top-level import here would be circular.
-        from .prompt import confirm_wallet
+        from .prompt import confirm_wallet, replay_command
 
         if proxy_for == "self":
             proxy_for = None
@@ -628,7 +628,7 @@ class AppContext:
                 shortfall = self.run(_shield_fee_warning)
                 if shortfall is not None:
                     plan.warnings.append(shortfall)
-            self.output.plan(plan)
+            self.output.plan(plan, command=replay_command())
             if not plan.ok:
                 raise typer.Exit(1)
             return None

--- a/sdk/python/bittensor/cli/output.py
+++ b/sdk/python/bittensor/cli/output.py
@@ -1378,10 +1378,19 @@ class Output:
         line.append(text, style=STYLE_COMMAND)
         self._out.print(line, soft_wrap=True)
 
-    def plan(self, plan: Plan) -> None:
-        """Render a dry-run plan (fee, effects, warnings, policy)."""
+    def plan(self, plan: Plan, *, command: Optional[str] = None) -> None:
+        """Render a dry-run plan (fee, effects, warnings, policy).
+
+        ``command`` is the replay command that submits this exact invocation
+        for real: shown as a copy-paste line, and carried in the JSON record
+        so an agent can pre-approve the plan and hand a human (or a later
+        automation step) the one command to run.
+        """
         if self.json_mode:
-            self._json(plan.to_dict())
+            record = plan.to_dict()
+            if command:
+                record["command"] = command
+            self._json(record)
             return
         summary = Text()
         summary.append("dry run:", style="dim")
@@ -1417,6 +1426,11 @@ class Output:
             )
         if not plan.ok:
             self._out.print(f"  [{STYLE_ERROR}]blocked by policy[/{STYLE_ERROR}]")
+        if command and plan.ok:
+            line = Text("  ")
+            line.append("run for real  ", style=STYLE_HINT)
+            line.append(command, style=STYLE_COMMAND)
+            self._out.print(line, soft_wrap=True)
         # The docs page carries parameters, verify reads, and the on-chain
         # implementation with source links.
         self._sub_diag("see", tx_docs_url(plan.op), console=self._out)

--- a/sdk/python/bittensor/cli/prompt.py
+++ b/sdk/python/bittensor/cli/prompt.py
@@ -316,6 +316,21 @@ def signer_specs(
     return specs
 
 
+def replay_command() -> str:
+    """The command that submits this invocation for real: the current argv plus
+    any prompted answers, minus ``--dry-run`` and ``--json``, quoted for
+    copy-paste. This is what a dry run hands to whoever actually runs it — the
+    confirmation prompt is kept (no ``--yes`` is injected), so the human still
+    sees the summary before signing; automation can append ``--yes --json``.
+    """
+    drop = {"--dry-run", "--json"}
+    tokens = [
+        Path(sys.argv[0]).name,
+        *(token for token in [*sys.argv[1:], *_entered_tokens] if token not in drop),
+    ]
+    return " ".join(shlex.quote(part) for part in tokens)
+
+
 def _flush_command_hint(exit_code: int) -> None:
     """Echo the equivalent non-interactive command so the flags are learnable.
 

--- a/sdk/python/bittensor/executor.py
+++ b/sdk/python/bittensor/executor.py
@@ -523,6 +523,8 @@ class Executor:
             violations=violations,
             call=call,
             extras=extras,
+            spend=intent.spend(),
+            args={k: v for k, v in intent.to_dict().items() if k != "op"},
         )
 
     async def execute(

--- a/sdk/python/bittensor/intents/plan.py
+++ b/sdk/python/bittensor/intents/plan.py
@@ -13,7 +13,7 @@ from typing import Any, Optional
 
 from ..balance import Balance
 from ..settings import tx_docs_url
-from ._money import UNBOUNDED, Money, tao_amount
+from ._money import UNBOUNDED, Money, Spend, tao_amount
 from .base import Intent
 
 
@@ -86,7 +86,15 @@ class Policy:
 
 @dataclass
 class Plan:
-    """A previewed, not-yet-submitted intent."""
+    """A previewed, not-yet-submitted intent.
+
+    ``to_dict`` is the machine-readable pre-approval record: alongside the
+    fee, effects, warnings, and policy verdict it carries the exact spend
+    (``spend_tao``, or ``spend_unbounded`` when the amount cannot be bounded
+    before execution — full-balance sweeps and ownership transfers) and the
+    intent's exact parsed arguments, so an agent can verify precisely what
+    would run before anyone signs.
+    """
 
     op: str
     summary: str
@@ -98,6 +106,10 @@ class Plan:
     violations: list[str] = field(default_factory=list)
     call: Any = field(default=None, repr=False)  # built call; not serialized
     extras: dict[str, Any] = field(default_factory=dict)  # build-time data for the result
+    # TAO leaving the signer: a Balance when bounded, UNBOUNDED, or None.
+    spend: Spend = None
+    # The intent's own parameters, JSON-native (money as exact decimal strings).
+    args: Optional[dict[str, Any]] = None
 
     @property
     def ok(self) -> bool:
@@ -110,7 +122,10 @@ class Plan:
             "summary": self.summary,
             "signer": self.signer,
             "signer_address": self.signer_address,
+            "args": self.args,
             "fee_tao": self.fee.tao if self.fee is not None else None,
+            "spend_tao": self.spend.tao if isinstance(self.spend, Balance) else None,
+            "spend_unbounded": self.spend is UNBOUNDED,
             "effects": self.effects,
             "warnings": self.warnings,
             "violations": self.violations,


### PR DESCRIPTION
## Summary

`--dry-run --json` becomes a complete pre-approval record: an agent can dry-run a transaction, verify exactly what would happen, and hand a human (or a later automation step) the one command that submits it for real.

New fields in the plan JSON:

- **`spend_tao`** — exact TAO leaving the signer, from `intent.spend()`; `null` when the amount cannot be bounded before execution
- **`spend_unbounded`** — `true` for full-balance sweeps (`--amount all`) and ownership transfers, so a reviewer knows the spend has no upper bound
- **`args`** — the intent's exact parsed parameters (money as exact decimal strings), so what was parsed can be verified against what was intended
- **`command`** — the replay command: the current invocation plus any prompted answers, minus `--dry-run`/`--json`, shell-quoted. No `--yes` is injected, so a human still gets the confirmation prompt; automation appends `--yes --json` itself

Human-mode dry runs print the same replay command as a `run for real` line, and raw-call dry runs (`btcli call ... --dry-run`) carry the `command` field too.

Example:

```json
{
  "op": "transfer",
  "summary": "transfer ALL TAO to 5Fn7...",
  "signer": "coldkey",
  "signer_address": "5Fc3...",
  "args": {"dest_ss58": "5Fn7...", "amount_tao": "all", "keep_alive": true},
  "fee_tao": 0.000170824,
  "spend_tao": null,
  "spend_unbounded": true,
  "warnings": ["transfers the entire transferable balance"],
  "violations": [],
  "ok": true,
  "docs_url": "https://www.bittensor.com/docs/tx/transfer",
  "command": "btcli tx transfer --dest 5Fn7... --amount all -w affine --network finney"
}
```

## Test plan

- [x] `pytest tests/unit` — 1069 passed
- [x] `ruff check` / `ruff format --check` on changed files
- [x] Live Finney dry runs: bounded transfer (`spend_tao` exact), `--amount all` (`spend_unbounded: true` + warning), human mode (`run for real` line), raw call (`command` in fields)
- [x] Interactive dry run: prompted `--amount-tao` answer is folded into the replay command

Made with [Cursor](https://cursor.com)