### PR TITLE
Recycle transaction fees instead of rewarding block authors

### DIFF
--- a/docs/tx/add-collateral.mdx
+++ b/docs/tx/add-collateral.mdx
@@ -23,7 +23,7 @@ to clear unshielded at an unbounded AMM price.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.add_collateral`](/code/pallets/subtensor/src/macros/dispatches.rs#L2524-L2534) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.add_collateral`](/code/pallets/subtensor/src/macros/dispatches.rs#L2529-L2539) |
 
 ## Parameters
 
@@ -77,7 +77,7 @@ result = sub.execute_tool("add_collateral", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.add_collateral` — [`pallets/subtensor/src/macros/dispatches.rs#L2526`](/code/pallets/subtensor/src/macros/dispatches.rs#L2524-L2534):
+`SubtensorModule.add_collateral` — [`pallets/subtensor/src/macros/dispatches.rs#L2531`](/code/pallets/subtensor/src/macros/dispatches.rs#L2529-L2539):
 
 ```rust
 #[pallet::call_index(144)]

--- a/docs/tx/announce-coldkey-swap.mdx
+++ b/docs/tx/announce-coldkey-swap.mdx
@@ -23,7 +23,7 @@ an unauthorized one with `dispute_coldkey_swap`.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.announce_coldkey_swap`](/code/pallets/subtensor/src/macros/dispatches.rs#L2060-L2088) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.announce_coldkey_swap`](/code/pallets/subtensor/src/macros/dispatches.rs#L2065-L2093) |
 
 ## Parameters
 
@@ -72,7 +72,7 @@ result = sub.execute_tool("announce_coldkey_swap", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.announce_coldkey_swap` — [`pallets/subtensor/src/macros/dispatches.rs#L2062`](/code/pallets/subtensor/src/macros/dispatches.rs#L2060-L2088):
+`SubtensorModule.announce_coldkey_swap` — [`pallets/subtensor/src/macros/dispatches.rs#L2067`](/code/pallets/subtensor/src/macros/dispatches.rs#L2065-L2093):
 
 ```rust
 #[pallet::call_index(125)]

--- a/docs/tx/clear-coldkey-swap-announcement.mdx
+++ b/docs/tx/clear-coldkey-swap-announcement.mdx
@@ -17,7 +17,7 @@ right call instead.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.clear_coldkey_swap_announcement`](/code/pallets/subtensor/src/macros/dispatches.rs#L2259-L2276) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.clear_coldkey_swap_announcement`](/code/pallets/subtensor/src/macros/dispatches.rs#L2264-L2281) |
 
 ## Parameters
 
@@ -62,7 +62,7 @@ result = sub.execute_tool("clear_coldkey_swap_announcement", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.clear_coldkey_swap_announcement` — [`pallets/subtensor/src/macros/dispatches.rs#L2261`](/code/pallets/subtensor/src/macros/dispatches.rs#L2259-L2276):
+`SubtensorModule.clear_coldkey_swap_announcement` — [`pallets/subtensor/src/macros/dispatches.rs#L2266`](/code/pallets/subtensor/src/macros/dispatches.rs#L2264-L2281):
 
 ```rust
 #[pallet::call_index(133)]

--- a/docs/tx/dispute-coldkey-swap.mdx
+++ b/docs/tx/dispute-coldkey-swap.mdx
@@ -18,7 +18,7 @@ you made yourself.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.dispute_coldkey_swap`](/code/pallets/subtensor/src/macros/dispatches.rs#L2129-L2148) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.dispute_coldkey_swap`](/code/pallets/subtensor/src/macros/dispatches.rs#L2134-L2153) |
 
 ## Parameters
 
@@ -63,7 +63,7 @@ result = sub.execute_tool("dispute_coldkey_swap", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.dispute_coldkey_swap` — [`pallets/subtensor/src/macros/dispatches.rs#L2131`](/code/pallets/subtensor/src/macros/dispatches.rs#L2129-L2148):
+`SubtensorModule.dispute_coldkey_swap` — [`pallets/subtensor/src/macros/dispatches.rs#L2136`](/code/pallets/subtensor/src/macros/dispatches.rs#L2134-L2153):
 
 ```rust
 #[pallet::call_index(127)]

--- a/docs/tx/lock-stake.mdx
+++ b/docs/tx/lock-stake.mdx
@@ -21,7 +21,7 @@ persists is controlled per coldkey per subnet with
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.lock_stake`](/code/pallets/subtensor/src/macros/dispatches.rs#L2331-L2341) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.lock_stake`](/code/pallets/subtensor/src/macros/dispatches.rs#L2336-L2346) |
 
 ## Parameters
 
@@ -74,7 +74,7 @@ result = sub.execute_tool("lock_stake", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.lock_stake` — [`pallets/subtensor/src/macros/dispatches.rs#L2333`](/code/pallets/subtensor/src/macros/dispatches.rs#L2331-L2341):
+`SubtensorModule.lock_stake` — [`pallets/subtensor/src/macros/dispatches.rs#L2338`](/code/pallets/subtensor/src/macros/dispatches.rs#L2336-L2346):
 
 ```rust
 #[pallet::call_index(136)]

--- a/docs/tx/move-lock.mdx
+++ b/docs/tx/move-lock.mdx
@@ -16,7 +16,7 @@ existing lock on the subnet to move.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.move_lock`](/code/pallets/subtensor/src/macros/dispatches.rs#L2355-L2364) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.move_lock`](/code/pallets/subtensor/src/macros/dispatches.rs#L2360-L2369) |
 
 ## Parameters
 
@@ -68,7 +68,7 @@ result = sub.execute_tool("move_lock", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.move_lock` — [`pallets/subtensor/src/macros/dispatches.rs#L2357`](/code/pallets/subtensor/src/macros/dispatches.rs#L2355-L2364):
+`SubtensorModule.move_lock` — [`pallets/subtensor/src/macros/dispatches.rs#L2362`](/code/pallets/subtensor/src/macros/dispatches.rs#L2360-L2369):
 
 ```rust
 #[pallet::call_index(137)]

--- a/docs/tx/set-min-collateral.mdx
+++ b/docs/tx/set-min-collateral.mdx
@@ -15,7 +15,7 @@ immediately). Zero clears the floor and restores pure drain behavior.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.set_min_collateral`](/code/pallets/subtensor/src/macros/dispatches.rs#L2559-L2568) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.set_min_collateral`](/code/pallets/subtensor/src/macros/dispatches.rs#L2564-L2573) |
 
 ## Parameters
 
@@ -68,7 +68,7 @@ result = sub.execute_tool("set_min_collateral", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.set_min_collateral` — [`pallets/subtensor/src/macros/dispatches.rs#L2561`](/code/pallets/subtensor/src/macros/dispatches.rs#L2559-L2568):
+`SubtensorModule.set_min_collateral` — [`pallets/subtensor/src/macros/dispatches.rs#L2566`](/code/pallets/subtensor/src/macros/dispatches.rs#L2564-L2573):
 
 ```rust
 #[pallet::call_index(145)]

--- a/docs/tx/set-perpetual-lock.mdx
+++ b/docs/tx/set-perpetual-lock.mdx
@@ -15,7 +15,7 @@ illiquid until you switch back to decaying and the lock runs off.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.set_perpetual_lock`](/code/pallets/subtensor/src/macros/dispatches.rs#L2371-L2380) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.set_perpetual_lock`](/code/pallets/subtensor/src/macros/dispatches.rs#L2376-L2385) |
 
 ## Parameters
 
@@ -67,7 +67,7 @@ result = sub.execute_tool("set_perpetual_lock", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.set_perpetual_lock` — [`pallets/subtensor/src/macros/dispatches.rs#L2373`](/code/pallets/subtensor/src/macros/dispatches.rs#L2371-L2380):
+`SubtensorModule.set_perpetual_lock` — [`pallets/subtensor/src/macros/dispatches.rs#L2378`](/code/pallets/subtensor/src/macros/dispatches.rs#L2376-L2385):
 
 ```rust
 #[pallet::call_index(138)]

--- a/docs/tx/set-root-claim-threshold.mdx
+++ b/docs/tx/set-root-claim-threshold.mdx
@@ -19,7 +19,7 @@ effect afterwards with the `root_claim_threshold` read.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | root (chain sudo) | SubtensorModule | [`SubtensorModule.sudo_set_root_claim_threshold`](/code/pallets/subtensor/src/macros/dispatches.rs#L2023-L2044), `Sudo.sudo` |
+| `coldkey` | root (chain sudo) | SubtensorModule | [`SubtensorModule.sudo_set_root_claim_threshold`](/code/pallets/subtensor/src/macros/dispatches.rs#L2028-L2049), `Sudo.sudo` |
 
 ## Verify
 
@@ -77,7 +77,7 @@ result = sub.execute_tool("set_root_claim_threshold", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.sudo_set_root_claim_threshold` — [`pallets/subtensor/src/macros/dispatches.rs#L2025`](/code/pallets/subtensor/src/macros/dispatches.rs#L2023-L2044):
+`SubtensorModule.sudo_set_root_claim_threshold` — [`pallets/subtensor/src/macros/dispatches.rs#L2030`](/code/pallets/subtensor/src/macros/dispatches.rs#L2028-L2049):
 
 ```rust
 #[pallet::call_index(124)]

--- a/docs/tx/stake-burn.mdx
+++ b/docs/tx/stake-burn.mdx
@@ -18,7 +18,7 @@ cap.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.add_stake_burn`](/code/pallets/subtensor/src/macros/dispatches.rs#L2243-L2253) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.add_stake_burn`](/code/pallets/subtensor/src/macros/dispatches.rs#L2248-L2258) |
 
 ## Parameters
 
@@ -74,7 +74,7 @@ result = sub.execute_tool("stake_burn", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.add_stake_burn` — [`pallets/subtensor/src/macros/dispatches.rs#L2245`](/code/pallets/subtensor/src/macros/dispatches.rs#L2243-L2253):
+`SubtensorModule.add_stake_burn` — [`pallets/subtensor/src/macros/dispatches.rs#L2250`](/code/pallets/subtensor/src/macros/dispatches.rs#L2248-L2258):
 
 ```rust
 #[pallet::call_index(132)]

--- a/docs/tx/swap-coldkey-announced.mdx
+++ b/docs/tx/swap-coldkey-announced.mdx
@@ -15,7 +15,7 @@ future operations sign with the new coldkey.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.swap_coldkey_announced`](/code/pallets/subtensor/src/macros/dispatches.rs#L2098-L2120) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.swap_coldkey_announced`](/code/pallets/subtensor/src/macros/dispatches.rs#L2103-L2125) |
 
 ## Parameters
 
@@ -64,7 +64,7 @@ result = sub.execute_tool("swap_coldkey_announced", {...}, wallet)
 
 ## On-chain implementation
 
-`SubtensorModule.swap_coldkey_announced` — [`pallets/subtensor/src/macros/dispatches.rs#L2100`](/code/pallets/subtensor/src/macros/dispatches.rs#L2098-L2120):
+`SubtensorModule.swap_coldkey_announced` — [`pallets/subtensor/src/macros/dispatches.rs#L2105`](/code/pallets/subtensor/src/macros/dispatches.rs#L2103-L2125):
 
 ```rust
 #[pallet::call_index(126)]

--- a/docs/tx/transfer-stake.mdx
+++ b/docs/tx/transfer-stake.mdx
@@ -32,7 +32,7 @@ owners.
 
 | Signer | Origin | Pallet | Wraps |
 | --- | --- | --- | --- |
-| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.transfer_stake`](/code/pallets/subtensor/src/macros/dispatches.rs#L1324-L1342), [`SubtensorModule.transfer_stake_and_hotkey`](/code/pallets/subtensor/src/macros/dispatches.rs#L2466-L2486) |
+| `coldkey` | signed account (pallet role may apply) | SubtensorModule | [`SubtensorModule.transfer_stake`](/code/pallets/subtensor/src/macros/dispatches.rs#L1324-L1342), [`SubtensorModule.transfer_stake_and_hotkey`](/code/pallets/subtensor/src/macros/dispatches.rs#L2471-L2491) |
 
 ## Parameters
 
@@ -120,7 +120,7 @@ pub fn transfer_stake(
 
 Delegates to [`do_transfer_stake`](/code/pallets/subtensor/src/staking/move_stake.rs#L120).
 
-`SubtensorModule.transfer_stake_and_hotkey` — [`pallets/subtensor/src/macros/dispatches.rs#L2468`](/code/pallets/subtensor/src/macros/dispatches.rs#L2466-L2486):
+`SubtensorModule.transfer_stake_and_hotkey` — [`pallets/subtensor/src/macros/dispatches.rs#L2473`](/code/pallets/subtensor/src/macros/dispatches.rs#L2471-L2491):
 
 ```rust
 #[pallet::call_index(143)]

--- a/pallets/subtensor/src/tests/stake_into_basket.rs
+++ b/pallets/subtensor/src/tests/stake_into_basket.rs
@@ -577,11 +577,7 @@ fn test_root_slot_yield_accrues_to_share_holders() {
         // Bob buys in directly: all-root basket at N/P = 1, so his TAO mints 1:1 exactly.
         let b = 10_000_000u64;
         add_balance_to_coldkey_account(&bob, TaoBalance::from(2 * b));
-        assert_ok!(SubtensorModule::do_stake_into_basket(
-            bob,
-            hotkey,
-            b.into(),
-        ));
+        assert_ok!(SubtensorModule::do_stake_into_basket(bob, hotkey, b.into(),));
         assert_eq!(SubtensorModule::get_basket_owed_shares(&hotkey, &bob), b);
         let bob_payout_before = SubtensorModule::get_basket_payout_tao(&hotkey, &bob);
         assert_eq!(bob_payout_before, b, "N/P = 1: payout == shares == TAO in");

--- a/pallets/transaction-fee/src/lib.rs
+++ b/pallets/transaction-fee/src/lib.rs
@@ -21,7 +21,7 @@ use pallet_evm::{
 // Runtime
 use sp_runtime::{
     DispatchError, Perbill, Saturating,
-    traits::{AccountIdConversion, DispatchInfoOf, PostDispatchInfoOf},
+    traits::{DispatchInfoOf, PostDispatchInfoOf},
     transaction_validity::{InvalidTransaction, TransactionValidityError},
 };
 
@@ -178,21 +178,38 @@ where
                 return Err(InvalidTransaction::Payment.into());
             }
 
-            // Sell the Alpha fee and send the resulting TAO to the burn account.
-            let burn_account: AccountIdOf<T> = T::BurnAccountId::get().into_account_truncating();
+            // Sell the Alpha fee and recycle the resulting TAO directly from the subnet
+            // account. This avoids relying on the payer having enough TAO to keep an account
+            // alive. Keeping both operations in one storage transaction ensures that a failure
+            // to recycle the TAO also rolls back the Alpha withdrawal and AMM updates.
             with_transaction(
                 || -> TransactionOutcome<Result<TaoBalance, DispatchError>> {
+                    let Some(subnet_account) =
+                        pallet_subtensor::Pallet::<T>::get_subnet_account_id(*netuid)
+                    else {
+                        return TransactionOutcome::Rollback(Err(
+                            pallet_subtensor::Error::<T>::SubnetNotExists.into(),
+                        ));
+                    };
                     match pallet_subtensor::Pallet::<T>::unstake_from_subnet(
                         hotkey,
                         coldkey,
-                        &burn_account,
+                        &subnet_account,
                         *netuid,
                         alpha_fee,
                         0.into(),
                         true,
                         false,
                     ) {
-                        Ok(tao_amount) => TransactionOutcome::Commit(Ok(tao_amount)),
+                        Ok(tao_amount) => {
+                            match pallet_subtensor::Pallet::<T>::recycle_tao(
+                                &subnet_account,
+                                tao_amount,
+                            ) {
+                                Ok(()) => TransactionOutcome::Commit(Ok(tao_amount)),
+                                Err(err) => TransactionOutcome::Rollback(Err(err)),
+                            }
+                        }
                         Err(err) => TransactionOutcome::Rollback(Err(err)),
                     }
                 },

--- a/pallets/transaction-fee/src/lib.rs
+++ b/pallets/transaction-fee/src/lib.rs
@@ -21,7 +21,7 @@ use pallet_evm::{
 // Runtime
 use sp_runtime::{
     DispatchError, Perbill, Saturating,
-    traits::{DispatchInfoOf, PostDispatchInfoOf},
+    traits::{AccountIdConversion, DispatchInfoOf, PostDispatchInfoOf},
     transaction_validity::{InvalidTransaction, TransactionValidityError},
 };
 
@@ -37,7 +37,7 @@ use smallvec::smallvec;
 use sp_core::H160;
 use sp_runtime::traits::SaturatedConversion;
 use sp_std::vec::Vec;
-use subtensor_runtime_common::{AlphaBalance, AuthorshipInfo, NetUid, TaoBalance};
+use subtensor_runtime_common::{AlphaBalance, NetUid, TaoBalance};
 
 // Tests
 #[cfg(test)]
@@ -97,27 +97,21 @@ type BalancesImbalanceOf<T> = FungibleImbalance<
 
 impl<T> OnUnbalanced<BalancesImbalanceOf<T>> for TransactionFeeHandler<T>
 where
-    T: frame_system::Config
-        + pallet_balances::Config
-        + pallet_subtensor::Config
-        + AuthorshipInfo<AccountIdOf<T>>,
+    T: frame_system::Config + pallet_balances::Config + pallet_subtensor::Config,
     <T as pallet_balances::Config>::Balance: Into<TaoBalance> + Copy,
 {
     fn on_nonzero_unbalanced(imbalance: BalancesImbalanceOf<T>) {
-        if let Some(author) = T::author() {
-            // Pay block author
-            let _ = <pallet_balances::Pallet<T> as Balanced<_>>::resolve(&author, imbalance);
-        } else {
-            // Fallback: if no author, burn (or just drop).
-            drop(imbalance);
-        }
+        let amount = imbalance.peek().into();
+        pallet_subtensor::TotalIssuance::<T>::mutate(|total| {
+            *total = total.saturating_sub(amount);
+        });
+        drop(imbalance);
     }
 }
 
 /// Handle Alpha fees
 impl<T> AlphaFeeHandler<T> for TransactionFeeHandler<T>
 where
-    T: AuthorshipInfo<AccountIdOf<T>>,
     T: frame_system::Config,
     T: pallet_subtensor::Config,
     T: pallet_subtensor_swap::Config,
@@ -184,34 +178,30 @@ where
                 return Err(InvalidTransaction::Payment.into());
             }
 
-            // Sell alpha_fee and burn received tao (ignore unstake_from_subnet return).
-            if let Some(author) = T::author() {
-                with_transaction(
-                    || -> TransactionOutcome<Result<TaoBalance, DispatchError>> {
-                        match pallet_subtensor::Pallet::<T>::unstake_from_subnet(
-                            hotkey,
-                            coldkey,
-                            &author,
-                            *netuid,
-                            alpha_fee,
-                            0.into(),
-                            true,
-                            false,
-                        ) {
-                            Ok(tao_amount) => TransactionOutcome::Commit(Ok(tao_amount)),
-                            Err(err) => TransactionOutcome::Rollback(Err(err)),
-                        }
-                    },
-                )
-                .map(|tao_amount| (alpha_fee, tao_amount, *netuid))
-                .map_err(|err| {
-                    log::warn!("Error withdrawing transaction fee in alpha: {err:?}");
-                    InvalidTransaction::Payment.into()
-                })
-            } else {
-                // Fallback: no author => no fees (do nothing)
-                Ok((0.into(), 0.into(), NetUid::ROOT))
-            }
+            // Sell the Alpha fee and send the resulting TAO to the burn account.
+            let burn_account: AccountIdOf<T> = T::BurnAccountId::get().into_account_truncating();
+            with_transaction(
+                || -> TransactionOutcome<Result<TaoBalance, DispatchError>> {
+                    match pallet_subtensor::Pallet::<T>::unstake_from_subnet(
+                        hotkey,
+                        coldkey,
+                        &burn_account,
+                        *netuid,
+                        alpha_fee,
+                        0.into(),
+                        true,
+                        false,
+                    ) {
+                        Ok(tao_amount) => TransactionOutcome::Commit(Ok(tao_amount)),
+                        Err(err) => TransactionOutcome::Rollback(Err(err)),
+                    }
+                },
+            )
+            .map(|tao_amount| (alpha_fee, tao_amount, *netuid))
+            .map_err(|err| {
+                log::warn!("Error withdrawing transaction fee in alpha: {err:?}");
+                InvalidTransaction::Payment.into()
+            })
         } else {
             Ok((0.into(), 0.into(), NetUid::ROOT))
         }
@@ -257,7 +247,7 @@ impl<F, OU> SubtensorTxFeeHandler<F, OU> {
     /// distributed evenly between subnets in case of multiple subnets.
     pub fn fees_in_alpha<T>(who: &AccountIdOf<T>, call: &CallOf<T>) -> Vec<(AccountIdOf<T>, NetUid)>
     where
-        T: frame_system::Config + pallet_subtensor::Config + AuthorshipInfo<AccountIdOf<T>>,
+        T: frame_system::Config + pallet_subtensor::Config,
         CallOf<T>: IsSubType<pallet_subtensor::Call<T>>,
         OU: AlphaFeeHandler<T>,
     {
@@ -362,7 +352,7 @@ impl<F, OU> SubtensorTxFeeHandler<F, OU> {
 
 impl<T, F, OU> OnChargeTransaction<T> for SubtensorTxFeeHandler<F, OU>
 where
-    T: PTPConfig + pallet_subtensor::Config + AuthorshipInfo<AccountIdOf<T>>,
+    T: PTPConfig + pallet_subtensor::Config,
     CallOf<T>: IsSubType<pallet_subtensor::Call<T>>,
     F: Balanced<T::AccountId>,
     OU: OnUnbalanced<Credit<T::AccountId, F>> + AlphaFeeHandler<T>,
@@ -465,7 +455,6 @@ where
                     OU::on_unbalanceds(Some(fee).into_iter().chain(Some(tip)));
                 }
                 WithdrawnFee::Alpha((alpha_fee, tao_amount, netuid)) => {
-                    // Block author already received the fee in withdraw_in_alpha, nothing to do here.
                     frame_system::Pallet::<T>::deposit_event(
                         pallet_subtensor::Event::<T>::TransactionFeePaidWithAlpha {
                             who: who.clone(),
@@ -560,10 +549,7 @@ where
 
     fn pay_priority_fee(tip: Self::LiquidityInfo) {
         if let Some(tip) = tip {
-            let author = <T::AddressMapping as AddressMapping<T::AccountId>>::into_account_id(
-                pallet_evm::Pallet::<T>::find_author(),
-            );
-            let _ = F::resolve(&author, tip);
+            OU::on_unbalanced(tip);
         }
     }
 }

--- a/pallets/transaction-fee/src/tests/burning.rs
+++ b/pallets/transaction-fee/src/tests/burning.rs
@@ -1,0 +1,142 @@
+use super::mock::*;
+
+use frame_support::{assert_ok, dispatch::GetDispatchInfo, pallet_prelude::Zero};
+use sp_runtime::traits::{AccountIdConversion, DispatchTransaction};
+use subtensor_runtime_common::AlphaBalance;
+
+#[test]
+fn tao_transaction_fees_are_burned() {
+    new_test_ext().execute_with(|| {
+        let payer = U256::from(42u64);
+        let block_builder = U256::from(MOCK_BLOCK_BUILDER);
+        add_balance_to_coldkey_account(&payer, TaoBalance::from(TAO));
+
+        let payer_balance_before = Balances::free_balance(payer);
+        let block_builder_balance_before = Balances::free_balance(block_builder);
+        let balances_issuance_before = Balances::total_issuance();
+        let subtensor_issuance_before = SubtensorModule::get_total_issuance();
+        assert_eq!(balances_issuance_before, subtensor_issuance_before);
+
+        let call = RuntimeCall::System(frame_system::Call::remark {
+            remark: vec![0; 32],
+        });
+        let info = call.get_dispatch_info();
+        let ext = pallet_transaction_payment::ChargeTransactionPayment::<Test>::from(
+            TaoBalance::from(1_000u64),
+        );
+        assert_ok!(ext.dispatch_transaction(
+            RuntimeOrigin::signed(payer).into(),
+            call,
+            &info,
+            0,
+            0,
+        ));
+
+        let charged = payer_balance_before.saturating_sub(Balances::free_balance(payer));
+        assert!(!charged.is_zero());
+        assert_eq!(
+            Balances::free_balance(block_builder),
+            block_builder_balance_before
+        );
+        assert_eq!(
+            balances_issuance_before.saturating_sub(Balances::total_issuance()),
+            charged
+        );
+        assert_eq!(
+            subtensor_issuance_before.saturating_sub(SubtensorModule::get_total_issuance()),
+            charged
+        );
+    });
+}
+
+#[test]
+fn alpha_transaction_fees_are_burned_without_a_block_author() {
+    new_test_ext().execute_with(|| {
+        let stake_amount = TAO;
+        let unstake_amount = AlphaBalance::from(TAO / 50);
+        let setup = setup_subnets(1, 1);
+        let netuid = setup.subnets[0].netuid;
+        let hotkey = setup.hotkeys[0];
+        setup_stake(netuid, &setup.coldkey, &hotkey, stake_amount);
+
+        let current_balance = Balances::free_balance(setup.coldkey);
+        remove_balance_from_coldkey_account(
+            &setup.coldkey,
+            current_balance - ExistentialDeposit::get(),
+        );
+
+        let block_builder = U256::from(MOCK_BLOCK_BUILDER);
+        let block_builder_balance_before = Balances::free_balance(block_builder);
+        let burn_account: U256 = BurnAccountId::get().into_account_truncating();
+        let burn_balance_before = Balances::free_balance(burn_account);
+        let balances_issuance_before = Balances::total_issuance();
+        let subtensor_issuance_before = SubtensorModule::get_total_issuance();
+        assert_eq!(balances_issuance_before, subtensor_issuance_before);
+        let alpha_before = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey,
+            &setup.coldkey,
+            netuid,
+        );
+
+        set_mock_block_author(None);
+        let call = RuntimeCall::SubtensorModule(pallet_subtensor::Call::remove_stake {
+            hotkey,
+            netuid,
+            amount_unstaked: unstake_amount,
+        });
+        let info = call.get_dispatch_info();
+        let ext = pallet_transaction_payment::ChargeTransactionPayment::<Test>::from(0.into());
+        assert_ok!(ext.dispatch_transaction(
+            RuntimeOrigin::signed(setup.coldkey).into(),
+            call,
+            &info,
+            0,
+            0,
+        ));
+
+        let alpha_after = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey,
+            &setup.coldkey,
+            netuid,
+        );
+        let alpha_fee = alpha_before - alpha_after - unstake_amount;
+        assert!(!alpha_fee.is_zero());
+
+        let burned_tao = System::events()
+            .iter()
+            .find_map(|event_record| match &event_record.event {
+                RuntimeEvent::SubtensorModule(SubtensorEvent::TransactionFeePaidWithAlpha {
+                    who,
+                    netuid: event_netuid,
+                    alpha_fee: event_alpha_fee,
+                    tao_amount,
+                }) if who == &setup.coldkey
+                    && *event_netuid == netuid
+                    && *event_alpha_fee == alpha_fee =>
+                {
+                    Some(*tao_amount)
+                }
+                _ => None,
+            })
+            .expect("expected TransactionFeePaidWithAlpha event");
+
+        assert!(!burned_tao.is_zero());
+        assert_eq!(
+            Balances::free_balance(burn_account) - burn_balance_before,
+            burned_tao
+        );
+        assert_eq!(
+            Balances::free_balance(block_builder),
+            block_builder_balance_before
+        );
+        assert_eq!(Balances::total_issuance(), balances_issuance_before);
+        assert_eq!(
+            SubtensorModule::get_total_issuance(),
+            subtensor_issuance_before
+        );
+        assert_eq!(
+            Balances::total_issuance(),
+            SubtensorModule::get_total_issuance()
+        );
+    });
+}

--- a/pallets/transaction-fee/src/tests/mock.rs
+++ b/pallets/transaction-fee/src/tests/mock.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::arithmetic_side_effects, clippy::unwrap_used)]
 
 use core::num::NonZeroU64;
+use std::cell::RefCell;
 
 use crate::TransactionFeeHandler;
 use frame_support::pallet_prelude::Zero;
@@ -142,15 +143,28 @@ pub struct MockAuthorshipProvider;
 
 pub const MOCK_BLOCK_BUILDER: u64 = 12345u64;
 
+thread_local! {
+    static MOCK_BLOCK_AUTHOR: RefCell<Option<U256>> =
+        RefCell::new(Some(U256::from(MOCK_BLOCK_BUILDER)));
+}
+
+pub fn set_mock_block_author(author: Option<U256>) {
+    MOCK_BLOCK_AUTHOR.with(|mock_author| *mock_author.borrow_mut() = author);
+}
+
+fn mock_block_author() -> Option<U256> {
+    MOCK_BLOCK_AUTHOR.with(|mock_author| *mock_author.borrow())
+}
+
 impl AuthorshipInfo<U256> for MockAuthorshipProvider {
     fn author() -> Option<U256> {
-        Some(U256::from(MOCK_BLOCK_BUILDER))
+        mock_block_author()
     }
 }
 
 impl AuthorshipInfo<U256> for Test {
     fn author() -> Option<U256> {
-        Some(U256::from(MOCK_BLOCK_BUILDER))
+        mock_block_author()
     }
 }
 
@@ -548,6 +562,7 @@ where
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
     sp_tracing::try_init_simple();
+    set_mock_block_author(Some(U256::from(MOCK_BLOCK_BUILDER)));
     let t = frame_system::GenesisConfig::<Test>::default()
         .build_storage()
         .unwrap();
@@ -702,38 +717,6 @@ pub(crate) fn swap_alpha_to_tao(netuid: NetUid, alpha: AlphaBalance) -> (u64, u6
     swap_alpha_to_tao_ext(netuid, alpha, false)
 }
 
-pub(crate) fn swap_tao_to_alpha_ext(
-    netuid: NetUid,
-    tao: TaoBalance,
-    drop_fees: bool,
-) -> (u64, u64) {
-    if netuid.is_root() {
-        return (tao.into(), 0);
-    }
-
-    let order = GetAlphaForTao::<Test>::with_amount(tao);
-    let result = <Test as pallet::Config>::SwapInterface::swap(
-        netuid.into(),
-        order,
-        <Test as pallet::Config>::SwapInterface::max_price(),
-        drop_fees,
-        true,
-    );
-
-    assert_ok!(&result);
-
-    let result = result.unwrap();
-
-    // we don't want to have silent 0 comparisons in tests
-    assert!(!result.amount_paid_out.is_zero());
-
-    (result.amount_paid_out.to_u64(), result.fee_paid.to_u64())
-}
-
-pub(crate) fn swap_tao_to_alpha(netuid: NetUid, tao: TaoBalance) -> (u64, u64) {
-    swap_tao_to_alpha_ext(netuid, tao, false)
-}
-
 #[allow(dead_code)]
 pub fn add_network(netuid: NetUid, tempo: u16) {
     SubtensorModule::init_new_network(netuid, tempo);
@@ -833,9 +816,9 @@ pub(crate) fn quote_remove_stake_after_alpha_fee(
     hotkey: &U256,
     netuid: NetUid,
     alpha: AlphaBalance,
-) -> (u64, u64) {
+) -> u64 {
     if netuid.is_root() {
-        return (alpha.into(), 0);
+        return alpha.into();
     }
 
     let call: RuntimeCall = RuntimeCall::SubtensorModule(pallet_subtensor::Call::remove_stake {
@@ -847,17 +830,15 @@ pub(crate) fn quote_remove_stake_after_alpha_fee(
     let tao_fee = pallet_transaction_payment::Pallet::<Test>::compute_fee(0, &info, 0.into());
 
     frame_support::storage::with_transaction(
-        || -> frame_support::storage::TransactionOutcome<
-            Result<(u64, u64), sp_runtime::DispatchError>,
-        > {
-            let alpha_balance =
-                SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(hotkey, coldkey, netuid);
+        || -> frame_support::storage::TransactionOutcome<Result<u64, sp_runtime::DispatchError>> {
+            let alpha_balance = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+                hotkey, coldkey, netuid,
+            );
 
-            let mut alpha_fee =
-                pallet_subtensor_swap::Pallet::<Test>::get_alpha_amount_for_tao(
-                    netuid,
-                    tao_fee.into(),
-                );
+            let mut alpha_fee = pallet_subtensor_swap::Pallet::<Test>::get_alpha_amount_for_tao(
+                netuid,
+                tao_fee.into(),
+            );
 
             if alpha_fee.is_zero() {
                 alpha_fee = alpha_balance;
@@ -878,14 +859,13 @@ pub(crate) fn quote_remove_stake_after_alpha_fee(
                 ));
             }
 
-            let alpha_after_fee =
-                SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
-                    hotkey, coldkey, netuid,
-                );
+            let alpha_after_fee = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+                hotkey, coldkey, netuid,
+            );
             let quoted_alpha = alpha.min(alpha_after_fee);
 
-            let quote = swap_alpha_to_tao(netuid, quoted_alpha);
-            frame_support::storage::TransactionOutcome::Rollback(Ok(quote))
+            let (tao_amount, _) = swap_alpha_to_tao(netuid, quoted_alpha);
+            frame_support::storage::TransactionOutcome::Rollback(Ok(tao_amount))
         },
     )
     .expect("transactional quote should not fail")

--- a/pallets/transaction-fee/src/tests/mod.rs
+++ b/pallets/transaction-fee/src/tests/mod.rs
@@ -13,8 +13,8 @@ use subtensor_runtime_common::AlphaBalance;
 use subtensor_swap_interface::SwapHandler;
 
 use mock::*;
-mod burning;
 mod mock;
+mod recycling;
 
 fn mark_collateral(netuid: NetUid, hotkey: &U256, coldkey: &U256, locked: AlphaBalance) {
     MinerCollateral::<Test>::insert(
@@ -322,6 +322,9 @@ fn test_remove_stake_fees_alpha() {
 
         let burn_account: U256 = BurnAccountId::get().into_account_truncating();
         let burn_balance_before = Balances::free_balance(burn_account);
+        let balances_issuance_before = Balances::total_issuance();
+        let subtensor_issuance_before = SubtensorModule::get_total_issuance();
+        assert_eq!(balances_issuance_before, subtensor_issuance_before);
 
         // Remove stake
         let balance_before = Balances::free_balance(sn.coldkey);
@@ -365,7 +368,7 @@ fn test_remove_stake_fees_alpha() {
         assert!(actual_alpha_fee > 0.into());
 
         let events = System::events();
-        let (alpha_event, burned_tao) = events
+        let (alpha_event, recycled_tao) = events
             .iter()
             .enumerate()
             .find_map(|(index, event_record)| match &event_record.event {
@@ -383,10 +386,19 @@ fn test_remove_stake_fees_alpha() {
                 _ => None,
             })
             .expect("expected TransactionFeePaidWithAlpha event");
-        assert!(!burned_tao.is_zero());
+        assert!(!recycled_tao.is_zero());
+        assert_eq!(Balances::free_balance(burn_account), burn_balance_before);
         assert_eq!(
-            Balances::free_balance(burn_account) - burn_balance_before,
-            burned_tao
+            balances_issuance_before - Balances::total_issuance(),
+            recycled_tao
+        );
+        assert_eq!(
+            subtensor_issuance_before - SubtensorModule::get_total_issuance(),
+            recycled_tao
+        );
+        assert_eq!(
+            Balances::total_issuance(),
+            SubtensorModule::get_total_issuance()
         );
         let tao_event = events
             .iter()
@@ -1904,6 +1916,9 @@ fn test_alpha_fee_only_from_free_stake_above_collateral() {
         let burn_account: U256 = BurnAccountId::get().into_account_truncating();
         let block_builder_balance_before = Balances::free_balance(block_builder);
         let burn_balance_before = Balances::free_balance(burn_account);
+        let balances_issuance_before = Balances::total_issuance();
+        let subtensor_issuance_before = SubtensorModule::get_total_issuance();
+        assert_eq!(balances_issuance_before, subtensor_issuance_before);
         let collateral_before = MinerCollateral::<Test>::get((netuid, hotkey, sn.coldkey))
             .expect("collateral entry")
             .locked;
@@ -1918,9 +1933,18 @@ fn test_alpha_fee_only_from_free_stake_above_collateral() {
         assert_eq!(taken, alpha_for_small);
         assert!(!tao_out.is_zero());
         assert_eq!(Balances::free_balance(block_builder), block_builder_balance_before);
+        assert_eq!(Balances::free_balance(burn_account), burn_balance_before);
         assert_eq!(
-            Balances::free_balance(burn_account).saturating_sub(burn_balance_before),
+            balances_issuance_before - Balances::total_issuance(),
             tao_out
+        );
+        assert_eq!(
+            subtensor_issuance_before - SubtensorModule::get_total_issuance(),
+            tao_out
+        );
+        assert_eq!(
+            Balances::total_issuance(),
+            SubtensorModule::get_total_issuance()
         );
 
         let alpha_after = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(

--- a/pallets/transaction-fee/src/tests/mod.rs
+++ b/pallets/transaction-fee/src/tests/mod.rs
@@ -3,10 +3,9 @@ use crate::{AlphaFeeHandler, SubtensorTxFeeHandler, TransactionFeeHandler, Trans
 use approx::assert_abs_diff_eq;
 use frame_support::dispatch::GetDispatchInfo;
 use frame_support::pallet_prelude::Zero;
-use frame_support::traits::Currency;
 use frame_support::{assert_err, assert_ok};
 use sp_runtime::{
-    traits::{DispatchTransaction, TransactionExtension, TxBaseImplication},
+    traits::{AccountIdConversion, DispatchTransaction, TransactionExtension, TxBaseImplication},
     transaction_validity::{InvalidTransaction, TransactionValidityError},
 };
 use substrate_fixed::types::U64F64;
@@ -14,6 +13,7 @@ use subtensor_runtime_common::AlphaBalance;
 use subtensor_swap_interface::SwapHandler;
 
 use mock::*;
+mod burning;
 mod mock;
 
 fn mark_collateral(netuid: NetUid, hotkey: &U256, coldkey: &U256, locked: AlphaBalance) {
@@ -306,7 +306,7 @@ fn test_remove_stake_fees_alpha() {
 
         // Simulate stake removal to get how much TAO should we get for unstaked Alpha
         // after the alpha-fee pre-withdrawal has already moved the pool.
-        let (expected_unstaked_tao, swap_fee) = mock::quote_remove_stake_after_alpha_fee(
+        let expected_unstaked_tao = mock::quote_remove_stake_after_alpha_fee(
             &sn.coldkey,
             &sn.hotkeys[0],
             sn.subnets[0].netuid,
@@ -320,9 +320,8 @@ fn test_remove_stake_fees_alpha() {
             current_balance - ExistentialDeposit::get(),
         );
 
-        // Get the block builder balance
-        let block_builder = U256::from(MOCK_BLOCK_BUILDER);
-        let block_builder_balance_before = Balances::free_balance(block_builder);
+        let burn_account: U256 = BurnAccountId::get().into_account_truncating();
+        let burn_balance_before = Balances::free_balance(burn_account);
 
         // Remove stake
         let balance_before = Balances::free_balance(sn.coldkey);
@@ -365,33 +364,30 @@ fn test_remove_stake_fees_alpha() {
         assert_abs_diff_eq!(actual_tao_fee, 0.into(), epsilon = 10.into());
         assert!(actual_alpha_fee > 0.into());
 
-        // Assert that swapped TAO from alpha fee goes to block author
-        let block_builder_fee_portion = 1.;
-        let expected_block_builder_swap_reward = swap_fee as f64 * block_builder_fee_portion;
-        let expected_tx_fee = 14000.; // Use very low value (0.000014) for less test flakiness, value before we 10x tx fees
-        let block_builder_balance_after = Balances::free_balance(block_builder);
-        let actual_block_builder_reward =
-            block_builder_balance_after - block_builder_balance_before;
-        assert!(
-            u64::from(actual_block_builder_reward) as f64
-                >= expected_block_builder_swap_reward + expected_tx_fee
-        );
-
         let events = System::events();
-        let alpha_event = events
+        let (alpha_event, burned_tao) = events
             .iter()
-            .position(|event_record| {
-                matches!(
-                    &event_record.event,
-                    RuntimeEvent::SubtensorModule(SubtensorEvent::TransactionFeePaidWithAlpha {
-                        who,
-                        netuid,
-                        alpha_fee,
-                        tao_amount: _,
-                    }) if who == &sn.coldkey && *alpha_fee == actual_alpha_fee && *netuid == sn.subnets[0].netuid
-                )
+            .enumerate()
+            .find_map(|(index, event_record)| match &event_record.event {
+                RuntimeEvent::SubtensorModule(SubtensorEvent::TransactionFeePaidWithAlpha {
+                    who,
+                    netuid,
+                    alpha_fee,
+                    tao_amount,
+                }) if who == &sn.coldkey
+                    && *alpha_fee == actual_alpha_fee
+                    && *netuid == sn.subnets[0].netuid =>
+                {
+                    Some((index, *tao_amount))
+                }
+                _ => None,
             })
             .expect("expected TransactionFeePaidWithAlpha event");
+        assert!(!burned_tao.is_zero());
+        assert_eq!(
+            Balances::free_balance(burn_account) - burn_balance_before,
+            burned_tao
+        );
         let tao_event = events
             .iter()
             .position(|event_record| {
@@ -431,10 +427,16 @@ fn test_alpha_fee_withdraw_failure_aborts_and_rolls_back() {
         // Force the alpha-fee unstake to fail after AMM bookkeeping by draining
         // the subnet account used by transfer_tao_from_subnet.
         let subnet_account = SubtensorModule::get_subnet_account_id(netuid).unwrap();
-        Balances::make_free_balance_be(&subnet_account, 0.into());
+        let subnet_balance = Balances::free_balance(subnet_account);
+        assert_ok!(SubtensorModule::burn_tao(&subnet_account, subnet_balance));
 
         let block_builder = U256::from(MOCK_BLOCK_BUILDER);
+        let burn_account: U256 = BurnAccountId::get().into_account_truncating();
         let block_builder_balance_before = Balances::free_balance(block_builder);
+        let burn_balance_before = Balances::free_balance(burn_account);
+        let balances_issuance_before = Balances::total_issuance();
+        let subtensor_issuance_before = SubtensorModule::get_total_issuance();
+        assert_eq!(balances_issuance_before, subtensor_issuance_before);
         let signer_balance_before = Balances::free_balance(sn.coldkey);
         let alpha_before = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
             &hotkey,
@@ -479,6 +481,16 @@ fn test_alpha_fee_withdraw_failure_aborts_and_rolls_back() {
         assert_eq!(
             Balances::free_balance(block_builder),
             block_builder_balance_before
+        );
+        assert_eq!(Balances::free_balance(burn_account), burn_balance_before);
+        assert_eq!(Balances::total_issuance(), balances_issuance_before);
+        assert_eq!(
+            SubtensorModule::get_total_issuance(),
+            subtensor_issuance_before
+        );
+        assert_eq!(
+            Balances::total_issuance(),
+            SubtensorModule::get_total_issuance()
         );
 
         assert!(!System::events().iter().any(|event_record| {
@@ -1737,59 +1749,6 @@ fn test_recycle_alpha_fees_alpha() {
     });
 }
 
-// cargo test --package subtensor-transaction-fee --lib -- tests::test_add_stake_fees_go_to_block_builder --exact --show-output
-#[test]
-fn test_add_stake_fees_go_to_block_builder() {
-    new_test_ext().execute_with(|| {
-        // Portion of swap fees that should go to the block builder
-        let block_builder_fee_portion = 1.;
-
-        // Get the block builder balance
-        let block_builder = U256::from(MOCK_BLOCK_BUILDER);
-        let block_builder_balance_before = Balances::free_balance(block_builder);
-
-        let stake_amount = TAO;
-        let sn = setup_subnets(1, 1);
-
-        // Simulate add stake to get the expected TAO fee
-        let (_, swap_fee) = mock::swap_tao_to_alpha(sn.subnets[0].netuid, stake_amount.into());
-
-        add_balance_to_coldkey_account(&sn.coldkey, (stake_amount * 10).into());
-
-        // Stake
-        let balance_before = Balances::free_balance(sn.coldkey);
-        let call = RuntimeCall::SubtensorModule(pallet_subtensor::Call::add_stake {
-            hotkey: sn.hotkeys[0],
-            netuid: sn.subnets[0].netuid,
-            amount_staked: stake_amount.into(),
-        });
-
-        // Dispatch the extrinsic with ChargeTransactionPayment extension
-        let info = call.get_dispatch_info();
-        let ext = pallet_transaction_payment::ChargeTransactionPayment::<Test>::from(0.into());
-        assert_ok!(ext.dispatch_transaction(
-            RuntimeOrigin::signed(sn.coldkey).into(),
-            call,
-            &info,
-            0,
-            0,
-        ));
-
-        let final_balance = Balances::free_balance(sn.coldkey);
-        let actual_tao_fee = balance_before - stake_amount.into() - final_balance;
-        assert!(!actual_tao_fee.is_zero());
-
-        // Expect that block builder balance has increased by both the swap fee and the transaction fee
-        let expected_block_builder_swap_reward = swap_fee as f64 * block_builder_fee_portion;
-        let expected_tx_fee = 14000.; // Use very low value (0.000014) for less test flakiness, value before we 10x tx fees
-        let block_builder_balance_after = Balances::free_balance(block_builder);
-        let actual_reward = block_builder_balance_after - block_builder_balance_before;
-        assert!(
-            u64::from(actual_reward) as f64 >= expected_block_builder_swap_reward + expected_tx_fee
-        );
-    });
-}
-
 // Fully collateral-bonded stake must not pay alpha fees. Regression for the
 // phantom-bond bug where fee unstake stripped stake while MinerCollateral.locked
 // stayed unchanged.
@@ -1941,10 +1900,14 @@ fn test_alpha_fee_only_from_free_stake_above_collateral() {
             )
         );
 
+        let block_builder = U256::from(MOCK_BLOCK_BUILDER);
+        let burn_account: U256 = BurnAccountId::get().into_account_truncating();
+        let block_builder_balance_before = Balances::free_balance(block_builder);
+        let burn_balance_before = Balances::free_balance(burn_account);
         let collateral_before = MinerCollateral::<Test>::get((netuid, hotkey, sn.coldkey))
             .expect("collateral entry")
             .locked;
-        let (taken, _tao_out, fee_netuid) =
+        let (taken, tao_out, fee_netuid) =
             <TransactionFeeHandler<Test> as AlphaFeeHandler<Test>>::withdraw_in_alpha(
                 &sn.coldkey,
                 &alpha_vec,
@@ -1953,6 +1916,12 @@ fn test_alpha_fee_only_from_free_stake_above_collateral() {
             .expect("free-slice fee should withdraw");
         assert_eq!(fee_netuid, netuid);
         assert_eq!(taken, alpha_for_small);
+        assert!(!tao_out.is_zero());
+        assert_eq!(Balances::free_balance(block_builder), block_builder_balance_before);
+        assert_eq!(
+            Balances::free_balance(burn_account).saturating_sub(burn_balance_before),
+            tao_out
+        );
 
         let alpha_after = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
             &hotkey,

--- a/pallets/transaction-fee/src/tests/recycling.rs
+++ b/pallets/transaction-fee/src/tests/recycling.rs
@@ -5,7 +5,7 @@ use sp_runtime::traits::{AccountIdConversion, DispatchTransaction};
 use subtensor_runtime_common::AlphaBalance;
 
 #[test]
-fn tao_transaction_fees_are_burned() {
+fn tao_transaction_fees_are_recycled() {
     new_test_ext().execute_with(|| {
         let payer = U256::from(42u64);
         let block_builder = U256::from(MOCK_BLOCK_BUILDER);
@@ -50,7 +50,7 @@ fn tao_transaction_fees_are_burned() {
 }
 
 #[test]
-fn alpha_transaction_fees_are_burned_without_a_block_author() {
+fn alpha_transaction_fees_are_recycled_without_a_block_author() {
     new_test_ext().execute_with(|| {
         let stake_amount = TAO;
         let unstake_amount = AlphaBalance::from(TAO / 50);
@@ -60,10 +60,8 @@ fn alpha_transaction_fees_are_burned_without_a_block_author() {
         setup_stake(netuid, &setup.coldkey, &hotkey, stake_amount);
 
         let current_balance = Balances::free_balance(setup.coldkey);
-        remove_balance_from_coldkey_account(
-            &setup.coldkey,
-            current_balance - ExistentialDeposit::get(),
-        );
+        remove_balance_from_coldkey_account(&setup.coldkey, current_balance);
+        assert_eq!(Balances::free_balance(setup.coldkey), TaoBalance::ZERO);
 
         let block_builder = U256::from(MOCK_BLOCK_BUILDER);
         let block_builder_balance_before = Balances::free_balance(block_builder);
@@ -102,7 +100,7 @@ fn alpha_transaction_fees_are_burned_without_a_block_author() {
         let alpha_fee = alpha_before - alpha_after - unstake_amount;
         assert!(!alpha_fee.is_zero());
 
-        let burned_tao = System::events()
+        let recycled_tao = System::events()
             .iter()
             .find_map(|event_record| match &event_record.event {
                 RuntimeEvent::SubtensorModule(SubtensorEvent::TransactionFeePaidWithAlpha {
@@ -120,19 +118,19 @@ fn alpha_transaction_fees_are_burned_without_a_block_author() {
             })
             .expect("expected TransactionFeePaidWithAlpha event");
 
-        assert!(!burned_tao.is_zero());
-        assert_eq!(
-            Balances::free_balance(burn_account) - burn_balance_before,
-            burned_tao
-        );
+        assert!(!recycled_tao.is_zero());
+        assert_eq!(Balances::free_balance(burn_account), burn_balance_before);
         assert_eq!(
             Balances::free_balance(block_builder),
             block_builder_balance_before
         );
-        assert_eq!(Balances::total_issuance(), balances_issuance_before);
         assert_eq!(
-            SubtensorModule::get_total_issuance(),
-            subtensor_issuance_before
+            balances_issuance_before - Balances::total_issuance(),
+            recycled_tao
+        );
+        assert_eq!(
+            subtensor_issuance_before - SubtensorModule::get_total_issuance(),
+            recycled_tao
         );
         assert_eq!(
             Balances::total_issuance(),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 443,
+    spec_version: 444,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/tests/evm_transaction_fee.rs
+++ b/runtime/tests/evm_transaction_fee.rs
@@ -38,7 +38,7 @@ fn initialize_block_with_aura_authority(authority: AuraId, slot: u64) {
 }
 
 #[test]
-fn evm_fees_are_burned_without_total_issuance_drift() {
+fn evm_fees_are_recycled_without_total_issuance_drift() {
     new_test_ext().execute_with(|| {
         initialize_block_with_aura_authority(AuraId::from(sr25519::Public::from_raw([1u8; 32])), 0);
 

--- a/runtime/tests/evm_transaction_fee.rs
+++ b/runtime/tests/evm_transaction_fee.rs
@@ -38,7 +38,7 @@ fn initialize_block_with_aura_authority(authority: AuraId, slot: u64) {
 }
 
 #[test]
-fn evm_fee_refund_does_not_change_total_issuance() {
+fn evm_fees_are_burned_without_total_issuance_drift() {
     new_test_ext().execute_with(|| {
         initialize_block_with_aura_authority(AuraId::from(sr25519::Public::from_raw([1u8; 32])), 0);
 
@@ -59,6 +59,8 @@ fn evm_fee_refund_does_not_change_total_issuance() {
         let balances_issuance_before = Balances::total_issuance();
         let subtensor_issuance_before = pallet_subtensor::Pallet::<Runtime>::get_total_issuance();
         let balance_before = Balances::total_balance(&account_id);
+        let substrate_author_balance_before = Balances::total_balance(&substrate_author);
+        let evm_author_balance_before = Balances::total_balance(&evm_author);
 
         assert_eq!(balances_issuance_before, subtensor_issuance_before);
 
@@ -82,13 +84,28 @@ fn evm_fee_refund_does_not_change_total_issuance() {
             Runtime,
         >>::pay_priority_fee(tip);
 
-        assert_eq!(
-            Balances::total_issuance(),
-            pallet_subtensor::Pallet::<Runtime>::get_total_issuance()
-        );
+        let balances_issuance_after = Balances::total_issuance();
+        let subtensor_issuance_after = pallet_subtensor::Pallet::<Runtime>::get_total_issuance();
+        assert_eq!(balances_issuance_after, subtensor_issuance_after);
         assert_eq!(
             Balances::total_balance(&account_id),
             balance_before - TaoBalance::from(5)
+        );
+        assert_eq!(
+            balances_issuance_before - balances_issuance_after,
+            TaoBalance::from(5)
+        );
+        assert_eq!(
+            subtensor_issuance_before - subtensor_issuance_after,
+            TaoBalance::from(5)
+        );
+        assert_eq!(
+            Balances::total_balance(&substrate_author),
+            substrate_author_balance_before
+        );
+        assert_eq!(
+            Balances::total_balance(&evm_author),
+            evm_author_balance_before
         );
     });
 }

--- a/sdk/python/bittensor/_generated/calls.py
+++ b/sdk/python/bittensor/_generated/calls.py
@@ -1,7 +1,7 @@
 """Generated from runtime metadata by codegen. DO NOT EDIT BY HAND.
 
 Regenerate with: python -m codegen <ws-endpoint>
-Spec version: 442
+Spec version: 444
 """
 from typing import Any, NamedTuple
 

--- a/sdk/python/bittensor/_generated/constants.py
+++ b/sdk/python/bittensor/_generated/constants.py
@@ -1,7 +1,7 @@
 """Generated from runtime metadata by codegen. DO NOT EDIT BY HAND.
 
 Regenerate with: python -m codegen <ws-endpoint>
-Spec version: 442
+Spec version: 444
 
 Pallet constant descriptors: unpack into substrate.constant.
 """

--- a/sdk/python/bittensor/_generated/errors.py
+++ b/sdk/python/bittensor/_generated/errors.py
@@ -1,7 +1,7 @@
 """Generated from runtime metadata by codegen. DO NOT EDIT BY HAND.
 
 Regenerate with: python -m codegen <ws-endpoint>
-Spec version: 442
+Spec version: 444
 """
 from dataclasses import dataclass
 

--- a/sdk/python/bittensor/_generated/runtime_apis.py
+++ b/sdk/python/bittensor/_generated/runtime_apis.py
@@ -1,7 +1,7 @@
 """Generated from runtime metadata by codegen. DO NOT EDIT BY HAND.
 
 Regenerate with: python -m codegen <ws-endpoint>
-Spec version: 442
+Spec version: 444
 
 Runtime API method descriptors: unpack into substrate.runtime_call.
 """

--- a/sdk/python/bittensor/_generated/storage.py
+++ b/sdk/python/bittensor/_generated/storage.py
@@ -1,7 +1,7 @@
 """Generated from runtime metadata by codegen. DO NOT EDIT BY HAND.
 
 Regenerate with: python -m codegen <ws-endpoint>
-Spec version: 442
+Spec version: 444
 
 Storage item descriptors: unpack into substrate.query/query_map. Each carries its VALUE's type identity (value_type_ident) so normalization can key on the runtime's own type names without a node round-trip.
 """

--- a/website/apps/bittensor-website/public/catalog/intents.json
+++ b/website/apps/bittensor-website/public/catalog/intents.json
@@ -56,9 +56,9 @@
         "pallet": "SubtensorModule",
         "call": "add_collateral",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2526,
-        "end_line": 2534,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2524-L2534",
+        "line": 2531,
+        "end_line": 2539,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2529-L2539",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -300,9 +300,9 @@
         "pallet": "SubtensorModule",
         "call": "announce_coldkey_swap",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2062,
-        "end_line": 2088,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2060-L2088",
+        "line": 2067,
+        "end_line": 2093,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2065-L2093",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -605,9 +605,9 @@
         "pallet": "SubtensorModule",
         "call": "clear_coldkey_swap_announcement",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2261,
-        "end_line": 2276,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2259-L2276",
+        "line": 2266,
+        "end_line": 2281,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2264-L2281",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -954,9 +954,9 @@
         "pallet": "SubtensorModule",
         "call": "dispute_coldkey_swap",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2131,
-        "end_line": 2148,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2129-L2148",
+        "line": 2136,
+        "end_line": 2153,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2134-L2153",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -1358,9 +1358,9 @@
         "pallet": "SubtensorModule",
         "call": "lock_stake",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2333,
-        "end_line": 2341,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2331-L2341",
+        "line": 2338,
+        "end_line": 2346,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2336-L2346",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -1405,9 +1405,9 @@
         "pallet": "SubtensorModule",
         "call": "move_lock",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2357,
-        "end_line": 2364,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2355-L2364",
+        "line": 2362,
+        "end_line": 2369,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2360-L2369",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -3188,9 +3188,9 @@
         "pallet": "SubtensorModule",
         "call": "set_min_collateral",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2561,
-        "end_line": 2568,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2559-L2568",
+        "line": 2566,
+        "end_line": 2573,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2564-L2573",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -3235,9 +3235,9 @@
         "pallet": "SubtensorModule",
         "call": "set_perpetual_lock",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2373,
-        "end_line": 2380,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2371-L2380",
+        "line": 2378,
+        "end_line": 2385,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2376-L2385",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -3290,9 +3290,9 @@
         "pallet": "SubtensorModule",
         "call": "sudo_set_root_claim_threshold",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2025,
-        "end_line": 2044,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2023-L2044",
+        "line": 2030,
+        "end_line": 2049,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2028-L2049",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -3674,9 +3674,9 @@
         "pallet": "SubtensorModule",
         "call": "add_stake_burn",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2245,
-        "end_line": 2253,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2243-L2253",
+        "line": 2250,
+        "end_line": 2258,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2248-L2258",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -3758,9 +3758,9 @@
         "pallet": "SubtensorModule",
         "call": "swap_coldkey_announced",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2100,
-        "end_line": 2120,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2098-L2120",
+        "line": 2105,
+        "end_line": 2125,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2103-L2125",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]
@@ -4127,9 +4127,9 @@
         "pallet": "SubtensorModule",
         "call": "transfer_stake_and_hotkey",
         "path": "pallets/subtensor/src/macros/dispatches.rs",
-        "line": 2468,
-        "end_line": 2486,
-        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2466-L2486",
+        "line": 2473,
+        "end_line": 2491,
+        "url": "/code/pallets/subtensor/src/macros/dispatches.rs#L2471-L2491",
         "raw_url": "/code/raw/pallets/subtensor/src/macros/dispatches.rs"
       }
     ]


### PR DESCRIPTION
## Motivation

Restore transaction-fee handling so block-producing validators do not receive transaction-fee revenue. Transaction fees are recycled by reducing TAO issuance. Existing AMM swap-fee behavior is unchanged.

## Changes

- Recycle native TAO transaction fees and tips instead of crediting the block author.
- For Alpha-paid transaction fees, swap the charged Alpha to TAO and atomically recycle the exact TAO output directly from the subnet account.
- Recycle both EVM base fees and priority fees through the same TAO fee handler.
- Remove the transaction-fee dependency on block authorship.
- Rename transaction-fee tests and comments to use "recycle" where issuance is reduced.

## Issuance invariants

Tests verify that:

- Balances total issuance and Subtensor total issuance remain equal.
- Both issuance ledgers decrease by the exact charged or converted TAO amount.
- Block-author balances remain unchanged.
- Alpha swap and TAO recycling changes roll back atomically on failure.
- Alpha-paid fees work without a block author and when the payer has zero TAO.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --package subtensor-transaction-fee --lib`
- `SKIP_WASM_BUILD=1 cargo test --package node-subtensor-runtime --test evm_transaction_fee`
- `cargo clippy --package subtensor-transaction-fee --all-targets -- -D warnings`
