### PR TITLE
fix(cli): harden key import and prompt policies

### DIFF
--- a/pallets/subtensor/src/tests/stake_into_basket.rs
+++ b/pallets/subtensor/src/tests/stake_into_basket.rs
@@ -577,11 +577,7 @@ fn test_root_slot_yield_accrues_to_share_holders() {
         // Bob buys in directly: all-root basket at N/P = 1, so his TAO mints 1:1 exactly.
         let b = 10_000_000u64;
         add_balance_to_coldkey_account(&bob, TaoBalance::from(2 * b));
-        assert_ok!(SubtensorModule::do_stake_into_basket(
-            bob,
-            hotkey,
-            b.into(),
-        ));
+        assert_ok!(SubtensorModule::do_stake_into_basket(bob, hotkey, b.into(),));
         assert_eq!(SubtensorModule::get_basket_owed_shares(&hotkey, &bob), b);
         let bob_payout_before = SubtensorModule::get_basket_payout_tao(&hotkey, &bob);
         assert_eq!(bob_payout_before, b, "N/P = 1: payout == shares == TAO in");

--- a/sdk/bittensor-core/src/keyfiles/mod.rs
+++ b/sdk/bittensor-core/src/keyfiles/mod.rs
@@ -269,11 +269,12 @@ fn keypair_from_raw_text(text: &str) -> Option<Keypair> {
     let trimmed = text.trim();
     let hex_body = trimmed.strip_prefix("0x").unwrap_or(trimmed);
     if matches!(hex_body.len(), 64 | 128) && hex_body.chars().all(|c| c.is_ascii_hexdigit()) {
-        if let Ok(bytes) = hex::decode(hex_body) {
-            if let Ok(keypair) = Keypair::from_seed(&bytes[..32], CRYPTO_SR25519) {
-                return Some(keypair);
-            }
+        if hex_body.len() == 64 {
+            return hex::decode(hex_body)
+                .ok()
+                .and_then(|bytes| Keypair::from_seed(&bytes, CRYPTO_SR25519).ok());
         }
+        return Keypair::from_private_key(trimmed, CRYPTO_SR25519).ok();
     }
     if looks_like_mnemonic(trimmed) {
         if let Ok(keypair) = Keypair::from_mnemonic(trimmed, CRYPTO_SR25519, None) {
@@ -527,7 +528,9 @@ mod tests {
             r#"{{"secretPhrase":"{}","ss58Address":"5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"}}"#,
             test_mnemonic()
         );
-        let error = deserialize_keypair_from_keyfile_data(json.as_bytes()).err().expect("mismatch must fail");
+        let error = deserialize_keypair_from_keyfile_data(json.as_bytes())
+            .err()
+            .expect("mismatch must fail");
         assert!(error.to_string().contains("does not match"));
     }
 
@@ -536,6 +539,16 @@ mod tests {
         let keypair = Keypair::from_mnemonic(&test_mnemonic(), CRYPTO_SR25519, None).unwrap();
         let seed_hex = format!("0x{}", hex::encode(keypair.seed_bytes().unwrap()));
         let restored = deserialize_keypair_from_keyfile_data(seed_hex.as_bytes()).unwrap();
+        assert_eq!(restored.ss58_address(), keypair.ss58_address());
+    }
+
+    #[test]
+    fn raw_hex_private_key_fallback() {
+        let keypair = Keypair::from_mnemonic(&test_mnemonic(), CRYPTO_SR25519, None).unwrap();
+        let private_key = keypair.private_key_bytes().unwrap();
+        assert_eq!(private_key.len(), 64);
+        let private_hex = format!("0x{}", hex::encode(private_key));
+        let restored = deserialize_keypair_from_keyfile_data(private_hex.as_bytes()).unwrap();
         assert_eq!(restored.ss58_address(), keypair.ss58_address());
     }
 
@@ -549,13 +562,17 @@ mod tests {
     #[test]
     fn polkadotjs_export_gets_actionable_error() {
         let json = r#"{"encoded":"abc","encoding":{"content":["pkcs8","sr25519"],"type":["scrypt","xsalsa20-poly1305"],"version":"3"},"address":"5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY","meta":{}}"#;
-        let error = deserialize_keypair_from_keyfile_data(json.as_bytes()).err().expect("polkadotjs export must fail");
+        let error = deserialize_keypair_from_keyfile_data(json.as_bytes())
+            .err()
+            .expect("polkadotjs export must fail");
         assert!(error.to_string().contains("regen-coldkey --json-path"));
     }
 
     #[test]
     fn unknown_json_error_names_found_fields() {
-        let error = deserialize_keypair_from_keyfile_data(br#"{"foo":1}"#).err().expect("unknown fields must fail");
+        let error = deserialize_keypair_from_keyfile_data(br#"{"foo":1}"#)
+            .err()
+            .expect("unknown fields must fail");
         assert!(error.to_string().contains("foo"));
     }
 }

--- a/sdk/python/bittensor/cli/call_names.py
+++ b/sdk/python/bittensor/cli/call_names.py
@@ -6,15 +6,15 @@ where the flag-level name resolution never runs. A user who writes an
 address-book name ("izzi") where the chain expects an AccountId would only
 see the codec's cryptic "Base 58 requirement is violated".
 
-This module closes that gap with the same lookup order the flags use —
-address book, proxy book, local wallet keys — plus a did-you-mean error for
-anything unresolvable. Account-typed values are recognized two ways:
+This module closes that gap through the same canonical lookup the flags use —
+address book, proxy book, saved multisigs, and local wallet keys — plus a
+did-you-mean error for anything unresolvable. Account-typed values are
+recognized two ways:
 
 - generated call builders (``bittensor.calls``) annotate scalar account
-  params as ``AccountId32`` / ``MultiAddress``; account *lists*
-  (``Vec<AccountId32>``, e.g. ``other_signatories``) lose that annotation in
-  codegen, so they are detected by their contents (see
-  ``_resolve_account_list``);
+  params as ``AccountId32`` / ``MultiAddress``; known signatory-list fields
+  are resolved explicitly because structural ``Vec<AccountId32>`` annotations
+  currently degrade to ``Any`` in codegen;
 - intent specs resolve their ``*_ss58`` args and signatory lists.
 
 Both paths recurse through nested call structures: sudo-wrapped and batch
@@ -82,8 +82,8 @@ def _resolve_value(app_ctx, param: str, annotation: Optional[str], value: Any, h
     if isinstance(value, list) and value:
         if all(_is_nested_call(item) for item in value):
             return [_resolve_nested_call(app_ctx, item, hint) for item in value]
-        if all(isinstance(item, str) for item in value):
-            return _resolve_account_list(app_ctx, param, value, hint)
+        if param in _SIGNATORY_FIELDS and all(isinstance(item, str) for item in value):
+            return [_resolve_account(app_ctx, param, item, hint) for item in value]
     return value
 
 
@@ -135,21 +135,6 @@ def _resolve_nested_call(app_ctx, value: dict, hint: str) -> dict:
             function: resolve_builder_params(app_ctx, f"{module}.{function}", args, param_hint=hint)
         }
     }
-
-
-def _resolve_account_list(app_ctx, param: str, values: list, hint: str) -> list:
-    """Resolve a list of strings that is provably an account list.
-
-    Codegen annotates ``Vec<AccountId32>`` params as ``Any``, so the contents
-    decide: the list is treated as accounts only when at least one element is
-    an ss58 address or a known name. Then every element must resolve — a
-    straggler is a typo, not data.
-    """
-    if not any(
-        is_bittensor_address(item) or _lookup(app_ctx, param, item) is not None for item in values
-    ):
-        return values
-    return [_resolve_account(app_ctx, param, item, hint) for item in values]
 
 
 # --- intent specs (`btcli tx` args, multisig inner calls, batch children) ------------------
@@ -208,28 +193,14 @@ def _resolve_account(app_ctx, param: str, value: str, hint: str) -> str:
 def _lookup(app_ctx, param: str, name: str) -> Optional[tuple[str, str]]:
     """(address, source description) for a known name, or None.
 
-    Mirrors ``AppContext.resolve_address``'s order: address book, proxy book,
-    then local wallet keys (hotkey-named params take HOTKEY or WALLET/HOTKEY;
-    everything else takes a wallet name, resolved to its coldkey).
+    Uses the same canonical lookup as ordinary CLI flags, including saved
+    multisig names for coldkey parameters.
     """
-    booked = cfg.get_address(name)
-    if booked:
-        return booked, f"address-book entry {name!r}"
-    proxy_entry = cfg.get_proxy(name)
-    proxied = proxy_entry.get("address") if proxy_entry else None
-    if isinstance(proxied, str) and proxied:
-        return proxied, f"proxy-book entry {name!r}"
     try:
-        if "hotkey" in param:
-            wallet_name, _, hotkey = name.rpartition("/")
-            handle = wallets.open_wallet(
-                wallet_name or app_ctx.wallet_name, hotkey, app_ctx.wallet_path
-            )
-            return handle.hotkey.ss58_address, f"hotkey {name!r}"
-        address = wallets.open_wallet(name=name, path=app_ctx.wallet_path).coldkeypub.ss58_address
-        return address, f"wallet {name!r}"
+        resolved = app_ctx.resolve_address_ref(param, name)
     except Exception:
         return None
+    return resolved.address, resolved.source
 
 
 def _unresolved(app_ctx, param: str, value: str) -> str:

--- a/sdk/python/bittensor/cli/context.py
+++ b/sdk/python/bittensor/cli/context.py
@@ -77,6 +77,15 @@ def ss58_param_help(param: str) -> str:
     return text
 
 
+@dataclass(frozen=True)
+class ResolvedAddress:
+    """A locally resolved account reference and how it was resolved."""
+
+    address: str
+    source: str
+    name: Optional[str] = None
+
+
 @dataclass
 class AppContext:
     network: str
@@ -310,6 +319,43 @@ class AppContext:
             keychain=self.keychain_password,
         )
 
+    def resolve_address_ref(self, param: str, value: str) -> ResolvedAddress:
+        """Resolve one explicit account reference without prompting or exiting.
+
+        This is the canonical lookup path shared by ordinary CLI flags and
+        account values nested inside raw-call / intent JSON. Callers own error
+        presentation; lookup failures from local wallet access are allowed to
+        propagate with their original context.
+        """
+        kind = "hotkey" if "hotkey" in param else "coldkey"
+        if is_bittensor_address(value):
+            booked = next(
+                (e["name"] for e in cfg.load_addresses() if e.get("address") == value), None
+            )
+            return ResolvedAddress(value, "ss58 address", booked)
+
+        booked = cfg.get_address(value)
+        if booked:
+            return ResolvedAddress(booked, f"address-book entry {value!r}", value)
+
+        proxy_entry = cfg.get_proxy(value)
+        proxied = proxy_entry.get("address") if proxy_entry else None
+        if isinstance(proxied, str) and proxied:
+            return ResolvedAddress(proxied, f"proxy-book entry {value!r}", value)
+
+        if kind == "coldkey":
+            derived = self._saved_multisig_address(value)
+            if derived:
+                return ResolvedAddress(derived, f"saved multisig {value!r}", value)
+
+        if kind == "hotkey":
+            wallet_name, _, hotkey = value.rpartition("/")
+            handle = wallets.open_wallet(wallet_name or self.wallet_name, hotkey, self.wallet_path)
+            return ResolvedAddress(handle.hotkey.ss58_address, f"hotkey {value!r}", value)
+
+        address = wallets.open_wallet(name=value, path=self.wallet_path).coldkeypub.ss58_address
+        return ResolvedAddress(address, f"wallet {value!r}", value)
+
     def resolve_address(self, param: str, value: Optional[str]) -> Optional[str]:
         """Resolve an address-typed CLI value (any ``*_ss58`` param) to an ss58 address.
 
@@ -344,65 +390,38 @@ class AppContext:
                 hotkey_help=("Hotkey this command targets." if param == "hotkey_ss58" else None),
                 accept_address=True,
             )
-        if value is not None and is_bittensor_address(value):
-            booked = next(
-                (e["name"] for e in cfg.load_addresses() if e.get("address") == value), None
-            )
-            self.output.name_address(value, booked)
-            self.output.classify_address(value, kind)
-            return value
         if value is not None:
-            booked = cfg.get_address(value)
-            if booked:
-                self.output.name_address(booked, value)
-                self.output.classify_address(booked, kind)
-                return booked
-            proxy_entry = cfg.get_proxy(value)
-            proxied = proxy_entry.get("address") if proxy_entry else None
-            if isinstance(proxied, str) and proxied:
-                self.output.name_address(proxied, value)
-                self.output.classify_address(proxied, kind)
-                return proxied
-            if kind == "coldkey":
-                derived = self._saved_multisig_address(value)
-                if derived:
-                    self.output.name_address(derived, value)
-                    self.output.classify_address(derived, kind)
-                    return derived
+            try:
+                resolved = self.resolve_address_ref(param, value)
+            except typer.Exit:
+                raise
+            except Exception as error:
+                self.output.error(f"cannot resolve {address_cli_name(param)} {value!r}: {error}")
+                raise typer.Exit(1)
+            self.output.name_address(resolved.address, resolved.name)
+            self.output.classify_address(resolved.address, kind)
+            return resolved.address
         try:
-            if value is None:
-                if param == "hotkey_ss58":
-                    address = self.wallet().hotkey.ss58_address
-                    self.output.name_address(address, f"{self.wallet_name}/{self.hotkey_name}")
-                    self.output.classify_address(address, "hotkey")
-                    return address
-                if param == "coldkey_ss58":
-                    # Same precedence as the write path: `-w <multisig>` means
-                    # the multisig account, even if a wallet dir shares the name.
-                    derived = self._saved_multisig_address(self.wallet_name)
-                    if derived:
-                        self.output.name_address(derived, self.wallet_name)
-                        self.output.classify_address(derived, "coldkey")
-                        return derived
-                    address = self.wallet().coldkeypub.ss58_address
-                    self.output.name_address(address, self.wallet_name)
-                    self.output.classify_address(address, "coldkey")
-                    return address
-                return None
-            if "hotkey" in param:
-                wallet_name, _, hotkey = value.rpartition("/")
-                handle = wallets.open_wallet(
-                    wallet_name or self.wallet_name, hotkey, self.wallet_path
-                )
-                self.output.name_address(handle.hotkey.ss58_address, value)
-                self.output.classify_address(handle.hotkey.ss58_address, "hotkey")
-                return handle.hotkey.ss58_address
-            address = wallets.open_wallet(name=value, path=self.wallet_path).coldkeypub.ss58_address
-            self.output.name_address(address, value)
-            self.output.classify_address(address, "coldkey")
-            return address
+            if param == "hotkey_ss58":
+                address = self.wallet().hotkey.ss58_address
+                self.output.name_address(address, f"{self.wallet_name}/{self.hotkey_name}")
+                self.output.classify_address(address, "hotkey")
+                return address
+            if param == "coldkey_ss58":
+                # Same precedence as the write path: `-w <multisig>` means
+                # the multisig account, even if a wallet dir shares the name.
+                derived = self._saved_multisig_address(self.wallet_name)
+                if derived:
+                    self.output.name_address(derived, self.wallet_name)
+                    self.output.classify_address(derived, "coldkey")
+                    return derived
+                address = self.wallet().coldkeypub.ss58_address
+                self.output.name_address(address, self.wallet_name)
+                self.output.classify_address(address, "coldkey")
+                return address
+            return None
         except Exception as error:
-            shown = value if value is not None else f"{self.wallet_name}/{self.hotkey_name}"
+            shown = f"{self.wallet_name}/{self.hotkey_name}"
             self.output.error(f"cannot resolve {address_cli_name(param)} {shown!r}: {error}")
             raise typer.Exit(1)
 

--- a/sdk/python/bittensor/cli/intent_prompts.py
+++ b/sdk/python/bittensor/cli/intent_prompts.py
@@ -1,0 +1,148 @@
+"""Declarative prompt policies for generated transaction commands.
+
+The generated command runner should not grow an ``if intent.op == ...`` branch
+for every richer prompt. Intent-specific choices live in this registry; the
+runner applies the same small transformation pipeline to every operation.
+"""
+
+from __future__ import annotations
+
+import functools
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+import typer
+
+from .context import AppContext
+from .prompt import PromptSpec, interactive
+from .root_helpers import claim_root_source_spec
+from .stake_picker import stake_source_spec, stake_target_spec, with_free_balance
+
+
+@dataclass(frozen=True)
+class PromptRule:
+    """Replace one ordinary prompt with a richer prompt at a stable position."""
+
+    field: str
+    build: Callable[[], PromptSpec]
+    before: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class PromptDecorator:
+    """Wrap the ordinary prompt for ``field`` without changing its position."""
+
+    field: str
+    apply: Callable[[PromptSpec], PromptSpec]
+
+
+@dataclass(frozen=True)
+class IntentPromptPolicy:
+    rules: tuple[PromptRule, ...] = ()
+    decorators: tuple[PromptDecorator, ...] = ()
+    notice: Optional[Callable[[dict], Optional[str]]] = None
+    required_after_prompt: tuple[str, ...] = ()
+
+
+def _source(field: str, netuid_field: Optional[str]) -> PromptRule:
+    return PromptRule(field, functools.partial(stake_source_spec, field, netuid_field))
+
+
+def _target(field: str, amount_field: str) -> PromptRule:
+    return PromptRule(field, functools.partial(stake_target_spec, field), before=amount_field)
+
+
+def _remove_stake_notice(kwargs: dict) -> Optional[str]:
+    if kwargs.get("netuid") is not None:
+        return None
+    if str(kwargs.get("amount_alpha") or "").strip().lower() != "all":
+        return None
+    return (
+        "note: `--amount all` unstakes everything on a single subnet (--netuid); "
+        "to unstake every position across all subnets, use `btcli stake unstake-all`"
+    )
+
+
+_POLICIES: dict[str, IntentPromptPolicy] = {
+    "remove_stake": IntentPromptPolicy(
+        rules=(_source("hotkey_ss58", "netuid"),), notice=_remove_stake_notice
+    ),
+    "remove_stake_limit": IntentPromptPolicy(rules=(_source("hotkey_ss58", "netuid"),)),
+    "unstake_all": IntentPromptPolicy(rules=(_source("hotkey_ss58", None),)),
+    "unstake_all_alpha": IntentPromptPolicy(rules=(_source("hotkey_ss58", None),)),
+    "swap_stake": IntentPromptPolicy(rules=(_source("hotkey_ss58", "origin_netuid"),)),
+    "transfer_stake": IntentPromptPolicy(rules=(_source("hotkey_ss58", "origin_netuid"),)),
+    "move_stake": IntentPromptPolicy(rules=(_source("origin_hotkey_ss58", "origin_netuid"),)),
+    "claim_root_with_hotkey": IntentPromptPolicy(
+        rules=(PromptRule("hotkey_ss58", claim_root_source_spec),),
+        required_after_prompt=("hotkey_ss58",),
+    ),
+    "add_stake": IntentPromptPolicy(
+        rules=(_target("hotkey_ss58", "amount_tao"),),
+        decorators=(PromptDecorator("amount_tao", with_free_balance),),
+    ),
+    "add_stake_limit": IntentPromptPolicy(
+        rules=(_target("hotkey_ss58", "amount_tao"),),
+        decorators=(PromptDecorator("amount_tao", with_free_balance),),
+    ),
+    "stake_burn": IntentPromptPolicy(
+        decorators=(PromptDecorator("amount_tao", with_free_balance),)
+    ),
+}
+
+
+def apply_intent_prompt_policy(
+    app_ctx: AppContext,
+    op: str,
+    missing: list[PromptSpec],
+    kwargs: dict,
+) -> list[PromptSpec]:
+    """Apply ``op``'s declarative prompt policy to the missing prompt list."""
+    policy = _POLICIES.get(op)
+    if policy is None:
+        return missing
+
+    if policy.notice is not None and (notice := policy.notice(kwargs)):
+        app_ctx.output.message(notice)
+
+    prompts_ok = (
+        not app_ctx.assume_yes and not app_ctx.uses_extension_signer() and interactive(app_ctx)
+    )
+    if not prompts_ok:
+        return missing
+
+    for rule in policy.rules:
+        if kwargs.get(rule.field) is not None:
+            continue
+        missing = [spec for spec in missing if spec.field != rule.field]
+        index = (
+            next(
+                (i for i, spec in enumerate(missing) if spec.field == rule.before),
+                len(missing),
+            )
+            if rule.before is not None
+            else 0
+        )
+        missing.insert(index, rule.build())
+
+    for decorator in policy.decorators:
+        missing = [
+            decorator.apply(spec) if spec.field == decorator.field else spec for spec in missing
+        ]
+    return missing
+
+
+def validate_intent_prompt_policy(app_ctx: AppContext, op: str, kwargs: dict) -> None:
+    """Enforce values that cannot silently fall back after policy prompting."""
+    policy = _POLICIES.get(op)
+    if policy is None:
+        return
+    missing = [field for field in policy.required_after_prompt if kwargs.get(field) is None]
+    if not missing:
+        return
+    flags = ", ".join(f"`--{field.removesuffix('_ss58').replace('_', '-')}`" for field in missing)
+    app_ctx.output.error(
+        f"missing required option: {flags}",
+        help="pass it explicitly, or run on a terminal to pick one",
+    )
+    raise typer.Exit(2)

--- a/sdk/python/bittensor/cli/prompt.py
+++ b/sdk/python/bittensor/cli/prompt.py
@@ -89,7 +89,7 @@ def _missing_error(app_ctx: AppContext, flags: list[str]) -> None:
     raise typer.Exit(2)
 
 
-def _ask(console: Console, app_ctx: AppContext, spec: PromptSpec) -> tuple[Any, str]:
+def ask(console: Console, app_ctx: AppContext, spec: PromptSpec) -> tuple[Any, str]:
     """Prompt for one option until an answer parses; returns (value, raw text)."""
     if spec.help:
         hint = Text("  ")
@@ -152,7 +152,7 @@ def fill_missing(app_ctx: AppContext, missing: list[PromptSpec], kwargs: dict[st
             _entered_tokens.extend(spec.custom(console, app_ctx, kwargs))
             console.print()
             continue
-        kwargs[spec.field], raw = _ask(console, app_ctx, spec)
+        kwargs[spec.field], raw = ask(console, app_ctx, spec)
         _entered_tokens.extend([raw] if spec.positional else [spec.flag, raw])
         console.print()
 
@@ -594,7 +594,7 @@ def _run_app(app: typer.Typer) -> None:
             console = Console(stderr=True, highlight=False)
             console.print()
             for spec in specs:
-                _, raw = _ask(console, app_ctx, spec)
+                _, raw = ask(console, app_ctx, spec)
                 entered = [raw] if spec.positional else [spec.flag, raw]
                 args += entered
                 _entered_tokens.extend(entered)

--- a/sdk/python/bittensor/cli/stake_picker.py
+++ b/sdk/python/bittensor/cli/stake_picker.py
@@ -25,40 +25,11 @@ from ..reads import StakePosition, StakeValuation
 from .context import AppContext, address_cli_name
 from .helpers import chain_identity_names, local_address_names
 from .output import STYLE_COMMAND, STYLE_HINT, STYLE_KEY, STYLE_NAME, Output
-from .prompt import PromptSpec, _ask
+from .prompt import PromptSpec, ask
 
 # Positions whose spot value is below this are dust: hidden from the pickers
 # (unless everything is dust) but still selectable by typing the netuid/hotkey.
 _DUST_RAO = 1_000_000  # τ0.001
-
-# op -> (hotkey field the stake comes from, netuid field naming its subnet).
-# A None netuid field means the op spans every subnet the hotkey is staked on.
-STAKE_SOURCE_FIELDS: dict[str, tuple[str, Optional[str]]] = {
-    "remove_stake": ("hotkey_ss58", "netuid"),
-    "remove_stake_limit": ("hotkey_ss58", "netuid"),
-    "unstake_all": ("hotkey_ss58", None),
-    "unstake_all_alpha": ("hotkey_ss58", None),
-    "swap_stake": ("hotkey_ss58", "origin_netuid"),
-    "transfer_stake": ("hotkey_ss58", "origin_netuid"),
-    "move_stake": ("origin_hotkey_ss58", "origin_netuid"),
-}
-
-# op -> hotkey field naming the *destination* validator. Unlike the source
-# picker above, this hotkey need not be local or hold stake: the wallet's own
-# hotkeys are offered for convenience, but any pasted ss58 / address-book name
-# works (staking to a validator does not require its keyfile).
-STAKE_TARGET_FIELDS: dict[str, str] = {
-    "add_stake": "hotkey_ss58",
-    "add_stake_limit": "hotkey_ss58",
-}
-
-# op -> money field whose interactive prompt should lead with the coldkey's
-# free balance (the amount these ops spend comes straight out of it).
-FREE_BALANCE_AMOUNT_FIELDS: dict[str, str] = {
-    "add_stake": "amount_tao",
-    "add_stake_limit": "amount_tao",
-    "stake_burn": "amount_tao",
-}
 
 
 def stake_target_spec(hotkey_field: str) -> PromptSpec:
@@ -170,7 +141,7 @@ def with_free_balance(spec: PromptSpec) -> PromptSpec:
         with console.status("[dim]reading balance…[/dim]"):
             balance = app_ctx.run(lambda c: c.read("balance", coldkey_ss58=owner))
         console.print(f"  [dim]free balance of {owner_label}: {balance}[/dim]")
-        value, raw = _ask(console, app_ctx, replace(spec, custom=None))
+        value, raw = ask(console, app_ctx, replace(spec, custom=None))
         kwargs[spec.field] = value
         return [spec.flag, raw]
 

--- a/sdk/python/bittensor/cli/tx.py
+++ b/sdk/python/bittensor/cli/tx.py
@@ -28,16 +28,8 @@ from ..settings import tx_docs_url
 from . import globals as g
 from .call_names import resolve_intent_args
 from .context import AppContext, address_cli_name, ctx_of, ss58_param_help
-from .prompt import PromptSpec, fill_missing, interactive, signer_specs
-from .root_helpers import claim_root_source_spec
-from .stake_picker import (
-    FREE_BALANCE_AMOUNT_FIELDS,
-    STAKE_SOURCE_FIELDS,
-    STAKE_TARGET_FIELDS,
-    stake_source_spec,
-    stake_target_spec,
-    with_free_balance,
-)
+from .intent_prompts import apply_intent_prompt_policy, validate_intent_prompt_policy
+from .prompt import PromptSpec, fill_missing, signer_specs
 
 # Field annotation (as a string, under PEP 563) -> the Python type Typer should
 # parse the option as. List/complex fields are taken as strings and parsed in the
@@ -249,65 +241,7 @@ def _make_command(intent_cls: type[Intent]):
                     if kwargs.get(netuid_field) is None:
                         kwargs[netuid_field] = netuid
         missing = [spec for spec in prompt_specs if kwargs.get(spec.field) is None]
-        # `--amount all` empties ONE subnet; people with the v9 "unstake
-        # everything" reflex land here without a netuid, so point at the real
-        # all-subnets command before demanding one.
-        if (
-            intent_cls.op == "remove_stake"
-            and kwargs.get("netuid") is None
-            and str(kwargs.get("amount_alpha") or "").strip().lower() == "all"
-        ):
-            app_ctx.output.message(
-                "note: `--amount all` unstakes everything on a single subnet (--netuid); "
-                "to unstake every position across all subnets, use `btcli stake unstake-all`"
-            )
-        # Unstake-style ops pick their source hotkey from the coldkey's live
-        # stake positions instead of a bare text prompt (or, worse, a silent
-        # fallback to the wallet's own hotkey, which rarely holds the stake).
-        source = STAKE_SOURCE_FIELDS.get(intent_cls.op)
-        if (
-            source is not None
-            and kwargs.get(source[0]) is None
-            and not app_ctx.assume_yes
-            and not app_ctx.uses_extension_signer()
-            and interactive(app_ctx)
-        ):
-            hotkey_field, netuid_field = source
-            missing = [spec for spec in missing if spec.field != hotkey_field]
-            missing.insert(0, stake_source_spec(hotkey_field, netuid_field))
-        # claim_root_with_hotkey targets one validator; pick from accrued yield,
-        # not the wallet's own hotkey (which rarely holds the claimable position).
-        if (
-            intent_cls.op == "claim_root_with_hotkey"
-            and kwargs.get("hotkey_ss58") is None
-            and not app_ctx.assume_yes
-            and not app_ctx.uses_extension_signer()
-            and interactive(app_ctx)
-        ):
-            missing = [spec for spec in missing if spec.field != "hotkey_ss58"]
-            missing.insert(0, claim_root_source_spec("hotkey_ss58"))
-        # Stake-destination ops (add_stake & co) pick their target hotkey from
-        # the wallet's own hotkeys — but any pasted ss58 / address-book name
-        # works, since the destination never has to exist locally — and their
-        # amount prompt leads with the coldkey's free balance so the answer
-        # (including `all`) can be an informed one.
-        prompts_ok = (
-            not app_ctx.assume_yes and not app_ctx.uses_extension_signer() and interactive(app_ctx)
-        )
-        target_field = STAKE_TARGET_FIELDS.get(intent_cls.op)
-        balance_field = FREE_BALANCE_AMOUNT_FIELDS.get(intent_cls.op)
-        if target_field is not None and kwargs.get(target_field) is None and prompts_ok:
-            # The picker slots in just before the amount, so the prompt order
-            # narrows down naturally: subnet, then validator, then how much.
-            index = next(
-                (i for i, spec in enumerate(missing) if spec.field == balance_field),
-                len(missing),
-            )
-            missing.insert(index, stake_target_spec(target_field))
-        if balance_field is not None and prompts_ok:
-            missing = [
-                with_free_balance(spec) if spec.field == balance_field else spec for spec in missing
-            ]
+        missing = apply_intent_prompt_policy(app_ctx, intent_cls.op, missing, kwargs)
         # The signing wallet is confirmed too (Enter accepts the configured
         # default); --yes and the extension signer keep the flag-only flow.
         if not app_ctx.assume_yes and not app_ctx.uses_extension_signer():
@@ -322,12 +256,7 @@ def _make_command(intent_cls: type[Intent]):
             )
         if missing:
             fill_missing(app_ctx, missing, kwargs)
-        if intent_cls.op == "claim_root_with_hotkey" and kwargs.get("hotkey_ss58") is None:
-            app_ctx.output.error(
-                "missing required option: `--hotkey`",
-                help="pass the validator hotkey to claim from, or run on a terminal to pick one",
-            )
-            raise typer.Exit(2)
+        validate_intent_prompt_policy(app_ctx, intent_cls.op, kwargs)
         # `self` is a sentinel (bypass the configured proxy_for default, see
         # AppContext.submit), so it must reach submit unresolved.
         raw_proxy_for = kwargs.pop("proxy_for", None)

--- a/sdk/python/tests/unit/test_cli.py
+++ b/sdk/python/tests/unit/test_cli.py
@@ -16,9 +16,11 @@ from typer.testing import CliRunner
 
 import bittensor.cli.commands.root as root_commands
 import bittensor.cli.context as cli_context
-from bittensor import RpcConnectionError, RpcPolicyError, __version__, wallets
+from bittensor import RpcConnectionError, RpcPolicyError, __version__, config, wallets
 from bittensor.balance import Balance
+from bittensor.cli.call_names import resolve_builder_params
 from bittensor.cli.main import app
+from bittensor.cli.output import Output
 from bittensor.cli.root_helpers import RootPosition, position_columns, position_rows
 from bittensor.client import Client
 from bittensor.intents import REGISTRY
@@ -243,6 +245,40 @@ class TestQueries:
         payload = json.loads(result.output)
         assert payload["coldkey"] == BOB
         assert payload["free_tao"] == pytest.approx(2.5)
+
+
+class TestAddressResolution:
+    @staticmethod
+    def app_context(wallet_dir: str) -> cli_context.AppContext:
+        return cli_context.AppContext(
+            network="finney",
+            wallet_name=_WALLET_NAME,
+            hotkey_name="default",
+            wallet_path=wallet_dir,
+            assume_yes=True,
+            dry_run=False,
+            output=Output(json_mode=True),
+        )
+
+    def test_raw_call_uses_canonical_saved_multisig_resolution(self, fake, wallet_dir):
+        config.add_multisig({"name": "treasury", "threshold": 1, "signatories": [BOB]})
+        app_ctx = self.app_context(wallet_dir)
+        expected = app_ctx.resolve_address_ref("new_coldkey", "treasury")
+
+        params = resolve_builder_params(
+            app_ctx,
+            "SubtensorModule.schedule_swap_coldkey",
+            {"new_coldkey": "treasury"},
+        )
+
+        assert params["new_coldkey"] == expected.address
+        assert expected.source == "saved multisig 'treasury'"
+
+    def test_raw_call_does_not_guess_arbitrary_string_lists_are_accounts(self, fake, wallet_dir):
+        app_ctx = self.app_context(wallet_dir)
+        params = {"remark": [BOB, "ordinary memo text"]}
+
+        assert resolve_builder_params(app_ctx, "System.remark", params) == params
 
 
 class TestRoot:

--- a/sdk/python/tests/unit/test_cli_intent_prompts.py
+++ b/sdk/python/tests/unit/test_cli_intent_prompts.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from bittensor.cli import intent_prompts
+from bittensor.cli.prompt import PromptSpec
+
+
+def _spec(field: str) -> PromptSpec:
+    return PromptSpec(
+        field=field,
+        flag=f"--{field.replace('_', '-')}",
+        help=None,
+        parse=lambda _ctx, value: value,
+    )
+
+
+def _context():
+    return SimpleNamespace(
+        assume_yes=False,
+        uses_extension_signer=lambda: False,
+        output=SimpleNamespace(message=lambda _message: None),
+    )
+
+
+def test_add_stake_policy_places_target_before_decorated_amount(monkeypatch):
+    monkeypatch.setattr(intent_prompts, "interactive", lambda _ctx: True)
+    missing = [_spec("netuid"), _spec("hotkey_ss58"), _spec("amount_tao")]
+
+    result = intent_prompts.apply_intent_prompt_policy(_context(), "add_stake", missing, {})
+
+    assert [spec.field for spec in result] == ["netuid", "hotkey_ss58", "amount_tao"]
+    assert result[1].custom is not None
+    assert result[2].custom is not None
+
+
+def test_remove_stake_policy_moves_source_picker_first(monkeypatch):
+    monkeypatch.setattr(intent_prompts, "interactive", lambda _ctx: True)
+    missing = [_spec("netuid"), _spec("hotkey_ss58"), _spec("amount_alpha")]
+
+    result = intent_prompts.apply_intent_prompt_policy(_context(), "remove_stake", missing, {})
+
+    assert [spec.field for spec in result] == ["hotkey_ss58", "netuid", "amount_alpha"]
+    assert result[0].custom is not None


### PR DESCRIPTION
## Summary

- restore raw 64-byte sr25519 private keys without truncating them into unrelated seeds
- route flag and nested-call account names through one canonical resolver, including saved multisigs
- stop inferring arbitrary string lists as account lists
- move intent-specific picker and balance prompts into a declarative policy registry
- apply the Rust formatting currently blocking the target branch

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p bittensor-core keyfiles --lib` (17 passed)
- `cargo clippy -p bittensor-core --all-targets -- -D warnings`
- `ruff check sdk/python/bittensor sdk/python/tests/unit`
- `ruff format --check sdk/python/bittensor sdk/python/tests/unit`
- `pytest -q tests/unit` (1079 passed, 1 skipped)