### PR TITLE
fix(subtensor): clear voting state on subnet dissolution

### DIFF
--- a/pallets/subtensor/src/subnets/dissolution.rs
+++ b/pallets/subtensor/src/subnets/dissolution.rs
@@ -197,6 +197,8 @@ impl<T: Config> Pallet<T> {
             ColdkeyMinerCollateral::<T>::clear_prefix(netuid, limit, None)
         }) && clear_prefix_with_meter(weight_meter, write_weight, |limit| {
             ColdkeyCollateralHotkeys::<T>::clear_prefix(netuid, limit, None)
+        }) && clear_prefix_with_meter(weight_meter, write_weight, |limit| {
+            VotingPower::<T>::clear_prefix(netuid, limit, None)
         });
 
         if !result {
@@ -281,7 +283,7 @@ impl<T: Config> Pallet<T> {
     pub fn remove_network_parameters(netuid: NetUid, weight_meter: &mut WeightMeter) -> bool {
         // Flat write charge for the `::remove(netuid)` list below. Bump this when
         // adding or removing entries from that list so the weight stays in step.
-        let removal_weight = T::DbWeight::get().writes(82);
+        let removal_weight = T::DbWeight::get().writes(86);
         if !weight_meter.can_consume(removal_weight) {
             return false;
         }
@@ -373,6 +375,10 @@ impl<T: Config> Pallet<T> {
         LastEpochBlock::<T>::remove(netuid);
         PendingEpochAt::<T>::remove(netuid);
         SubnetEpochIndex::<T>::remove(netuid);
+        TotalVotingPower::<T>::remove(netuid);
+        VotingPowerTrackingEnabled::<T>::remove(netuid);
+        VotingPowerDisableAtBlock::<T>::remove(netuid);
+        VotingPowerEmaAlpha::<T>::remove(netuid);
 
         if SubnetIdentitiesV3::<T>::contains_key(netuid) {
             SubnetIdentitiesV3::<T>::remove(netuid);

--- a/pallets/subtensor/src/tests/voting_power.rs
+++ b/pallets/subtensor/src/tests/voting_power.rs
@@ -390,6 +390,43 @@ fn test_total_voting_power_tracks_updates_removals_and_swaps() {
     });
 }
 
+#[test]
+fn test_dissolve_clears_voting_power_state_before_netuid_reuse() {
+    new_test_ext(1).execute_with(|| {
+        let f = VotingPowerTestFixture::new();
+        let second_hotkey = U256::from(99);
+        let default_ema_alpha = VotingPowerEmaAlpha::<Test>::get(f.netuid);
+
+        VotingPower::<Test>::insert(f.netuid, f.hotkey, 123);
+        VotingPower::<Test>::insert(f.netuid, second_hotkey, 456);
+        TotalVotingPower::<Test>::insert(f.netuid, 579);
+        VotingPowerTrackingEnabled::<Test>::insert(f.netuid, true);
+        VotingPowerDisableAtBlock::<Test>::insert(f.netuid, 1_000);
+        VotingPowerEmaAlpha::<Test>::insert(f.netuid, MAX_VOTING_POWER_EMA_ALPHA);
+
+        assert_ok!(SubtensorModule::do_dissolve_network(f.netuid));
+        run_block_idle();
+
+        assert!(VotingPower::<Test>::iter_prefix(f.netuid).next().is_none());
+        assert!(!TotalVotingPower::<Test>::contains_key(f.netuid));
+        assert!(!VotingPowerTrackingEnabled::<Test>::contains_key(f.netuid));
+        assert!(!VotingPowerDisableAtBlock::<Test>::contains_key(f.netuid));
+        assert!(!VotingPowerEmaAlpha::<Test>::contains_key(f.netuid));
+
+        SubtensorModule::init_new_network(f.netuid, 10);
+
+        assert_eq!(VotingPower::<Test>::get(f.netuid, f.hotkey), 0);
+        assert_eq!(VotingPower::<Test>::get(f.netuid, second_hotkey), 0);
+        assert_eq!(TotalVotingPower::<Test>::get(f.netuid), 0);
+        assert!(!VotingPowerTrackingEnabled::<Test>::get(f.netuid));
+        assert_eq!(VotingPowerDisableAtBlock::<Test>::get(f.netuid), 0);
+        assert_eq!(
+            VotingPowerEmaAlpha::<Test>::get(f.netuid),
+            default_ema_alpha
+        );
+    });
+}
+
 // SKIP_WASM_BUILD=1 RUST_LOG=debug cargo test --package pallet-subtensor --lib -- tests::voting_power::test_voting_power_cleared_when_deregistered --exact --nocapture
 #[test]
 fn test_voting_power_cleared_when_deregistered() {


### PR DESCRIPTION
## Summary

- clear per-validator voting-power rows through the existing metered subnet map cleanup
- remove voting-power aggregate and configuration values during subnet parameter cleanup
- cover dissolution and netuid reuse with an end-to-end regression test

## Why

Voting-power state is scoped by netuid. Without lifecycle cleanup, a new subnet that reuses a dissolved netuid can inherit validator rows, aggregate voting power, tracking state, a pending disable block, and a custom EMA alpha from the previous subnet.

The validator map remains weight-metered so dissolution stays resumable for subnets with many entries. Netuid reuse is already blocked until cleanup completes.

Stacked on #3058.

## Tests

- SKIP_WASM_BUILD=1 cargo test --package pallet-subtensor --lib -- tests::voting_power::
- SKIP_WASM_BUILD=1 cargo test --package pallet-subtensor --lib -- tests::networks::dissolve_clears_all_per_subnet_storages --exact
- cargo fmt --all -- --check