### PR TITLE
Feat/syncclient finalized block property

### DIFF
--- a/docs/concepts/client.mdx
+++ b/docs/concepts/client.mdx
@@ -122,7 +122,8 @@ via the raw-call escape hatch ([Advanced submission](/docs/concepts/advanced)).
 ## Blocks, time, and waiting
 
 ```python
-await client.block()                       # current block number
+await client.block()                       # current best block number
+await client.finalized_block()             # latest finalized block number
 await client.block_info(123)               # header + extrinsics + timestamp
 async for header in await client.blocks(): ...   # subscribe to new blocks
 
@@ -130,6 +131,11 @@ await client.wait_for_block(1_000_000)
 await client.wait_for_timestamp("2026-08-01T00:00:00Z")
 await client.wait_for_epoch(netuid=1)      # next epoch boundary on a subnet
 ```
+
+`block()` returns the current best chain head, which can be ahead of finality.
+Use `finalized_block()` when work must only act on blocks the connected node
+reports as finalized. In blocking mode these are the `sub.block` and
+`sub.finalized_block` properties; each access performs a fresh chain read.
 
 ## Pinned snapshots
 

--- a/sdk/python/bittensor/_substrate.py
+++ b/sdk/python/bittensor/_substrate.py
@@ -120,6 +120,10 @@ class Substrate(Protocol):
         """Current chain block number."""
         ...
 
+    async def finalized_block_number(self) -> int:
+        """Latest finalized chain block number."""
+        ...
+
     async def block_time(self) -> float:
         """Seconds per block, detected from the chain."""
         ...
@@ -404,6 +408,13 @@ class RpcSubstrate:
 
     async def block_number(self) -> int:
         return await self._read(lambda raw: raw.get_block_number(None))
+
+    async def finalized_block_number(self) -> int:
+        async def read(raw: SubstrateConnection) -> int:
+            head = await raw.get_chain_finalised_head()
+            return await raw.get_block_number(head)
+
+        return await self._read(read)
 
     async def block_time(self) -> float:
         """Seconds per block, from the chain's ``Aura.SlotDuration`` constant.

--- a/sdk/python/bittensor/_subtensor.py
+++ b/sdk/python/bittensor/_subtensor.py
@@ -5,6 +5,7 @@
     # Inline, blocking (connects lazily; no close() needed)
     sub = bt.Subtensor()                    # defaults to finney
     print(sub.block)                        # current block number
+    print(sub.finalized_block)              # latest finalized block number
     print(sub.time)                         # UTC time of the head block
     print(sub.spec_version)                 # runtime spec_version
     print(sub.balances.balance(coldkey_ss58="5F..."))
@@ -53,8 +54,8 @@ class Subtensor(SyncClient):
     of code. The first blocking call locks the instance into blocking mode;
     the first ``await`` locks it into async mode. Attribute *inspection* has
     no side effects (safe to repr, probe, or autocomplete a cold instance) —
-    except the chain-reading properties ``block``, ``time``, and
-    ``spec_version``, whose *evaluation* is a blocking read.
+    except the chain-reading properties ``block``, ``finalized_block``,
+    ``time``, and ``spec_version``, whose *evaluation* is a blocking read.
 
     Blocking mode needs no ``close()``: the connection opens on first call and
     is cleaned up when the instance is garbage collected (or at process exit).

--- a/sdk/python/bittensor/client.py
+++ b/sdk/python/bittensor/client.py
@@ -585,6 +585,10 @@ class Client:
         """Current chain block number."""
         return await self._substrate.block_number()
 
+    async def finalized_block(self) -> int:
+        """Latest finalized chain block number."""
+        return await self._substrate.finalized_block_number()
+
     async def spec_version(self) -> int:
         """The connected runtime's ``spec_version`` (at the chain head)."""
         return await self._substrate.spec_version()

--- a/sdk/python/bittensor/sync.py
+++ b/sdk/python/bittensor/sync.py
@@ -319,6 +319,11 @@ class SyncClient:
         return self._call(self._client.block())
 
     @property
+    def finalized_block(self) -> int:
+        """Latest finalized chain block number. Reads the chain on every access."""
+        return self._call(self._client.finalized_block())
+
+    @property
     def time(self) -> datetime:
         """UTC timestamp of the current chain head block. Reads the chain on
         every access; ``timestamp(block=...)`` reads another block's time."""

--- a/sdk/python/tests/harness/fake_substrate.py
+++ b/sdk/python/tests/harness/fake_substrate.py
@@ -129,6 +129,7 @@ class FakeSubstrate:
         self.connected = False
         self.closed = False
         self.block = 100
+        self.finalized_block = 99
         self.runtime_spec_version = 300
 
         # (module, item) -> {params-tuple: value}
@@ -206,6 +207,9 @@ class FakeSubstrate:
 
     async def block_number(self) -> int:
         return self.block
+
+    async def finalized_block_number(self) -> int:
+        return self.finalized_block
 
     async def block_time(self) -> float:
         # Same derivation as production: the chain's Aura.SlotDuration constant.

--- a/sdk/python/tests/unit/test_facades.py
+++ b/sdk/python/tests/unit/test_facades.py
@@ -15,10 +15,12 @@ import inspect
 
 import pytest
 
+from bittensor import Subtensor
 from bittensor.client import Client
 from bittensor.namespaces import NAMESPACES
 from bittensor.snapshot import Snapshot
 from bittensor.sync import _NAMESPACES, SyncClient, SyncSnapshot, _SyncNamespace
+from tests.harness.fake_substrate import FakeSubstrate
 
 NAMESPACE_CLASSES = NAMESPACES
 
@@ -122,5 +124,26 @@ def test_sync_client_constructs_offline():
     try:
         assert client.network == "finney"
         assert client._state["connected"] is False
+    finally:
+        client.close()
+
+
+async def test_client_returns_latest_finalized_block():
+    substrate = FakeSubstrate()
+    substrate.finalized_block = 97
+    client = Client("local", substrate=substrate)
+
+    assert await client.finalized_block() == 97
+
+
+def test_subtensor_exposes_latest_finalized_block_as_property():
+    substrate = FakeSubstrate()
+    substrate.block = 100
+    substrate.finalized_block = 97
+    client = Subtensor("local", substrate=substrate)
+    client._call = asyncio.run
+    try:
+        assert client.finalized_block == 97
+        assert client.block == 100
     finally:
         client.close()

--- a/sdk/python/tests/unit/test_rpc.py
+++ b/sdk/python/tests/unit/test_rpc.py
@@ -373,6 +373,23 @@ async def test_rpc_substrate_exposes_public_blank_timeout_error(monkeypatch):
         await substrate.connect()
 
 
+async def test_rpc_substrate_resolves_finalized_head_to_block_number():
+    finalized_hash = "0x" + "ab" * 32
+
+    class FinalizedConnection:
+        async def get_chain_finalised_head(self):
+            return finalized_hash
+
+        async def get_block_number(self, block_hash):
+            assert block_hash == finalized_hash
+            return 97
+
+    substrate = RpcSubstrate("wss://rpc.example", fallback_endpoints=[])
+    substrate._substrate = FinalizedConnection()
+
+    assert await substrate.finalized_block_number() == 97
+
+
 async def test_rpc_substrate_stream_preserves_public_policy_metadata():
     class RefusedStream:
         async def subscribe_heads(self, **kwargs):


### PR DESCRIPTION
## Description
Adds a `bittensor.Subtensor().finalized_block` property that retrieves the most recent finalized block.


## Related Issue(s)

- Closes #3068

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

This is an entirely new property with nothing existing being removed or changed

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
