### PR TITLE
Restore miner-burn emission scaling

### DIFF
--- a/docs/concepts/emissions.mdx
+++ b/docs/concepts/emissions.mdx
@@ -71,27 +71,37 @@ protocol-owned alpha.
 
 ## Subnet emission shares
 
-Each block's TAO emission is divided in two clear steps. First, the chain turns
-each eligible subnet's **EMA price** into a share of total demand:
+Each block's TAO emission is divided in three steps. First, the chain turns each
+eligible subnet's **EMA price** into a share of total demand:
 
 ```
 demand_share_i = price_ema_i / Σ price_ema
 ```
 
-`MinerBurned` does not change this cross-subnet share. It still records what
-happened to miner incentive inside the subnet, but one subnet's local burn or
-recycle choice does not change another subnet's emission.
-
-Second, the **emission gate** reduces weak demand before the final shares are
-normalized. The gate has a midpoint called `theta`. By default, `theta` is the
-32nd-highest positive demand share. It is normally recalculated every 360
-blocks and stays fixed between updates. A subnet at the midpoint passes half
-of its demand weight. Subnets well above it pass almost all; subnets well below
-it pass much less:
+Next, the chain scales that price share by `1 − MinerBurned` and renormalizes:
 
 ```
-gate_i = 1 / (1 + (theta / demand_share_i)^h)
-final_share_i = demand_share_i × gate_i / Σ(demand_share × gate)
+burn_adjusted_share_i = demand_share_i × (1 − miner_burned_i)
+                        / Σ(demand_share × (1 − miner_burned))
+```
+
+`MinerBurned` is the proportion of the last tempo's miner incentive withheld
+because it was directed to subnet-owner hotkeys. Withheld incentive counts
+whether it is recycled or burned, so changing `RecycleOrBurn` cannot bypass the
+scaling. If every adjusted weight is zero, the runtime restores the unadjusted
+price shares so emission is not stranded.
+
+Finally, the **emission gate** reduces weak burn-adjusted shares before the final
+shares are normalized. The gate has a midpoint called `theta`. By default,
+`theta` is the 32nd-highest positive adjusted share. It is normally recalculated
+every 360 blocks and stays fixed between updates. A subnet at the midpoint
+passes half of its adjusted weight. Subnets well above it pass almost all;
+subnets well below it pass much less:
+
+```
+gate_i = 1 / (1 + (theta / burn_adjusted_share_i)^h)
+final_share_i = burn_adjusted_share_i × gate_i
+                / Σ(burn_adjusted_share × gate)
 ```
 
 The default exponent `h` is 3. This makes the gate gradual rather than a hard

--- a/docs/guides/evm/precompile-design.mdx
+++ b/docs/guides/evm/precompile-design.mdx
@@ -336,7 +336,7 @@ interface IPrecompileRegistry {
 }
 ```
 
-In v444, the fields have the following behavior:
+In v445, the fields have the following behavior:
 
 | Field | Meaning |
 |---|---|
@@ -346,7 +346,7 @@ In v444, the fields have the following behavior:
 | `newSelector` | Reserved; always `0x00000000`. |
 | `message` | Reserved; always empty. |
 
-The `selector` parameter is also reserved and is not interpreted in v444. A
+The `selector` parameter is also reserved and is not interpreted in v445. A
 response therefore does not prove that a selector exists or describe its
 lifecycle. Tooling must use the canonical Solidity interfaces and JSON ABIs to
 discover supported selectors.
@@ -455,6 +455,6 @@ Precompiles are a long-lived contract between Subtensor and deployed EVM code.
 Keep addresses and released selectors stable, version functions additively,
 preserve old semantics whenever possible, and replace raw storage access with
 typed views that insulate callers from storage layouts. Use deprecation to guide
-migration and reversible disablement to handle operational risk. The v444
+migration and reversible disablement to handle operational risk. The v445
 registry reports whole-precompile disablement; function-level lifecycle status
 remains a future extension.

--- a/docs/guides/evm/precompiles/registry.mdx
+++ b/docs/guides/evm/precompiles/registry.mdx
@@ -10,7 +10,7 @@ description: Registry for precompile availability.
 | Address | `0x0000000000000000000000000000000000000813` |
 | Status | Deployed |
 
-In v444, the registry reports the current operational availability of a whole
+In v445, the registry reports the current operational availability of a whole
 precompile through `isDisabled`. It does not report whether an individual
 selector exists, is deprecated, or has a replacement.
 
@@ -35,7 +35,7 @@ interface IPrecompileRegistry {
 
 The `selector` parameter and the `isDeprecated`, `newPrecompile`, `newSelector`,
 and `message` result fields are reserved for future selector-lifecycle support.
-In v444 those fields are not populated, and the selector is not interpreted.
+In v445 those fields are not populated, and the selector is not interpreted.
 Do not use this call to test whether a selector is supported; use the canonical
 Solidity interfaces and JSON ABIs for selector discovery.
 

--- a/docs/migration.mdx
+++ b/docs/migration.mdx
@@ -521,12 +521,11 @@ the upgrade. See the release notes for
   to the highest-conviction hotkey when total conviction reaches 10% of
   `SubnetAlphaOut`. Existing conviction counts toward this threshold. See
   [Conviction](/docs/guides/conviction).
-- **Cross-subnet emissions.** V444 allocation uses each subnet's EMA price,
-  followed by the emission gate. `MinerBurned` no longer changes a subnet's
-  cross-network share. [`root_proportion`](/code/pallets/subtensor/src/coinbase/block_step.rs#L74-L84)
-  is also not part of the inter-subnet split; it still applies inside each
-  subnet for injection caps and root dividends. Update emission calculations
-  and forecasts. See [Emissions](/docs/concepts/emissions).
+- **Cross-subnet emissions.** Allocation continues to use each subnet's EMA
+  price scaled by `1 − MinerBurned`, followed by the emission gate.
+  [`root_proportion`](/code/pallets/subtensor/src/coinbase/block_step.rs#L74-L84)
+  is not part of the inter-subnet split; it still applies inside each subnet
+  for injection caps and root dividends. See [Emissions](/docs/concepts/emissions).
 
 ### Proxies and coldkeys
 

--- a/docs/migration.mdx
+++ b/docs/migration.mdx
@@ -513,7 +513,7 @@ if not result.success:
 The v11 package ships against a runtime that also changed behavior. These are
 not rename mappings — scripts that still "work" can fail or mis-account after
 the upgrade. See the release notes for
-[V431](/releases/v431-upgrade) and [V444](/releases/v444-upgrade).
+[V431](/releases/v431-upgrade) and [V445](/releases/v445-upgrade).
 
 ### Ownership and emissions
 

--- a/pallets/subtensor/src/coinbase/run_coinbase.rs
+++ b/pallets/subtensor/src/coinbase/run_coinbase.rs
@@ -737,10 +737,9 @@ impl<T: Config> Pallet<T> {
                     "incentives: hotkey: {hotkey:?} is SN owner hotkey or associated hotkey, skipping {incentive:?}"
                 );
                 // Miner emission directed to an owner (immune) hotkey is withheld from
-                // miners whether it is recycled or burned. Count both toward the recorded
-                // withheld proportion so the metric is independent of the subnet's
-                // RecycleOrBurn configuration. The proportion is informational only and
-                // does not affect the subnet's emission share.
+                // miners whether it is recycled or burned. Count both toward the withheld
+                // proportion so the emission penalty cannot be dodged by choosing Recycle
+                // and an unset RecycleOrBurn config is not uniquely penalized.
                 withheld_incentive = withheld_incentive.saturating_add(incentive);
                 // Check if we should recycle or burn the incentive
                 match RecycleOrBurn::<T>::try_get(netuid) {

--- a/pallets/subtensor/src/coinbase/subnet_emissions.rs
+++ b/pallets/subtensor/src/coinbase/subnet_emissions.rs
@@ -347,13 +347,42 @@ impl<T: Config> Pallet<T> {
         offset_flows
     }
 
-    // Price-based emission shares: each subnet's share is its EMA price normalized
-    // by the sum of EMA prices, passed through the emission gate. Emit-disabled
-    // subnets are zeroed and their share redistributed to enabled subnets in
-    // `get_subnet_block_emissions`, so the effective emission is
-    // e_i = gate(s_i) * s_i / sum(gate(s_j) * s_j) over emit-enabled subnets.
+    // Price-based emission shares: normalize EMA prices, reweight each share by
+    // (1 - MinerBurned), renormalize, then pass the result through the emission
+    // gate. Emit-disabled subnets are zeroed and their share redistributed to
+    // enabled subnets in `get_subnet_block_emissions`.
     pub(crate) fn get_shares(subnets_to_emit_to: &[NetUid]) -> BTreeMap<NetUid, U64F64> {
-        let mut shares = Self::get_shares_price_ema(subnets_to_emit_to);
+        let price_shares = Self::get_shares_price_ema(subnets_to_emit_to);
+
+        // Reallocate emission away from subnets that withhold miner emission.
+        // The effective pre-gate weight is price_i * (1 - miner_burned_i).
+        let zero = U64F64::saturating_from_num(0);
+        let one = U64F64::saturating_from_num(1);
+        let weighted: BTreeMap<NetUid, U64F64> = price_shares
+            .iter()
+            .map(|(netuid, share)| {
+                let burned = U64F64::saturating_from_num(MinerBurned::<T>::get(netuid)).min(one);
+                let factor = one.saturating_sub(burned);
+
+                (*netuid, share.saturating_mul(factor))
+            })
+            .collect();
+
+        let total_weight = weighted
+            .values()
+            .copied()
+            .fold(zero, |acc, weight| acc.saturating_add(weight));
+
+        let mut shares = if total_weight > zero {
+            weighted
+                .into_iter()
+                .map(|(netuid, weight)| (netuid, weight.safe_div(total_weight)))
+                .collect()
+        } else {
+            // If every weight is zero (for example, every eligible subnet has
+            // MinerBurned == 1), restore the price shares so emission is not stranded.
+            price_shares
+        };
 
         Self::maybe_update_emission_gate_bar(&shares);
         Self::apply_emission_gate(&mut shares);

--- a/pallets/subtensor/src/coinbase/subnet_emissions.rs
+++ b/pallets/subtensor/src/coinbase/subnet_emissions.rs
@@ -353,9 +353,19 @@ impl<T: Config> Pallet<T> {
     // enabled subnets in `get_subnet_block_emissions`.
     pub(crate) fn get_shares(subnets_to_emit_to: &[NetUid]) -> BTreeMap<NetUid, U64F64> {
         let price_shares = Self::get_shares_price_ema(subnets_to_emit_to);
+        let mut shares = Self::scale_price_shares_by_miner_burn(price_shares);
 
-        // Reallocate emission away from subnets that withhold miner emission.
-        // The effective pre-gate weight is price_i * (1 - miner_burned_i).
+        Self::maybe_update_emission_gate_bar(&shares);
+        Self::apply_emission_gate(&mut shares);
+        shares
+    }
+
+    /// Scales normalized EMA-price shares by `(1 - MinerBurned)` and
+    /// renormalizes them. If every resulting weight is zero, returns the
+    /// original price shares so emission is not stranded.
+    fn scale_price_shares_by_miner_burn(
+        price_shares: BTreeMap<NetUid, U64F64>,
+    ) -> BTreeMap<NetUid, U64F64> {
         let zero = U64F64::saturating_from_num(0);
         let one = U64F64::saturating_from_num(1);
         let weighted: BTreeMap<NetUid, U64F64> = price_shares
@@ -373,20 +383,14 @@ impl<T: Config> Pallet<T> {
             .copied()
             .fold(zero, |acc, weight| acc.saturating_add(weight));
 
-        let mut shares = if total_weight > zero {
+        if total_weight > zero {
             weighted
                 .into_iter()
                 .map(|(netuid, weight)| (netuid, weight.safe_div(total_weight)))
                 .collect()
         } else {
-            // If every weight is zero (for example, every eligible subnet has
-            // MinerBurned == 1), restore the price shares so emission is not stranded.
             price_shares
-        };
-
-        Self::maybe_update_emission_gate_bar(&shares);
-        Self::apply_emission_gate(&mut shares);
-        shares
+        }
     }
 
     /// Blocks between emission gate bar recomputations. Matching the standard

--- a/pallets/subtensor/src/tests/subnet_emissions.rs
+++ b/pallets/subtensor/src/tests/subnet_emissions.rs
@@ -192,36 +192,73 @@ fn get_shares_ignores_root_prop_storage_when_prices_and_burns_match() {
     });
 }
 
-/// Regression: `get_shares` must be independent of `MinerBurned`. The removed
-/// formula weighted each price share by (1 - miner_burned) and renormalized,
-/// so under it a burn split of 0 : 1 yields shares 1 : 0 and a split of
-/// 0.25 : 0.75 yields 0.75 : 0.25. This test fails if that weighting is
-/// reintroduced.
+/// Miner-burn scaling is applied before the emission gate. Equal EMA prices
+/// with burns 0.25 : 0.75 produce pre-gate shares 0.75 : 0.25. With the
+/// default h=3 gate and theta=0.25, the final shares are 81/95 : 14/95.
 #[test]
-fn get_shares_independent_of_miner_burned() {
-    // (burn_n1, burn_n2): boundary values and a non-boundary split.
-    for (burn_n1, burn_n2) in [(0.0, 1.0), (1.0, 0.0), (0.25, 0.75)] {
-        new_test_ext(1).execute_with(|| {
-            let owner_hotkey = U256::from(90);
-            let owner_coldkey = U256::from(91);
-            let n1 = add_dynamic_network(&owner_hotkey, &owner_coldkey);
-            let n2 = add_dynamic_network(&owner_hotkey, &owner_coldkey);
+fn get_shares_scales_by_miner_burn_before_gate() {
+    new_test_ext(1).execute_with(|| {
+        let owner_hotkey = U256::from(90);
+        let owner_coldkey = U256::from(91);
+        let n1 = add_dynamic_network(&owner_hotkey, &owner_coldkey);
+        let n2 = add_dynamic_network(&owner_hotkey, &owner_coldkey);
 
-            // Equal prices; only the miner-burn values differ.
-            SubnetMovingPrice::<Test>::insert(n1, i96f32(1.0));
-            SubnetMovingPrice::<Test>::insert(n2, i96f32(1.0));
-            MinerBurned::<Test>::insert(n1, U96F32::saturating_from_num(burn_n1));
-            MinerBurned::<Test>::insert(n2, U96F32::saturating_from_num(burn_n2));
+        SubnetMovingPrice::<Test>::insert(n1, i96f32(1.0));
+        SubnetMovingPrice::<Test>::insert(n2, i96f32(1.0));
+        MinerBurned::<Test>::insert(n1, U96F32::saturating_from_num(0.25));
+        MinerBurned::<Test>::insert(n2, U96F32::saturating_from_num(0.75));
 
-            let shares = SubtensorModule::get_shares(&[n1, n2]);
-            let s1 = shares.get(&n1).copied().unwrap().to_num::<f64>();
-            let s2 = shares.get(&n2).copied().unwrap().to_num::<f64>();
+        let shares = SubtensorModule::get_shares(&[n1, n2]);
+        let s1 = shares.get(&n1).copied().unwrap().to_num::<f64>();
+        let s2 = shares.get(&n2).copied().unwrap().to_num::<f64>();
 
-            assert_abs_diff_eq!(s1, 0.5_f64, epsilon = 1e-9);
-            assert_abs_diff_eq!(s2, 0.5_f64, epsilon = 1e-9);
-            assert_abs_diff_eq!(s1 + s2, 1.0_f64, epsilon = 1e-9);
-        });
-    }
+        assert_abs_diff_eq!(
+            EmissionGateBar::<Test>::get().to_num::<f64>(),
+            0.25,
+            epsilon = 1e-9
+        );
+        assert_abs_diff_eq!(s1, 81.0 / 95.0, epsilon = 1e-6);
+        assert_abs_diff_eq!(s2, 14.0 / 95.0, epsilon = 1e-6);
+        assert_abs_diff_eq!(s1 + s2, 1.0, epsilon = 1e-9);
+    });
+}
+
+#[test]
+fn get_shares_full_miner_burn_gets_zero() {
+    new_test_ext(1).execute_with(|| {
+        let owner_hotkey = U256::from(92);
+        let owner_coldkey = U256::from(93);
+        let n1 = add_dynamic_network(&owner_hotkey, &owner_coldkey);
+        let n2 = add_dynamic_network(&owner_hotkey, &owner_coldkey);
+
+        SubnetMovingPrice::<Test>::insert(n1, i96f32(1.0));
+        SubnetMovingPrice::<Test>::insert(n2, i96f32(1.0));
+        MinerBurned::<Test>::insert(n1, U96F32::saturating_from_num(1.0));
+        MinerBurned::<Test>::insert(n2, U96F32::saturating_from_num(0.0));
+
+        let shares = SubtensorModule::get_shares(&[n1, n2]);
+        assert_abs_diff_eq!(shares[&n1].to_num::<f64>(), 0.0, epsilon = 1e-9);
+        assert_abs_diff_eq!(shares[&n2].to_num::<f64>(), 1.0, epsilon = 1e-9);
+    });
+}
+
+#[test]
+fn get_shares_all_full_miner_burn_falls_back_to_price_shares() {
+    new_test_ext(1).execute_with(|| {
+        let owner_hotkey = U256::from(94);
+        let owner_coldkey = U256::from(95);
+        let n1 = add_dynamic_network(&owner_hotkey, &owner_coldkey);
+        let n2 = add_dynamic_network(&owner_hotkey, &owner_coldkey);
+
+        SubnetMovingPrice::<Test>::insert(n1, i96f32(1.0));
+        SubnetMovingPrice::<Test>::insert(n2, i96f32(1.0));
+        MinerBurned::<Test>::insert(n1, U96F32::saturating_from_num(1.0));
+        MinerBurned::<Test>::insert(n2, U96F32::saturating_from_num(1.0));
+
+        let shares = SubtensorModule::get_shares(&[n1, n2]);
+        assert_abs_diff_eq!(shares[&n1].to_num::<f64>(), 0.5, epsilon = 1e-9);
+        assert_abs_diff_eq!(shares[&n2].to_num::<f64>(), 0.5, epsilon = 1e-9);
+    });
 }
 
 /// Empty candidate set: no panic, empty map, bar stays unset.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 444,
+    spec_version: 445,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/sdk/python/bittensor/_generated/calls.py
+++ b/sdk/python/bittensor/_generated/calls.py
@@ -1,7 +1,7 @@
 """Generated from runtime metadata by codegen. DO NOT EDIT BY HAND.
 
 Regenerate with: python -m codegen <ws-endpoint>
-Spec version: 444
+Spec version: 445
 """
 from typing import Any, NamedTuple
 

--- a/sdk/python/bittensor/_generated/constants.py
+++ b/sdk/python/bittensor/_generated/constants.py
@@ -1,7 +1,7 @@
 """Generated from runtime metadata by codegen. DO NOT EDIT BY HAND.
 
 Regenerate with: python -m codegen <ws-endpoint>
-Spec version: 444
+Spec version: 445
 
 Pallet constant descriptors: unpack into substrate.constant.
 """

--- a/sdk/python/bittensor/_generated/errors.py
+++ b/sdk/python/bittensor/_generated/errors.py
@@ -1,7 +1,7 @@
 """Generated from runtime metadata by codegen. DO NOT EDIT BY HAND.
 
 Regenerate with: python -m codegen <ws-endpoint>
-Spec version: 444
+Spec version: 445
 """
 from dataclasses import dataclass
 

--- a/sdk/python/bittensor/_generated/runtime_apis.py
+++ b/sdk/python/bittensor/_generated/runtime_apis.py
@@ -1,7 +1,7 @@
 """Generated from runtime metadata by codegen. DO NOT EDIT BY HAND.
 
 Regenerate with: python -m codegen <ws-endpoint>
-Spec version: 444
+Spec version: 445
 
 Runtime API method descriptors: unpack into substrate.runtime_call.
 """

--- a/sdk/python/bittensor/_generated/storage.py
+++ b/sdk/python/bittensor/_generated/storage.py
@@ -1,7 +1,7 @@
 """Generated from runtime metadata by codegen. DO NOT EDIT BY HAND.
 
 Regenerate with: python -m codegen <ws-endpoint>
-Spec version: 444
+Spec version: 445
 
 Storage item descriptors: unpack into substrate.query/query_map. Each carries its VALUE's type identity (value_type_ident) so normalization can key on the runtime's own type names without a node round-trip.
 """

--- a/website/apps/bittensor-website/public/catalog/emission-snapshot.json
+++ b/website/apps/bittensor-website/public/catalog/emission-snapshot.json
@@ -3,7 +3,7 @@
   "network": "finney",
   "chainSpecVersion": 443,
   "emissionMode": "price_ema_miner_burn_hill_gate",
-  "emissionGateSource": "v444_defaults_recomputed",
+  "emissionGateSource": "v445_defaults_recomputed",
   "dataSource": {
     "subnets": "taomarketcap.com",
     "chain": "finney",

--- a/website/apps/bittensor-website/public/catalog/emission-snapshot.json
+++ b/website/apps/bittensor-website/public/catalog/emission-snapshot.json
@@ -1,8 +1,8 @@
 {
-  "fetchedAt": "2026-08-10T19:50:58.619291Z",
+  "fetchedAt": "2026-08-11T16:37:11.729288Z",
   "network": "finney",
   "chainSpecVersion": 443,
-  "emissionMode": "v444_price_ema_hill_gate",
+  "emissionMode": "price_ema_miner_burn_hill_gate",
   "emissionGateSource": "v444_defaults_recomputed",
   "dataSource": {
     "subnets": "taomarketcap.com",
@@ -10,835 +10,988 @@
     "tmcEndpoint": "https://api.taomarketcap.com/public/v1/subnets/"
   },
   "blockEmissionTao": 0.5,
-  "totalIssuanceTao": 11219409.114,
-  "totalIssuanceRao": 11219409114200811,
-  "rootTao": 5413546.52,
-  "emaPriceSum": 1.3084,
+  "totalIssuanceTao": 11222524.602,
+  "totalIssuanceRao": 11222524602355523,
+  "rootTao": 5411665.86,
+  "emaPriceSum": 1.3036,
   "rootDividendGateOpen": true,
   "taoWeight": 0.18,
   "emissionGateRank": 32,
   "emissionGateQuantile": 0.61,
   "emissionGateExponent": 3.0,
-  "emissionGateBar": 0.00733118,
+  "emissionGateBar": 0.00794042,
   "emissionInputs": [
     {
       "netuid": 1,
-      "emaPrice": 0.008054,
+      "emaPrice": 0.008041,
+      "minerBurned": 0.52743466,
       "emissionEnabled": true
     },
     {
       "netuid": 2,
-      "emaPrice": 0.004216,
+      "emaPrice": 0.004181,
+      "minerBurned": 0.82661404,
       "emissionEnabled": true
     },
     {
       "netuid": 3,
-      "emaPrice": 0.02563,
+      "emaPrice": 0.025466,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 4,
-      "emaPrice": 0.057038,
+      "emaPrice": 0.056618,
+      "minerBurned": 0.07230859,
       "emissionEnabled": true
     },
     {
       "netuid": 5,
-      "emaPrice": 0.013702,
+      "emaPrice": 0.013659,
+      "minerBurned": 0.42237093,
       "emissionEnabled": true
     },
     {
       "netuid": 6,
-      "emaPrice": 0.002964,
+      "emaPrice": 0.003066,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 7,
-      "emaPrice": 0.003321,
+      "emaPrice": 0.003367,
+      "minerBurned": 0.90417399,
       "emissionEnabled": true
     },
     {
       "netuid": 8,
-      "emaPrice": 0.029832,
+      "emaPrice": 0.029893,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 9,
-      "emaPrice": 0.033401,
+      "emaPrice": 0.033205,
+      "minerBurned": 1.0,
       "emissionEnabled": true
     },
     {
       "netuid": 10,
-      "emaPrice": 0.006398,
+      "emaPrice": 0.006447,
+      "minerBurned": 1.0,
       "emissionEnabled": false
     },
     {
       "netuid": 11,
-      "emaPrice": 0.007657,
+      "emaPrice": 0.007319,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 12,
-      "emaPrice": 0.004999,
+      "emaPrice": 0.004997,
+      "minerBurned": 0.99407092,
       "emissionEnabled": false
     },
     {
       "netuid": 13,
-      "emaPrice": 0.006294,
+      "emaPrice": 0.006284,
+      "minerBurned": 0.70894014,
       "emissionEnabled": true
     },
     {
       "netuid": 14,
-      "emaPrice": 0.010195,
+      "emaPrice": 0.010257,
+      "minerBurned": 1.0,
       "emissionEnabled": false
     },
     {
       "netuid": 15,
-      "emaPrice": 0.021038,
+      "emaPrice": 0.022328,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 16,
-      "emaPrice": 0.003094,
+      "emaPrice": 0.002972,
+      "minerBurned": 0.0,
       "emissionEnabled": false
     },
     {
       "netuid": 17,
-      "emaPrice": 0.009592,
+      "emaPrice": 0.009435,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 18,
-      "emaPrice": 0.00515,
+      "emaPrice": 0.005063,
+      "minerBurned": 0.04716244,
       "emissionEnabled": true
     },
     {
       "netuid": 19,
-      "emaPrice": 0.010228,
+      "emaPrice": 0.010212,
+      "minerBurned": 0.38279278,
       "emissionEnabled": true
     },
     {
       "netuid": 20,
-      "emaPrice": 0.002892,
+      "emaPrice": 0.002888,
+      "minerBurned": 1.0,
       "emissionEnabled": false
     },
     {
       "netuid": 21,
-      "emaPrice": 0.003186,
+      "emaPrice": 0.00317,
+      "minerBurned": 0.45150375,
       "emissionEnabled": true
     },
     {
       "netuid": 22,
-      "emaPrice": 0.003353,
+      "emaPrice": 0.003352,
+      "minerBurned": 0.52455545,
       "emissionEnabled": true
     },
     {
       "netuid": 23,
-      "emaPrice": 0.004562,
+      "emaPrice": 0.00455,
+      "minerBurned": 1.0,
       "emissionEnabled": true
     },
     {
       "netuid": 24,
-      "emaPrice": 0.004405,
+      "emaPrice": 0.004442,
+      "minerBurned": 1.0,
       "emissionEnabled": true
     },
     {
       "netuid": 25,
-      "emaPrice": 0.010332,
+      "emaPrice": 0.010057,
+      "minerBurned": 1.0,
       "emissionEnabled": false
     },
     {
       "netuid": 26,
-      "emaPrice": 0.004317,
+      "emaPrice": 0.004172,
+      "minerBurned": 0.5016723,
       "emissionEnabled": false
     },
     {
       "netuid": 27,
-      "emaPrice": 0.002477,
+      "emaPrice": 0.002441,
+      "minerBurned": 1.0,
       "emissionEnabled": false
     },
     {
       "netuid": 28,
-      "emaPrice": 0.016706,
+      "emaPrice": 0.016987,
+      "minerBurned": 0.10477993,
       "emissionEnabled": true
     },
     {
       "netuid": 29,
       "emaPrice": 0.003131,
+      "minerBurned": 0.0,
       "emissionEnabled": false
     },
     {
       "netuid": 30,
-      "emaPrice": 0.004021,
+      "emaPrice": 0.004025,
+      "minerBurned": 1.0,
       "emissionEnabled": false
     },
     {
       "netuid": 31,
-      "emaPrice": 0.005064,
+      "emaPrice": 0.004764,
+      "minerBurned": 1.0,
       "emissionEnabled": false
     },
     {
       "netuid": 32,
-      "emaPrice": 0.003187,
+      "emaPrice": 0.003171,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 33,
-      "emaPrice": 0.005635,
+      "emaPrice": 0.005672,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 34,
       "emaPrice": 0.012238,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 35,
-      "emaPrice": 0.002785,
+      "emaPrice": 0.002724,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 36,
-      "emaPrice": 0.00167,
+      "emaPrice": 0.001521,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 37,
-      "emaPrice": 0.003596,
+      "emaPrice": 0.00366,
+      "minerBurned": 1.0,
       "emissionEnabled": false
     },
     {
       "netuid": 38,
-      "emaPrice": 0.011619,
+      "emaPrice": 0.011583,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 39,
-      "emaPrice": 0.006459,
+      "emaPrice": 0.006456,
+      "minerBurned": 1.0,
       "emissionEnabled": true
     },
     {
       "netuid": 40,
-      "emaPrice": 0.006692,
+      "emaPrice": 0.006581,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 41,
-      "emaPrice": 0.005026,
+      "emaPrice": 0.005016,
+      "minerBurned": 0.72833058,
       "emissionEnabled": true
     },
     {
       "netuid": 42,
-      "emaPrice": 0.002774,
+      "emaPrice": 0.002767,
+      "minerBurned": 1.0,
       "emissionEnabled": false
     },
     {
       "netuid": 43,
-      "emaPrice": 0.005369,
+      "emaPrice": 0.005353,
+      "minerBurned": 0.79643628,
       "emissionEnabled": false
     },
     {
       "netuid": 44,
-      "emaPrice": 0.042633,
+      "emaPrice": 0.041827,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 45,
-      "emaPrice": 0.002634,
+      "emaPrice": 0.002625,
+      "minerBurned": 0.68900336,
       "emissionEnabled": false
     },
     {
       "netuid": 46,
-      "emaPrice": 0.004547,
+      "emaPrice": 0.004772,
+      "minerBurned": 1.0,
       "emissionEnabled": true
     },
     {
       "netuid": 47,
-      "emaPrice": 0.002858,
+      "emaPrice": 0.002951,
+      "minerBurned": 1.0,
       "emissionEnabled": false
     },
     {
       "netuid": 48,
-      "emaPrice": 0.004478,
+      "emaPrice": 0.004481,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 49,
-      "emaPrice": 0.007034,
+      "emaPrice": 0.00701,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 50,
-      "emaPrice": 0.004823,
+      "emaPrice": 0.004831,
+      "minerBurned": 1.08e-06,
       "emissionEnabled": true
     },
     {
       "netuid": 51,
-      "emaPrice": 0.073255,
+      "emaPrice": 0.073811,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 52,
-      "emaPrice": 0.00678,
+      "emaPrice": 0.00676,
+      "minerBurned": 1.0,
       "emissionEnabled": false
     },
     {
       "netuid": 53,
-      "emaPrice": 0.03318,
+      "emaPrice": 0.031652,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 54,
-      "emaPrice": 0.004743,
+      "emaPrice": 0.004638,
+      "minerBurned": 0.30939764,
       "emissionEnabled": true
     },
     {
       "netuid": 55,
-      "emaPrice": 0.002857,
+      "emaPrice": 0.002796,
+      "minerBurned": 0.02000552,
       "emissionEnabled": true
     },
     {
       "netuid": 56,
-      "emaPrice": 0.016981,
+      "emaPrice": 0.017013,
+      "minerBurned": 0.72379724,
       "emissionEnabled": true
     },
     {
       "netuid": 57,
-      "emaPrice": 0.005359,
+      "emaPrice": 0.005288,
+      "minerBurned": 1.0,
       "emissionEnabled": false
     },
     {
       "netuid": 58,
-      "emaPrice": 0.008788,
+      "emaPrice": 0.008798,
+      "minerBurned": 1.0,
       "emissionEnabled": false
     },
     {
       "netuid": 59,
-      "emaPrice": 0.002019,
+      "emaPrice": 0.001975,
+      "minerBurned": 1.0,
       "emissionEnabled": true
     },
     {
       "netuid": 60,
-      "emaPrice": 0.004075,
+      "emaPrice": 0.003998,
+      "minerBurned": 0.5,
       "emissionEnabled": true
     },
     {
       "netuid": 61,
-      "emaPrice": 0.008461,
+      "emaPrice": 0.008466,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 62,
-      "emaPrice": 0.012264,
+      "emaPrice": 0.012144,
+      "minerBurned": 0.13338149,
       "emissionEnabled": true
     },
     {
       "netuid": 63,
-      "emaPrice": 0.008203,
+      "emaPrice": 0.008208,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 64,
-      "emaPrice": 0.086481,
+      "emaPrice": 0.086255,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 65,
-      "emaPrice": 0.002534,
+      "emaPrice": 0.00251,
+      "minerBurned": 1.0,
       "emissionEnabled": true
     },
     {
       "netuid": 66,
-      "emaPrice": 0.003033,
+      "emaPrice": 0.002983,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 67,
-      "emaPrice": 0.006518,
+      "emaPrice": 0.006471,
+      "minerBurned": 0.03652611,
       "emissionEnabled": true
     },
     {
       "netuid": 68,
-      "emaPrice": 0.024419,
+      "emaPrice": 0.024017,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 69,
-      "emaPrice": 0.009912,
+      "emaPrice": 0.009892,
+      "minerBurned": 1.0,
       "emissionEnabled": false
     },
     {
       "netuid": 70,
-      "emaPrice": 0.001371,
+      "emaPrice": 0.00134,
+      "minerBurned": 0.0,
       "emissionEnabled": false
     },
     {
       "netuid": 71,
-      "emaPrice": 0.003849,
+      "emaPrice": 0.0038,
+      "minerBurned": 1.0,
       "emissionEnabled": true
     },
     {
       "netuid": 72,
-      "emaPrice": 0.002701,
+      "emaPrice": 0.002626,
+      "minerBurned": 1.0,
       "emissionEnabled": false
     },
     {
       "netuid": 73,
-      "emaPrice": 0.003274,
+      "emaPrice": 0.003278,
+      "minerBurned": 1.0,
       "emissionEnabled": false
     },
     {
       "netuid": 74,
-      "emaPrice": 0.003809,
+      "emaPrice": 0.003794,
+      "minerBurned": 0.62999936,
       "emissionEnabled": true
     },
     {
       "netuid": 75,
-      "emaPrice": 0.019342,
+      "emaPrice": 0.018814,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 76,
-      "emaPrice": 0.002632,
+      "emaPrice": 0.00261,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 77,
-      "emaPrice": 0.006135,
+      "emaPrice": 0.00612,
+      "minerBurned": 0.0,
       "emissionEnabled": false
     },
     {
       "netuid": 78,
-      "emaPrice": 0.002605,
+      "emaPrice": 0.002534,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 79,
-      "emaPrice": 0.007527,
+      "emaPrice": 0.007579,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 80,
-      "emaPrice": 0.014918,
+      "emaPrice": 0.014729,
+      "minerBurned": 0.90650646,
       "emissionEnabled": true
     },
     {
       "netuid": 81,
-      "emaPrice": 0.007893,
+      "emaPrice": 0.007889,
+      "minerBurned": 0.01844684,
       "emissionEnabled": true
     },
     {
       "netuid": 82,
-      "emaPrice": 0.004499,
+      "emaPrice": 0.004648,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 83,
-      "emaPrice": 0.010613,
+      "emaPrice": 0.010587,
+      "minerBurned": 0.0,
       "emissionEnabled": false
     },
     {
       "netuid": 84,
-      "emaPrice": 0.002521,
+      "emaPrice": 0.002544,
+      "minerBurned": 0.0,
       "emissionEnabled": false
     },
     {
       "netuid": 85,
-      "emaPrice": 0.005342,
+      "emaPrice": 0.005324,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 87,
-      "emaPrice": 0.003704,
+      "emaPrice": 0.00365,
+      "minerBurned": 1.0,
       "emissionEnabled": false
     },
     {
       "netuid": 88,
-      "emaPrice": 0.004539,
+      "emaPrice": 0.005168,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 89,
-      "emaPrice": 0.003664,
+      "emaPrice": 0.003655,
+      "minerBurned": 0.2,
       "emissionEnabled": true
     },
     {
       "netuid": 90,
-      "emaPrice": 0.025303,
+      "emaPrice": 0.025993,
+      "minerBurned": 0.86008526,
       "emissionEnabled": false
     },
     {
       "netuid": 91,
-      "emaPrice": 0.009309,
+      "emaPrice": 0.009029,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 92,
-      "emaPrice": 0.003914,
+      "emaPrice": 0.003814,
+      "minerBurned": 0.0,
       "emissionEnabled": false
     },
     {
       "netuid": 93,
-      "emaPrice": 0.00976,
+      "emaPrice": 0.009616,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 94,
-      "emaPrice": 0.00375,
+      "emaPrice": 0.003652,
+      "minerBurned": 1.0,
       "emissionEnabled": true
     },
     {
       "netuid": 95,
-      "emaPrice": 0.057053,
+      "emaPrice": 0.057009,
+      "minerBurned": 1.0,
       "emissionEnabled": false
     },
     {
       "netuid": 96,
-      "emaPrice": 0.008541,
+      "emaPrice": 0.008529,
+      "minerBurned": 0.41741,
       "emissionEnabled": true
     },
     {
       "netuid": 97,
-      "emaPrice": 0.025306,
+      "emaPrice": 0.024897,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 98,
-      "emaPrice": 0.002965,
+      "emaPrice": 0.002966,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 99,
-      "emaPrice": 0.004781,
+      "emaPrice": 0.004726,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 100,
-      "emaPrice": 0.005732,
+      "emaPrice": 0.006412,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 101,
-      "emaPrice": 0.004636,
+      "emaPrice": 0.004631,
+      "minerBurned": 0.90102437,
       "emissionEnabled": true
     },
     {
       "netuid": 102,
-      "emaPrice": 0.008691,
+      "emaPrice": 0.00926,
+      "minerBurned": 0.25060051,
       "emissionEnabled": true
     },
     {
       "netuid": 103,
-      "emaPrice": 0.009532,
+      "emaPrice": 0.009905,
+      "minerBurned": 0.0,
       "emissionEnabled": false
     },
     {
       "netuid": 104,
-      "emaPrice": 0.004384,
+      "emaPrice": 0.004367,
+      "minerBurned": 0.9639356,
       "emissionEnabled": false
     },
     {
       "netuid": 105,
-      "emaPrice": 0.007274,
+      "emaPrice": 0.007393,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 106,
-      "emaPrice": 0.003108,
+      "emaPrice": 0.003041,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 107,
-      "emaPrice": 0.06158,
+      "emaPrice": 0.060843,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 108,
-      "emaPrice": 0.004023,
+      "emaPrice": 0.003638,
+      "minerBurned": 1.0,
       "emissionEnabled": false
     },
     {
       "netuid": 109,
-      "emaPrice": 0.003304,
+      "emaPrice": 0.003345,
+      "minerBurned": 1.0,
       "emissionEnabled": false
     },
     {
       "netuid": 110,
-      "emaPrice": 0.00737,
+      "emaPrice": 0.007125,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 111,
-      "emaPrice": 0.004958,
+      "emaPrice": 0.00529,
+      "minerBurned": 1.0,
       "emissionEnabled": false
     },
     {
       "netuid": 112,
-      "emaPrice": 0.002535,
+      "emaPrice": 0.002502,
+      "minerBurned": 0.80094412,
       "emissionEnabled": true
     },
     {
       "netuid": 113,
-      "emaPrice": 0.00273,
+      "emaPrice": 0.002727,
+      "minerBurned": 1.0,
       "emissionEnabled": false
     },
     {
       "netuid": 114,
-      "emaPrice": 0.011642,
+      "emaPrice": 0.011322,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 115,
-      "emaPrice": 0.003533,
+      "emaPrice": 0.003086,
+      "minerBurned": 1.0,
       "emissionEnabled": false
     },
     {
       "netuid": 116,
-      "emaPrice": 0.007126,
+      "emaPrice": 0.006622,
+      "minerBurned": 1.0,
       "emissionEnabled": false
     },
     {
       "netuid": 117,
-      "emaPrice": 0.002574,
+      "emaPrice": 0.002566,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 118,
-      "emaPrice": 0.009272,
+      "emaPrice": 0.009178,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 119,
       "emaPrice": 0.003091,
+      "minerBurned": 1.0,
       "emissionEnabled": false
     },
     {
       "netuid": 120,
-      "emaPrice": 0.059987,
+      "emaPrice": 0.060463,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 121,
-      "emaPrice": 0.004739,
+      "emaPrice": 0.004741,
+      "minerBurned": 1.0,
       "emissionEnabled": true
     },
     {
       "netuid": 122,
-      "emaPrice": 0.004685,
+      "emaPrice": 0.004615,
+      "minerBurned": 1.0,
       "emissionEnabled": false
     },
     {
       "netuid": 123,
-      "emaPrice": 0.002703,
+      "emaPrice": 0.002672,
+      "minerBurned": 0.41245638,
       "emissionEnabled": true
     },
     {
       "netuid": 124,
-      "emaPrice": 0.010121,
+      "emaPrice": 0.010072,
+      "minerBurned": 0.0,
       "emissionEnabled": true
     },
     {
       "netuid": 125,
-      "emaPrice": 0.00328,
+      "emaPrice": 0.003267,
+      "minerBurned": 1.0,
       "emissionEnabled": false
     },
     {
       "netuid": 126,
-      "emaPrice": 0.005165,
+      "emaPrice": 0.005009,
+      "minerBurned": 0.3047695,
       "emissionEnabled": true
     },
     {
       "netuid": 127,
-      "emaPrice": 0.002883,
+      "emaPrice": 0.002904,
+      "minerBurned": 0.70639378,
       "emissionEnabled": true
     },
     {
       "netuid": 128,
-      "emaPrice": 0.002938,
+      "emaPrice": 0.002916,
+      "minerBurned": 0.0,
       "emissionEnabled": false
     }
   ],
   "featuredSubnet": {
     "netuid": 4,
     "name": "Targon",
-    "spotPrice": 0.056784,
-    "emaPrice": 0.057038,
+    "spotPrice": 0.056624,
+    "emaPrice": 0.056618,
+    "minerBurned": 0.07230859,
     "emissionEnabled": true,
-    "taoIn": 136777.6,
-    "alphaIn": 2408742.63,
-    "alphaOut": 3498348.62,
-    "demandShare": 0.04359424,
-    "gateFactor": 0.99526659,
-    "taoShare": 0.07641434,
-    "taoPerBlock": 0.03820717
+    "taoIn": 136634.82,
+    "alphaIn": 2413022.19,
+    "alphaOut": 3501181.98,
+    "demandShare": 0.04343117,
+    "burnAdjustedShare": 0.05698358,
+    "gateFactor": 0.99730159,
+    "taoShare": 0.07542274,
+    "taoPerBlock": 0.03771137
   },
   "topSubnets": [
     {
       "netuid": 64,
       "name": "Chutes",
-      "spotPrice": 0.085869,
-      "emaPrice": 0.086481,
+      "spotPrice": 0.085763,
+      "emaPrice": 0.086255,
+      "minerBurned": 0.0,
       "emissionEnabled": true,
-      "taoIn": 220039.08,
-      "alphaIn": 2562495.19,
-      "alphaOut": 3327621.07,
-      "demandShare": 0.06609757,
-      "gateFactor": 0.99863738,
-      "taoShare": 0.11625179,
-      "taoPerBlock": 0.0581259
+      "taoIn": 219979.27,
+      "alphaIn": 2564964.24,
+      "alphaOut": 3332267.14,
+      "demandShare": 0.06616545,
+      "burnAdjustedShare": 0.09357848,
+      "gateFactor": 0.99938943,
+      "taoShare": 0.12411856,
+      "taoPerBlock": 0.06205928
     },
     {
       "netuid": 51,
       "name": "lium.io",
-      "spotPrice": 0.073558,
-      "emaPrice": 0.073255,
+      "spotPrice": 0.074515,
+      "emaPrice": 0.073811,
+      "minerBurned": 0.0,
       "emissionEnabled": true,
-      "taoIn": 140987.41,
-      "alphaIn": 1916689.46,
-      "alphaOut": 3668935.54,
-      "demandShare": 0.05598891,
-      "gateFactor": 0.99776003,
-      "taoShare": 0.09838627,
-      "taoPerBlock": 0.04919314
+      "taoIn": 141970.5,
+      "alphaIn": 1905258.42,
+      "alphaOut": 3687515.95,
+      "demandShare": 0.05661977,
+      "burnAdjustedShare": 0.08007792,
+      "gateFactor": 0.99902598,
+      "taoShare": 0.10617336,
+      "taoPerBlock": 0.05308668
     },
     {
       "netuid": 107,
       "name": "Minos",
-      "spotPrice": 0.061349,
-      "emaPrice": 0.06158,
+      "spotPrice": 0.060403,
+      "emaPrice": 0.060843,
+      "minerBurned": 0.0,
       "emissionEnabled": true,
-      "taoIn": 19184.4,
-      "alphaIn": 312709.51,
-      "alphaOut": 1406061.78,
-      "demandShare": 0.04706569,
-      "gateFactor": 0.99623495,
-      "taoShare": 0.08257957,
-      "taoPerBlock": 0.04128978
+      "taoIn": 19172.35,
+      "alphaIn": 317408.35,
+      "alphaOut": 1409812.54,
+      "demandShare": 0.04667213,
+      "burnAdjustedShare": 0.06600887,
+      "gateFactor": 0.99826233,
+      "taoShare": 0.08745266,
+      "taoPerBlock": 0.04372633
     },
     {
       "netuid": 120,
       "name": "Affine",
-      "spotPrice": 0.060743,
-      "emaPrice": 0.059987,
+      "spotPrice": 0.059335,
+      "emaPrice": 0.060463,
+      "minerBurned": 0.0,
       "emissionEnabled": true,
-      "taoIn": 84377.64,
-      "alphaIn": 1389096.16,
-      "alphaOut": 2556991.84,
-      "demandShare": 0.04584816,
-      "gateFactor": 0.99592822,
-      "taoShare": 0.08041856,
-      "taoPerBlock": 0.04020928
+      "taoIn": 83468.17,
+      "alphaIn": 1406725.51,
+      "alphaOut": 2546641.18,
+      "demandShare": 0.04638063,
+      "burnAdjustedShare": 0.06559661,
+      "gateFactor": 0.99822942,
+      "taoShare": 0.0869036,
+      "taoPerBlock": 0.0434518
     },
     {
       "netuid": 4,
       "name": "Targon",
-      "spotPrice": 0.056784,
-      "emaPrice": 0.057038,
+      "spotPrice": 0.056624,
+      "emaPrice": 0.056618,
+      "minerBurned": 0.07230859,
       "emissionEnabled": true,
-      "taoIn": 136777.6,
-      "alphaIn": 2408742.63,
-      "alphaOut": 3498348.62,
-      "demandShare": 0.04359424,
-      "gateFactor": 0.99526659,
-      "taoShare": 0.07641434,
-      "taoPerBlock": 0.03820717
+      "taoIn": 136634.82,
+      "alphaIn": 2413022.19,
+      "alphaOut": 3501181.98,
+      "demandShare": 0.04343117,
+      "burnAdjustedShare": 0.05698358,
+      "gateFactor": 0.99730159,
+      "taoShare": 0.07542274,
+      "taoPerBlock": 0.03771137
     },
     {
       "netuid": 44,
       "name": "Score",
-      "spotPrice": 0.042135,
-      "emaPrice": 0.042633,
+      "spotPrice": 0.042201,
+      "emaPrice": 0.041827,
+      "minerBurned": 0.0,
       "emissionEnabled": true,
-      "taoIn": 69596.55,
-      "alphaIn": 1651741.69,
-      "alphaOut": 3998290.27,
-      "demandShare": 0.03258447,
-      "gateFactor": 0.98873914,
-      "taoShare": 0.05674123,
-      "taoPerBlock": 0.02837062
-    },
-    {
-      "netuid": 9,
-      "name": "iota",
-      "spotPrice": 0.03345,
-      "emaPrice": 0.033401,
-      "emissionEnabled": true,
-      "taoIn": 60926.17,
-      "alphaIn": 1821422.27,
-      "alphaOut": 3951121.46,
-      "demandShare": 0.02552844,
-      "gateFactor": 0.97686426,
-      "taoShare": 0.04392025,
-      "taoPerBlock": 0.02196013
+      "taoIn": 69689.46,
+      "alphaIn": 1651357.73,
+      "alphaOut": 4005821.33,
+      "demandShare": 0.03208512,
+      "burnAdjustedShare": 0.04537832,
+      "gateFactor": 0.99467077,
+      "taoShare": 0.05990372,
+      "taoPerBlock": 0.02995186
     },
     {
       "netuid": 53,
       "name": "engy",
-      "spotPrice": 0.032,
-      "emaPrice": 0.03318,
+      "spotPrice": 0.033562,
+      "emaPrice": 0.031652,
+      "minerBurned": 0.0,
       "emissionEnabled": true,
-      "taoIn": 35107.27,
-      "alphaIn": 1097096.66,
-      "alphaOut": 4580364.57,
-      "demandShare": 0.02535953,
-      "gateFactor": 0.97640986,
-      "taoShare": 0.04360936,
-      "taoPerBlock": 0.02180468
+      "taoIn": 35983.37,
+      "alphaIn": 1072141.54,
+      "alphaOut": 4612463.02,
+      "demandShare": 0.02427997,
+      "burnAdjustedShare": 0.03433941,
+      "gateFactor": 0.9877872,
+      "taoShare": 0.04501759,
+      "taoPerBlock": 0.0225088
     },
     {
       "netuid": 8,
       "name": "Vanta",
-      "spotPrice": 0.029842,
-      "emaPrice": 0.029832,
+      "spotPrice": 0.029939,
+      "emaPrice": 0.029893,
+      "minerBurned": 0.0,
       "emissionEnabled": true,
-      "taoIn": 81218.94,
-      "alphaIn": 2721615.73,
-      "alphaOut": 3019607.15,
-      "demandShare": 0.02280065,
-      "gateFactor": 0.96782796,
-      "taoShare": 0.03886437,
-      "taoPerBlock": 0.01943219
+      "taoIn": 81377.2,
+      "alphaIn": 2718128.48,
+      "alphaOut": 3030229.05,
+      "demandShare": 0.02293066,
+      "burnAdjustedShare": 0.03243107,
+      "gateFactor": 0.98553499,
+      "taoShare": 0.04241889,
+      "taoPerBlock": 0.02120944
     },
     {
       "netuid": 3,
       "name": "deprecated",
-      "spotPrice": 0.025426,
-      "emaPrice": 0.02563,
+      "spotPrice": 0.025225,
+      "emaPrice": 0.025466,
+      "minerBurned": 0.0,
       "emissionEnabled": true,
-      "taoIn": 74149.25,
-      "alphaIn": 2916243.4,
-      "alphaOut": 2819141.61,
-      "demandShare": 0.01958905,
-      "gateFactor": 0.95019266,
-      "taoShare": 0.0327817,
-      "taoPerBlock": 0.01639085
+      "taoIn": 73878.81,
+      "alphaIn": 2928735.47,
+      "alphaOut": 2813772.82,
+      "demandShare": 0.01953474,
+      "burnAdjustedShare": 0.02762819,
+      "gateFactor": 0.97681092,
+      "taoShare": 0.03581698,
+      "taoPerBlock": 0.01790849
     },
     {
       "netuid": 97,
       "name": "Albedo",
-      "spotPrice": 0.024872,
-      "emaPrice": 0.025306,
+      "spotPrice": 0.024758,
+      "emaPrice": 0.024897,
+      "minerBurned": 0.0,
       "emissionEnabled": true,
-      "taoIn": 11057.13,
-      "alphaIn": 444567.2,
-      "alphaOut": 932144.63,
-      "demandShare": 0.01934142,
-      "gateFactor": 0.94835504,
-      "taoShare": 0.03230469,
-      "taoPerBlock": 0.01615235
+      "taoIn": 11095.78,
+      "alphaIn": 448165.46,
+      "alphaOut": 936842.91,
+      "demandShare": 0.01909827,
+      "burnAdjustedShare": 0.02701088,
+      "gateFactor": 0.9752247,
+      "taoShare": 0.03495984,
+      "taoPerBlock": 0.01747992
     },
     {
       "netuid": 68,
       "name": "NOVA",
-      "spotPrice": 0.02442,
-      "emaPrice": 0.024419,
+      "spotPrice": 0.023941,
+      "emaPrice": 0.024017,
+      "minerBurned": 0.0,
       "emissionEnabled": true,
-      "taoIn": 46153.92,
-      "alphaIn": 1890019.99,
-      "alphaOut": 3609349.49,
-      "demandShare": 0.01866348,
-      "gateFactor": 0.94285369,
-      "taoShare": 0.03099155,
-      "taoPerBlock": 0.01549578
+      "taoIn": 45722.1,
+      "alphaIn": 1909747.31,
+      "alphaOut": 3596531.4,
+      "demandShare": 0.01842323,
+      "burnAdjustedShare": 0.02605616,
+      "gateFactor": 0.97247808,
+      "taoShare": 0.03362918,
+      "taoPerBlock": 0.01681459
+    },
+    {
+      "netuid": 15,
+      "name": "ORO",
+      "spotPrice": 0.02277,
+      "emaPrice": 0.022328,
+      "minerBurned": 0.0,
+      "emissionEnabled": true,
+      "taoIn": 10754.4,
+      "alphaIn": 472315.91,
+      "alphaOut": 1283562.57,
+      "demandShare": 0.01712761,
+      "burnAdjustedShare": 0.02422376,
+      "gateFactor": 0.965977,
+      "taoShare": 0.0310552,
+      "taoPerBlock": 0.0155276
     }
   ]
 }

--- a/website/apps/bittensor-website/scripts/fetch-emission-snapshot.py
+++ b/website/apps/bittensor-website/scripts/fetch-emission-snapshot.py
@@ -1,12 +1,12 @@
 """Refresh public/catalog/emission-snapshot.json from TaoMarketCap + Finney.
 
 Subnet prices and EMA sums use TMC's public API. Eligibility, emission-enabled
-flags, total issuance, and root pool TAO come from Finney storage. The output
-models the v444 pure-price EMA allocation and Hill gate. On spec 444 or later,
-the gate settings and cadence-held midpoint come from chain storage. Before the
-upgrade, the output previews the first v444 calculation with the upgrade
-defaults. It does not use the deprecated ``BlockEmission`` or ``MinerBurned``
-storage items.
+flags, MinerBurned proportions, total issuance, and root pool TAO come from
+Finney storage. The output models price EMA with miner-burn scaling and the
+Hill gate. On spec 444 or later, the gate settings and cadence-held midpoint
+come from chain storage. Before the upgrade, the output previews the v444 gate
+settings while retaining miner-burn scaling. It does not use the deprecated
+``BlockEmission`` storage item.
 
 Usage (from bittensor-website/, with the bittensor SDK venv active):
 
@@ -44,6 +44,15 @@ def fixed_u64f64_num(value) -> float:
         return int(value["bits"]) / 2**64
     if isinstance(value, int):
         return value / 2**64
+    return float(value)
+
+
+def fixed_u96f32_num(value) -> float:
+    """Convert the SDK's U96F32 representation to a float."""
+    if isinstance(value, dict) and "bits" in value:
+        return int(value["bits"]) / 2**32
+    if isinstance(value, int):
+        return value / 2**32
     return float(value)
 
 
@@ -99,7 +108,7 @@ def subnet_name(row: dict) -> str:
     return identities.get("subnetName") or f"SN{row['netuid']}"
 
 
-def row_from_tmc(row: dict, emission_enabled: bool) -> dict:
+def row_from_tmc(row: dict, emission_enabled: bool, miner_burned: float) -> dict:
     snap = row.get("latest_snapshot") or {}
     netuid = int(row["netuid"])
     spot = tmc_num(snap.get("price"))
@@ -112,6 +121,7 @@ def row_from_tmc(row: dict, emission_enabled: bool) -> dict:
         "name": subnet_name(row),
         "spotPrice": round(spot, 6),
         "emaPrice": round(ema, 6),
+        "minerBurned": round(min(max(miner_burned, 0.0), 1.0), 8),
         "emissionEnabled": emission_enabled,
         "taoIn": round(tao_in, 2),
         "alphaIn": round(alpha_in, 2),
@@ -140,17 +150,19 @@ async def chain_fields(client: bt.Client, netuids: list[int]) -> dict:
     root_tao = int(await view.query(st.SubtensorModule.SubnetTAO, [0]))
     tao_weight_raw = int(await view.query(st.SubtensorModule.TaoWeight))
 
-    async def subnet_flags(netuid: int) -> tuple[int, dict[str, bool]]:
+    async def subnet_flags(netuid: int) -> tuple[int, dict[str, bool | float]]:
         (
             first_emission,
             subtoken_enabled,
             registration_allowed,
             emission_enabled,
+            miner_burned,
         ) = await asyncio.gather(
             view.query(st.SubtensorModule.FirstEmissionBlockNumber, [netuid]),
             view.query(st.SubtensorModule.SubtokenEnabled, [netuid]),
             view.query(st.SubtensorModule.NetworkRegistrationAllowed, [netuid]),
             view.query(st.SubtensorModule.SubnetEmissionEnabled, [netuid]),
+            view.query(st.SubtensorModule.MinerBurned, [netuid]),
         )
         return netuid, {
             "eligible": (
@@ -159,6 +171,7 @@ async def chain_fields(client: bt.Client, netuids: list[int]) -> dict:
                 and bool(registration_allowed)
             ),
             "emissionEnabled": bool(emission_enabled),
+            "minerBurned": fixed_u96f32_num(miner_burned),
         }
 
     flags = dict(await asyncio.gather(*(subnet_flags(netuid) for netuid in netuids)))
@@ -219,18 +232,28 @@ def apply_shares(
     gate_bar: float | None = None,
     gate_exponent: float = DEFAULT_EMISSION_GATE_EXPONENT,
 ) -> float:
-    """Apply v444 pure-price demand shares, the Hill gate, and enable flags."""
+    """Apply price shares, miner-burn scaling, the Hill gate, and enable flags."""
     price_sum = sum(max(subnet["emaPrice"], 0.0) for subnet in subnets)
     demand_shares = [
         max(subnet["emaPrice"], 0.0) / price_sum if price_sum > 0 else 0.0
         for subnet in subnets
     ]
+    burn_weights = [
+        share * (1.0 - min(max(subnet["minerBurned"], 0.0), 1.0))
+        for subnet, share in zip(subnets, demand_shares)
+    ]
+    burn_weight_sum = sum(burn_weights)
+    burn_adjusted_shares = (
+        [weight / burn_weight_sum for weight in burn_weights]
+        if burn_weight_sum > 0
+        else demand_shares
+    )
     if gate_bar is None:
-        gate_bar = select_emission_gate_bar(demand_shares)
+        gate_bar = select_emission_gate_bar(burn_adjusted_shares)
 
     gate_factors = []
     gated_weights = []
-    for share in demand_shares:
+    for share in burn_adjusted_shares:
         gate = (
             1.0 / (1.0 + (gate_bar / share) ** gate_exponent)
             if share > 0 and gate_bar > 0
@@ -240,15 +263,15 @@ def apply_shares(
         gated_weights.append(share * gate)
 
     if sum(gated_weights) == 0:
-        gated_weights = demand_shares
+        gated_weights = burn_adjusted_shares
 
     enabled_total = sum(
         weight
         for subnet, weight in zip(subnets, gated_weights)
         if subnet["emissionEnabled"]
     )
-    for subnet, demand_share, gate, weight in zip(
-        subnets, demand_shares, gate_factors, gated_weights
+    for subnet, demand_share, burn_adjusted_share, gate, weight in zip(
+        subnets, demand_shares, burn_adjusted_shares, gate_factors, gated_weights
     ):
         share = (
             weight / enabled_total
@@ -256,6 +279,7 @@ def apply_shares(
             else 0.0
         )
         subnet["demandShare"] = round(demand_share, 8)
+        subnet["burnAdjustedShare"] = round(burn_adjusted_share, 8)
         subnet["gateFactor"] = round(gate, 8)
         subnet["taoShare"] = round(share, 8)
         subnet["taoPerBlock"] = round(block_emission * share, 8)
@@ -283,6 +307,7 @@ async def build_snapshot() -> dict:
         row_from_tmc(
             row,
             chain["subnetFlags"][int(row["netuid"])]["emissionEnabled"],
+            chain["subnetFlags"][int(row["netuid"])]["minerBurned"],
         )
         for row in eligible_rows
     ]
@@ -312,7 +337,7 @@ async def build_snapshot() -> dict:
         "fetchedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "network": "finney",
         "chainSpecVersion": chain["specVersion"],
-        "emissionMode": "v444_price_ema_hill_gate",
+        "emissionMode": "price_ema_miner_burn_hill_gate",
         "emissionGateSource": gate["source"],
         "dataSource": {
             "subnets": "taomarketcap.com",
@@ -334,6 +359,7 @@ async def build_snapshot() -> dict:
             {
                 "netuid": subnet["netuid"],
                 "emaPrice": subnet["emaPrice"],
+                "minerBurned": subnet["minerBurned"],
                 "emissionEnabled": subnet["emissionEnabled"],
             }
             for subnet in subnets

--- a/website/apps/bittensor-website/scripts/fetch-emission-snapshot.py
+++ b/website/apps/bittensor-website/scripts/fetch-emission-snapshot.py
@@ -3,8 +3,8 @@
 Subnet prices and EMA sums use TMC's public API. Eligibility, emission-enabled
 flags, MinerBurned proportions, total issuance, and root pool TAO come from
 Finney storage. The output models price EMA with miner-burn scaling and the
-Hill gate. On spec 444 or later, the gate settings and cadence-held midpoint
-come from chain storage. Before the upgrade, the output previews the v444 gate
+Hill gate. On spec 445 or later, the gate settings and cadence-held midpoint
+come from chain storage. Before the upgrade, the output previews the v445 gate
 settings while retaining miner-burn scaling. It does not use the deprecated
 ``BlockEmission`` storage item.
 
@@ -177,7 +177,7 @@ async def chain_fields(client: bt.Client, netuids: list[int]) -> dict:
     flags = dict(await asyncio.gather(*(subnet_flags(netuid) for netuid in netuids)))
 
     gate = None
-    if spec_version >= 444:
+    if spec_version >= 445:
         rank, quantile, exponent, bar = await asyncio.gather(
             view.query(st.SubtensorModule.EmissionBarRank),
             view.query(st.SubtensorModule.EmissionBarQuantile),
@@ -210,7 +210,7 @@ def select_emission_gate_bar(
     rank: int = DEFAULT_EMISSION_BAR_RANK,
     quantile: float = DEFAULT_EMISSION_BAR_QUANTILE,
 ) -> float:
-    """Mirror ``maybe_update_emission_gate_bar`` for the v444 snapshot."""
+    """Mirror ``maybe_update_emission_gate_bar`` for the v445 snapshot."""
     positive = sorted((share for share in demand_shares if share > 0), reverse=True)
     if not positive:
         return 0.0
@@ -316,7 +316,7 @@ async def build_snapshot() -> dict:
         "quantile": DEFAULT_EMISSION_BAR_QUANTILE,
         "exponent": DEFAULT_EMISSION_GATE_EXPONENT,
         "bar": None,
-        "source": "v444_defaults_recomputed",
+        "source": "v445_defaults_recomputed",
     }
     gate_bar = apply_shares(
         subnets,

--- a/website/apps/bittensor-website/src/app/(pages-without-footer)/releases/page.tsx
+++ b/website/apps/bittensor-website/src/app/(pages-without-footer)/releases/page.tsx
@@ -23,14 +23,14 @@ type Release = {
 // Newest first. Add new releases to the top.
 const releases: Release[] = [
   {
-    tag: 'v444',
+    tag: 'v445',
     date: 'August 2026',
     title: 'EVM, btcli, and Reliability',
     summary:
       'This release completes the typed EVM surface, makes multisigs first-class btcli wallets, ' +
       'recycles transaction fees, adds human-readable ' +
       'Ledger orders, and lands a broad reliability pass.',
-    href: '/releases/v444-upgrade',
+    href: '/releases/v445-upgrade',
   },
   {
     tag: 'v441',

--- a/website/apps/bittensor-website/src/app/(pages-without-footer)/releases/page.tsx
+++ b/website/apps/bittensor-website/src/app/(pages-without-footer)/releases/page.tsx
@@ -25,10 +25,10 @@ const releases: Release[] = [
   {
     tag: 'v444',
     date: 'August 2026',
-    title: 'Pure Price Emissions',
+    title: 'EVM, btcli, and Reliability',
     summary:
-      'Subnet emission returns to pure price EMA through the gate. The release also completes ' +
-      'the typed EVM surface, makes multisigs first-class btcli wallets, adds human-readable ' +
+      'This release completes the typed EVM surface, makes multisigs first-class btcli wallets, ' +
+      'recycles transaction fees, adds human-readable ' +
       'Ledger orders, and lands a broad reliability pass.',
     href: '/releases/v444-upgrade',
   },

--- a/website/apps/bittensor-website/src/app/(pages-without-footer)/releases/v444-upgrade/page.tsx
+++ b/website/apps/bittensor-website/src/app/(pages-without-footer)/releases/v444-upgrade/page.tsx
@@ -6,10 +6,9 @@ import {Suspense} from 'react';
 import styles from '../v436-upgrade/page.module.css';
 
 export const metadata: Metadata = {
-  title: 'The V444 Upgrade — Pure Price Emissions',
+  title: 'The V444 Upgrade — EVM, btcli, and Reliability',
   description:
-    'Subnet emission returns to pure price EMA through the emission gate, while v444 ' +
-    'completes the EVM surface, makes btcli safer for multisigs and automation, adds ' +
+    'V444 completes the EVM surface, makes btcli safer for multisigs and automation, adds ' +
     'human-readable Ledger orders, and lands a broad reliability pass.',
   alternates: {canonical: '/releases/v444-upgrade'},
 };
@@ -27,85 +26,21 @@ const page = () => {
         <section className={styles.title_section}>
           <h1 className={styles.paper_title}>The V444 Upgrade</h1>
           <p className={styles.subtitle} style={{fontSize: '10px'}}>
-            Pure Price Emissions · August 2026
+            EVM, btcli, and Reliability · August 2026
           </p>
         </section>
 
         <section className={styles.section}>
           <h2 className={styles.subtitle}>Introduction</h2>
           <p>
-            The market signal becomes simple again in spec <strong>444</strong>: a subnet&apos;s
-            share of network emission is determined by its moving price, passed through the emission
-            gate. The share is no longer reduced when a subnet directs miner incentive to an owner
-            or burn hotkey. Recycling and burning still do exactly what the subnet chose locally;
-            they no longer change its standing against every other subnet.
-          </p>
-          <p>
-            The release also makes the chain substantially easier to use from every external
-            surface. Solidity contracts gain 31 functions across five new Bittensor precompiles,
-            plus 135 additions to existing interfaces. A saved multisig now behaves like a wallet
-            throughout <code>btcli</code>. Automated dry runs carry enough information to approve
-            and replay a transaction safely. Ledger users can read the actual fields of a limit
-            order before signing it. Underneath those interfaces, v444 corrects transaction-pool
-            validation, proxy charging, commitment cleanup, storage growth, and GRANDPA finality.
-          </p>
-        </section>
-
-        <section className={styles.section}>
-          <h2 className={styles.subtitle}>Price is the signal</h2>
-          <p>
-            The emission gate introduced in <DocLink href='/releases/v440-upgrade'>v440</DocLink>{' '}
-            starts with each subnet&apos;s share of price EMA, then suppresses emission below the
-            market-set bar. A second factor had been applied before that gate:{' '}
-            <code>1 − MinerBurned</code>. That meant two subnets with the same demand could receive
-            different cross-network emission solely because one withheld miner incentive for
-            recycling or burning.
-          </p>
-          <Code
-            language='rust'
-            code={`before v444:  s_i = normalize(price_ema_i × (1 − miner_burned_i))
-              e_i ∝ s_i × gate(s_i)
-
-v444:         s_i = normalize(price_ema_i)
-              e_i ∝ s_i × gate(s_i)`}
-          />
-          <p>
-            V444 removes that extra multiplier. The on-chain value remains as an informational
-            measure called <code>MinerBurned</code>. The miner-incentive path still recycles or
-            burns according to the subnet&apos;s configuration. What changes is the boundary between
-            local token policy and network allocation: demand determines how much emission a subnet
-            earns; the subnet determines what it does with the miner portion after that.
-          </p>
-          <table className={styles.metrics_table}>
-            <thead>
-              <tr>
-                <th>Miner incentive policy</th>
-                <th>Effect on subnet&apos;s network share in v444</th>
-                <th>Local effect</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>Paid to miners</td>
-                <td>Price EMA through the gate</td>
-                <td>Miner alpha is distributed</td>
-              </tr>
-              <tr>
-                <td>Withheld and recycled</td>
-                <td>Price EMA through the gate</td>
-                <td>Value returns through the recycle path</td>
-              </tr>
-              <tr>
-                <td>Withheld and burned</td>
-                <td>Price EMA through the gate</td>
-                <td>Value is removed by the burn path</td>
-              </tr>
-            </tbody>
-          </table>
-          <p>
-            Subnet teams do not need to change a setting. Forecasting software should remove the
-            miner-burn factor from cross-subnet share calculations and retain it only where it
-            describes the subnet&apos;s own incentive accounting.
+            Spec <strong>444</strong> makes the chain substantially easier to use from every
+            external surface. Solidity contracts gain 31 functions across five new Bittensor
+            precompiles, plus 135 additions to existing interfaces. A saved multisig now behaves
+            like a wallet throughout <code>btcli</code>. Automated dry runs carry enough information
+            to approve and replay a transaction safely. Ledger users can read the actual fields of a
+            limit order before signing it. Underneath those interfaces, v444 recycles transaction
+            fees and corrects transaction-pool validation, proxy charging, commitment cleanup,
+            storage growth, and GRANDPA finality.
           </p>
         </section>
 
@@ -378,11 +313,6 @@ partial fills <true|false>, signer <ss58>`}
         <section className={styles.section}>
           <h2 className={styles.subtitle}>What to do</h2>
           <ul className={styles.list}>
-            <li>
-              <strong>Subnet teams and analysts:</strong> remove <code>1 − MinerBurned</code> from
-              cross-subnet emission forecasts. The emission gate remains active and miner recycling
-              or burning remains a local policy.
-            </li>
             <li>
               <strong>EVM integrators:</strong> refresh the complete canonical ABI set before using
               v444 selectors. Add <code>0x…080f</code> through <code>0x…0813</code> only from the

--- a/website/apps/bittensor-website/src/app/(pages-without-footer)/releases/v445-upgrade/page.tsx
+++ b/website/apps/bittensor-website/src/app/(pages-without-footer)/releases/v445-upgrade/page.tsx
@@ -6,11 +6,11 @@ import {Suspense} from 'react';
 import styles from '../v436-upgrade/page.module.css';
 
 export const metadata: Metadata = {
-  title: 'The V444 Upgrade — EVM, btcli, and Reliability',
+  title: 'The V445 Upgrade — EVM, btcli, and Reliability',
   description:
-    'V444 completes the EVM surface, makes btcli safer for multisigs and automation, adds ' +
+    'V445 completes the EVM surface, makes btcli safer for multisigs and automation, adds ' +
     'human-readable Ledger orders, and lands a broad reliability pass.',
-  alternates: {canonical: '/releases/v444-upgrade'},
+  alternates: {canonical: '/releases/v445-upgrade'},
 };
 
 const DocLink = ({href, children}: {href: string; children: React.ReactNode}) => (
@@ -24,7 +24,7 @@ const page = () => {
     <Suspense fallback={<div style={{minHeight: '100vh', backgroundColor: 'white'}} />}>
       <FadeInWrapper className={styles.page_container}>
         <section className={styles.title_section}>
-          <h1 className={styles.paper_title}>The V444 Upgrade</h1>
+          <h1 className={styles.paper_title}>The V445 Upgrade</h1>
           <p className={styles.subtitle} style={{fontSize: '10px'}}>
             EVM, btcli, and Reliability · August 2026
           </p>
@@ -33,12 +33,12 @@ const page = () => {
         <section className={styles.section}>
           <h2 className={styles.subtitle}>Introduction</h2>
           <p>
-            Spec <strong>444</strong> makes the chain substantially easier to use from every
+            Spec <strong>445</strong> makes the chain substantially easier to use from every
             external surface. Solidity contracts gain 31 functions across five new Bittensor
             precompiles, plus 135 additions to existing interfaces. A saved multisig now behaves
             like a wallet throughout <code>btcli</code>. Automated dry runs carry enough information
             to approve and replay a transaction safely. Ledger users can read the actual fields of a
-            limit order before signing it. Underneath those interfaces, v444 recycles transaction
+            limit order before signing it. Underneath those interfaces, v445 recycles transaction
             fees and corrects transaction-pool validation, proxy charging, commitment cleanup,
             storage growth, and GRANDPA finality.
           </p>
@@ -132,13 +132,13 @@ IRuntimeConfiguration config =
 uint256 chainId = config.getEvmChainId();`}
           />
           <p>
-            In v444, only the registry&apos;s <code>isDisabled</code> field is populated. Its
+            In v445, only the registry&apos;s <code>isDisabled</code> field is populated. Its
             selector parameter and selector-lifecycle fields are reserved for a future extension and
             must not be used to infer whether a selector exists.
           </p>
           <p>
             Canonical Solidity interfaces, JSON ABIs, generated Python ABI copies, documentation,
-            gas accounting, and tests ship together. Integrators should use the v444 copies rather
+            gas accounting, and tests ship together. Integrators should use the v445 copies rather
             than reconstructing selectors from release notes. The new maintainer documentation also
             fixes the rules for ABI versioning, state exposure, lifecycle metadata, coverage, and
             backwards compatibility so later runtime releases can extend this surface without
@@ -208,7 +208,7 @@ btcli wallet transfer --dest 5F... --amount-tao 10 -w team-treasury`}
           <h2 className={styles.subtitle}>Read the order before signing it</h2>
           <p>
             <DocLink href='/releases/v438-upgrade'>V438</DocLink> let Ledger and compatible signers
-            authorize limit orders by signing a wrapped order hash. V444 adds an alternative
+            authorize limit orders by signing a wrapped order hash. V445 adds an alternative
             clear-signing form: one canonical printable message containing the order type, amount,
             subnet, limit or trigger price, expiry, hotkey, relayer policy, fee, slippage, chain ID,
             partial-fill policy, and signer. The hardware wallet displays those fields before
@@ -245,7 +245,7 @@ partial fills <true|false>, signer <ss58>`}
             <thead>
               <tr>
                 <th>Area</th>
-                <th>Change in v444</th>
+                <th>Change in v445</th>
               </tr>
             </thead>
             <tbody>
@@ -315,13 +315,13 @@ partial fills <true|false>, signer <ss58>`}
           <ul className={styles.list}>
             <li>
               <strong>EVM integrators:</strong> refresh the complete canonical ABI set before using
-              v444 selectors. Add <code>0x…080f</code> through <code>0x…0813</code> only from the
+              v445 selectors. Add <code>0x…080f</code> through <code>0x…0813</code> only from the
               published interfaces, and use the registry to inspect whole-precompile availability.
               Re-estimate aggregate staking reads and do not rely on fixed gas stipends.
             </li>
             <li>
               <strong>SDK and CLI users:</strong> older clients that read current chain metadata can
-              keep using existing commands. To use the new v444 features, upgrade to{' '}
+              keep using existing commands. To use the new v445 features, upgrade to{' '}
               <code>bittensor 11.1.0</code> and <code>bittensor-core 0.1.3</code> alongside the
               runtime upgrade. Existing wallet files remain usable, and saved multisigs can now be
               passed directly as <code>-w</code>. Rebuild any offline signing payload prepared
@@ -335,7 +335,7 @@ partial fills <true|false>, signer <ss58>`}
           </ul>
           <p>
             Signers: after the release train proposes, use{' '}
-            <code>btcli upgrade sign --url &lt;v444 release URL&gt; -w &lt;wallet&gt;</code>.
+            <code>btcli upgrade sign --url &lt;v445 release URL&gt; -w &lt;wallet&gt;</code>.
           </p>
         </section>
 

--- a/website/apps/bittensor-website/src/components/docs/emission-network-snapshot.tsx
+++ b/website/apps/bittensor-website/src/components/docs/emission-network-snapshot.tsx
@@ -48,8 +48,8 @@ export function EmissionNetworkSnapshot() {
       <p className='mt-6 border-t border-line pt-4 text-[0.8125rem] leading-relaxed text-mute'>
         This preview starts with each eligible subnet&apos;s{' '}
         <strong className='font-medium text-fg'>SubnetMovingPrice</strong> (EMA of spot alpha price,
-        capped at 1.0), turns it into a share of the total, then applies the emission gate.{' '}
-        <code>MinerBurned</code> is not part of this cross-subnet allocation. Top modeled recipient:{' '}
+        capped at 1.0), scales it by <code>1 − MinerBurned</code>, then applies the emission gate.
+        Top modeled recipient:{' '}
         <strong className='font-medium text-fg'>
           SN{snapshot.topSubnets[0]?.netuid} {snapshot.topSubnets[0]?.name}
         </strong>{' '}

--- a/website/apps/bittensor-website/src/components/docs/subnet-emission-share-chart.tsx
+++ b/website/apps/bittensor-website/src/components/docs/subnet-emission-share-chart.tsx
@@ -34,6 +34,7 @@ export function SubnetEmissionShareChart() {
   const {snapshot, loading} = useEmissionSnapshot();
   const [selectedIdx, setSelectedIdx] = useState(2);
   const [whatIfEma, setWhatIfEma] = useState<number | null>(null);
+  const [whatIfBurn, setWhatIfBurn] = useState<number | null>(null);
 
   const rows = useMemo(() => snapshot.topSubnets.slice(0, 8), [snapshot.topSubnets]);
   const selected = rows[selectedIdx] ?? rows[0];
@@ -43,10 +44,13 @@ export function SubnetEmissionShareChart() {
       ...input,
       emaPrice:
         input.netuid === selected?.netuid && whatIfEma !== null ? whatIfEma : input.emaPrice,
+      minerBurned:
+        input.netuid === selected?.netuid && whatIfBurn !== null ? whatIfBurn : input.minerBurned,
     }));
     const result = subnetEmissionShares(
       inputs.map((input) => input.emaPrice),
       {
+        minerBurned: inputs.map((input) => input.minerBurned),
         emissionEnabled: inputs.map((input) => input.emissionEnabled),
         rank: snapshot.emissionGateRank,
         quantile: snapshot.emissionGateQuantile,
@@ -56,8 +60,9 @@ export function SubnetEmissionShareChart() {
     );
     const indexByNetuid = new Map(inputs.map((input, index) => [input.netuid, index]));
     const priceByNetuid = new Map(inputs.map((input) => [input.netuid, input.emaPrice]));
-    return {indexByNetuid, priceByNetuid, ...result};
-  }, [selected?.netuid, snapshot, whatIfEma]);
+    const burnByNetuid = new Map(inputs.map((input) => [input.netuid, input.minerBurned]));
+    return {indexByNetuid, priceByNetuid, burnByNetuid, ...result};
+  }, [selected?.netuid, snapshot, whatIfBurn, whatIfEma]);
   const shares = useMemo(
     () =>
       rows.map((row) => {
@@ -132,6 +137,7 @@ export function SubnetEmissionShareChart() {
                 `${ctx.parsed.x.toFixed(1)}% of ${formatTao(blockEmission)}/block`,
                 `${formatTao(tao, 4)}/block`,
                 `Price EMA ${calculation.priceByNetuid.get(row.netuid)?.toFixed(4) ?? '0.0000'}`,
+                `MinerBurned ${formatPct(calculation.burnByNetuid.get(row.netuid) ?? 0)}`,
               ];
             },
           },
@@ -158,6 +164,7 @@ export function SubnetEmissionShareChart() {
         if (elements[0]) {
           setSelectedIdx(elements[0].index);
           setWhatIfEma(null);
+          setWhatIfBurn(null);
         }
       },
     }),
@@ -165,16 +172,17 @@ export function SubnetEmissionShareChart() {
   );
 
   const displayEma = whatIfEma ?? selected?.emaPrice ?? 0;
+  const displayBurn = whatIfBurn ?? selected?.minerBurned ?? 0;
   const selectedInputIdx = selected ? calculation.indexByNetuid.get(selected.netuid) : undefined;
-  const selectedDemandShare =
-    selectedInputIdx === undefined ? 0 : calculation.demandShares[selectedInputIdx];
+  const selectedBurnAdjustedShare =
+    selectedInputIdx === undefined ? 0 : calculation.burnAdjustedShares[selectedInputIdx];
   const selectedGateFactor =
     selectedInputIdx === undefined ? 0 : calculation.gateFactors[selectedInputIdx];
 
   return (
     <ExplainerPanel
       title='Subnet TAO share preview'
-      caption="The slider keeps the snapshot's gate midpoint fixed, just as the chain does between 360-block updates. Click a bar, then move its price EMA to see how demand and the gate affect its final share."
+      caption="The sliders keep the snapshot's gate midpoint fixed, just as the chain does between 360-block updates. Click a bar, then vary its price EMA or miner-burn proportion."
     >
       <div className='h-56'>
         {loading ? (
@@ -188,7 +196,7 @@ export function SubnetEmissionShareChart() {
 
       {selected && (
         <>
-          <div className='mt-6 grid grid-cols-2 gap-x-8 gap-y-4 border-t border-line pt-4 sm:grid-cols-4'>
+          <div className='mt-6 grid grid-cols-2 gap-x-8 gap-y-4 border-t border-line pt-4 sm:grid-cols-5'>
             <ExplainerStat
               label={subnetLabel(selected.netuid, selected.name)}
               value={formatPct(shares[selectedIdx] ?? 0)}
@@ -201,9 +209,14 @@ export function SubnetEmissionShareChart() {
               hint={`Spot ${selected.spotPrice.toFixed(4)} τ/α`}
             />
             <ExplainerStat
+              label='MinerBurned'
+              value={formatPct(displayBurn, 1)}
+              hint='Withheld miner-incentive proportion'
+            />
+            <ExplainerStat
               label='Share before gate'
-              value={formatPct(selectedDemandShare, 1)}
-              hint="This subnet's fraction of total price EMA"
+              value={formatPct(selectedBurnAdjustedShare, 1)}
+              hint='Price share after miner-burn scaling'
             />
             <ExplainerStat
               label='Demand that passes'
@@ -212,7 +225,7 @@ export function SubnetEmissionShareChart() {
             />
           </div>
 
-          <div className='mt-6 border-t border-line pt-4'>
+          <div className='mt-6 grid gap-5 border-t border-line pt-4 sm:grid-cols-2'>
             <ExplainerSlider
               label={`What-if EMA for SN${selected.netuid}`}
               value={displayEma}
@@ -221,6 +234,15 @@ export function SubnetEmissionShareChart() {
               step={0.005}
               display={displayEma.toFixed(4)}
               onChange={(v) => setWhatIfEma(v)}
+            />
+            <ExplainerSlider
+              label={`What-if MinerBurned for SN${selected.netuid}`}
+              value={displayBurn}
+              min={0}
+              max={1}
+              step={0.01}
+              display={formatPct(displayBurn, 0)}
+              onChange={(v) => setWhatIfBurn(v)}
             />
           </div>
         </>

--- a/website/apps/bittensor-website/src/lib/emission-math.ts
+++ b/website/apps/bittensor-website/src/lib/emission-math.ts
@@ -47,6 +47,7 @@ export function halvingThresholdsTao(count = 8): number[] {
 
 export type SubnetEmissionResult = {
   demandShares: number[];
+  burnAdjustedShares: number[];
   gateFactors: number[];
   shares: number[];
   gateBar: number;
@@ -70,10 +71,11 @@ export function selectEmissionGateBar(
   return positive[positive.length - 1];
 }
 
-/** v444 `get_shares` plus emission-enabled redistribution in subnet_emissions.rs */
+/** `get_shares` plus emission-enabled redistribution in subnet_emissions.rs */
 export function subnetEmissionShares(
   prices: number[],
   options: {
+    minerBurned?: number[];
     emissionEnabled?: boolean[];
     rank?: number;
     quantile?: number;
@@ -84,18 +86,25 @@ export function subnetEmissionShares(
   const safePrices = prices.map((price) => Math.max(price, 0));
   const priceSum = safePrices.reduce((sum, price) => sum + price, 0);
   const demandShares = safePrices.map((price) => (priceSum > 0 ? price / priceSum : 0));
+  const minerBurned = options.minerBurned ?? prices.map(() => 0);
+  const burnWeights = demandShares.map(
+    (share, index) => share * (1 - Math.min(Math.max(minerBurned[index] ?? 0, 0), 1)),
+  );
+  const burnWeightSum = burnWeights.reduce((sum, weight) => sum + weight, 0);
+  const burnAdjustedShares =
+    burnWeightSum > 0 ? burnWeights.map((weight) => weight / burnWeightSum) : demandShares;
   const gateBar =
-    options.gateBar ?? selectEmissionGateBar(demandShares, options.rank, options.quantile);
+    options.gateBar ?? selectEmissionGateBar(burnAdjustedShares, options.rank, options.quantile);
   const exponent = options.exponent ?? DEFAULT_EMISSION_GATE_EXPONENT;
-  const gateFactors = demandShares.map((share) => {
+  const gateFactors = burnAdjustedShares.map((share) => {
     if (share <= 0) return 0;
     if (gateBar <= 0) return 1;
     return 1 / (1 + (gateBar / share) ** exponent);
   });
 
-  let gatedWeights = demandShares.map((share, index) => share * gateFactors[index]);
+  let gatedWeights = burnAdjustedShares.map((share, index) => share * gateFactors[index]);
   if (gatedWeights.reduce((sum, weight) => sum + weight, 0) === 0) {
-    gatedWeights = demandShares;
+    gatedWeights = burnAdjustedShares;
   }
 
   const emissionEnabled = options.emissionEnabled ?? prices.map(() => true);
@@ -107,7 +116,7 @@ export function subnetEmissionShares(
     emissionEnabled[index] !== false && enabledTotal > 0 ? weight / enabledTotal : 0,
   );
 
-  return {demandShares, gateFactors, shares, gateBar};
+  return {demandShares, burnAdjustedShares, gateFactors, shares, gateBar};
 }
 
 /** `update_moving_price` smoothing factor in stake_utils.rs */

--- a/website/apps/bittensor-website/src/lib/emission-snapshot.ts
+++ b/website/apps/bittensor-website/src/lib/emission-snapshot.ts
@@ -6,11 +6,13 @@ export type SubnetEmissionRow = {
   name: string;
   spotPrice: number;
   emaPrice: number;
+  minerBurned: number;
   emissionEnabled: boolean;
   taoIn: number;
   alphaIn: number;
   alphaOut: number;
   demandShare: number;
+  burnAdjustedShare: number;
   gateFactor: number;
   taoShare: number;
   taoPerBlock: number;
@@ -19,6 +21,7 @@ export type SubnetEmissionRow = {
 export type EmissionInput = {
   netuid: number;
   emaPrice: number;
+  minerBurned: number;
   emissionEnabled: boolean;
 };
 
@@ -26,7 +29,7 @@ export type EmissionSnapshot = {
   fetchedAt: string;
   network: string;
   chainSpecVersion: number;
-  emissionMode: 'v444_price_ema_hill_gate' | string;
+  emissionMode: 'price_ema_miner_burn_hill_gate' | string;
   emissionGateSource: 'chain_storage' | 'v444_defaults_recomputed';
   blockEmissionTao: number;
   totalIssuanceTao: number;

--- a/website/apps/bittensor-website/src/lib/emission-snapshot.ts
+++ b/website/apps/bittensor-website/src/lib/emission-snapshot.ts
@@ -30,7 +30,7 @@ export type EmissionSnapshot = {
   network: string;
   chainSpecVersion: number;
   emissionMode: 'price_ema_miner_burn_hill_gate' | string;
-  emissionGateSource: 'chain_storage' | 'v444_defaults_recomputed';
+  emissionGateSource: 'chain_storage' | 'v445_defaults_recomputed';
   blockEmissionTao: number;
   totalIssuanceTao: number;
   totalIssuanceRao?: number;


### PR DESCRIPTION
## Motivation

Restore the miner-burn adjustment to cross-subnet emission allocation. A subnet’s normalized EMA-price share should be scaled by the portion of miner incentive that was not withheld, so subnet-owner-directed miner emission affects its network-wide allocation regardless of whether that value is recycled or burned.

## Changes

- Restore `price_share × (1 − MinerBurned)` weighting in `pallets/subtensor/src/coinbase/subnet_emissions.rs`.
- Renormalize burn-adjusted weights before applying the emission gate.
- Fall back to unadjusted price shares when every burn-adjusted weight is zero, preventing emission from being stranded.
- Keep `MinerBurned` independent of the subnet’s `RecycleOrBurn` configuration.
- Update emission documentation, release notes, website calculations, snapshot generation, and snapshot data to match runtime behavior.

## Economic behavior

For subnet `i`, the runtime computes:

```text
demand_share_i = price_ema_i / Σ price_ema
burn_adjusted_share_i = demand_share_i × (1 − miner_burned_i)
                        / Σ(demand_share × (1 − miner_burned))
final_share_i ∝ burn_adjusted_share_i × gate(burn_adjusted_share_i)
```

`MinerBurned` is clamped to one and all runtime arithmetic uses saturating fixed-point operations. If all adjusted weights are zero, allocation reverts to normalized EMA-price shares.

## Files of interest

- `pallets/subtensor/src/coinbase/subnet_emissions.rs`
- `pallets/subtensor/src/coinbase/run_coinbase.rs`
- `pallets/subtensor/src/tests/subnet_emissions.rs`
- `docs/concepts/emissions.mdx`
- `website/apps/bittensor-website/src/lib/emission-math.ts`

## Testing

Added regression coverage for unequal miner-burn values, a fully burned subnet, and the all-subnets-fully-burned fallback.

## Runtime and migration impact

This changes runtime economic behavior but introduces no storage migration. The existing runtime `spec_version` is 444, above the referenced Finney snapshot version 443, so no additional bump is required for the `main`-branch check.