### PR TITLE
feat(cli): external multisig signing and friendlier signer prompts

### DIFF
--- a/sdk/python/bittensor/cli/call.py
+++ b/sdk/python/bittensor/cli/call.py
@@ -46,6 +46,7 @@ the multisig, combining both wrappers. Each signatory approves the same
 
 from __future__ import annotations
 
+import contextlib
 import json
 from typing import Any, Optional
 
@@ -151,12 +152,14 @@ def call(
     signatories: Optional[str] = typer.Option(
         None,
         "--signatories",
-        help="Full signer set: ss58, address-book names, or wallet names (include yourself).",
+        help="Full signer set: wallet names, address-book names, or ss58 "
+        "(comma/space-separated; include yourself).",
     ),
     other_signatories: Optional[str] = typer.Option(
         None,
         "--other-signatories",
-        help="Other signers only (book names or ss58); your -w wallet coldkey is added.",
+        help="Other signers only: wallet names, address-book names, or ss58 "
+        "(comma/space-separated); your -w wallet coldkey is added.",
     ),
     signer: str = typer.Option(
         "coldkey", "--signer", help="Which wallet key signs: 'coldkey' or 'hotkey'."
@@ -203,31 +206,50 @@ def call(
         proxy_for = app_ctx.resolve_address("proxy_for", proxy_for)
     proxy_type_value = force_proxy_type.value if force_proxy_type else None
     via_multisig = threshold is not None
+    if app_ctx.signatory_wallet and not via_multisig:
+        # A typo'd or missing multisig name must not degrade into a plain raw
+        # call: the user explicitly asked for a multisig member to sign.
+        raise typer.BadParameter(
+            "--signatory only applies when dispatching through a multisig, but "
+            f"-w {app_ctx.wallet_name!r} is not in this environment's multisig book "
+            "(`btcli multisig list`) and no --multisig/--signatories were given",
+            param_hint="--signatory",
+        )
     if via_multisig and len(sigs) < threshold:
         raise typer.BadParameter(
             f"need at least {threshold} signatories, got {len(sigs)}",
             param_hint="--signatories",
         )
-    # ``-w <multisig>`` (no separate signatory wallet): pick a local member.
+    # ``-w <multisig>`` (no separate signatory wallet): the signing member is
+    # the external signer's account when one is configured (vault/ledger/
+    # extension — no local wallet files needed), else a local member wallet.
     if via_multisig:
-        signer_ss58 = None
         try:
-            signer_ss58 = app_ctx.wallet().coldkeypub.ss58_address
-        except Exception:
-            signer_ss58 = None
-        if signer_ss58 not in sigs:
-            try:
-                member_name, _ss58 = ms_helpers.pick_local_signatory(
-                    app_ctx,
-                    preset=preset or app_ctx.wallet_name,
-                    signatories=sigs,
-                )
-            except ValueError as error:
-                raise typer.BadParameter(str(error), param_hint="--wallet") from error
+            external_member = ms_helpers.external_signer_member(
+                app_ctx, preset=preset or app_ctx.wallet_name, signatories=sigs
+            )
+        except ValueError as error:
+            raise typer.BadParameter(str(error), param_hint="--signer-address") from error
+        if external_member is not None:
             app_ctx.multisig_wallet_name = preset or app_ctx.wallet_name
-            app_ctx.wallet_name = member_name
-            app_ctx.wallet_given = True
-    signing = app_ctx.signer(signer)
+        elif not app_ctx.uses_external_signer():
+            signer_ss58 = None
+            try:
+                signer_ss58 = app_ctx.wallet().coldkeypub.ss58_address
+            except Exception:
+                signer_ss58 = None
+            if signer_ss58 not in sigs:
+                try:
+                    member_name, _ss58 = ms_helpers.pick_local_signatory(
+                        app_ctx,
+                        preset=preset or app_ctx.wallet_name,
+                        signatories=sigs,
+                    )
+                except ValueError as error:
+                    raise typer.BadParameter(str(error), param_hint="--wallet") from error
+                app_ctx.multisig_wallet_name = preset or app_ctx.wallet_name
+                app_ctx.wallet_name = member_name
+                app_ctx.wallet_given = True
     label = target + (" via Sudo.sudo" if sudo else "")
     if proxy_for:
         label += f" as {proxy_for} via proxy"
@@ -285,40 +307,58 @@ def call(
         success_msg = f"submitted {label}"
 
     app_ctx.confirm(prompt)
+    if app_ctx.uses_vault_signer():
+        # Display-only context for the vault page ("what am I signing?").
+        app_ctx.vault_signer().summary = label
     if via_multisig:
         signatory_refs = _signatory_refs
 
         async def _submit_multisig(client):
-            ms = await client.multisig(sigs, threshold)
-            call = await prepare(client)
-            composed = await client.compose(call)
-            result = await ms.approve(call, signing, signer=signer)
-            followup = await ms_helpers.multisig_followup_from_composed(
-                client,
-                app_ctx,
-                call_hash=ms_helpers.hex_bytes(composed.call_hash),
-                call_data=ms_helpers.hex_bytes(composed.data),
-                raw_call_hash=composed.call_hash,
-                ms=ms,
-                signatories=sigs,
-                threshold=threshold,
-                signatory_refs=signatory_refs,
-                target=target,
-                params=params,
-                args_file=args_file,
-                sudo=sudo,
-                proxy_for=proxy_for,
-                force_proxy_type=proxy_type_value,
-                preset=preset,
-                signer_role=signer,
-                result=result,
-            )
-            result.data["multisig_followup"] = followup
-            return result
+            signing = await app_ctx.resolve_signing_wallet(signer, pick_account=True)
+            result = None
+            try:
+                ms = await client.multisig(sigs, threshold)
+                call = await prepare(client)
+                composed = await client.compose(call)
+                result = await ms.approve(call, signing, signer=signer)
+                followup = await ms_helpers.multisig_followup_from_composed(
+                    client,
+                    app_ctx,
+                    call_hash=ms_helpers.hex_bytes(composed.call_hash),
+                    call_data=ms_helpers.hex_bytes(composed.data),
+                    raw_call_hash=composed.call_hash,
+                    ms=ms,
+                    signatories=sigs,
+                    threshold=threshold,
+                    signatory_refs=signatory_refs,
+                    target=target,
+                    params=params,
+                    args_file=args_file,
+                    sudo=sudo,
+                    proxy_for=proxy_for,
+                    force_proxy_type=proxy_type_value,
+                    preset=preset,
+                    signer_role=signer,
+                    result=result,
+                )
+                result.data["multisig_followup"] = followup
+                return result
+            finally:
+                await _release_signer(signing, result)
 
         result = app_ctx.run(_submit_multisig)
     else:
-        result = app_ctx.run(lambda client: _submit(client, prepare, signing, signer))
+
+        async def _submit_direct(client):
+            signing = await app_ctx.resolve_signing_wallet(signer, pick_account=True)
+            result = None
+            try:
+                result = await _submit(client, prepare, signing, signer)
+                return result
+            finally:
+                await _release_signer(signing, result)
+
+        result = app_ctx.run(_submit_direct)
     if not app_ctx.output.result(result, success_msg):
         raise typer.Exit(1)
 
@@ -336,3 +376,14 @@ async def _multisig_address(client, signatories, threshold):
 
 async def _submit(client, prepare, wallet, signer):
     return await client.submit_call(await prepare(client), wallet, signer=signer)
+
+
+async def _release_signer(signing, result) -> None:
+    """Report the outcome to and close an external signer (vault page,
+    extension bridge); local wallet signers have neither hook."""
+    if hasattr(signing, "report_transaction_result"):
+        with contextlib.suppress(Exception):
+            await signing.report_transaction_result(bool(result is not None and result.success))
+    if hasattr(signing, "close"):
+        with contextlib.suppress(Exception):
+            await signing.close()

--- a/sdk/python/bittensor/cli/commands/multisig.py
+++ b/sdk/python/bittensor/cli/commands/multisig.py
@@ -7,7 +7,7 @@ Saved signer sets are reused by `btcli call --multisig NAME` and
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Optional
 
 import typer
 
@@ -17,13 +17,51 @@ from .. import multisig_helpers as ms_helpers
 from .. import upgrade_helpers as uh
 from ..context import AppContext, ctx_of
 from ..globals import with_globals
-from ..prompt import confirm_wallet
+from ..prompt import PromptSpec, confirm_wallet, fill_missing
 from .upgrade import load_pending_upgrades, render_upgrade_records
 
 app = typer.Typer(
     no_args_is_help=True,
     help="Save multisig signer sets and track pending multisig operations.",
 )
+
+_SIGNATORIES_HELP = (
+    "Full signer set: wallet names, address-book names, or ss58 addresses "
+    "(comma-separated, space-separated, or mixed)."
+)
+
+
+def _parse_signatory_refs(app_ctx: AppContext, raw: str) -> list[str]:
+    """Validate a prompted/typed signatory list; each ref must resolve."""
+    refs = ms_helpers.split_signatory_refs(raw)
+    if not refs:
+        raise ValueError(
+            "need at least one signatory (wallet name, address-book name, or ss58)"
+        )
+    for ref in refs:
+        address = app_ctx.resolve_address("coldkey_ss58", ref)
+        if not address:
+            raise ValueError(f"cannot resolve {ref!r}")
+    return refs
+
+
+def _prompt_signatory_refs(app_ctx: AppContext) -> list[str]:
+    """Ask for the signer set when neither --signatories nor --signatory was given."""
+    answers: dict[str, Any] = {}
+    fill_missing(
+        app_ctx,
+        [
+            PromptSpec(
+                field="signatories",
+                flag="--signatories",
+                help=_SIGNATORIES_HELP,
+                parse=_parse_signatory_refs,
+                placeholder="name1, name2  or  name1 name2",
+            )
+        ],
+        answers,
+    )
+    return answers["signatories"]
 
 
 @app.command(
@@ -48,10 +86,13 @@ def multisig_add(
     signatories: Optional[str] = typer.Option(
         None,
         "--signatories",
-        help="Full signer set: ss58, address-book names, or wallet names.",
+        help=_SIGNATORIES_HELP,
     ),
     signatory: Optional[list[str]] = typer.Option(
-        None, "--signatory", help="One signatory ref; repeat for each member."
+        None,
+        "--signatory",
+        help="One signatory ref; repeat for each member "
+        "(wallet name, address-book name, or ss58).",
     ),
     note: str = typer.Option("", "--note", help="Free-form note stored with the entry."),
     overwrite: bool = typer.Option(
@@ -70,18 +111,9 @@ def multisig_add(
             app_ctx, help_text="Name to save the multisig under (-w name).", must_exist=False
         )
         name = app_ctx.wallet_name
-    refs: list[str] = []
-    if signatories:
-        refs.extend(part.strip() for part in signatories.split(",") if part.strip())
-    if signatory:
-        refs.extend(signatory)
-    refs = list(dict.fromkeys(refs))
+    refs = ms_helpers.collect_signatory_refs(signatories, signatory)
     if not refs:
-        app_ctx.output.error(
-            "no signatories provided",
-            help="pass `--signatories` or one or more `--signatory`",
-        )
-        raise typer.Exit(1)
+        refs = _prompt_signatory_refs(app_ctx)
     resolved = [app_ctx.resolve_address("coldkey_ss58", ref) for ref in refs]
     resolved = list(dict.fromkeys(resolved))
     if threshold > len(resolved):
@@ -203,12 +235,14 @@ def multisig_pending(
     signatories: Optional[str] = typer.Option(
         None,
         "--signatories",
-        help="Full signer set: ss58, address-book names, or wallet names (include yourself).",
+        help="Full signer set: wallet names, address-book names, or ss58 "
+        "(comma/space-separated; include yourself).",
     ),
     other_signatories: Optional[str] = typer.Option(
         None,
         "--other-signatories",
-        help="Other signers only (book names or ss58); your -w wallet coldkey is added.",
+        help="Other signers only: wallet names, address-book names, or ss58 "
+        "(comma/space-separated); your -w wallet coldkey is added.",
     ),
     signer: str = typer.Option(
         "coldkey", "--signer", help="Which wallet key is in the signer set: 'coldkey' or 'hotkey'."

--- a/sdk/python/bittensor/cli/context.py
+++ b/sdk/python/bittensor/cli/context.py
@@ -110,6 +110,9 @@ class AppContext:
     # multisig book name lives here while ``wallet_name`` is the local member
     # coldkey that actually signs.
     multisig_wallet_name: Optional[str] = None
+    # ``--signatory``: which member wallet signs when ``-w`` names a saved
+    # multisig (replaces the interactive member picker).
+    signatory_wallet: Optional[str] = None
     # Diagnostic log verbosity (-v count); kept so per-command --quiet/--verbose
     # overrides can reconfigure logging without losing the root-level setting.
     verbosity: int = 0
@@ -176,31 +179,51 @@ class AppContext:
             self._ledger_signer = signer
         return self._ledger_signer
 
+    def external_signer_address(self) -> Optional[str]:
+        """The account the external backend signs with, without device/browser I/O.
+
+        Resolution order: ``--signer-address`` (raw ss58 or an address-book
+        name), the persisted ``signer_address`` config value, then — for the
+        vault backend — the configured wallet's coldkeypub (a pubkey-only
+        wallet is the natural companion to a Vault-held key). Returns None
+        when no external backend is active or nothing resolves; extension
+        account picking and Ledger derivation happen later, at signing time.
+        """
+        if not self.uses_external_signer():
+            return None
+        address = self.signer_address or cfg.get("signer_address")
+        if address and not is_bittensor_address(address):
+            address = cfg.get_address(address) or address
+        if address and is_bittensor_address(address):
+            return str(address)
+        if not address and self.uses_vault_signer():
+            try:
+                return self.wallet().coldkeypub.ss58_address
+            except Exception:
+                return None
+        return None
+
     def vault_signer(self) -> VaultSigner:
         """The Polkadot Vault (QR) signer for this invocation (built once).
 
-        The signing address is ``--signer-address`` (raw ss58 or an
-        address-book name), else the persisted ``signer_address`` config
-        value, falling back to the configured wallet's coldkeypub — a
-        pubkey-only wallet is the natural companion to a Vault-held key.
+        The signing address comes from :meth:`external_signer_address`.
         Nothing opens until the transport actually asks for a signature.
         """
         if self._vault_signer is None:
-            address = self.signer_address or cfg.get("signer_address")
-            if address and not is_bittensor_address(address):
-                address = cfg.get_address(address) or address
+            address = self.external_signer_address()
             if not address:
-                try:
-                    address = self.wallet().coldkeypub.ss58_address
-                except Exception:
+                raw = self.signer_address or cfg.get("signer_address")
+                if raw:
+                    self.output.error(
+                        f"--signer-address {raw!r} is not a valid ss58 address "
+                        "or known address-book name"
+                    )
+                else:
                     self.output.error(
                         "the vault signer needs an account address",
                         help="pass --signer-address <ss58>, or configure a wallet whose "
                         "coldkeypub matches the key held in Polkadot Vault",
                     )
-                    raise typer.Exit(2)
-            if not is_bittensor_address(address):
-                self.output.error(f"--signer-address {address!r} is not a valid ss58 address")
                 raise typer.Exit(2)
             signer = VaultSigner(
                 address,
@@ -450,8 +473,12 @@ class AppContext:
             self._resolving_multisigs.discard(name)
 
     def resolve_signatory_list(self, raw: str) -> list[str]:
-        """Resolve comma-separated signatory refs (ss58, address-book name, wallet)."""
-        parts = [part.strip() for part in raw.split(",") if part.strip()]
+        """Resolve signatory refs (ss58, address-book name, wallet).
+
+        ``raw`` may be comma-separated, space-separated, or mixed
+        (``a,b``, ``a, b``, ``a b``).
+        """
+        parts = ms_helpers.split_signatory_refs(raw)
         if not parts:
             raise ValueError("need at least one signatory")
         resolved: list[str] = []
@@ -530,6 +557,17 @@ class AppContext:
         except ValueError as error:
             self.output.error(str(error))
             raise typer.Exit(2) from error
+        if self.signatory_wallet and self.multisig_wallet_name is None:
+            # A typo'd or missing multisig name must not degrade into a plain
+            # single-signer transaction: the user explicitly asked for a
+            # multisig member to sign.
+            self.output.error(
+                f"--signatory given, but -w {self.wallet_name!r} is not in this "
+                "environment's multisig book (`btcli multisig list`)",
+                help="pass -w <saved-multisig-name>, or drop --signatory to sign "
+                f"directly as {self.wallet_name!r}",
+            )
+            raise typer.Exit(2)
         semantic_intent = intent.semantic_intent()
 
         # MEV shielding: explicit flag > persistent config > the intent's own
@@ -1039,15 +1077,18 @@ class AppContext:
         reviewers can act straight from `multisig pending`."""
         if not result.success or not result.data.get("multisig_call_hash"):
             return
-        if self.uses_external_signer():
-            return  # no local wallet to derive the signer address from
         try:
-            wallet = self.wallet()
-            signer_address = (
-                wallet.hotkey.ss58_address
-                if intent.signer == "hotkey"
-                else wallet.coldkeypub.ss58_address
-            )
+            if self.uses_external_signer():
+                signer_address = self.external_signer_address()
+                if not signer_address:
+                    return  # extension account was picked interactively; unknown here
+            else:
+                wallet = self.wallet()
+                signer_address = (
+                    wallet.hotkey.ss58_address
+                    if intent.signer == "hotkey"
+                    else wallet.coldkeypub.ss58_address
+                )
             followup = await ms_helpers.multisig_followup_for_intent(
                 client, self, intent=intent, result=result, signer_address=signer_address
             )

--- a/sdk/python/bittensor/cli/globals.py
+++ b/sdk/python/bittensor/cli/globals.py
@@ -191,6 +191,17 @@ _TX_FLOW = [
             rich_help_panel=PANEL_EXECUTION,
         ),
     ),
+    (
+        "signatory_wallet",
+        Optional[str],
+        typer.Option(
+            None,
+            "--signatory",
+            help="When -w names a saved multisig: the member wallet that signs this "
+            "approval (skips the interactive member picker).",
+            rich_help_panel=PANEL_EXECUTION,
+        ),
+    ),
 ]
 
 # Password sources for unlocking encrypted local coldkeys.
@@ -367,6 +378,8 @@ def apply(ctx: typer.Context, kwargs: dict[str, Any]) -> None:
         obj.dry_run = True
     if (v := kwargs.pop("mev_shield", None)) is not None:
         obj.mev_shield = v
+    if v := kwargs.pop("signatory_wallet", None):
+        obj.signatory_wallet = v
     quiet_override = kwargs.pop("quiet", False)
     if quiet_override:
         obj.output.quiet = True

--- a/sdk/python/bittensor/cli/main.py
+++ b/sdk/python/bittensor/cli/main.py
@@ -495,19 +495,27 @@ def _warn_if_legacy_config() -> None:
     """One-line stderr warning when a v9-era ``~/.bittensor/config.yml`` exists.
 
     This CLI never reads it, so settings people expect (network, wallet, ...)
-    silently fall back to defaults — the most common migration confusion. Warn
-    until the stale file is renamed or removed.
+    silently fall back to defaults — the most common migration confusion. The
+    warning is shown once; a marker file next to the config records that it
+    was already printed (delete the marker to see it again).
     """
     legacy = Path.home() / ".bittensor" / "config.yml"
     if not legacy.is_file():
         return
+    marker = legacy.parent / ".btcli_legacy_config_warned"
+    if marker.is_file():
+        return
     print(
         f"warning: {legacy} is the legacy (v9) btcli config and is ignored by this CLI; "
         f"migrate values with `btcli config set` (stored in {config_path()}), then rename "
-        f"or delete the old file to silence this warning. "
+        f"or delete the old file. "
         f"Migration guide: {DOCS_URL}/migration",
         file=sys.stderr,
     )
+    try:
+        marker.touch()
+    except OSError:
+        pass  # unwritable ~/.bittensor; warn again next time
 
 
 def main() -> None:

--- a/sdk/python/bittensor/cli/multisig_helpers.py
+++ b/sdk/python/bittensor/cli/multisig_helpers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 import shlex
 from hashlib import blake2b
 from typing import Any, Optional
@@ -14,6 +15,36 @@ from .._generated import storage as st
 from .._transport.codec import multisig_account
 from ..result import ChainError, ExtrinsicResult
 from ..wallets import is_bittensor_address
+
+# One or more commas and/or whitespace between signatory refs
+# (``a,b``, ``a, b``, ``a b``, ``a, b c``).
+_SIGNATORY_SEP = re.compile(r"[,\s]+")
+
+
+def split_signatory_refs(raw: str) -> list[str]:
+    """Split a signatory list into individual refs.
+
+    Each token is an ss58 address, address-book name, or local wallet name.
+    Accepts comma-separated, space-separated, or mixed input.
+    """
+    text = raw.strip()
+    if not text:
+        return []
+    return [part for part in _SIGNATORY_SEP.split(text) if part]
+
+
+def collect_signatory_refs(
+    signatories: Optional[str] = None,
+    signatory: Optional[list[str]] = None,
+) -> list[str]:
+    """Merge ``--signatories`` and repeated ``--signatory`` into unique refs."""
+    refs: list[str] = []
+    if signatories:
+        refs.extend(split_signatory_refs(signatories))
+    if signatory:
+        for item in signatory:
+            refs.extend(split_signatory_refs(item))
+    return list(dict.fromkeys(refs))
 
 
 def hex_bytes(value: bytes | str) -> str:
@@ -166,9 +197,11 @@ def build_replay_command(
         if force_proxy_type:
             parts.append(f"--force-proxy-type {shlex.quote(force_proxy_type)}")
     if preset:
-        # ``-w <multisig>`` auto-picks a local member and wraps the call; each
-        # co-signer can paste the same command on their machine.
+        # ``-w <multisig>`` wraps the call; ``--signatory`` pins the member
+        # (name or ss58) so the right key signs even when several member
+        # wallets exist on the co-signer's machine.
         parts.append(f"-w {shlex.quote(preset)}")
+        parts.append(f"--signatory {shlex.quote(wallet_label)}")
     elif other_signatory_labels:
         parts.append(f"--multisig-threshold {threshold}")
         parts.append(f"--other-signatories {shlex.quote(','.join(other_signatory_labels))}")
@@ -230,10 +263,10 @@ def resolve_multisig(
     if signatories and other_signatories:
         raise ValueError("pass either --signatories or --other-signatories, not both")
     if signatories:
-        refs = [part.strip() for part in signatories.split(",") if part.strip()]
+        refs = split_signatory_refs(signatories)
         sigs = app_ctx.resolve_signatory_list(signatories)
     elif other_signatories:
-        refs = [part.strip() for part in other_signatories.split(",") if part.strip()]
+        refs = split_signatory_refs(other_signatories)
         sigs = app_ctx.resolve_signatory_list(other_signatories)
         wallet = app_ctx.wallet()
         self_addr = (
@@ -279,6 +312,30 @@ _MULTISIG_OPS = frozenset(
 )
 
 
+def external_signer_member(
+    app_ctx, *, preset: str, signatories: list[str]
+) -> Optional[tuple[str, str]]:
+    """The multisig member an external backend (vault/ledger/extension) signs for.
+
+    Returns ``(name, ss58)`` when ``--signer-address`` (or its config/wallet
+    fallbacks) resolves to one of ``signatories`` — that member signs, and no
+    local wallet files are needed. Returns None when no external backend is
+    active or no address is configured (callers fall back to picking a local
+    member wallet). Errors when the external address is not a member, since
+    signing would produce an approval the multisig ignores.
+    """
+    address = app_ctx.external_signer_address()
+    if not address:
+        return None
+    if address not in signatories:
+        raise ValueError(
+            f"external signer account {address} is not a member of multisig {preset!r}; "
+            "pass --signer-address with one of its signatories"
+        )
+    name = resolve_signatory_name(app_ctx, address)
+    return name, address
+
+
 def local_signatory_wallets(app_ctx, signatories: list[str]) -> list[tuple[str, str]]:
     """Local coldkey wallets whose ss58 is in ``signatories``: ``(name, ss58)``."""
     wanted = set(signatories)
@@ -298,17 +355,29 @@ def local_signatory_wallets(app_ctx, signatories: list[str]) -> list[tuple[str, 
 def pick_local_signatory(app_ctx, *, preset: str, signatories: list[str]) -> tuple[str, str]:
     """Choose which local member coldkey signs for a saved multisig.
 
-    Returns ``(wallet_name, ss58)``. Auto-selects when exactly one member is
-    present locally; prompts when several are; errors when none are.
+    Returns ``(wallet_name, ss58)``. ``--signatory`` names the member wallet
+    outright; otherwise auto-selects when exactly one member is present
+    locally, prompts when several are, and errors when none are.
     """
     from .prompt import PromptSpec, fill_missing, interactive
 
     locals_ = local_signatory_wallets(app_ctx, signatories)
+    chosen = getattr(app_ctx, "signatory_wallet", None)
+    if chosen:
+        for name, ss58 in locals_:
+            if chosen == name or chosen == ss58:
+                return name, ss58
+        known = ", ".join(name for name, _ in locals_) or "none found under --wallet-path"
+        raise ValueError(
+            f"--signatory {chosen!r} is not a local member wallet of multisig {preset!r}; "
+            f"local members: {known}"
+        )
     if not locals_:
         raise ValueError(
             f"no local signatory wallet for multisig {preset!r}; "
-            "install one of its member coldkeys under --wallet-path, or pass "
-            f"`--multisig {preset} -w <signatory>`"
+            "install one of its member coldkeys under --wallet-path, pass "
+            f"`--multisig {preset} -w <signatory>`, or sign externally with "
+            "`--signer vault --signer-address <member>` (also: extension, ledger)"
         )
     if len(locals_) == 1:
         name, ss58 = locals_[0]
@@ -322,8 +391,8 @@ def pick_local_signatory(app_ctx, *, preset: str, signatories: list[str]) -> tup
     if app_ctx.assume_yes or not interactive(app_ctx):
         raise ValueError(
             f"multisig {preset!r} has {len(locals_)} local member wallets "
-            f"({', '.join(by_name)}); pass `-w <signatory>` (with "
-            f"`--multisig {preset}`) to choose one non-interactively"
+            f"({', '.join(by_name)}); pass `--signatory <member>` to choose one "
+            "non-interactively"
         )
 
     def _parse(app_ctx_, raw: str) -> str:
@@ -338,7 +407,7 @@ def pick_local_signatory(app_ctx, *, preset: str, signatories: list[str]) -> tup
         [
             PromptSpec(
                 field="signatory_wallet",
-                flag="--wallet",
+                flag="--signatory",
                 help=f"Which local member of multisig {preset!r} signs this approval.",
                 parse=_parse,
                 default=locals_[0][0],
@@ -404,12 +473,19 @@ def wrap_intent_for_multisig_wallet(app_ctx, intent):
         return intent
 
     threshold, signatories, _refs = resolve_multisig_preset(app_ctx, preset)
-    member_name, signer_ss58 = pick_local_signatory(app_ctx, preset=preset, signatories=signatories)
-
-    # Remember the multisig account name for summaries; the signing wallet is
-    # the local member that actually unlocks a coldkey.
+    external = external_signer_member(app_ctx, preset=preset, signatories=signatories)
+    if external:
+        # An external backend (vault/ledger/extension) holds the member key;
+        # no local wallet files are involved, so wallet_name stays untouched.
+        member_name, signer_ss58 = external
+    else:
+        member_name, signer_ss58 = pick_local_signatory(
+            app_ctx, preset=preset, signatories=signatories
+        )
+        # The signing wallet is the local member that actually unlocks a coldkey.
+        app_ctx.wallet_name = member_name
+    # Remember the multisig account name for summaries.
     app_ctx.multisig_wallet_name = preset
-    app_ctx.wallet_name = member_name
     app_ctx.wallet_given = True
 
     others = [ss58 for ss58 in signatories if ss58 != signer_ss58]

--- a/sdk/python/bittensor/cli/output.py
+++ b/sdk/python/bittensor/cli/output.py
@@ -1531,7 +1531,11 @@ class Output:
             self._out.print(":")
             self._print_copyable(str(entry.get("command", "")))
         self._out.print()
-        tail = _prose("add `--macos-password` or `--keychain-password` if the co-signer uses them")
+        tail = _prose(
+            "add `--macos-password` or `--keychain-password` if the co-signer uses them; "
+            "members whose key lives elsewhere append `--signer vault|ledger|extension` "
+            "(with `--signer-address <member>` when no local wallet names it)"
+        )
         tail.style = "dim"
         self._out.print(tail)
 

--- a/sdk/python/bittensor/extension/bridge.py
+++ b/sdk/python/bittensor/extension/bridge.py
@@ -23,6 +23,12 @@ _BRIDGE_HTML = _STATIC_DIR / "bridge.html"
 
 logger = logging.getLogger(__name__)
 
+# Browsers speculatively open (and silently drop) TCP connections to the page's
+# port, which the websockets server logs as a full InvalidMessage traceback.
+# Route its logging to a muted logger: handshake noise is meaningless here.
+_WS_LOGGER = logging.getLogger(__name__ + ".ws")
+_WS_LOGGER.setLevel(logging.CRITICAL)
+
 
 @dataclass
 class _BridgeState:
@@ -57,6 +63,7 @@ class BridgeServer:
                 self.host,
                 self.port,
                 process_request=self._process_request,
+                logger=_WS_LOGGER,
             )
             logger.debug(f"Bridge server listening on {self.http_url}")
         if open_browser:

--- a/sdk/python/bittensor/extension/session.py
+++ b/sdk/python/bittensor/extension/session.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import signal
+import socket
 import subprocess
 import sys
 from pathlib import Path
@@ -85,6 +86,12 @@ def _read_daemon_pid() -> Optional[int]:
     return pid
 
 
+def _port_in_use(host: str, port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.settimeout(0.5)
+        return probe.connect_ex((host, port)) == 0
+
+
 def start_bridge_daemon(
     *,
     host: str = DEFAULT_BRIDGE_HOST,
@@ -93,6 +100,19 @@ def start_bridge_daemon(
     """Spawn a detached bridge process if one is not already running."""
     if _read_daemon_pid() is not None:
         return
+
+    # No pid file of ours, yet something is listening: a bridge owned by a
+    # different environment (another HOME/user) or an unrelated app. A spawned
+    # daemon would fail to bind and die silently, so fail fast and say why —
+    # otherwise the caller polls to a generic 15 s timeout.
+    if _port_in_use(host, port):
+        raise BridgeError(
+            f"cannot start the extension bridge: {host}:{port} is already in use by "
+            "another process — likely a bridge from a different environment "
+            f"(`lsof -nP -i :{port}` shows it; stop it with `btcli extension stop` "
+            "from that environment or kill the pid), or run this bridge elsewhere "
+            f"with --extension-bridge http://{host}:{port + 1} (BT_EXTENSION_BRIDGE)"
+        )
 
     pid_path = bridge_pid_path()
     pid_path.parent.mkdir(parents=True, exist_ok=True)

--- a/sdk/python/bittensor/vault/server.py
+++ b/sdk/python/bittensor/vault/server.py
@@ -36,6 +36,12 @@ _SPECS_PNG = _STATIC_DIR / "bittensor-chain-specs.png"
 
 logger = logging.getLogger(__name__)
 
+# Browsers speculatively open (and silently drop) TCP connections to the page's
+# port, which the websockets server logs as a full InvalidMessage traceback.
+# Route its logging to a muted logger: handshake noise is meaningless here.
+_WS_LOGGER = logging.getLogger(__name__ + ".ws")
+_WS_LOGGER.setLevel(logging.CRITICAL)
+
 
 class VaultPageError(BittensorError):
     """The vault page reported a failure (camera denied, user cancelled, ...)."""
@@ -66,6 +72,7 @@ class VaultSessionServer:
             self.host,
             self.port,
             process_request=self._process_request,
+            logger=_WS_LOGGER,
         )
         self.port = self._server.sockets[0].getsockname()[1]
         logger.debug(f"vault page server listening on {self.http_url}")

--- a/sdk/python/tests/unit/test_multisig_safety.py
+++ b/sdk/python/tests/unit/test_multisig_safety.py
@@ -32,6 +32,7 @@ async def test_saved_multisig_preserves_inner_policy_and_mev_contract(monkeypatc
         wallet_given=True,
         multisig_wallet_name=None,
         output=output,
+        external_signer_address=lambda: None,
     )
     monkeypatch.setattr(multisig_helpers.cfg, "get_multisig", lambda name: {"name": name})
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- Let vault/ledger/extension members approve multisig calls without local wallet files; add `--signatory` to pick the local member when `-w` is a saved multisig.
- Prompt for signatories on `btcli multisig add` when omitted, and accept comma-, space-, or mixed-separated wallet names, address-book names, and ss58.
- Fail fast when the extension bridge port is already in use; mute speculative websocket handshake noise on vault/bridge servers; show the legacy config warning once.

## Test plan
- [ ] `btcli multisig add` (interactive): enter threshold + name, then a space-separated and a comma-separated signer list
- [ ] `btcli multisig add -w NAME --threshold 2 --signatories a,b,c` and `--signatories a b c`
- [ ] Multisig approval with `--signer vault|extension|ledger` and `--signer-address <member>` (no local member coldkey)
- [ ] `-w <saved-multisig> --signatory <member>` skips the interactive member picker
- [ ] `--signatory` without a multisig `-w` errors instead of falling through to a plain call
- [ ] Extension bridge: start while another process owns the port → clear error (not a 15s timeout)


Made with [Cursor](https://cursor.com)