### PR TITLE
reduce bloat

### DIFF
--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -332,7 +332,7 @@ jobs:
           wasm-pack --version
       - name: wasm smoke test (node)
         run: |
-          wasm-pack build sdk/bittensor-core-wasm --target nodejs --out-dir pkg-node
+          wasm-pack build sdk/bittensor-core-wasm --target nodejs --out-dir pkg-node --no-opt
           node sdk/bittensor-core-wasm/tests/smoke.mjs
       - name: Report wasm compiler cache
         if: always()

--- a/pallets/commitments/src/lib.rs
+++ b/pallets/commitments/src/lib.rs
@@ -473,6 +473,11 @@ impl<T: Config> Pallet<T> {
                             continue;
                         };
 
+                        if commit.header.v.len() != 32 || commit.header.w.len() != 32 {
+                            log::warn!("Invalid TLECiphertext header for {who:?}");
+                            continue;
+                        }
+
                         let decrypted_bytes: Vec<u8> =
                             tld::<TinyBLS381, AESGCMStreamCipherProvider>(commit, sig)
                                 .map_err(|e| {

--- a/pallets/commitments/src/tests.rs
+++ b/pallets/commitments/src/tests.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::expect_used, clippy::indexing_slicing)]
 
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use codec::Encode;
 use sp_std::prelude::*;
 use subtensor_runtime_common::{NetUid, TaoBalance};
@@ -21,6 +22,7 @@ use frame_support::{
     weights::{Weight, constants::RocksDbWeight},
 };
 use frame_system::{Pallet as System, RawOrigin};
+use tle::{curves::drand::TinyBLS381, tlock::TLECiphertext};
 
 fn purge_netuid_with_meter(netuid: NetUid, limit: Weight) -> bool {
     let mut weight_meter = frame_support::weights::WeightMeter::with_limit(limit);
@@ -358,6 +360,43 @@ fn reveal_timelocked_commitment_cant_deserialize_ciphertext() {
         System::<Test>::set_block_number(99999);
         assert_ok!(Pallet::<Test>::reveal_timelocked_commitments());
         assert!(RevealedCommitments::<Test>::get(netuid, who).is_none());
+    });
+}
+
+#[test]
+fn reveal_timelocked_commitment_rejects_invalid_ciphertext_header() {
+    new_test_ext().execute_with(|| {
+        let who = 42;
+        let netuid = NetUid::from(9);
+        let reveal_round = 1000;
+        let ciphertext = produce_ciphertext(b"Some data", reveal_round);
+        let mut commit = TLECiphertext::<TinyBLS381>::deserialize_compressed(&ciphertext[..])
+            .expect("valid ciphertext");
+        commit.header.v.clear();
+        commit.header.w = vec![1];
+
+        let mut malformed = Vec::new();
+        commit
+            .serialize_compressed(&mut malformed)
+            .expect("serialize malformed ciphertext");
+        let data = Data::TimelockEncrypted {
+            encrypted: malformed.try_into().expect("ciphertext fits"),
+            reveal_round,
+        };
+        let info = CommitmentInfo {
+            fields: BoundedVec::try_from(vec![data]).expect("one field fits"),
+        };
+
+        assert_ok!(Pallet::<Test>::set_commitment(
+            RuntimeOrigin::signed(who),
+            netuid,
+            Box::new(info),
+        ));
+        let sig = hex::decode(DRAND_QUICKNET_SIG_HEX).expect("valid signature hex");
+        insert_drand_pulse(reveal_round, &sig);
+
+        assert_ok!(Pallet::<Test>::reveal_timelocked_commitments());
+        assert!(CommitmentOf::<Test>::get(netuid, who).is_none());
     });
 }
 

--- a/pallets/subtensor/src/coinbase/reveal_commits.rs
+++ b/pallets/subtensor/src/coinbase/reveal_commits.rs
@@ -117,6 +117,13 @@ impl<T: Config> Pallet<T> {
                     }
                 };
 
+                if commit.header.v.len() != 32 || commit.header.w.len() != 32 {
+                    log::trace!(
+                        "Failed to reveal commit for mechanism {netuid_index} submitted by {who:?} due to invalid ciphertext header"
+                    );
+                    continue;
+                }
+
                 let decrypted_bytes: Vec<u8> = match tld::<TinyBLS381, AESGCMStreamCipherProvider>(
                     commit, sig,
                 ) {

--- a/pallets/subtensor/src/tests/weights.rs
+++ b/pallets/subtensor/src/tests/weights.rs
@@ -22,9 +22,9 @@ use substrate_fixed::types::I32F32;
 use subtensor_runtime_common::NetUidStorageIndex;
 use tle::{
     curves::drand::TinyBLS381,
-    ibe::fullident::Identity,
+    ibe::fullident::{Ciphertext as IBECiphertext, Identity},
     stream_ciphers::AESGCMStreamCipherProvider,
-    tlock::{tld, tle},
+    tlock::{TLECiphertext, tld, tle},
 };
 use w3f_bls::EngineBLS;
 
@@ -4605,6 +4605,56 @@ fn test_reveal_crv3_commits_decryption_failure() {
         let weights_matrix = SubtensorModule::get_weights(netuid.into());
         let weights = weights_matrix.get(neuron_uid).cloned().unwrap_or_default();
         assert!(weights.iter().all(|&w| w == I32F32::from_num(0)));
+    });
+}
+
+#[test]
+fn test_reveal_crv3_commits_rejects_invalid_ciphertext_header() {
+    new_test_ext(1).execute_with(|| {
+        let netuid = NetUid::from(1);
+        let hotkey = U256::from(1);
+        let reveal_round = 1000;
+
+        add_network(netuid, 5, 0);
+        register_ok_neuron(netuid, hotkey, U256::from(2), 100_000);
+        SubtensorModule::set_weights_set_rate_limit(netuid, 0);
+        SubtensorModule::set_commit_reveal_weights_enabled(netuid, true);
+
+        let public_key = hex::decode("83cf0f2896adee7eb8b5f01fcad3912212c437e0073e911fb90022d3e760183c8c4b450b6a0a6c3ac6a5776a2d1064510d1fec758c921cc22b0e17e63aaf4bcb5ed66304de9cf809bd274ca73bab4af5a6e9c76a4bc09e76eae8991ef5ece45a")
+            .expect("valid public key hex");
+        let u = <TinyBLS381 as EngineBLS>::PublicKeyGroup::deserialize_compressed(&public_key[..])
+            .expect("valid public key");
+        let commit = TLECiphertext::<TinyBLS381> {
+            header: IBECiphertext { u, v: vec![], w: vec![1] },
+            body: vec![],
+            cipher_suite: vec![],
+        };
+        let mut commit_bytes = Vec::new();
+        commit
+            .serialize_compressed(&mut commit_bytes)
+            .expect("serialize malformed ciphertext");
+
+        assert_ok!(SubtensorModule::do_commit_timelocked_weights(
+            RuntimeOrigin::signed(hotkey),
+            netuid,
+            commit_bytes.try_into().expect("ciphertext fits"),
+            reveal_round,
+            SubtensorModule::get_commit_reveal_weights_version(),
+        ));
+        step_epochs(1, netuid);
+
+        let signature = hex::decode("b44679b9a59af2ec876b1a6b1ad52ea9b1615fc3982b19576350f93447cb1125e342b73a8dd2bacbe47e4b6b63ed5e39")
+            .expect("valid signature hex");
+        pallet_drand::Pulses::<Test>::insert(
+            reveal_round,
+            Pulse {
+                round: reveal_round,
+                randomness: vec![0; 32].try_into().expect("randomness fits"),
+                signature: signature.try_into().expect("signature fits"),
+            },
+        );
+
+        assert_ok!(SubtensorModule::reveal_crv3_commits_for_subnet(netuid));
     });
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 444,
+    spec_version: 445,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/sdk/bittensor-core-wasm/tests/smoke.mjs
+++ b/sdk/bittensor-core-wasm/tests/smoke.mjs
@@ -1,6 +1,6 @@
 // Node smoke test for the wasm binding, driven by the same golden fixtures
 // the Python SDK tests use. Build first:
-//   wasm-pack build sdk/bittensor-core-wasm --target nodejs --out-dir pkg-node
+//   wasm-pack build sdk/bittensor-core-wasm --target nodejs --out-dir pkg-node --no-opt
 // Then: node sdk/bittensor-core-wasm/tests/smoke.mjs
 
 import { readFileSync } from "node:fs";


### PR DESCRIPTION
## Motivation

Malformed timelock ciphertexts with incorrectly sized `v` or `w` header fields can reach the TLE decryption implementation. Rejecting these inputs early avoids unnecessary processing and prevents malformed commitments from persisting or disrupting reveal processing.

## Changes

- Validate that both TLE ciphertext header fields are exactly 32 bytes before decryption.
- Apply the validation to the commitments pallet and CRv3 weight-reveal path.
- Add regression tests for malformed ciphertext headers in both paths.
- Build the Node.js WASM smoke-test artifact with `--no-opt` and update its documented command.
- Bump the runtime `spec_version` from 444 to 445.

## Files of interest

- `pallets/commitments/src/lib.rs`
- `pallets/commitments/src/tests.rs`
- `pallets/subtensor/src/coinbase/reveal_commits.rs`
- `pallets/subtensor/src/tests/weights.rs`
- `runtime/src/lib.rs`
- `.github/workflows/check-rust.yml`

## Behavioral impact

Malformed timelock commitments whose header fields are not exactly 32 bytes are discarded when their reveal is processed. Valid commitments are unaffected.

## Migration and runtime version

No storage migration is required. This is runtime-affecting, so `spec_version` is bumped to 445.

## Testing

Regression tests were added for malformed TLE headers in both commitment-reveal implementations. The WASM smoke-test build command was updated to match CI.