### PR TITLE
Feat/ Move Stake Limit

### DIFF
--- a/chain-extensions/src/lib.rs
+++ b/chain-extensions/src/lib.rs
@@ -223,6 +223,56 @@ where
         }
     }
 
+    fn dispatch_move_stake_limit_v1<Env>(
+        env: &mut Env,
+        origin: RawOrigin<T::AccountId>,
+    ) -> Result<RetVal, DispatchError>
+    where
+        Env: SubtensorExtensionEnv<T>,
+        <<T as SysConfig>::Lookup as StaticLookup>::Source: From<<T as SysConfig>::AccountId>,
+    {
+        let (
+            origin_hotkey,
+            destination_hotkey,
+            origin_netuid,
+            destination_netuid,
+            alpha_amount,
+            limit_price,
+            allow_partial,
+        ): (
+            T::AccountId,
+            T::AccountId,
+            NetUid,
+            NetUid,
+            AlphaBalance,
+            TaoBalance,
+            bool,
+        ) = env
+            .read_as()
+            .map_err(|_| DispatchError::Other("Failed to decode input parameters"))?;
+
+        env.charge_weight(
+            <<T as pallet_subtensor::Config>::WeightInfo as SubtensorWeightInfo>::move_stake_limit(
+            ),
+        )?;
+
+        let call_result = pallet_subtensor::Pallet::<T>::move_stake_limit(
+            origin.into(),
+            origin_hotkey,
+            destination_hotkey,
+            origin_netuid,
+            destination_netuid,
+            alpha_amount,
+            limit_price,
+            allow_partial,
+        );
+
+        match call_result {
+            Ok(_) => Ok(RetVal::Converging(Output::Success as u32)),
+            Err(e) => Ok(RetVal::Converging(Output::from(e) as u32)),
+        }
+    }
+
     fn dispatch_transfer_stake_v1<Env>(
         env: &mut Env,
         origin: RawOrigin<T::AccountId>,
@@ -691,6 +741,14 @@ where
             FunctionId::CallerMoveStakeV1 => {
                 let origin = convert_origin(env.origin());
                 Self::dispatch_move_stake_v1(env, origin)
+            }
+            FunctionId::MoveStakeLimitV1 => {
+                let origin = RawOrigin::Signed(env.caller());
+                Self::dispatch_move_stake_limit_v1(env, origin)
+            }
+            FunctionId::CallerMoveStakeLimitV1 => {
+                let origin = convert_origin(env.origin());
+                Self::dispatch_move_stake_limit_v1(env, origin)
             }
             FunctionId::TransferStakeV1 => {
                 let origin = RawOrigin::Signed(env.caller());

--- a/chain-extensions/src/mock.rs
+++ b/chain-extensions/src/mock.rs
@@ -160,6 +160,7 @@ impl frame_support::traits::InstanceFilter<RuntimeCall> for subtensor_runtime_co
                     | RuntimeCall::SubtensorModule(pallet_subtensor::Call::swap_stake { .. })
                     | RuntimeCall::SubtensorModule(pallet_subtensor::Call::swap_stake_limit { .. })
                     | RuntimeCall::SubtensorModule(pallet_subtensor::Call::move_stake { .. })
+                    | RuntimeCall::SubtensorModule(pallet_subtensor::Call::move_stake_limit { .. })
                     | RuntimeCall::SubtensorModule(pallet_subtensor::Call::transfer_stake { .. })
             ),
             _ => false,

--- a/chain-extensions/src/tests.rs
+++ b/chain-extensions/src/tests.rs
@@ -570,6 +570,79 @@ fn move_stake_success_moves_alpha_between_hotkeys() {
 }
 
 #[test]
+fn move_stake_limit_success_moves_alpha_between_hotkeys() {
+    mock::new_test_ext(1).execute_with(|| {
+        let owner_hotkey = U256::from(6201);
+        let owner_coldkey = U256::from(6202);
+        let coldkey = U256::from(7201);
+        let origin_hotkey = U256::from(7202);
+        let destination_hotkey = U256::from(7203);
+        let min_stake = DefaultMinStake::<mock::Test>::get();
+        let stake_amount_raw = min_stake.to_u64().saturating_mul(240);
+        let netuid = mock::add_dynamic_network(&owner_hotkey, &owner_coldkey);
+
+        mock::setup_reserves(
+            netuid,
+            stake_amount_raw.saturating_mul(15).into(),
+            AlphaBalance::from(stake_amount_raw.saturating_mul(25)),
+        );
+        mock::register_ok_neuron(netuid, origin_hotkey, coldkey, 0);
+        mock::register_ok_neuron(netuid, destination_hotkey, coldkey, 1);
+        add_balance_to_coldkey_account(&coldkey, (stake_amount_raw + 1_000_000_000).into());
+        assert_ok!(pallet_subtensor::Pallet::<mock::Test>::add_stake(
+            RawOrigin::Signed(coldkey).into(),
+            origin_hotkey,
+            netuid,
+            stake_amount_raw.into(),
+        ));
+
+        let origin_before =
+            pallet_subtensor::Pallet::<mock::Test>::get_stake_for_hotkey_and_coldkey_on_subnet(
+                &origin_hotkey,
+                &coldkey,
+                netuid,
+            );
+        let amount: AlphaBalance = (origin_before.to_u64() / 2).into();
+        let expected_weight = <<mock::Test as pallet_subtensor::Config>::WeightInfo as SubtensorWeightInfo>::move_stake_limit();
+        let mut env = MockEnv::new(
+            FunctionId::MoveStakeLimitV1,
+            coldkey,
+            (
+                origin_hotkey,
+                destination_hotkey,
+                netuid,
+                netuid,
+                amount,
+                TaoBalance::MAX,
+                false,
+            )
+                .encode(),
+        )
+        .with_expected_weight(expected_weight);
+
+        let ret = SubtensorChainExtension::<mock::Test>::dispatch(&mut env).unwrap();
+        assert_success(ret);
+        assert_eq!(env.charged_weight(), Some(expected_weight));
+        assert_eq!(
+            pallet_subtensor::Pallet::<mock::Test>::get_stake_for_hotkey_and_coldkey_on_subnet(
+                &origin_hotkey,
+                &coldkey,
+                netuid,
+            ),
+            origin_before - amount
+        );
+        assert_eq!(
+            pallet_subtensor::Pallet::<mock::Test>::get_stake_for_hotkey_and_coldkey_on_subnet(
+                &destination_hotkey,
+                &coldkey,
+                netuid,
+            ),
+            amount
+        );
+    });
+}
+
+#[test]
 fn unstake_all_alpha_success_moves_stake_to_root() {
     mock::new_test_ext(1).execute_with(|| {
         let owner_hotkey = U256::from(4101);

--- a/chain-extensions/src/types.rs
+++ b/chain-extensions/src/types.rs
@@ -44,6 +44,8 @@ pub enum FunctionId {
     GetSubnetRegistrationStateV1 = 34,
     GetColdkeyLockV1 = 35,
     GetStakeAvailabilityV1 = 36,
+    MoveStakeLimitV1 = 37,
+    CallerMoveStakeLimitV1 = 38,
 }
 
 #[freeze_struct("5dc33d60abed5c08")]
@@ -188,11 +190,13 @@ mod function_id_tests {
         assert_eq!(FunctionId::GetSubnetRegistrationStateV1 as u16, 34);
         assert_eq!(FunctionId::GetColdkeyLockV1 as u16, 35);
         assert_eq!(FunctionId::GetStakeAvailabilityV1 as u16, 36);
+        assert_eq!(FunctionId::MoveStakeLimitV1 as u16, 37);
+        assert_eq!(FunctionId::CallerMoveStakeLimitV1 as u16, 38);
     }
 
     #[test]
     fn caller_ids_roundtrip_try_from_primitive() {
-        for id in 16u16..=36u16 {
+        for id in 16u16..=38u16 {
             let v = FunctionId::try_from_primitive(id)
                 .unwrap_or_else(|_| panic!("try_from_primitive failed for {id}"));
             assert_eq!(v as u16, id);

--- a/eco-tests/src/tests_mentat_indexer.rs
+++ b/eco-tests/src/tests_mentat_indexer.rs
@@ -340,6 +340,28 @@ fn indexer_extrinsic_move_stake() {
 }
 
 #[test]
+fn indexer_extrinsic_move_stake_limit() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let origin_hotkey = U256::from(2);
+        let destination_hotkey = U256::from(3);
+        let origin_netuid = NetUid::from(1u16);
+        let destination_netuid = NetUid::from(2u16);
+
+        let _ = SubtensorModule::move_stake_limit(
+            RuntimeOrigin::signed(coldkey),
+            origin_hotkey,
+            destination_hotkey,
+            origin_netuid,
+            destination_netuid,
+            AlphaBalance::from(1_000_000_000u64),
+            TaoBalance::from(1_000_000_000u64),
+            false,
+        );
+    });
+}
+
+#[test]
 fn indexer_extrinsic_set_children() {
     new_test_ext(1).execute_with(|| {
         let coldkey = U256::from(1);

--- a/ink-contract/lib.rs
+++ b/ink-contract/lib.rs
@@ -43,6 +43,8 @@ pub enum FunctionId {
     GetSubnetRegistrationStateV1 = 34,
     GetColdkeyLockV1 = 35,
     GetStakeAvailabilityV1 = 36,
+    MoveStakeLimitV1 = 37,
+    CallerMoveStakeLimitV1 = 38,
 }
 
 #[ink::chain_extension(extension = 0x1000)]
@@ -287,6 +289,28 @@ pub trait RuntimeReadWrite {
         coldkey: <CustomEnvironment as ink::env::Environment>::AccountId,
         netuid: u16,
     ) -> StakeAvailability;
+
+    #[ink(function = 37)]
+    fn move_stake_limit(
+        origin_hotkey: <CustomEnvironment as ink::env::Environment>::AccountId,
+        destination_hotkey: <CustomEnvironment as ink::env::Environment>::AccountId,
+        origin_netuid: u16,
+        destination_netuid: u16,
+        amount: u64,
+        limit_price: u64,
+        allow_partial: bool,
+    );
+
+    #[ink(function = 38)]
+    fn caller_move_stake_limit(
+        origin_hotkey: <CustomEnvironment as ink::env::Environment>::AccountId,
+        destination_hotkey: <CustomEnvironment as ink::env::Environment>::AccountId,
+        origin_netuid: u16,
+        destination_netuid: u16,
+        amount: u64,
+        limit_price: u64,
+        allow_partial: bool,
+    );
 }
 
 #[ink::scale_derive(Encode, Decode, TypeInfo)]
@@ -534,6 +558,31 @@ mod bittensor {
                 .extension()
                 .swap_stake_limit(
                     hotkey.into(),
+                    origin_netuid,
+                    destination_netuid,
+                    amount,
+                    limit_price,
+                    allow_partial,
+                )
+                .map_err(|_e| ReadWriteErrorCode::WriteFailed)
+        }
+
+        #[ink(message)]
+        pub fn move_stake_limit(
+            &self,
+            origin_hotkey: [u8; 32],
+            destination_hotkey: [u8; 32],
+            origin_netuid: u16,
+            destination_netuid: u16,
+            amount: u64,
+            limit_price: u64,
+            allow_partial: bool,
+        ) -> Result<(), ReadWriteErrorCode> {
+            self.env()
+                .extension()
+                .move_stake_limit(
+                    origin_hotkey.into(),
+                    destination_hotkey.into(),
                     origin_netuid,
                     destination_netuid,
                     amount,
@@ -792,6 +841,31 @@ mod bittensor {
                 .extension()
                 .caller_swap_stake_limit(
                     hotkey.into(),
+                    origin_netuid,
+                    destination_netuid,
+                    amount,
+                    limit_price,
+                    allow_partial,
+                )
+                .map_err(|_e| ReadWriteErrorCode::WriteFailed)
+        }
+
+        #[ink(message)]
+        pub fn caller_move_stake_limit(
+            &self,
+            origin_hotkey: [u8; 32],
+            destination_hotkey: [u8; 32],
+            origin_netuid: u16,
+            destination_netuid: u16,
+            amount: u64,
+            limit_price: u64,
+            allow_partial: bool,
+        ) -> Result<(), ReadWriteErrorCode> {
+            self.env()
+                .extension()
+                .caller_move_stake_limit(
+                    origin_hotkey.into(),
+                    destination_hotkey.into(),
                     origin_netuid,
                     destination_netuid,
                     amount,

--- a/pallets/subtensor/src/benchmarks/benchmarks.rs
+++ b/pallets/subtensor/src/benchmarks/benchmarks.rs
@@ -1090,6 +1090,66 @@ mod pallet_benchmarks {
     }
 
     #[benchmark]
+    fn move_stake_limit() {
+        let coldkey: T::AccountId = whitelisted_caller::<AccountIdOf<T>>();
+        let origin_hotkey: T::AccountId = account("A", 0, 1);
+        let destination_hotkey: T::AccountId = account("B", 0, 2);
+        let origin_netuid = NetUid::from(1);
+        let destination_netuid = NetUid::from(2);
+
+        for netuid in [origin_netuid, destination_netuid] {
+            SubtokenEnabled::<T>::insert(netuid, true);
+            Subtensor::<T>::init_new_network(netuid, 1);
+            Subtensor::<T>::set_network_registration_allowed(netuid, true);
+            add_lock::<T>(&coldkey, netuid);
+        }
+
+        let tao_reserve = TaoBalance::from(150_000_000_000_u64);
+        let alpha_in = AlphaBalance::from(100_000_000_000_u64);
+        set_reserves::<T>(origin_netuid, tao_reserve, alpha_in);
+        SubnetTAO::<T>::insert(destination_netuid, tao_reserve);
+        Subtensor::<T>::increase_total_stake(1_000_000_000_000_u64.into());
+
+        let balance = TaoBalance::from(900_000_000_000_u64);
+        let stake_limit = TaoBalance::from(6_000_000_000_u64);
+        let move_limit = TaoBalance::from(1_000_000_000_u64);
+        let amount_to_stake = TaoBalance::from(440_000_000_000_u64);
+        let amount_to_move = AlphaBalance::from(30_000_000_000_u64);
+        add_balance_to_coldkey_account::<T>(&coldkey, balance);
+
+        assert_ok!(Subtensor::<T>::burned_register(
+            RawOrigin::Signed(coldkey.clone()).into(),
+            origin_netuid,
+            origin_hotkey.clone()
+        ));
+        assert_ok!(Subtensor::<T>::burned_register(
+            RawOrigin::Signed(coldkey.clone()).into(),
+            destination_netuid,
+            destination_hotkey.clone()
+        ));
+        assert_ok!(Subtensor::<T>::add_stake_limit(
+            RawOrigin::Signed(coldkey.clone()).into(),
+            origin_hotkey.clone(),
+            origin_netuid,
+            amount_to_stake,
+            stake_limit,
+            true,
+        ));
+
+        #[extrinsic_call]
+        _(
+            RawOrigin::Signed(coldkey),
+            origin_hotkey,
+            destination_hotkey,
+            origin_netuid,
+            destination_netuid,
+            amount_to_move,
+            move_limit,
+            true,
+        );
+    }
+
+    #[benchmark]
     fn transfer_stake() {
         let coldkey: T::AccountId = whitelisted_caller();
         let dest: T::AccountId = account("B", 0, 2);

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -1533,6 +1533,37 @@ mod dispatches {
             )
         }
 
+        /// Moves stake from one hotkey to another and, when the subnets differ,
+        /// protects the swap with a relative price limit.
+        ///
+        /// `limit_price` is the minimum acceptable destination-alpha per
+        /// origin-alpha ratio, scaled by 1e9. When `allow_partial` is false the
+        /// call is fill-or-kill; otherwise it moves only the amount executable
+        /// before the limit is crossed.
+        #[pallet::call_index(149)]
+        #[pallet::weight(<T as crate::pallet::Config>::WeightInfo::move_stake_limit())]
+        pub fn move_stake_limit(
+            origin: OriginFor<T>,
+            origin_hotkey: T::AccountId,
+            destination_hotkey: T::AccountId,
+            origin_netuid: NetUid,
+            destination_netuid: NetUid,
+            alpha_amount: AlphaBalance,
+            limit_price: TaoBalance,
+            allow_partial: bool,
+        ) -> DispatchResult {
+            Self::do_move_stake_limit(
+                origin,
+                origin_hotkey,
+                destination_hotkey,
+                origin_netuid,
+                destination_netuid,
+                alpha_amount,
+                limit_price,
+                allow_partial,
+            )
+        }
+
         /// Attempts to associate a hotkey with a coldkey.
         ///
         /// # Arguments

--- a/pallets/subtensor/src/staking/move_stake.rs
+++ b/pallets/subtensor/src/staking/move_stake.rs
@@ -74,6 +74,48 @@ impl<T: Config> Pallet<T> {
         Ok(())
     }
 
+    /// Moves stake from one hotkey to another across subnets with a relative
+    /// price limit on the cross-subnet swap.
+    pub fn do_move_stake_limit(
+        origin: OriginFor<T>,
+        origin_hotkey: T::AccountId,
+        destination_hotkey: T::AccountId,
+        origin_netuid: NetUid,
+        destination_netuid: NetUid,
+        alpha_amount: AlphaBalance,
+        limit_price: TaoBalance,
+        allow_partial: bool,
+    ) -> dispatch::DispatchResult {
+        let coldkey = ensure_signed(origin)?;
+
+        let tao_moved = Self::transition_stake_internal(
+            &coldkey,
+            &coldkey,
+            &origin_hotkey,
+            &destination_hotkey,
+            origin_netuid,
+            destination_netuid,
+            alpha_amount,
+            Some(limit_price),
+            Some(allow_partial),
+            false,
+        )?;
+
+        log::debug!(
+            "StakeMoved(coldkey:{coldkey:?}, origin_hotkey:{origin_hotkey:?}, origin_netuid:{origin_netuid:?}, destination_hotkey:{destination_hotkey:?}, destination_netuid:{destination_netuid:?}, amount:{tao_moved:?})"
+        );
+        Self::deposit_event(Event::StakeMoved(
+            coldkey,
+            origin_hotkey,
+            origin_netuid,
+            destination_hotkey,
+            destination_netuid,
+            tao_moved,
+        ));
+
+        Ok(())
+    }
+
     /// Toggles the atomic alpha transfers for a specific subnet.
     ///
     /// # Arguments

--- a/pallets/subtensor/src/tests/staking.rs
+++ b/pallets/subtensor/src/tests/staking.rs
@@ -4429,6 +4429,143 @@ fn test_move_stake_limit_partial() {
     });
 }
 
+struct MoveStakeLimitFixture {
+    coldkey: U256,
+    origin_hotkey: U256,
+    destination_hotkey: U256,
+    origin_netuid: NetUid,
+    destination_netuid: NetUid,
+    stake_amount: AlphaBalance,
+    move_amount: AlphaBalance,
+    limit_price: TaoBalance,
+}
+
+fn setup_move_stake_limit_fixture() -> MoveStakeLimitFixture {
+    let subnet_owner_coldkey = U256::from(1001);
+    let subnet_owner_hotkey = U256::from(1002);
+    let coldkey = U256::from(1);
+    let origin_hotkey = U256::from(2);
+    let destination_hotkey = U256::from(3);
+    let stake_amount = AlphaBalance::from(150_000_000_000_u64);
+    let move_amount = AlphaBalance::from(150_000_000_000_u64);
+
+    let origin_netuid = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
+    let destination_netuid = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
+    register_ok_neuron(origin_netuid, origin_hotkey, coldkey, 192213123);
+    register_ok_neuron(destination_netuid, destination_hotkey, coldkey, 192213124);
+
+    SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
+        &origin_hotkey,
+        &coldkey,
+        origin_netuid,
+        stake_amount,
+    );
+
+    // Registration initializes swap V3 state. Clear it so these reserves
+    // deterministically control both prices and the amount executable at the limit.
+    for netuid in [origin_netuid, destination_netuid] {
+        let mut weight_meter =
+            frame_support::weights::WeightMeter::with_limit(Weight::from_parts(u64::MAX, u64::MAX));
+        assert!(
+            <Test as pallet::Config>::SwapInterface::clear_protocol_liquidity(
+                netuid,
+                &mut weight_meter,
+            )
+        );
+    }
+
+    let tao_reserve = TaoBalance::from(150_000_000_000_u64);
+    let alpha_in = AlphaBalance::from(100_000_000_000_u64);
+    SubnetTAO::<Test>::insert(origin_netuid, tao_reserve);
+    SubnetAlphaIn::<Test>::insert(origin_netuid, alpha_in);
+    SubnetTAO::<Test>::insert(destination_netuid, tao_reserve * 100_000.into());
+    SubnetAlphaIn::<Test>::insert(destination_netuid, alpha_in * 100_000.into());
+
+    MoveStakeLimitFixture {
+        coldkey,
+        origin_hotkey,
+        destination_hotkey,
+        origin_netuid,
+        destination_netuid,
+        stake_amount,
+        move_amount,
+        limit_price: TaoBalance::from(990_000_000_u64),
+    }
+}
+
+#[test]
+fn test_move_stake_limit_fill_or_kill_preserves_stake_when_limit_is_exceeded() {
+    new_test_ext(1).execute_with(|| {
+        let fixture = setup_move_stake_limit_fixture();
+
+        assert_err!(
+            SubtensorModule::move_stake_limit(
+                RuntimeOrigin::signed(fixture.coldkey),
+                fixture.origin_hotkey,
+                fixture.destination_hotkey,
+                fixture.origin_netuid,
+                fixture.destination_netuid,
+                fixture.move_amount,
+                fixture.limit_price,
+                false,
+            ),
+            Error::<Test>::SlippageTooHigh
+        );
+        assert_eq!(
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+                &fixture.origin_hotkey,
+                &fixture.coldkey,
+                fixture.origin_netuid,
+            ),
+            fixture.stake_amount
+        );
+        assert_eq!(
+            SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+                &fixture.destination_hotkey,
+                &fixture.coldkey,
+                fixture.destination_netuid,
+            ),
+            AlphaBalance::ZERO
+        );
+    });
+}
+
+#[test]
+fn test_move_stake_limit_partial_moves_stake_to_distinct_hotkey() {
+    new_test_ext(1).execute_with(|| {
+        let fixture = setup_move_stake_limit_fixture();
+
+        assert_ok!(SubtensorModule::move_stake_limit(
+            RuntimeOrigin::signed(fixture.coldkey),
+            fixture.origin_hotkey,
+            fixture.destination_hotkey,
+            fixture.origin_netuid,
+            fixture.destination_netuid,
+            fixture.move_amount,
+            fixture.limit_price,
+            true,
+        ));
+
+        let origin_alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+            &fixture.origin_hotkey,
+            &fixture.coldkey,
+            fixture.origin_netuid,
+        );
+        let destination_alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+            &fixture.destination_hotkey,
+            &fixture.coldkey,
+            fixture.destination_netuid,
+        );
+
+        assert_abs_diff_eq!(
+            origin_alpha,
+            AlphaBalance::from(149_000_000_000_u64),
+            epsilon = 100_000_000.into()
+        );
+        assert!(destination_alpha > AlphaBalance::ZERO);
+    });
+}
+
 /// cargo test --package pallet-subtensor --lib -- tests::staking::test_unstake_all_hits_liquidity_min --exact --show-output
 #[test]
 fn test_unstake_all_hits_liquidity_min() {

--- a/pallets/subtensor/src/weights.rs
+++ b/pallets/subtensor/src/weights.rs
@@ -64,6 +64,7 @@ pub trait WeightInfo {
 	fn remove_stake() -> Weight;
 	fn remove_stake_limit() -> Weight;
 	fn swap_stake_limit() -> Weight;
+	fn move_stake_limit() -> Weight;
 	fn transfer_stake() -> Weight;
 	fn transfer_stake_and_hotkey() -> Weight;
 	fn add_collateral() -> Weight;
@@ -1661,6 +1662,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		Weight::from_parts(484_000_000, 11077)
 			.saturating_add(T::DbWeight::get().reads(49_u64))
 			.saturating_add(T::DbWeight::get().writes(24_u64))
+	}
+	fn move_stake_limit() -> Weight {
+		// Same swap path as `swap_stake_limit`, plus the distinct destination
+		// hotkey's owner proof/read.
+		Self::swap_stake_limit()
+			.saturating_add(Weight::from_parts(0, 2493))
+			.saturating_add(T::DbWeight::get().reads(1_u64))
 	}
 	/// Storage: `SubtensorModule::NetworksAdded` (r:1 w:0)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)
@@ -5284,6 +5292,11 @@ impl WeightInfo for () {
 		Weight::from_parts(484_000_000, 11077)
 			.saturating_add(RocksDbWeight::get().reads(49_u64))
 			.saturating_add(RocksDbWeight::get().writes(24_u64))
+	}
+	fn move_stake_limit() -> Weight {
+		Self::swap_stake_limit()
+			.saturating_add(Weight::from_parts(0, 2493))
+			.saturating_add(RocksDbWeight::get().reads(1_u64))
 	}
 	/// Storage: `SubtensorModule::NetworksAdded` (r:1 w:0)
 	/// Proof: `SubtensorModule::NetworksAdded` (`max_values`: None, `max_size`: None, mode: `Measured`)

--- a/pallets/transaction-fee/src/lib.rs
+++ b/pallets/transaction-fee/src/lib.rs
@@ -301,6 +301,12 @@ impl<F, OU> SubtensorTxFeeHandler<F, OU> {
                 origin_netuid,
                 ..
             }) => alpha_vec.push((origin_hotkey.clone(), *origin_netuid)),
+            Some(SubtensorCall::move_stake_limit {
+                origin_hotkey,
+                destination_hotkey: _,
+                origin_netuid,
+                ..
+            }) => alpha_vec.push((origin_hotkey.clone(), *origin_netuid)),
             Some(SubtensorCall::transfer_stake {
                 destination_coldkey: _,
                 hotkey,

--- a/pallets/transaction-fee/src/tests/mod.rs
+++ b/pallets/transaction-fee/src/tests/mod.rs
@@ -1296,6 +1296,67 @@ fn test_move_stake_fees_alpha() {
     });
 }
 
+// cargo test --package subtensor-transaction-fee --lib -- tests::test_move_stake_limit_fees_alpha --exact --show-output
+#[test]
+fn test_move_stake_limit_fees_alpha() {
+    new_test_ext().execute_with(|| {
+        let stake_amount = TAO;
+        let move_amount = AlphaBalance::from(TAO / 50);
+        let sn = setup_subnets(2, 2);
+        setup_stake(
+            sn.subnets[0].netuid,
+            &sn.coldkey,
+            &sn.hotkeys[0],
+            stake_amount,
+        );
+
+        let current_balance = Balances::free_balance(sn.coldkey);
+        remove_balance_from_coldkey_account(
+            &sn.coldkey,
+            current_balance - ExistentialDeposit::get(),
+        );
+        let balance_before = Balances::free_balance(sn.coldkey);
+        let alpha_before = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+            &sn.hotkeys[0],
+            &sn.coldkey,
+            sn.subnets[0].netuid,
+        );
+        let call = RuntimeCall::SubtensorModule(pallet_subtensor::Call::move_stake_limit {
+            origin_hotkey: sn.hotkeys[0],
+            destination_hotkey: sn.hotkeys[1],
+            origin_netuid: sn.subnets[0].netuid,
+            destination_netuid: sn.subnets[1].netuid,
+            alpha_amount: move_amount,
+            limit_price: TaoBalance::from(1_000_u64),
+            allow_partial: false,
+        });
+
+        let info = call.get_dispatch_info();
+        let ext = pallet_transaction_payment::ChargeTransactionPayment::<Test>::from(0.into());
+        assert_ok!(ext.dispatch_transaction(
+            RuntimeOrigin::signed(sn.coldkey).into(),
+            call,
+            &info,
+            0,
+            0,
+        ));
+
+        let alpha_after = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+            &sn.hotkeys[0],
+            &sn.coldkey,
+            sn.subnets[0].netuid,
+        );
+        let destination_alpha = SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(
+            &sn.hotkeys[1],
+            &sn.coldkey,
+            sn.subnets[1].netuid,
+        );
+        assert!(destination_alpha > AlphaBalance::ZERO);
+        assert_eq!(balance_before, Balances::free_balance(sn.coldkey));
+        assert!(alpha_before - alpha_after - move_amount > AlphaBalance::ZERO);
+    });
+}
+
 // cargo test --package subtensor-transaction-fee --lib -- tests::test_transfer_stake_fees_alpha --exact --show-output
 #[test]
 fn test_transfer_stake_fees_alpha() {

--- a/precompiles/src/lib.rs
+++ b/precompiles/src/lib.rs
@@ -588,6 +588,7 @@ mod address_and_selector_tests {
             "unstakeAllAlpha(bytes32)",
             "swapStake(bytes32,uint16,uint16,uint64)",
             "swapStakeLimit(bytes32,uint16,uint16,uint64,uint64,bool)",
+            "moveStakeLimit(bytes32,bytes32,uint16,uint16,uint64,uint64,bool)",
             "recycleAlpha(bytes32,uint64,uint16)",
             "setColdkeyAutoStakeHotkey(uint16,bytes32)",
             "claimRoot(uint16[])",

--- a/precompiles/src/solidity/stakingV2.abi
+++ b/precompiles/src/solidity/stakingV2.abi
@@ -311,6 +311,49 @@
     "inputs": [
       {
         "internalType": "bytes32",
+        "name": "originHotkey",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "destinationHotkey",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint16",
+        "name": "originNetuid",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint16",
+        "name": "destinationNetuid",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint64",
+        "name": "alphaAmount",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "limitPrice",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bool",
+        "name": "allowPartial",
+        "type": "bool"
+      }
+    ],
+    "name": "moveStakeLimit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
         "name": "delegate",
         "type": "bytes32"
       }

--- a/precompiles/src/solidity/stakingV2.sol
+++ b/precompiles/src/solidity/stakingV2.sol
@@ -591,6 +591,25 @@ interface IStaking {
         uint64 limitPrice,
         bool allowPartial
     ) external;
+    /**
+     * @notice Moves alpha between hotkeys and subnets subject to a relative price limit.
+     * @param originHotkey Hotkey from which alpha is removed.
+     * @param destinationHotkey Hotkey to which the resulting alpha is credited.
+     * @param originNetuid Subnet from which alpha is removed.
+     * @param destinationNetuid Subnet into which TAO is staked.
+     * @param alphaAmount Origin alpha requested to move, in raw alpha units.
+     * @param limitPrice Minimum destination-alpha per origin-alpha ratio, scaled by 1e9.
+     * @param allowPartial Whether to execute only the amount available before the limit.
+     */
+    function moveStakeLimit(
+        bytes32 originHotkey,
+        bytes32 destinationHotkey,
+        uint16 originNetuid,
+        uint16 destinationNetuid,
+        uint64 alphaAmount,
+        uint64 limitPrice,
+        bool allowPartial
+    ) external;
     function recycleAlpha(bytes32 hotkey, uint64 amount, uint16 netuid) external;
     function setColdkeyAutoStakeHotkey(uint16 netuid, bytes32 hotkey) external;
     function claimRoot(uint16[] calldata subnets) external;

--- a/precompiles/src/staking.rs
+++ b/precompiles/src/staking.rs
@@ -1097,6 +1097,7 @@ where
     }
 
     #[precompile::public("moveStakeLimit(bytes32,bytes32,uint16,uint16,uint64,uint64,bool)")]
+    #[allow(clippy::too_many_arguments)]
     fn move_stake_limit(
         handle: &mut impl PrecompileHandle,
         origin_hotkey: H256,

--- a/precompiles/src/staking.rs
+++ b/precompiles/src/staking.rs
@@ -1096,6 +1096,31 @@ where
         )
     }
 
+    #[precompile::public("moveStakeLimit(bytes32,bytes32,uint16,uint16,uint64,uint64,bool)")]
+    fn move_stake_limit(
+        handle: &mut impl PrecompileHandle,
+        origin_hotkey: H256,
+        destination_hotkey: H256,
+        origin_netuid: u16,
+        destination_netuid: u16,
+        alpha_amount: u64,
+        limit_price: u64,
+        allow_partial: bool,
+    ) -> EvmResult<()> {
+        dispatch_subtensor(
+            handle,
+            pallet_subtensor::Call::<R>::move_stake_limit {
+                origin_hotkey: origin_hotkey.0.into(),
+                destination_hotkey: destination_hotkey.0.into(),
+                origin_netuid: origin_netuid.into(),
+                destination_netuid: destination_netuid.into(),
+                alpha_amount: AlphaBalance::from(alpha_amount),
+                limit_price: TaoBalance::from(limit_price),
+                allow_partial,
+            },
+        )
+    }
+
     #[precompile::public("recycleAlpha(bytes32,uint64,uint16)")]
     fn recycle_alpha(
         handle: &mut impl PrecompileHandle,
@@ -2247,6 +2272,50 @@ mod tests {
                 ),
             )
             .execute_returns(());
+    }
+
+    #[test]
+    fn staking_precompile_v2_move_stake_limit_dispatches_to_distinct_hotkey() {
+        new_test_ext().execute_with(|| {
+            let netuid = setup_staking_subnet();
+            let caller = addr_from_index(0x20a1);
+            let coldkey = mapped_account(caller);
+            let origin_hotkey = AccountId::from([0x71; 32]);
+            let destination_hotkey = AccountId::from([0x72; 32]);
+
+            fund_account(&coldkey, COLDKEY_BALANCE);
+            add_stake_v2(caller, &origin_hotkey, TEST_NETUID_U16, INITIAL_STAKE_RAO);
+            ensure_hotkey_exists(&destination_hotkey);
+            let origin_before = stake_for(&origin_hotkey, &coldkey, netuid);
+            let amount = origin_before / 2;
+
+            precompiles::<StakingPrecompileV2<Runtime>>()
+                .prepare_test(
+                    caller,
+                    addr_from_index(StakingPrecompileV2::<Runtime>::INDEX),
+                    encode_with_selector(
+                        selector_u32(
+                            "moveStakeLimit(bytes32,bytes32,uint16,uint16,uint64,uint64,bool)",
+                        ),
+                        (
+                            H256::from_slice(origin_hotkey.as_ref()),
+                            H256::from_slice(destination_hotkey.as_ref()),
+                            TEST_NETUID_U16,
+                            TEST_NETUID_U16,
+                            amount,
+                            u64::MAX,
+                            false,
+                        ),
+                    ),
+                )
+                .execute_returns(());
+
+            assert_eq!(
+                stake_for(&origin_hotkey, &coldkey, netuid),
+                origin_before - amount
+            );
+            assert_eq!(stake_for(&destination_hotkey, &coldkey, netuid), amount);
+        });
     }
 
     fn assert_proxy_effects(caller: H160, netuid: NetUid) {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 447,
+    spec_version: 448,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/proxy_filters/call_groups.rs
+++ b/runtime/src/proxy_filters/call_groups.rs
@@ -303,6 +303,7 @@ call_filter_group!(
         RuntimeCall::SubtensorModule(SubtensorCall::unstake_all),
         RuntimeCall::SubtensorModule(SubtensorCall::unstake_all_alpha),
         RuntimeCall::SubtensorModule(SubtensorCall::move_stake),
+        RuntimeCall::SubtensorModule(SubtensorCall::move_stake_limit),
         RuntimeCall::SubtensorModule(SubtensorCall::swap_stake),
         RuntimeCall::SubtensorModule(SubtensorCall::swap_stake_limit),
         RuntimeCall::SubtensorModule(SubtensorCall::stake_into_basket),

--- a/runtime/src/proxy_filters/mod.rs
+++ b/runtime/src/proxy_filters/mod.rs
@@ -478,6 +478,7 @@ mod tests {
                 "SubtensorModule::unstake_all",
                 "SubtensorModule::unstake_all_alpha",
                 "SubtensorModule::move_stake",
+                "SubtensorModule::move_stake_limit",
                 "SubtensorModule::set_min_collateral",
                 "SubtensorModule::stake_into_basket",
                 "SubtensorModule::swap_stake",

--- a/sdk/bittensor-core/src/transaction.rs
+++ b/sdk/bittensor-core/src/transaction.rs
@@ -495,6 +495,42 @@ impl IntentCall {
         )
     }
 
+    /// Move stake between hotkeys/subnets with a relative cross-subnet price limit.
+    pub fn move_stake_limit(
+        origin_hotkey: impl Into<String>,
+        origin_netuid: u16,
+        destination_hotkey: impl Into<String>,
+        destination_netuid: u16,
+        amount_alpha_rao: u128,
+        limit_price: u128,
+        allow_partial: bool,
+    ) -> Self {
+        Self::trusted(
+            "move_stake_limit",
+            SignerRole::Coldkey,
+            "SubtensorModule",
+            "move_stake_limit",
+            Value::record(vec![
+                ("origin_hotkey".into(), Value::str(origin_hotkey)),
+                ("destination_hotkey".into(), Value::str(destination_hotkey)),
+                (
+                    "origin_netuid".into(),
+                    Value::Uint(u128::from(origin_netuid)),
+                ),
+                (
+                    "destination_netuid".into(),
+                    Value::Uint(u128::from(destination_netuid)),
+                ),
+                ("alpha_amount".into(), Value::Uint(amount_alpha_rao)),
+                ("limit_price".into(), Value::Uint(limit_price)),
+                ("allow_partial".into(), Value::Bool(allow_partial)),
+            ]),
+            Spend::None,
+            [origin_netuid, destination_netuid],
+            false,
+        )
+    }
+
     /// Swap stake between two subnets on one hotkey.
     pub fn swap_stake(
         hotkey: impl Into<String>,
@@ -1163,6 +1199,20 @@ mod tests {
     #[test]
     fn trusted_move_stake_uses_constructor_derived_netuids() {
         let intent = IntentCall::move_stake("5origin", 1, "5destination", 2, 10);
+        let policy = Policy {
+            allowed_netuids: Some(BTreeSet::from([1])),
+            ..Policy::default()
+        };
+        assert_eq!(
+            policy.check(&intent, Some(0)),
+            vec![String::from("netuid 2 is not allowed by policy")]
+        );
+    }
+
+    #[test]
+    fn trusted_move_stake_limit_uses_constructor_derived_netuids() {
+        let intent =
+            IntentCall::move_stake_limit("5origin", 1, "5destination", 2, 10, 900_000_000, false);
         let policy = Policy {
             allowed_netuids: Some(BTreeSet::from([1])),
             ..Policy::default()

--- a/sdk/python/bittensor/_generated/calls.py
+++ b/sdk/python/bittensor/_generated/calls.py
@@ -341,6 +341,11 @@ class SubtensorModule:
         return Call('SubtensorModule', 'move_stake', {'origin_hotkey': origin_hotkey, 'destination_hotkey': destination_hotkey, 'origin_netuid': origin_netuid, 'destination_netuid': destination_netuid, 'alpha_amount': alpha_amount})
 
     @staticmethod
+    def move_stake_limit(origin_hotkey: 'AccountId32', destination_hotkey: 'AccountId32', origin_netuid: 'NetUid', destination_netuid: 'NetUid', alpha_amount: 'AlphaBalance', limit_price: 'TaoBalance', allow_partial: 'bool') -> Call:
+        'Moves stake from one hotkey to another and protects a cross-subnet swap with a relative price limit.'
+        return Call('SubtensorModule', 'move_stake_limit', {'origin_hotkey': origin_hotkey, 'destination_hotkey': destination_hotkey, 'origin_netuid': origin_netuid, 'destination_netuid': destination_netuid, 'alpha_amount': alpha_amount, 'limit_price': limit_price, 'allow_partial': allow_partial})
+
+    @staticmethod
     def recycle_alpha(hotkey: 'AccountId32', amount: 'AlphaBalance', netuid: 'NetUid') -> Call:
         'Recycles alpha from a cold/hot key pair, reducing AlphaOut on a subnet  # Arguments * `origin`: The origin of the call (must be signed by the coldkey) * `hotkey`: The hotkey account * `amount`: The amount of alpha to recycle * `netuid`: The subnet ID  # Events Emits a `TokensRecycled` event on success.'
         return Call('SubtensorModule', 'recycle_alpha', {'hotkey': hotkey, 'amount': amount, 'netuid': netuid})
@@ -1642,5 +1647,4 @@ class LimitOrders:
     def set_pallet_status(enabled: 'bool') -> Call:
         'Set a status for the limit orders pallet  Must be called by root It allows disabling or enabling the pallet true means enabling, false means disabling'
         return Call('LimitOrders', 'set_pallet_status', {'enabled': enabled})
-
 

--- a/sdk/python/bittensor/evm/abi/stakingV2.json
+++ b/sdk/python/bittensor/evm/abi/stakingV2.json
@@ -311,6 +311,49 @@
     "inputs": [
       {
         "internalType": "bytes32",
+        "name": "originHotkey",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "destinationHotkey",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint16",
+        "name": "originNetuid",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint16",
+        "name": "destinationNetuid",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint64",
+        "name": "alphaAmount",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "limitPrice",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bool",
+        "name": "allowPartial",
+        "type": "bool"
+      }
+    ],
+    "name": "moveStakeLimit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
         "name": "delegate",
         "type": "bytes32"
       }

--- a/sdk/python/bittensor/evm/precompiles.py
+++ b/sdk/python/bittensor/evm/precompiles.py
@@ -215,6 +215,7 @@ CALLER_ROLES: dict[str, dict[str, str]] = {
         "removeStakeFull": "coldkey (must own the stake)",
         "removeStakeFullLimit": "coldkey (must own the stake)",
         "moveStake": "coldkey (must own the stake)",
+        "moveStakeLimit": "coldkey (must own the stake)",
         "transferStake": "coldkey (must own the stake)",
         "burnAlpha": "coldkey (must own the stake)",
         "addProxy": "delegating coldkey",

--- a/sdk/python/bittensor/intents/_money.py
+++ b/sdk/python/bittensor/intents/_money.py
@@ -94,6 +94,8 @@ _FALLBACK_AMOUNT_UNITS: dict[tuple[str, str, str], str] = {
     ("SubtensorModule", "remove_stake_limit", "amount_unstaked"): "ALPHA",
     ("SubtensorModule", "remove_stake_limit", "limit_price"): "TAO",
     ("SubtensorModule", "move_stake", "alpha_amount"): "ALPHA",
+    ("SubtensorModule", "move_stake_limit", "alpha_amount"): "ALPHA",
+    ("SubtensorModule", "move_stake_limit", "limit_price"): "TAO",
     ("SubtensorModule", "transfer_stake", "alpha_amount"): "ALPHA",
     ("SubtensorModule", "transfer_stake_and_hotkey", "alpha_amount"): "ALPHA",
     ("SubtensorModule", "swap_stake", "alpha_amount"): "ALPHA",

--- a/sdk/python/bittensor/intents/staking.py
+++ b/sdk/python/bittensor/intents/staking.py
@@ -356,7 +356,9 @@ class MoveStake(Intent):
     free balance: the stake leaves the origin hotkey on the origin subnet and
     lands on the destination hotkey at the destination subnet. Moving within
     one subnet just changes which validator backs the stake; moving across
-    subnets swaps through both pools and can incur slippage on each leg.
+    subnets swaps through both pools and can incur slippage on each leg. Those
+    cross-subnet moves are slippage-protected by default with the same relative
+    price limit used by ``swap_stake``.
     Ownership stays with the signing coldkey — use ``transfer_stake`` to hand
     the position to another coldkey, or ``swap_stake`` when only the subnet
     changes.
@@ -364,7 +366,7 @@ class MoveStake(Intent):
 
     op = "move_stake"
     signer = "coldkey"
-    wraps = (("SubtensorModule", "move_stake"),)
+    wraps = (("SubtensorModule", "move_stake"), ("SubtensorModule", "move_stake_limit"))
     mev_shield_default = True
 
     origin_hotkey_ss58: str = field(metadata={"help": "Hotkey the stake moves away from."})
@@ -377,13 +379,38 @@ class MoveStake(Intent):
             "amount; ``all`` is not accepted)."
         }
     )
+    slippage_protection: bool = field(default=True, metadata={"help": SLIPPAGE_PROTECTION_HELP})
+    rate_tolerance: float = field(
+        default=DEFAULT_RATE_TOLERANCE, metadata={"help": RATE_TOLERANCE_HELP}
+    )
 
     def __post_init__(self):
         self.amount_alpha = call_amount(
             self.amount_alpha, self.wraps[0], "alpha_amount", netuid=self.origin_netuid
         )
+        _check_rate_tolerance(self.rate_tolerance)
 
     async def build(self, substrate, wallet: Any):
+        if self.slippage_protection and self.origin_netuid != self.dest_netuid:
+            origin_price = await _alpha_price_rao(substrate, self.origin_netuid)
+            dest_price = await _alpha_price_rao(substrate, self.dest_netuid)
+            if dest_price <= 0:
+                raise BittensorError(
+                    f"netuid {self.dest_netuid} has no alpha price; cannot derive a "
+                    "slippage limit — disable slippage protection to submit anyway"
+                )
+            ratio_rao = origin_price * RAO_PER_TAO // dest_price
+            return await substrate.compose(
+                calls.SubtensorModule.move_stake_limit(
+                    origin_hotkey=self.origin_hotkey_ss58,
+                    destination_hotkey=self.dest_hotkey_ss58,
+                    origin_netuid=self.origin_netuid,
+                    destination_netuid=self.dest_netuid,
+                    alpha_amount=self.amount_alpha.rao,
+                    limit_price=int(ratio_rao * (1 - self.rate_tolerance)),
+                    allow_partial=False,
+                )
+            )
         return await substrate.compose(
             calls.SubtensorModule.move_stake(
                 origin_hotkey=self.origin_hotkey_ss58,
@@ -395,10 +422,17 @@ class MoveStake(Intent):
         )
 
     def summary(self) -> str:
+        note = ""
+        if self.origin_netuid != self.dest_netuid:
+            note = (
+                f" (fails if price ratio moves >{self.rate_tolerance:.2%})"
+                if self.slippage_protection
+                else " (no slippage protection)"
+            )
         return (
             f"move {self.amount_alpha} from {self.origin_hotkey_ss58} "
             f"on netuid {self.origin_netuid} to {self.dest_hotkey_ss58} "
-            f"on netuid {self.dest_netuid}"
+            f"on netuid {self.dest_netuid}{note}"
         )
 
     def touches_netuids(self) -> list[int]:

--- a/sdk/python/tests/unit/test_slippage_protection.py
+++ b/sdk/python/tests/unit/test_slippage_protection.py
@@ -1,6 +1,6 @@
 """Default slippage protection on the staking intents.
 
-``add_stake``, ``remove_stake``, and ``swap_stake`` are slippage-protected by
+``add_stake``, ``remove_stake``, ``move_stake``, and ``swap_stake`` are slippage-protected by
 default: at build time they read the spot price and compose the ``*_limit``
 call variant with a fill-or-kill limit derived from ``rate_tolerance`` (5%).
 These tests pin the call selection, the limit-price math against seeded
@@ -22,6 +22,13 @@ RAO = 10**9
 ADD = {"hotkey_ss58": BOB_HOT, "netuid": 1, "amount_tao": 1.0}
 REMOVE = {"hotkey_ss58": BOB_HOT, "netuid": 1, "amount_alpha": 1.0}
 SWAP = {"hotkey_ss58": BOB_HOT, "origin_netuid": 1, "dest_netuid": 2, "amount_alpha": 1.0}
+MOVE = {
+    "origin_hotkey_ss58": BOB_HOT,
+    "origin_netuid": 1,
+    "dest_hotkey_ss58": BOB_HOT,
+    "dest_netuid": 2,
+    "amount_alpha": 1.0,
+}
 
 
 @pytest.fixture()
@@ -64,6 +71,13 @@ class TestDefaultProtection:
         assert call.params["allow_partial"] is False
 
     @pytest.mark.asyncio
+    async def test_move_stake_composes_limit_call(self, substrate, wallet):
+        call = await build("move_stake", MOVE).build(substrate, wallet)
+        assert call.function == "move_stake_limit"
+        assert call.params["limit_price"] == int(2 * RAO * 0.95)
+        assert call.params["allow_partial"] is False
+
+    @pytest.mark.asyncio
     async def test_custom_tolerance_moves_the_limit(self, substrate, wallet):
         call = await build("add_stake", {**ADD, "rate_tolerance": 0.1}).build(substrate, wallet)
         assert call.params["limit_price"] == int(2 * RAO * 1.1)
@@ -98,6 +112,7 @@ class TestOptOut:
             ("add_stake", ADD, "add_stake"),
             ("remove_stake", REMOVE, "remove_stake"),
             ("swap_stake", SWAP, "swap_stake"),
+            ("move_stake", MOVE, "move_stake"),
         ],
     )
     @pytest.mark.asyncio
@@ -110,7 +125,8 @@ class TestOptOut:
 class TestFailureModes:
     @pytest.mark.parametrize("bad", [-0.1, 1.0, 5])
     @pytest.mark.parametrize(
-        ("op", "args"), [("add_stake", ADD), ("remove_stake", REMOVE), ("swap_stake", SWAP)]
+        ("op", "args"),
+        [("add_stake", ADD), ("remove_stake", REMOVE), ("move_stake", MOVE), ("swap_stake", SWAP)],
     )
     def test_out_of_range_tolerance_rejected_at_construction(self, op, args, bad):
         with pytest.raises(BittensorError, match="rate_tolerance"):
@@ -140,7 +156,7 @@ class TestErrorSurface:
         assert "slippage_protection=False" in error.remediation
 
     def test_schema_exposes_the_protection_fields(self):
-        for op in ("add_stake", "remove_stake", "swap_stake"):
+        for op in ("add_stake", "remove_stake", "move_stake", "swap_stake"):
             schema = REGISTRY[op].json_schema()
             assert schema["properties"]["slippage_protection"]["type"] == "boolean"
             assert schema["properties"]["rate_tolerance"]["type"] == "number"

--- a/ts-tests/e2e-shards.json
+++ b/ts-tests/e2e-shards.json
@@ -31,6 +31,7 @@
                     "files": [
                         "suites/zombienet_staking/01-add-stake-limit.test.ts",
                         "suites/zombienet_staking/02.04-claim-root-hotkey-swap.test.ts",
+                        "suites/zombienet_staking/03.01-move-stake-limit.test.ts",
                         "suites/zombienet_staking/04-remove-stake.test.ts",
                         "suites/zombienet_staking/06-remove-stake-limit.test.ts",
                         "suites/zombienet_staking/08-swap-stake-limit.test.ts"

--- a/ts-tests/suites/zombienet_staking/03.01-move-stake-limit.test.ts
+++ b/ts-tests/suites/zombienet_staking/03.01-move-stake-limit.test.ts
@@ -1,0 +1,155 @@
+import { describeSuite } from "@moonwall/cli";
+import { subtensor } from "@polkadot-api/descriptors";
+import type { TypedApi } from "polkadot-api";
+import { beforeAll, expect } from "vitest";
+import {
+    addNewSubnetwork,
+    addStake,
+    forceSetBalance,
+    generateKeyringPair,
+    getStake,
+    moveStakeLimit,
+    startCall,
+    sudoSetLockReductionInterval,
+    tao,
+} from "../../utils";
+
+describeSuite({
+    id: "03_01_move_stake_limit",
+    title: "▶ move_stake_limit extrinsic",
+    foundationMethods: "zombie",
+    testCases: ({ it, context, log }) => {
+        let api: TypedApi<typeof subtensor>;
+
+        beforeAll(async () => {
+            api = context.papi("Node").getTypedApi(subtensor);
+            await sudoSetLockReductionInterval(api, 1);
+        });
+
+        it({
+            id: "T01",
+            title: "should move stake to another hotkey with a price limit (allow partial)",
+            test: async () => {
+                const originHotkey = generateKeyringPair("sr25519");
+                const destinationHotkey = generateKeyringPair("sr25519");
+                const coldkey = generateKeyringPair("sr25519");
+                const originHotkeyAddress = originHotkey.address;
+                const destinationHotkeyAddress = destinationHotkey.address;
+                const coldkeyAddress = coldkey.address;
+
+                await forceSetBalance(api, originHotkeyAddress);
+                await forceSetBalance(api, destinationHotkeyAddress);
+                await forceSetBalance(api, coldkeyAddress);
+
+                const originNetuid = await addNewSubnetwork(api, originHotkey, coldkey);
+                await startCall(api, originNetuid, coldkey);
+                const destinationNetuid = await addNewSubnetwork(api, destinationHotkey, coldkey);
+                await startCall(api, destinationNetuid, coldkey);
+
+                await addStake(api, coldkey, originHotkeyAddress, originNetuid, tao(100));
+
+                const originStakeBefore = await getStake(api, originHotkeyAddress, coldkeyAddress, originNetuid);
+                const destinationStakeBefore = await getStake(
+                    api,
+                    destinationHotkeyAddress,
+                    coldkeyAddress,
+                    destinationNetuid
+                );
+                expect(originStakeBefore, "Origin hotkey should have stake before move").toBeGreaterThan(0n);
+
+                const moveAmount = originStakeBefore / 2n;
+                const limitPrice = (tao(1) * 99n) / 100n;
+                await moveStakeLimit(
+                    api,
+                    coldkey,
+                    originHotkeyAddress,
+                    destinationHotkeyAddress,
+                    originNetuid,
+                    destinationNetuid,
+                    moveAmount,
+                    limitPrice,
+                    true
+                );
+
+                const originStakeAfter = await getStake(api, originHotkeyAddress, coldkeyAddress, originNetuid);
+                const destinationStakeAfter = await getStake(
+                    api,
+                    destinationHotkeyAddress,
+                    coldkeyAddress,
+                    destinationNetuid
+                );
+
+                log(
+                    `Origin stake: ${originStakeBefore} -> ${originStakeAfter}, destination stake: ${destinationStakeBefore} -> ${destinationStakeAfter}`
+                );
+                expect(originStakeAfter, "Origin stake should decrease").toBeLessThan(originStakeBefore);
+                expect(destinationStakeAfter, "Destination stake should increase").toBeGreaterThan(
+                    destinationStakeBefore
+                );
+            },
+        });
+
+        it({
+            id: "T02",
+            title: "should move stake to another hotkey with a price limit (fill or kill)",
+            test: async () => {
+                const originHotkey = generateKeyringPair("sr25519");
+                const destinationHotkey = generateKeyringPair("sr25519");
+                const coldkey = generateKeyringPair("sr25519");
+                const originHotkeyAddress = originHotkey.address;
+                const destinationHotkeyAddress = destinationHotkey.address;
+                const coldkeyAddress = coldkey.address;
+
+                await forceSetBalance(api, originHotkeyAddress);
+                await forceSetBalance(api, destinationHotkeyAddress);
+                await forceSetBalance(api, coldkeyAddress);
+
+                const originNetuid = await addNewSubnetwork(api, originHotkey, coldkey);
+                await startCall(api, originNetuid, coldkey);
+                const destinationNetuid = await addNewSubnetwork(api, destinationHotkey, coldkey);
+                await startCall(api, destinationNetuid, coldkey);
+
+                await addStake(api, coldkey, originHotkeyAddress, originNetuid, tao(100));
+
+                const originStakeBefore = await getStake(api, originHotkeyAddress, coldkeyAddress, originNetuid);
+                const destinationStakeBefore = await getStake(
+                    api,
+                    destinationHotkeyAddress,
+                    coldkeyAddress,
+                    destinationNetuid
+                );
+                expect(originStakeBefore, "Origin hotkey should have stake before move").toBeGreaterThan(0n);
+
+                const moveAmount = originStakeBefore / 2n;
+                const limitPrice = tao(1) / 10n;
+                await moveStakeLimit(
+                    api,
+                    coldkey,
+                    originHotkeyAddress,
+                    destinationHotkeyAddress,
+                    originNetuid,
+                    destinationNetuid,
+                    moveAmount,
+                    limitPrice,
+                    false
+                );
+
+                const originStakeAfter = await getStake(api, originHotkeyAddress, coldkeyAddress, originNetuid);
+                const destinationStakeAfter = await getStake(
+                    api,
+                    destinationHotkeyAddress,
+                    coldkeyAddress,
+                    destinationNetuid
+                );
+
+                log(
+                    `Origin stake: ${originStakeBefore} -> ${originStakeAfter}, destination stake: ${destinationStakeBefore} -> ${destinationStakeAfter}`
+                );
+                expect(originStakeAfter, "Origin stake should decrease").toBeLessThan(originStakeBefore);
+                expect(destinationStakeAfter, "Destination stake should increase").toBeGreaterThan(
+                    destinationStakeBefore
+                );
+            },
+        });
+    },
+});

--- a/ts-tests/suites/zombienet_staking/03.01-move-stake-limit.test.ts
+++ b/ts-tests/suites/zombienet_staking/03.01-move-stake-limit.test.ts
@@ -9,6 +9,7 @@ import {
     generateKeyringPair,
     getStake,
     moveStakeLimit,
+    sendTransaction,
     startCall,
     sudoSetLockReductionInterval,
     tao,
@@ -91,7 +92,7 @@ describeSuite({
 
         it({
             id: "T02",
-            title: "should move stake to another hotkey with a price limit (fill or kill)",
+            title: "should reject fill-or-kill move when the price limit is exceeded",
             test: async () => {
                 const originHotkey = generateKeyringPair("sr25519");
                 const destinationHotkey = generateKeyringPair("sr25519");
@@ -120,19 +121,27 @@ describeSuite({
                 );
                 expect(originStakeBefore, "Origin hotkey should have stake before move").toBeGreaterThan(0n);
 
+                // limit_price is dest-alpha per origin-alpha, scaled by 1e9. A floor above the
+                // current relative price makes max executable amount 0, so fill-or-kill must abort.
+                const originPrice = await api.apis.SwapRuntimeApi.current_alpha_price(originNetuid);
+                const destinationPrice = await api.apis.SwapRuntimeApi.current_alpha_price(destinationNetuid);
+                expect(destinationPrice, "Destination subnet should have a non-zero alpha price").toBeGreaterThan(0n);
+                const limitPrice = (originPrice * tao(1)) / destinationPrice + 1n;
                 const moveAmount = originStakeBefore / 2n;
-                const limitPrice = tao(1) / 10n;
-                await moveStakeLimit(
-                    api,
-                    coldkey,
-                    originHotkeyAddress,
-                    destinationHotkeyAddress,
-                    originNetuid,
-                    destinationNetuid,
-                    moveAmount,
-                    limitPrice,
-                    false
-                );
+
+                const tx = api.tx.SubtensorModule.move_stake_limit({
+                    origin_hotkey: originHotkeyAddress,
+                    destination_hotkey: destinationHotkeyAddress,
+                    origin_netuid: originNetuid,
+                    destination_netuid: destinationNetuid,
+                    alpha_amount: moveAmount,
+                    limit_price: limitPrice,
+                    allow_partial: false,
+                });
+                const result = await sendTransaction(tx, coldkey);
+
+                expect(result.success, "fill-or-kill should fail when the limit cannot be met").toBe(false);
+                expect(result.errorMessage, "should fail with SlippageTooHigh").toContain("SlippageTooHigh");
 
                 const originStakeAfter = await getStake(api, originHotkeyAddress, coldkeyAddress, originNetuid);
                 const destinationStakeAfter = await getStake(
@@ -145,10 +154,8 @@ describeSuite({
                 log(
                     `Origin stake: ${originStakeBefore} -> ${originStakeAfter}, destination stake: ${destinationStakeBefore} -> ${destinationStakeAfter}`
                 );
-                expect(originStakeAfter, "Origin stake should decrease").toBeLessThan(originStakeBefore);
-                expect(destinationStakeAfter, "Destination stake should increase").toBeGreaterThan(
-                    destinationStakeBefore
-                );
+                expect(originStakeAfter, "Origin stake should be unchanged").toBe(originStakeBefore);
+                expect(destinationStakeAfter, "Destination stake should be unchanged").toBe(destinationStakeBefore);
             },
         });
     },

--- a/ts-tests/utils/staking.ts
+++ b/ts-tests/utils/staking.ts
@@ -182,6 +182,29 @@ export async function moveStake(
     await waitForTransactionWithRetry(api, tx, coldkey, "move_stake");
 }
 
+export async function moveStakeLimit(
+    api: TypedApi<typeof subtensor>,
+    coldkey: KeyringPair,
+    originHotkey: string,
+    destinationHotkey: string,
+    originNetuid: number,
+    destinationNetuid: number,
+    amount: bigint,
+    limitPrice: bigint,
+    allowPartial: boolean
+): Promise<void> {
+    const tx = api.tx.SubtensorModule.move_stake_limit({
+        origin_hotkey: originHotkey,
+        destination_hotkey: destinationHotkey,
+        origin_netuid: originNetuid,
+        destination_netuid: destinationNetuid,
+        alpha_amount: amount,
+        limit_price: limitPrice,
+        allow_partial: allowPartial,
+    });
+    await waitForTransactionWithRetry(api, tx, coldkey, "move_stake_limit");
+}
+
 export async function swapStake(
     api: TypedApi<typeof subtensor>,
     coldkey: KeyringPair,


### PR DESCRIPTION
## Motivation

Moving stake between different hotkeys and subnets currently lacks the slippage protection available to limited stake swaps. This PR adds a price-limited move operation so callers can require a minimum destination-alpha/origin-alpha ratio and choose fill-or-kill or partial execution.

Closes #3081.

## Changes

- Adds the `move_stake_limit` runtime extrinsic and dispatch implementation.
- Adds benchmarking and weight accounting for the new operation.
- Exposes the call through chain extensions, ink!, the staking V2 EVM precompile and ABI, proxy filters, transaction-fee handling, Rust/Python SDK interfaces, and generated calls.
- Enables default slippage protection for cross-subnet Python `move_stake` intents.
- Adds pallet, chain-extension, precompile, SDK, fee, indexer, and end-to-end test coverage, including fill-or-kill and partial-fill behavior with distinct hotkeys.

## Behavioral impact

For cross-subnet moves, `limit_price` is the minimum acceptable destination-alpha per origin-alpha ratio scaled by `1e9`. With `allow_partial = false`, the call fails atomically when the requested amount cannot execute within the limit. With `allow_partial = true`, it moves only the amount executable before crossing the limit. Same-subnet moves continue to transfer stake directly between hotkeys.

The Python `move_stake` intent now selects this limited call by default for cross-subnet moves, using the current origin/destination price ratio and configured tolerance. Users may explicitly disable slippage protection.

## Runtime and migration

This is a runtime API/extrinsic change with no storage migration. `runtime/src/lib.rs` bumps `spec_version` from 447 to 448.

## Testing

Added focused coverage for runtime dispatch, full and partial limit behavior, chain-extension dispatch, EVM precompile dispatch, transaction fees, SDK policy and call construction, generated/indexer compatibility, and a zombienet end-to-end flow.