### PR TITLE
fix: stop /code/search.json 500ing on Vercel

### DIFF
--- a/website/apps/bittensor-website/.gitignore
+++ b/website/apps/bittensor-website/.gitignore
@@ -34,6 +34,7 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
-# generated (fumadocs collections, compiled docs stylesheet)
+# generated (fumadocs collections, compiled docs stylesheet, /code search snapshot)
 /.source/
 /src/app/docs/docs.css
+/src/lib/generated/code-corpus.json

--- a/website/apps/bittensor-website/next.config.mjs
+++ b/website/apps/bittensor-website/next.config.mjs
@@ -1,6 +1,46 @@
 import {createMDX} from 'fumadocs-mdx/next';
+import {mkdirSync, readdirSync, readFileSync, writeFileSync} from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 const withMDX = createMDX();
+
+// Keep in sync with CODE_ROOTS / exclusions in src/lib/code.ts.
+const CODE_ROOTS = [
+  'pallets',
+  'runtime',
+  'primitives',
+  'common',
+  'precompiles',
+  'chain-extensions',
+];
+const EXCLUDED_DIRS = new Set(['tests', 'target']);
+const EXCLUDED_FILES = new Set(['tests.rs', 'mock.rs', 'benchmarks.rs', 'benchmarking.rs']);
+
+const appDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(appDir, '../../..');
+
+/** Bundle the /code corpus so search.json does not walk the repo at request time. */
+function writeCodeCorpus() {
+  /** @type {Record<string, string>} */
+  const corpus = {};
+  function walk(dir) {
+    for (const entry of readdirSync(dir, {withFileTypes: true})) {
+      const abs = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (!EXCLUDED_DIRS.has(entry.name)) walk(abs);
+      } else if (entry.name.endsWith('.rs') && !EXCLUDED_FILES.has(entry.name)) {
+        corpus[path.relative(repoRoot, abs)] = readFileSync(abs, 'utf8');
+      }
+    }
+  }
+  for (const root of CODE_ROOTS) walk(path.join(repoRoot, root));
+  const out = path.join(appDir, 'src/lib/generated/code-corpus.json');
+  mkdirSync(path.dirname(out), {recursive: true});
+  writeFileSync(out, JSON.stringify(corpus));
+}
+
+writeCodeCorpus();
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/website/apps/bittensor-website/src/app/code/search.json/route.ts
+++ b/website/apps/bittensor-website/src/app/code/search.json/route.ts
@@ -1,4 +1,5 @@
 import { buildCommit, searchCode } from '@/lib/code';
+import corpus from '@/lib/generated/code-corpus.json';
 import { codeRoute } from '@/lib/shared';
 
 export const dynamic = 'force-dynamic';
@@ -6,6 +7,9 @@ export const dynamic = 'force-dynamic';
 /**
  * Agent-facing content search over the on-chain Rust corpus.
  * GET /code/search.json?q=<literal>&limit=20
+ *
+ * The corpus is a build-time snapshot (next.config.mjs) bundled into this
+ * function — the Vercel checkout is not available at request time.
  */
 export function GET(req: Request) {
   const url = new URL(req.url);
@@ -22,7 +26,7 @@ export function GET(req: Request) {
     );
   }
 
-  const results = searchCode(q, Number.isFinite(limit) ? limit : 20);
+  const results = searchCode(q, Number.isFinite(limit) ? limit : 20, corpus);
   return Response.json({
     commit: buildCommit(),
     q,

--- a/website/apps/bittensor-website/src/lib/code.ts
+++ b/website/apps/bittensor-website/src/lib/code.ts
@@ -4,8 +4,10 @@ import { execSync } from 'node:child_process';
 
 // The on-chain source viewer (/code) reads the Rust straight out of the
 // repository checkout at build time, the same way the docs content is read
-// from ../../../docs (see source.config.ts). Every page is prerendered, so
-// nothing here runs at request time.
+// from ../../../docs (see source.config.ts). Pages, raw files, and index.json
+// are prerendered. /code/search.json is request-time (it needs ?q=) and
+// searches a build-time snapshot — see next.config.mjs — so it never walks
+// the repo on Vercel.
 const repoRoot = path.resolve(process.cwd(), '../../..');
 
 // What actually runs on (or compiles into) the chain: the pallets, the
@@ -94,39 +96,43 @@ function codeContents(): Map<string, string> {
  * Literal substring search over the on-chain Rust corpus (paths + contents).
  * Built for agents: one HTTP hop instead of cloning or fetching every file.
  */
-export function searchCode(query: string, limit = 20): CodeSearchHit[] {
+export function searchCode(
+  query: string,
+  limit = 20,
+  // Default walks the checkout (local / build). Production search.json passes
+  // the snapshot so this never touches the filesystem at request time.
+  contents: Map<string, string> | Record<string, string> = codeContents(),
+): CodeSearchHit[] {
   const q = query.trim();
   if (q.length < 2) return [];
   const capped = Math.min(Math.max(limit, 1), 50);
   const hits: CodeSearchHit[] = [];
-  const contents = codeContents();
+  const files = contents instanceof Map ? contents : new Map(Object.entries(contents));
 
-  for (const file of codeFiles()) {
-    if (file.path.includes(q)) {
+  for (const filePath of files.keys()) {
+    if (filePath.includes(q)) {
       hits.push({
-        path: file.path,
+        path: filePath,
         kind: 'path',
-        raw_url: `/code/raw/${file.path}`,
-        url: `/code/${file.path}`,
+        raw_url: `/code/raw/${filePath}`,
+        url: `/code/${filePath}`,
       });
       if (hits.length >= capped) return hits;
     }
   }
 
-  for (const file of codeFiles()) {
-    const text = contents.get(file.path);
-    if (!text) continue;
+  for (const [filePath, text] of files) {
     const lines = text.split('\n');
     for (let i = 0; i < lines.length; i++) {
       if (!lines[i].includes(q)) continue;
       const line = i + 1;
       hits.push({
-        path: file.path,
+        path: filePath,
         line,
         text: lines[i].trim().slice(0, 200),
         kind: 'content',
-        raw_url: `/code/raw/${file.path}`,
-        url: `/code/${file.path}#L${line}`,
+        raw_url: `/code/raw/${filePath}`,
+        url: `/code/${filePath}#L${line}`,
       });
       if (hits.length >= capped) return hits;
     }

--- a/website/apps/bittensor-website/src/lib/code.ts
+++ b/website/apps/bittensor-website/src/lib/code.ts
@@ -107,7 +107,12 @@ export function searchCode(
   if (q.length < 2) return [];
   const capped = Math.min(Math.max(limit, 1), 50);
   const hits: CodeSearchHit[] = [];
-  const files = contents instanceof Map ? contents : new Map(Object.entries(contents));
+  // Path-sorted so a capped result set is stable across snapshot/build order.
+  const files = new Map(
+    (contents instanceof Map ? [...contents] : Object.entries(contents)).sort(
+      ([a], [b]) => (a < b ? -1 : a > b ? 1 : 0),
+    ),
+  );
 
   for (const filePath of files.keys()) {
     if (filePath.includes(q)) {

--- a/website/apps/bittensor-website/src/lib/generated/code-corpus.json.d.ts
+++ b/website/apps/bittensor-website/src/lib/generated/code-corpus.json.d.ts
@@ -1,0 +1,2 @@
+declare const corpus: Record<string, string>;
+export default corpus;


### PR DESCRIPTION
## Motivation

`/code/search.json` currently walks the Rust repository checkout for every request. Vercel serverless functions do not include that checkout, causing the endpoint to return HTTP 500.

## Changes

- Generate a JSON snapshot of the searchable Rust corpus while Next.js loads its build configuration.
- Bundle that snapshot with the search route and pass it to `searchCode` at request time.
- Allow `searchCode` to accept either the generated record or its existing filesystem-backed map.
- Ignore the generated corpus while retaining its TypeScript declaration.

Files of interest:

- `website/apps/bittensor-website/next.config.mjs`
- `website/apps/bittensor-website/src/app/code/search.json/route.ts`
- `website/apps/bittensor-website/src/lib/code.ts`

## Behavioral impact

The search API retains its existing response format and query behavior, but searches the build-time source snapshot instead of accessing the repository filesystem at request time. Local and build-time callers can continue using the existing filesystem-backed default.

## Runtime and migration impact

Website-only change. No on-chain runtime behavior, storage migration, or `spec_version` bump is involved.

## Testing

Static review of corpus generation, route wiring, and search behavior.