### PR TITLE
Fix production code search packaging

### DIFF
--- a/website/apps/bittensor-website/next.config.mjs
+++ b/website/apps/bittensor-website/next.config.mjs
@@ -1,10 +1,31 @@
 import {createMDX} from 'fumadocs-mdx/next';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {CODE_ROOTS, EXCLUDED_CODE_DIRS, EXCLUDED_CODE_FILES} from './src/lib/code-corpus.mjs';
 
 const withMDX = createMDX();
+const appDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(appDir, '../../..');
+const codeCorpusIncludes = CODE_ROOTS.map((root) => `../../../${root}/**/*.rs`);
+const codeCorpusExcludes = CODE_ROOTS.flatMap((root) => [
+  ...EXCLUDED_CODE_DIRS.map((dir) => `../../../${root}/**/${dir}/**`),
+  ...EXCLUDED_CODE_FILES.map((file) => `../../../${root}/**/${file}`),
+]);
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+
+  // /code/search.json reads the Rust corpus at request time. The paths are
+  // computed in src/lib/code.ts, so Next cannot discover them automatically
+  // when tracing the serverless function.
+  outputFileTracingRoot: repoRoot,
+  outputFileTracingIncludes: {
+    '/code/search.json': codeCorpusIncludes,
+  },
+  outputFileTracingExcludes: {
+    '/code/search.json': codeCorpusExcludes,
+  },
 
   async redirects() {
     return [

--- a/website/apps/bittensor-website/package.json
+++ b/website/apps/bittensor-website/package.json
@@ -4,8 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "yarn build:docs-css && next dev --webpack",
-    "build": "yarn build:docs-css && next build --webpack",
+    "build": "yarn build:docs-css && next build --webpack && yarn check:code-search-trace",
     "build:docs-css": "tailwindcss -i src/app/docs/docs.tw.css -o src/app/docs/docs.css --minify",
+    "check:code-search-trace": "node scripts/check-code-search-trace.mjs",
     "start": "next start",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "postinstall": "fumadocs-mdx"

--- a/website/apps/bittensor-website/scripts/check-code-search-trace.mjs
+++ b/website/apps/bittensor-website/scripts/check-code-search-trace.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {CODE_ROOTS, EXCLUDED_CODE_DIRS, EXCLUDED_CODE_FILES} from '../src/lib/code-corpus.mjs';
+
+const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const tracePath = path.join(appDir, '.next/server/app/code/search.json/route.js.nft.json');
+const trace = JSON.parse(fs.readFileSync(tracePath, 'utf8'));
+const tracedFiles = new Set(trace.files.map((file) => path.resolve(path.dirname(tracePath), file)));
+const repoRoot = path.resolve(appDir, '../../..');
+const excludedDirs = new Set(EXCLUDED_CODE_DIRS);
+const excludedFiles = new Set(EXCLUDED_CODE_FILES);
+const expectedFiles = [];
+
+function walk(dir) {
+  for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+    const filePath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!excludedDirs.has(entry.name)) walk(filePath);
+    } else if (entry.name.endsWith('.rs') && !excludedFiles.has(entry.name)) {
+      expectedFiles.push(filePath);
+    }
+  }
+}
+
+for (const root of CODE_ROOTS) walk(path.join(repoRoot, root));
+
+const missingFiles = expectedFiles.filter((file) => !tracedFiles.has(file));
+const tracedCorpusFiles = [...tracedFiles].filter(
+  (file) =>
+    file.endsWith('.rs') &&
+    CODE_ROOTS.some((root) => file.startsWith(path.join(repoRoot, root) + path.sep)),
+);
+
+assert.deepEqual(
+  missingFiles,
+  [],
+  `search route trace is missing ${missingFiles.length} corpus files`,
+);
+assert.equal(
+  tracedCorpusFiles.length,
+  expectedFiles.length,
+  'search route trace contains Rust files excluded from the search corpus',
+);
+
+console.log(`search route trace contains all ${expectedFiles.length} corpus files`);

--- a/website/apps/bittensor-website/src/lib/code-corpus.mjs
+++ b/website/apps/bittensor-website/src/lib/code-corpus.mjs
@@ -1,0 +1,11 @@
+export const CODE_ROOTS = [
+  'pallets',
+  'runtime',
+  'primitives',
+  'common',
+  'precompiles',
+  'chain-extensions',
+];
+
+export const EXCLUDED_CODE_DIRS = ['tests', 'target'];
+export const EXCLUDED_CODE_FILES = ['tests.rs', 'mock.rs', 'benchmarks.rs', 'benchmarking.rs'];

--- a/website/apps/bittensor-website/src/lib/code.ts
+++ b/website/apps/bittensor-website/src/lib/code.ts
@@ -1,6 +1,9 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
+import { CODE_ROOTS, EXCLUDED_CODE_DIRS, EXCLUDED_CODE_FILES } from './code-corpus.mjs';
+
+export { CODE_ROOTS } from './code-corpus.mjs';
 
 // The on-chain source viewer (/code) reads the Rust straight out of the
 // repository checkout at build time, the same way the docs content is read
@@ -12,17 +15,8 @@ const repoRoot = path.resolve(process.cwd(), '../../..');
 // runtime that assembles them, and the shared primitives. Excluded on
 // purpose: node/ (the client binary), support/ (proc-macro tooling),
 // vendor/ (upstream forks), and all tests, mocks, and benchmark code.
-export const CODE_ROOTS = [
-  'pallets',
-  'runtime',
-  'primitives',
-  'common',
-  'precompiles',
-  'chain-extensions',
-];
-
-const EXCLUDED_DIRS = new Set(['tests', 'target']);
-const EXCLUDED_FILES = new Set(['tests.rs', 'mock.rs', 'benchmarks.rs', 'benchmarking.rs']);
+const EXCLUDED_DIRS = new Set(EXCLUDED_CODE_DIRS);
+const EXCLUDED_FILES = new Set(EXCLUDED_CODE_FILES);
 
 export interface CodeFile {
   /** Repo-relative path, e.g. "pallets/subtensor/src/coinbase/run_coinbase.rs". */


### PR DESCRIPTION
## Problem

`/code/search.json` returns an empty HTTP 500 response for every valid query in production, including the documented `?q=do_move_stake` example. This prevents agents and other tooling from searching the chain source corpus without cloning the repository.

Short invalid queries still return 400 because they exit before the failing code path. The static code index and raw-file routes also work because they read the repository during the build.

## Root cause

The search route is dynamic and reads Rust files at request time through computed filesystem paths. Next.js cannot infer those files during automatic output tracing, so the deployed Vercel function does not contain the corpus and fails when a valid query reaches filesystem access.

## Fix

- Include the production Rust corpus in the `/code/search.json` server-function trace.
- Exclude tests, mocks, targets, and benchmarks that are not searchable.
- Move corpus roots and exclusions into one canonical module shared by the code viewer, deployment configuration, and regression check.
- Run a trace regression check after every website build. It verifies that all 254 searchable Rust files, and no excluded Rust files, are packaged with the route.

Future Rust changes are picked up automatically on website builds. Adding a new top-level corpus root requires changing only the canonical corpus module.

## Verification

- `yarn workspace @raofoundation/bittensor-website build`
  - production build passed
  - TypeScript passed
  - trace check found all 254 corpus files
- `yarn workspace @raofoundation/bittensor-website lint`
  - passed with no errors; 81 pre-existing warnings remain
- Local production server checks:
  - `do_move_stake` returned 200 with two results
  - a no-result query returned 200 with an empty result list
  - a one-character query returned the expected 400 response
