### PR TITLE
Add repository CI preflight guidance for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,8 +114,10 @@ Run the relevant E2E suite when behavior changes. Commit an intentional
 
 Runtime-affecting changes trigger the spec-version gate. The literal
 `spec_version` in `runtime/src/lib.rs` must be newer than mainnet unless the PR
-has the `no-spec-version-bump` label. Do not silently bump the version for a
-non-release change; explicitly tell the maintainer that the label is required.
+has the `no-spec-version-bump` label. Treat this as advisory: do not change
+`spec_version` unless the user explicitly requests that release action. Never
+initiate a bump merely to satisfy CI. Instead, tell the maintainer that the PR
+needs the label or a deliberate, separately authorized version bump.
 
 Adding or changing a dispatchable requires matching benchmarks and
 `WeightInfo` wiring. Run the pallet's benchmark tests:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,20 +1,20 @@
 # Repository Agent Guidance
 
-## CI preflight is part of the change
+## Quick CI preflight
 
-Before handing off a change, run the checks below that correspond to every
-area touched. Use the repository's locked dependency installs and the same
-commands CI uses.
+Before handing off implementation work, run only the quick, deterministic
+checks below that match the changed files. Heavy compilation, tests, audits,
+and environment-sensitive validation belong in CI unless the user explicitly
+requests them.
 
-These checks apply only to implementation work requested by the user. This
-file does not authorize commits, pushes, labels, PR changes, dependency
+This file does not authorize commits, pushes, labels, PR changes, dependency
 updates, or unrelated cleanup. Review and diagnostic tasks remain read-only.
+If scope or ownership is unclear, do not take action; report what remains.
 
 Before any command that can rewrite files, inspect `git status --short` and
 preserve all pre-existing changes as user-owned work. Run check mode first. Use
-fix mode only when the failure is in files within the current task, then inspect
-the resulting diff. If ownership or scope is unclear, do not modify, stage, or
-revert the file; report the required follow-up instead.
+fix mode only for a failure attributable to files in the current task, then
+inspect the resulting diff.
 
 Always finish with:
 
@@ -23,151 +23,111 @@ git diff --check
 git status --short
 ```
 
-Inspect all generated and lockfile changes. Include an output only when it is
-clearly attributable to the current task. Report the exact checks run and call
-out any check that was skipped or could not run.
+Report the exact checks run and any check skipped because its existing locked
+environment was unavailable. Do not install dependencies solely for this quick
+preflight.
 
-## Rust changes
+## Rust formatting
 
-For any Rust source, manifest, fixture, or feature change, run:
+For Rust source, manifest, fixture, or feature changes, run:
 
 ```bash
 cargo fmt --check --all
-SKIP_WASM_BUILD=1 cargo clippy --workspace --all-targets -- -D warnings
-SKIP_WASM_BUILD=1 cargo clippy --workspace --all-targets --all-features -- -D warnings
 ```
 
-If the formatting check fails only in task-owned files, run `cargo fmt --all`
-and repeat the check. Run the relevant package tests as well. Clippy checks
-both feature modes and treats warnings as errors; do not assume passing the
-default mode is enough. Avoid `scripts/fix_rust.sh` for routine preflight
-because it creates a commit.
+If it fails only because of task-owned files, run `cargo fmt --all`, inspect the
+diff, and repeat the check. Do not run `scripts/fix_rust.sh`; it creates a
+commit.
 
-When `Cargo.toml` or `Cargo.lock` changes, verify that `Cargo.lock` reflects the
-intended dependency graph and run `cargo audit`. A newly published advisory may
-be unrelated to the patch; investigate and report it rather than adding an
-ignore or mechanically upgrading dependencies.
+Leave Clippy, Rust builds and tests, and `cargo audit` to CI unless explicitly
+requested. If `Cargo.toml` or `Cargo.lock` changed, confirm the lockfile change
+is intentional; do not update dependencies or add advisory ignores merely to
+make CI pass.
 
-## Python SDK changes
+## Python SDK formatting and ABI drift
 
-The Python SDK uses `uv` and its committed lockfile. From `sdk/python`, run:
+If the existing `sdk/python` environment is available, run from that directory:
 
 ```bash
-uv sync --locked --all-extras --dev
-just check
+uv run --no-sync ruff check .
+uv run --no-sync ruff format --check .
 ```
 
-`just check` covers Ruff formatting/linting, type checking, unit tests, and
-offline code-generation consistency. If it reports a fixable Ruff failure only
-in task-owned files, run `just fmt` and repeat `just check`. Include a `uv.lock`
-update only with the intentional dependency change that caused it.
+For failures confined to task-owned files, use
+`uv run --no-sync ruff check . --fix` and
+`uv run --no-sync ruff format .`, inspect the diff, and repeat both checks.
+Leave full type checking and tests to CI.
 
 The Solidity ABI files in `precompiles/src/solidity/*.abi` are canonical. When
-one changes, update the matching vendored JSON under
-`sdk/python/bittensor/evm/abi/` and run the SDK checks. Do not edit only the
-vendored copy.
-
-Runtime metadata bindings in `sdk/python/bittensor/_generated/` are committed
-outputs. A metadata-affecting runtime change requires an upgraded local node,
-then from `sdk/python`:
+one of those or a vendored ABI changes, run this narrow consistency test from
+`sdk/python`:
 
 ```bash
-just regen
+uv run --no-sync pytest tests/unit/test_evm.py::TestVendoredAbiSync -q
 ```
 
-Include both the regenerated bindings and the recorded golden fixture. Do not
-regenerate them against an old or unrelated runtime. If the correct upgraded
-node is not already available or its provenance is uncertain, report the
-required regeneration instead of guessing.
+Update `sdk/python/bittensor/evm/abi/*.json` only when drift is caused by the
+current canonical ABI change. Do not edit only the vendored copy.
 
-## Generated reference docs and website
+Runtime metadata bindings under `sdk/python/bittensor/_generated/` require the
+correct upgraded node. Do not regenerate them as routine preflight. If CI or
+the task indicates they are stale, report the required regeneration unless the
+user explicitly requests it and the correct node provenance is known.
+
+## Generated reference docs
 
 Changes to Python registries, calls, queries, errors, hyperparameters, or other
-inputs consumed by the docs generator require regeneration. From `sdk/python`:
+docs-generator inputs require this check from `sdk/python` when its existing
+locked environment is available:
 
 ```bash
-uv sync --locked --all-extras --dev
-just check-docs
+uv run --no-sync python ../../website/apps/bittensor-website/scripts/generate.py --check
 ```
 
-If the check reports drift attributable to the current task, run
-`just regen-docs`, repeat `just check-docs`, and inspect the generated diff.
-Unexpected broad drift is a reason to stop and report it, not to sweep it into
-the task. Generated surfaces include `docs/tx/`, `docs/query/`, `docs/errors/`,
-hyperparameter index/meta files, and
-`website/apps/bittensor-website/public/catalog/`. Change the source registry or
-generator rather than hand-editing generated output.
+If drift is attributable to the current task, run
+`uv run --no-sync python ../../website/apps/bittensor-website/scripts/generate.py`,
+repeat the check, and inspect the generated diff. Unexpected broad drift is a
+reason to stop and report it. Do not hand-edit generated files under
+`docs/tx/`, `docs/query/`, `docs/errors/`, generated hyperparameter index/meta
+files, or `website/apps/bittensor-website/public/catalog/`.
 
-For documentation or website changes, also run:
+For rendered Markdown and MDX changes, verify that pages have string `title`
+and `description` frontmatter and that referenced MDX components exist. Leave
+the full website install and build to CI.
 
-```bash
-cd website
-yarn install --immutable
-yarn turbo run build --filter=@raofoundation/bittensor-website
-```
+## TypeScript formatting
 
-Every rendered Markdown or MDX page must have string `title` and `description`
-frontmatter. Verify that referenced MDX components exist and are imported.
-Include a `website/yarn.lock` update only with its intentional dependency
-change.
-
-## TypeScript test changes
-
-From `ts-tests`, use the committed pnpm lockfile:
+For `ts-tests` changes, run this when its existing locked environment is
+available:
 
 ```bash
-pnpm install --frozen-lockfile
 pnpm run fmt
-pnpm run lint
 ```
 
-If formatting fails only in task-owned files, run `pnpm run fmt:fix`, then
-repeat the formatting and lint checks. Run the relevant E2E suite when behavior
-changes. Include a `pnpm-lock.yaml` update only with its intentional dependency
-change.
+If it fails only in task-owned files, run `pnpm run fmt:fix`, inspect the diff,
+and repeat the check. Leave lint, type checking, builds, and E2E tests to CI.
 
-## Runtime version and weights
+## Advisory-only checks
 
-Runtime-affecting changes trigger the spec-version gate. The literal
-`spec_version` in `runtime/src/lib.rs` must be newer than mainnet unless the PR
-has the `no-spec-version-bump` label. Treat this as advisory: do not change
-`spec_version` unless the user explicitly requests that release action. Never
-initiate a bump merely to satisfy CI. Instead, tell the maintainer that the PR
-needs the label or a deliberate, separately authorized version bump.
+Runtime-affecting changes may require a `spec_version` newer than mainnet or the
+`no-spec-version-bump` PR label. Do not change `spec_version` or apply labels
+unless the user explicitly requests that action; report the requirement.
 
 Adding or changing a dispatchable requires matching benchmarks and
-`WeightInfo` wiring. Run the pallet's benchmark tests:
-
-```bash
-cargo test -p <pallet> --features runtime-benchmarks benchmarks
-```
-
-CI performs the reference measurement and prepares a patch. Tell the maintainer
-when the `apply-benchmark-patch` label is needed; do not apply it automatically.
-Do not run `./scripts/benchmark_all.sh`, commit locally measured weights, or
-invent weight values unless the user explicitly requests a measurement on
+`WeightInfo` wiring. CI performs reference measurements and prepares a patch.
+Do not apply benchmark labels, run `scripts/benchmark_all.sh`, commit locally
+measured weights, or invent weight values unless explicitly requested on
 appropriate reference hardware.
 
-## Workflow and dependency-file changes
+Treat unexpected lockfile changes as a stop-and-report condition. Relevant
+lockfiles are `Cargo.lock`, `sdk/python/uv.lock`,
+`ts-tests/pnpm-lock.yaml`, `website/yarn.lock`, and
+`.github/docs-preview-vercel/package-lock.json`. Do not regenerate or revert a
+pre-existing lockfile change merely to make the working tree or CI clean.
 
-Treat `.github/**` changes as CI code. Run the relevant repository workflow or
-unit scripts and run `actionlint` when it is available. Preserve action pinning
-and do not add an unapproved third-party action merely to make a workflow pass.
+For `.github/**` changes, run `actionlint` only when it is already available.
+Leave workflow execution to CI, preserve action pinning, and do not add an
+unapproved third-party action merely to make a workflow pass.
 
-Use the package manager that owns each lockfile:
-
-- Rust: `Cargo.lock`
-- Python SDK: `sdk/python/uv.lock`
-- TypeScript tests: `ts-tests/pnpm-lock.yaml`
-- Website: `website/yarn.lock`
-- Docs preview: `.github/docs-preview-vercel/package-lock.json`
-
-Use locked or frozen install modes in preflight. If a lockfile changes without
-an intentional dependency change, stop and report it. Do not regenerate or
-revert a pre-existing lockfile change merely to make the working tree or CI
-clean.
-
-Do not start the full clone/regression workflow solely as routine preflight.
-Use it only when the task explicitly requires runtime, migration, or
-chain-state-sensitive validation. It is not a substitute for the cheap checks
-above.
+Do not start clone/regression workflows, full builds, comprehensive test
+suites, dependency audits, or benchmark generation as routine preflight.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,17 @@
 
 Before handing off a change, run the checks below that correspond to every
 area touched. Use the repository's locked dependency installs and the same
-commands CI uses. Run formatters in fix mode first, then their check mode.
+commands CI uses.
+
+These checks apply only to implementation work requested by the user. This
+file does not authorize commits, pushes, labels, PR changes, dependency
+updates, or unrelated cleanup. Review and diagnostic tasks remain read-only.
+
+Before any command that can rewrite files, inspect `git status --short` and
+preserve all pre-existing changes as user-owned work. Run check mode first. Use
+fix mode only when the failure is in files within the current task, then inspect
+the resulting diff. If ownership or scope is unclear, do not modify, stage, or
+revert the file; report the required follow-up instead.
 
 Always finish with:
 
@@ -13,24 +23,25 @@ git diff --check
 git status --short
 ```
 
-Inspect all generated and lockfile changes. Commit intentional outputs; do not
-leave required regeneration for CI to discover. Report the exact checks run
-and call out any check that was skipped or could not run.
+Inspect all generated and lockfile changes. Include an output only when it is
+clearly attributable to the current task. Report the exact checks run and call
+out any check that was skipped or could not run.
 
 ## Rust changes
 
 For any Rust source, manifest, fixture, or feature change, run:
 
 ```bash
-cargo fmt --all
 cargo fmt --check --all
 SKIP_WASM_BUILD=1 cargo clippy --workspace --all-targets -- -D warnings
 SKIP_WASM_BUILD=1 cargo clippy --workspace --all-targets --all-features -- -D warnings
 ```
 
-Run the relevant package tests as well. Clippy checks both feature modes and
-treats warnings as errors; do not assume passing the default mode is enough.
-Avoid `scripts/fix_rust.sh` for routine preflight because it creates a commit.
+If the formatting check fails only in task-owned files, run `cargo fmt --all`
+and repeat the check. Run the relevant package tests as well. Clippy checks
+both feature modes and treats warnings as errors; do not assume passing the
+default mode is enough. Avoid `scripts/fix_rust.sh` for routine preflight
+because it creates a commit.
 
 When `Cargo.toml` or `Cargo.lock` changes, verify that `Cargo.lock` reflects the
 intended dependency graph and run `cargo audit`. A newly published advisory may
@@ -43,14 +54,13 @@ The Python SDK uses `uv` and its committed lockfile. From `sdk/python`, run:
 
 ```bash
 uv sync --locked --all-extras --dev
-just fmt
 just check
 ```
 
 `just check` covers Ruff formatting/linting, type checking, unit tests, and
-offline code-generation consistency. Re-run it after `just fmt` changes files.
-Commit an intentional `uv.lock` update with the dependency change that caused
-it.
+offline code-generation consistency. If it reports a fixable Ruff failure only
+in task-owned files, run `just fmt` and repeat `just check`. Include a `uv.lock`
+update only with the intentional dependency change that caused it.
 
 The Solidity ABI files in `precompiles/src/solidity/*.abi` are canonical. When
 one changes, update the matching vendored JSON under
@@ -65,8 +75,10 @@ then from `sdk/python`:
 just regen
 ```
 
-Commit both the regenerated bindings and the recorded golden fixture. Do not
-regenerate them against an old or unrelated runtime.
+Include both the regenerated bindings and the recorded golden fixture. Do not
+regenerate them against an old or unrelated runtime. If the correct upgraded
+node is not already available or its provenance is uncertain, report the
+required regeneration instead of guessing.
 
 ## Generated reference docs and website
 
@@ -75,14 +87,16 @@ inputs consumed by the docs generator require regeneration. From `sdk/python`:
 
 ```bash
 uv sync --locked --all-extras --dev
-just regen-docs
 just check-docs
 ```
 
-Commit all resulting reference pages and catalog data. Generated surfaces
-include `docs/tx/`, `docs/query/`, `docs/errors/`, hyperparameter index/meta
-files, and `website/apps/bittensor-website/public/catalog/`. Change the source
-registry or generator rather than hand-editing generated output.
+If the check reports drift attributable to the current task, run
+`just regen-docs`, repeat `just check-docs`, and inspect the generated diff.
+Unexpected broad drift is a reason to stop and report it, not to sweep it into
+the task. Generated surfaces include `docs/tx/`, `docs/query/`, `docs/errors/`,
+hyperparameter index/meta files, and
+`website/apps/bittensor-website/public/catalog/`. Change the source registry or
+generator rather than hand-editing generated output.
 
 For documentation or website changes, also run:
 
@@ -94,7 +108,8 @@ yarn turbo run build --filter=@raofoundation/bittensor-website
 
 Every rendered Markdown or MDX page must have string `title` and `description`
 frontmatter. Verify that referenced MDX components exist and are imported.
-Commit an intentional `website/yarn.lock` update with its dependency change.
+Include a `website/yarn.lock` update only with its intentional dependency
+change.
 
 ## TypeScript test changes
 
@@ -102,13 +117,14 @@ From `ts-tests`, use the committed pnpm lockfile:
 
 ```bash
 pnpm install --frozen-lockfile
-pnpm run fmt:fix
 pnpm run fmt
 pnpm run lint
 ```
 
-Run the relevant E2E suite when behavior changes. Commit an intentional
-`pnpm-lock.yaml` update with its dependency change.
+If formatting fails only in task-owned files, run `pnpm run fmt:fix`, then
+repeat the formatting and lint checks. Run the relevant E2E suite when behavior
+changes. Include a `pnpm-lock.yaml` update only with its intentional dependency
+change.
 
 ## Runtime version and weights
 
@@ -126,9 +142,11 @@ Adding or changing a dispatchable requires matching benchmarks and
 cargo test -p <pallet> --features runtime-benchmarks benchmarks
 ```
 
-When measured weights must change, follow
-`docs/internals/benchmarks-and-weights.mdx` and use
-`./scripts/benchmark_all.sh <pallet>` rather than inventing weight values.
+CI performs the reference measurement and prepares a patch. Tell the maintainer
+when the `apply-benchmark-patch` label is needed; do not apply it automatically.
+Do not run `./scripts/benchmark_all.sh`, commit locally measured weights, or
+invent weight values unless the user explicitly requests a measurement on
+appropriate reference hardware.
 
 ## Workflow and dependency-file changes
 
@@ -145,8 +163,11 @@ Use the package manager that owns each lockfile:
 - Docs preview: `.github/docs-preview-vercel/package-lock.json`
 
 Use locked or frozen install modes in preflight. If a lockfile changes without
-an intentional dependency change, stop and resolve the drift before handoff.
+an intentional dependency change, stop and report it. Do not regenerate or
+revert a pre-existing lockfile change merely to make the working tree or CI
+clean.
 
-The full clone/regression workflow is warranted for runtime behavior,
-migrations, and chain-state-sensitive changes. It is not a substitute for the
-cheap formatting, generation, lint, lockfile, and docs checks above.
+Do not start the full clone/regression workflow solely as routine preflight.
+Use it only when the task explicitly requires runtime, migration, or
+chain-state-sensitive validation. It is not a substitute for the cheap checks
+above.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,150 @@
+# Repository Agent Guidance
+
+## CI preflight is part of the change
+
+Before handing off a change, run the checks below that correspond to every
+area touched. Use the repository's locked dependency installs and the same
+commands CI uses. Run formatters in fix mode first, then their check mode.
+
+Always finish with:
+
+```bash
+git diff --check
+git status --short
+```
+
+Inspect all generated and lockfile changes. Commit intentional outputs; do not
+leave required regeneration for CI to discover. Report the exact checks run
+and call out any check that was skipped or could not run.
+
+## Rust changes
+
+For any Rust source, manifest, fixture, or feature change, run:
+
+```bash
+cargo fmt --all
+cargo fmt --check --all
+SKIP_WASM_BUILD=1 cargo clippy --workspace --all-targets -- -D warnings
+SKIP_WASM_BUILD=1 cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+Run the relevant package tests as well. Clippy checks both feature modes and
+treats warnings as errors; do not assume passing the default mode is enough.
+Avoid `scripts/fix_rust.sh` for routine preflight because it creates a commit.
+
+When `Cargo.toml` or `Cargo.lock` changes, verify that `Cargo.lock` reflects the
+intended dependency graph and run `cargo audit`. A newly published advisory may
+be unrelated to the patch; investigate and report it rather than adding an
+ignore or mechanically upgrading dependencies.
+
+## Python SDK changes
+
+The Python SDK uses `uv` and its committed lockfile. From `sdk/python`, run:
+
+```bash
+uv sync --locked --all-extras --dev
+just fmt
+just check
+```
+
+`just check` covers Ruff formatting/linting, type checking, unit tests, and
+offline code-generation consistency. Re-run it after `just fmt` changes files.
+Commit an intentional `uv.lock` update with the dependency change that caused
+it.
+
+The Solidity ABI files in `precompiles/src/solidity/*.abi` are canonical. When
+one changes, update the matching vendored JSON under
+`sdk/python/bittensor/evm/abi/` and run the SDK checks. Do not edit only the
+vendored copy.
+
+Runtime metadata bindings in `sdk/python/bittensor/_generated/` are committed
+outputs. A metadata-affecting runtime change requires an upgraded local node,
+then from `sdk/python`:
+
+```bash
+just regen
+```
+
+Commit both the regenerated bindings and the recorded golden fixture. Do not
+regenerate them against an old or unrelated runtime.
+
+## Generated reference docs and website
+
+Changes to Python registries, calls, queries, errors, hyperparameters, or other
+inputs consumed by the docs generator require regeneration. From `sdk/python`:
+
+```bash
+uv sync --locked --all-extras --dev
+just regen-docs
+just check-docs
+```
+
+Commit all resulting reference pages and catalog data. Generated surfaces
+include `docs/tx/`, `docs/query/`, `docs/errors/`, hyperparameter index/meta
+files, and `website/apps/bittensor-website/public/catalog/`. Change the source
+registry or generator rather than hand-editing generated output.
+
+For documentation or website changes, also run:
+
+```bash
+cd website
+yarn install --immutable
+yarn turbo run build --filter=@raofoundation/bittensor-website
+```
+
+Every rendered Markdown or MDX page must have string `title` and `description`
+frontmatter. Verify that referenced MDX components exist and are imported.
+Commit an intentional `website/yarn.lock` update with its dependency change.
+
+## TypeScript test changes
+
+From `ts-tests`, use the committed pnpm lockfile:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm run fmt:fix
+pnpm run fmt
+pnpm run lint
+```
+
+Run the relevant E2E suite when behavior changes. Commit an intentional
+`pnpm-lock.yaml` update with its dependency change.
+
+## Runtime version and weights
+
+Runtime-affecting changes trigger the spec-version gate. The literal
+`spec_version` in `runtime/src/lib.rs` must be newer than mainnet unless the PR
+has the `no-spec-version-bump` label. Do not silently bump the version for a
+non-release change; explicitly tell the maintainer that the label is required.
+
+Adding or changing a dispatchable requires matching benchmarks and
+`WeightInfo` wiring. Run the pallet's benchmark tests:
+
+```bash
+cargo test -p <pallet> --features runtime-benchmarks benchmarks
+```
+
+When measured weights must change, follow
+`docs/internals/benchmarks-and-weights.mdx` and use
+`./scripts/benchmark_all.sh <pallet>` rather than inventing weight values.
+
+## Workflow and dependency-file changes
+
+Treat `.github/**` changes as CI code. Run the relevant repository workflow or
+unit scripts and run `actionlint` when it is available. Preserve action pinning
+and do not add an unapproved third-party action merely to make a workflow pass.
+
+Use the package manager that owns each lockfile:
+
+- Rust: `Cargo.lock`
+- Python SDK: `sdk/python/uv.lock`
+- TypeScript tests: `ts-tests/pnpm-lock.yaml`
+- Website: `website/yarn.lock`
+- Docs preview: `.github/docs-preview-vercel/package-lock.json`
+
+Use locked or frozen install modes in preflight. If a lockfile changes without
+an intentional dependency change, stop and resolve the drift before handoff.
+
+The full clone/regression workflow is warranted for runtime behavior,
+migrations, and chain-state-sensitive changes. It is not a substitute for the
+cheap formatting, generation, lint, lockfile, and docs checks above.


### PR DESCRIPTION
## Summary

- add repository-wide agent guidance based on recent PR CI failure patterns
- require change-aware formatting, lint, generation, locked dependency, and docs-site preflight checks
- document Python ABI and metadata drift, generated reference docs, runtime weights, and workflow validation
- keep spec-version bumps advisory and require explicit authorization before changing the version

## Validation

- `git diff --check`
- verified the comparison against `release-448` contains only the new root `AGENTS.md`

This targets the head branch of #3089 so the guidance can accompany the release branch.