### PR TITLE
docs: document chain consensus

### DIFF
--- a/docs/concepts/chain-consensus.mdx
+++ b/docs/concepts/chain-consensus.mdx
@@ -1,0 +1,51 @@
+---
+title: Chain consensus
+description: How Subtensor produces and finalizes blocks today, and the planned transition from Proof of Authority to Nominated Proof of Stake.
+---
+
+Subtensor currently uses **Proof of Authority (PoA)** for blockchain consensus.
+A permissioned set of validator authorities produces and finalizes blocks. This
+is separate from [Yuma Consensus](/docs/internals/consensus), which determines
+how subnet participants are evaluated and rewarded.
+
+## Current mechanism: Proof of Authority
+
+Subtensor separates block production from finality:
+
+| Layer            | Current mechanism                             | Role                                                                                                                                                |
+| ---------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Block production | [Aura](/code/runtime/src/lib.rs#L363-L369)    | Assigns block-production slots to members of the authorized validator set.                                                                          |
+| Block finality   | [GRANDPA](/code/runtime/src/lib.rs#L371-L381) | Finalizes a chain after more than two-thirds of authority voting weight agrees, making its blocks irreversible under the protocol's finality rules. |
+
+Only approved authorities can author blocks or vote on finality. Other nodes can
+independently verify the chain, relay blocks and transactions, and expose RPC
+services, but they do not join the authority set merely by running a node or
+holding TAO.
+
+The authority set can be changed through privileged on-chain administration.
+This permissioned validator selection is why the current chain-level mechanism
+is classified as PoA.
+
+## Planned transition to Nominated Proof of Stake
+
+The roadmap is to replace PoA with **Nominated Proof of Stake (NPoS)**. Under
+NPoS, validator selection is stake-backed: nominators support validator
+candidates, and the active validator set is selected from that support.
+
+The current roadmap targets this transition within roughly the next year. This
+is a planning estimate, not a fixed activation date. Implementation details and
+timing may change before on-chain activation.
+
+Until that transition is activated on-chain, Subtensor remains a PoA network.
+
+## Chain consensus and Yuma Consensus
+
+The term “consensus” appears in two different contexts in Bittensor:
+
+- **Chain consensus** decides who may produce blocks and when those blocks are
+  final. It currently uses PoA with Aura and GRANDPA.
+- **Yuma Consensus** aggregates subnet validators' miner evaluations and helps
+  determine participant incentives. It does not produce or finalize blockchain
+  blocks.
+
+See [Yuma Consensus](/docs/internals/consensus) for the subnet-level mechanism.

--- a/docs/concepts/meta.json
+++ b/docs/concepts/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Concepts",
-  "pages": ["network", "emissions", "wallets", "money", "staking-pools", "client", "transactions", "advanced"]
+  "pages": ["network", "emissions", "wallets", "money", "staking-pools", "client", "transactions", "chain-consensus", "advanced"]
 }

--- a/docs/internals/consensus.mdx
+++ b/docs/internals/consensus.mdx
@@ -3,6 +3,11 @@ title: Yuma Consensus
 description: The consensus mechanism, its game-theoretic framework, Monte Carlo simulations, and consensus guarantees.
 ---
 
+<Callout type="note">
+  For blockchain consensus, see [Chain
+  consensus](/docs/concepts/chain-consensus).
+</Callout>
+
 Bittensor uses a subjective utility consensus mechanism called Yuma Consensus which rewards subnet validators with scoring incentive for producing evaluations of miner-value which are in agreement with the subjective evaluations produced by other subnet validators weighted by stake. Subnet servers receive incentive for their share of the utility according to the subnet validator consensus. Yuma Consensus pertains to subnet validation, instead of blockchain validation (substrate), so this writing will always refer to subnet validators and servers.
 
 ### Problem definition


### PR DESCRIPTION
## Summary

- document Subtensor's current chain consensus as Proof of Authority using Aura and GRANDPA
- describe the planned transition to Nominated Proof of Stake as a non-binding roadmap target within roughly the next year
- distinguish chain consensus from Yuma Consensus
- place the page near the bottom of the Concepts navigation for a stable, low-prominence compliance reference

## Validation

- `yarn prettier --check ../docs/concepts/chain-consensus.mdx`
- `yarn turbo build --force` (2,690 static pages generated)