### PR TITLE
Cleanup staking hotkeys on stake removal

### DIFF
--- a/clones/js-tests/package.json
+++ b/clones/js-tests/package.json
@@ -19,6 +19,7 @@
     "test:mainnet-lock-conviction": "tsx tests/mainnet-lock-conviction-read.ts",
     "test:mainnet-hotkey-conviction-increases": "tsx tests/mainnet-hotkey-conviction-increases.ts",
     "test:alpha-deprecated-stake-histogram": "tsx tests/test-alpha-deprecated-stake-histogram.ts",
+    "test:staking-hotkeys-cleanup-migration": "tsx tests/test-staking-hotkeys-cleanup-migration.ts",
     "test:testnet-lock-conviction": "tsx tests/testnet-lock-conviction-smoke.ts",
     "test:testnet-swap-hotkey-v2-lock-conviction": "tsx tests/testnet-swap-hotkey-v2-lock-conviction.ts",
     "test:localnet-subnet-alpha-reserve-drain": "tsx tests/test-localnet-subnet-alpha-reserve-drain.ts",

--- a/clones/js-tests/tests/test-staking-hotkeys-cleanup-migration.ts
+++ b/clones/js-tests/tests/test-staking-hotkeys-cleanup-migration.ts
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+
+import { connectApi } from "../lib/api.js";
+import { createTempLogger } from "../lib/file-log.js";
+
+const WS_ENDPOINT = process.env.WS_ENDPOINT ?? "ws://127.0.0.1:9944";
+const PAGE_SIZE = Number(process.env.STAKING_HOTKEYS_PAGE_SIZE ?? 1000);
+const MIGRATION_TIMEOUT_MS = Number(process.env.STAKING_HOTKEYS_MIGRATION_TIMEOUT_MS ?? 30 * 60_000);
+const MIGRATION_NAME = new TextEncoder().encode("migrate_cleanup_staking_hotkeys");
+const logger = createTempLogger("staking-hotkeys-cleanup-migration.log");
+
+async function main() {
+  await logger.start();
+  const api = await connectApi(WS_ENDPOINT, { log: (...args) => logger.info(...args) });
+
+  try {
+    assert.ok(
+      api.query.subtensorModule?.hasMigrationRun,
+      "SubtensorModule.HasMigrationRun is not available",
+    );
+    assert.ok(api.query.subtensorModule?.stakingHotkeys, "SubtensorModule.StakingHotkeys is not available");
+    assert.ok(api.query.subtensorModule?.alpha, "SubtensorModule.Alpha is not available");
+    assert.ok(api.query.subtensorModule?.alphaV2, "SubtensorModule.AlphaV2 is not available");
+    assert.ok(api.query.subtensorModule?.basketClaimed, "SubtensorModule.BasketClaimed is not available");
+
+    const startHeader = await api.rpc.chain.getHeader();
+    await logger.info(`migration_wait_start_block=${startHeader.number.toString()}`);
+    await waitForMigration(api);
+
+    // Freeze every paged query at one post-migration block so the audit cannot combine state
+    // from different blocks while the accelerated clone continues sealing.
+    const header = await api.rpc.chain.getHeader();
+    const blockHash = await api.rpc.chain.getBlockHash(header.number.unwrap());
+    const apiAt = await api.at(blockHash);
+    await logger.info(`audit_block=${header.number.toString()}`);
+    await logger.info(`audit_block_hash=${blockHash.toString()}`);
+
+    const stakedPairs = new Set<string>();
+    const alphaStats = await collectNonzeroPairs(apiAt.query.subtensorModule.alpha, stakedPairs, "Alpha");
+    const alphaV2Stats = await collectNonzeroPairs(
+      apiAt.query.subtensorModule.alphaV2,
+      stakedPairs,
+      "AlphaV2",
+    );
+
+    const basketPairs = new Set<string>();
+    const basketStats = await collectNonzeroPairs(
+      apiAt.query.subtensorModule.basketClaimed,
+      basketPairs,
+      "BasketClaimed",
+    );
+
+    let rows = 0;
+    let relationships = 0;
+    let relationshipsWithStake = 0;
+    let basketProtectedWithoutStake = 0;
+    let staleRelationships = 0;
+    let emptyRows = 0;
+    const staleExamples: string[] = [];
+
+    await forEachEntry(apiAt.query.subtensorModule.stakingHotkeys, "StakingHotkeys", async ([key, value]) => {
+      const coldkey = key.args[0].toString();
+      const hotkeys = value as unknown as Iterable<{ toString(): string }>;
+      let rowRelationships = 0;
+      rows += 1;
+
+      for (const hotkeyCodec of hotkeys) {
+        const hotkey = hotkeyCodec.toString();
+        const pair = pairKey(hotkey, coldkey);
+        rowRelationships += 1;
+        relationships += 1;
+
+        if (stakedPairs.has(pair)) {
+          relationshipsWithStake += 1;
+        } else if (basketPairs.has(pair)) {
+          basketProtectedWithoutStake += 1;
+        } else {
+          staleRelationships += 1;
+          if (staleExamples.length < 20) {
+            staleExamples.push(`${coldkey}|${hotkey}`);
+          }
+        }
+      }
+
+      if (rowRelationships === 0) {
+        emptyRows += 1;
+      }
+    });
+
+    await logger.info(`staking_hotkeys_rows=${rows}`);
+    await logger.info(`staking_hotkeys_relationships=${relationships}`);
+    await logger.info(`relationships_with_nonzero_stake=${relationshipsWithStake}`);
+    await logger.info(`basket_protected_without_stake=${basketProtectedWithoutStake}`);
+    await logger.info(`stale_relationships_without_stake_or_basket=${staleRelationships}`);
+    await logger.info(`empty_staking_hotkeys_rows=${emptyRows}`);
+    await logger.info(`stale_examples=${JSON.stringify(staleExamples)}`);
+    await logger.info(`alpha_rows=${alphaStats.rows} alpha_zero_rows=${alphaStats.zeroRows}`);
+    await logger.info(`alpha_v2_rows=${alphaV2Stats.rows} alpha_v2_zero_rows=${alphaV2Stats.zeroRows}`);
+    await logger.info(
+      `basket_claimed_rows=${basketStats.rows} basket_claimed_zero_rows=${basketStats.zeroRows}`,
+    );
+
+    assert.equal(
+      staleRelationships,
+      0,
+      `found ${staleRelationships} StakingHotkeys relationships with neither stake nor basket state`,
+    );
+    assert.equal(emptyRows, 0, `found ${emptyRows} empty StakingHotkeys rows`);
+  } finally {
+    await api.disconnect();
+    await logger.flush();
+  }
+}
+
+async function waitForMigration(api) {
+  const deadline = Date.now() + MIGRATION_TIMEOUT_MS;
+  let lastLoggedBlock = -1;
+
+  while (Date.now() < deadline) {
+    const [completed, header] = await Promise.all([
+      api.query.subtensorModule.hasMigrationRun(MIGRATION_NAME),
+      api.rpc.chain.getHeader(),
+    ]);
+    const block = header.number.toNumber();
+
+    if (completed.isTrue) {
+      await logger.info(`migration_completed_block=${block}`);
+      return;
+    }
+
+    if (lastLoggedBlock < 0 || block - lastLoggedBlock >= 100) {
+      await logger.info(`migration_pending_block=${block}`);
+      lastLoggedBlock = block;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+
+  throw new Error(`migration did not complete within ${MIGRATION_TIMEOUT_MS}ms`);
+}
+
+async function collectNonzeroPairs(query, destination: Set<string>, label: string) {
+  let rows = 0;
+  let zeroRows = 0;
+
+  await forEachEntry(query, label, async ([key, value]) => {
+    rows += 1;
+    if (codecIsZero(value)) {
+      zeroRows += 1;
+      return;
+    }
+
+    const hotkey = key.args[0].toString();
+    const coldkey = key.args[1].toString();
+    destination.add(pairKey(hotkey, coldkey));
+  });
+
+  return { rows, zeroRows };
+}
+
+async function forEachEntry(query, label: string, visit: (entry: any) => Promise<void>) {
+  let startKey;
+  let pages = 0;
+  let entriesSeen = 0;
+
+  for (;;) {
+    const entries = await query.entriesPaged({ args: [], pageSize: PAGE_SIZE, startKey });
+    if (entries.length === 0) {
+      break;
+    }
+
+    pages += 1;
+    for (const entry of entries) {
+      await visit(entry);
+      entriesSeen += 1;
+    }
+    startKey = entries.at(-1)[0];
+
+    if (pages === 1 || pages % 100 === 0) {
+      await logger.info(`${label}_progress_pages=${pages} entries=${entriesSeen}`);
+    }
+  }
+
+  await logger.info(`${label}_scan_complete_pages=${pages} entries=${entriesSeen}`);
+}
+
+function pairKey(hotkey: string, coldkey: string): string {
+  return `${hotkey}|${coldkey}`;
+}
+
+function codecIsZero(codec): boolean {
+  const json = codec.toJSON();
+  if (json && typeof json === "object" && "mantissa" in json) {
+    return BigInt(json.mantissa) === 0n;
+  }
+  if (typeof codec.toBigInt === "function") {
+    return codec.toBigInt() === 0n;
+  }
+  return BigInt(codec.toString()) === 0n;
+}
+
+main().catch(async (error) => {
+  await logger.error(error);
+  await logger.flush();
+  process.exit(1);
+});

--- a/pallets/subtensor/src/benchmarks/benchmarks.rs
+++ b/pallets/subtensor/src/benchmarks/benchmarks.rs
@@ -906,6 +906,10 @@ mod pallet_benchmarks {
             netuid,
             alpha_to_move,
         );
+
+        let staking_hotkeys = StakingHotkeys::<T>::get(&coldkey);
+        assert!(!staking_hotkeys.contains(&origin));
+        assert!(staking_hotkeys.contains(&destination));
     }
 
     #[benchmark]
@@ -952,7 +956,10 @@ mod pallet_benchmarks {
             staked_amt
         ));
 
-        let amount_unstaked = AlphaBalance::from(30_000_000_000_u64);
+        // Remove the complete relationship so the benchmark includes the
+        // StakingHotkeys cleanup path.
+        let amount_unstaked =
+            Subtensor::<T>::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
 
         #[extrinsic_call]
         _(
@@ -961,6 +968,8 @@ mod pallet_benchmarks {
             netuid,
             amount_unstaked,
         );
+
+        assert!(!StakingHotkeys::<T>::contains_key(&coldkey));
     }
 
     #[benchmark]
@@ -1006,13 +1015,12 @@ mod pallet_benchmarks {
             staked_amt
         ));
 
-        let amount_unstaked = AlphaBalance::from(30_000_000_000_u64);
-
-        let current_price = T::SwapInterface::current_alpha_price(netuid);
-        let limit = current_price
-            .saturating_mul(U64F64::saturating_from_num(999_900_000))
-            .saturating_to_num::<u64>()
-            .into();
+        // Remove the complete relationship so the benchmark includes the
+        // StakingHotkeys cleanup path. A permissive limit keeps this on the
+        // successful full-fill path.
+        let amount_unstaked =
+            Subtensor::<T>::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid);
+        let limit = T::SwapInterface::min_price();
 
         #[extrinsic_call]
         _(
@@ -1023,6 +1031,8 @@ mod pallet_benchmarks {
             limit,
             true,
         );
+
+        assert!(!StakingHotkeys::<T>::contains_key(&coldkey));
     }
 
     #[benchmark]
@@ -1050,9 +1060,7 @@ mod pallet_benchmarks {
 
         let amount = TaoBalance::from(900_000_000_000_u64);
         let limit_stake = TaoBalance::from(6_000_000_000_u64);
-        let limit_swap = TaoBalance::from(1_000_000_000_u64);
         let amount_to_be_staked = TaoBalance::from(440_000_000_000_u64);
-        let amount_swapped = AlphaBalance::from(30_000_000_000_u64);
         add_balance_to_coldkey_account::<T>(&coldkey.clone(), amount);
         add_lock::<T>(&coldkey, netuid1);
         add_lock::<T>(&coldkey, netuid2);
@@ -1077,6 +1085,12 @@ mod pallet_benchmarks {
             allow
         ));
 
+        // Swap the complete origin relationship so the benchmark includes
+        // its cleanup before the destination stake recreates it.
+        let amount_swapped =
+            Subtensor::<T>::get_stake_for_hotkey_and_coldkey_on_subnet(&hot, &coldkey, netuid1);
+        let limit_swap = TaoBalance::ZERO;
+
         #[extrinsic_call]
         _(
             RawOrigin::Signed(coldkey.clone()),
@@ -1086,6 +1100,11 @@ mod pallet_benchmarks {
             amount_swapped,
             limit_swap,
             allow,
+        );
+
+        assert!(
+            Subtensor::<T>::get_stake_for_hotkey_and_coldkey_on_subnet(&hot, &coldkey, netuid1,)
+                .is_zero()
         );
     }
 
@@ -1138,6 +1157,9 @@ mod pallet_benchmarks {
             netuid,
             alpha_to_transfer,
         );
+
+        assert!(!StakingHotkeys::<T>::contains_key(&coldkey));
+        assert!(StakingHotkeys::<T>::get(&dest).contains(&hot));
     }
 
     #[benchmark]
@@ -1191,6 +1213,9 @@ mod pallet_benchmarks {
             netuid,
             alpha_to_transfer,
         );
+
+        assert!(!StakingHotkeys::<T>::contains_key(&coldkey));
+        assert!(StakingHotkeys::<T>::get(&dest).contains(&dest_hot));
     }
 
     #[benchmark]
@@ -1332,6 +1357,11 @@ mod pallet_benchmarks {
             netuid1,
             netuid2,
             alpha_to_swap,
+        );
+
+        assert!(
+            Subtensor::<T>::get_stake_for_hotkey_and_coldkey_on_subnet(&hot, &coldkey, netuid1,)
+                .is_zero()
         );
     }
 
@@ -1747,6 +1777,8 @@ mod pallet_benchmarks {
             netuid,
             Some(limit),
         );
+
+        assert!(!StakingHotkeys::<T>::contains_key(&coldkey));
     }
 
     #[benchmark]

--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -211,7 +211,10 @@ mod hooks {
                 .saturating_add(migrations::migrate_backfill_historical_alpha_burned::migrate_backfill_historical_alpha_burned::<T>())
                 // Schedule the large storage-GC sweep. Actual work is bounded by the remaining
                 // on_idle weight over subsequent blocks.
-                .saturating_add(migrations::migrate_storage_bloat_v2::kickoff_storage_bloat_cleanup::<T>());
+                .saturating_add(migrations::migrate_storage_bloat_v2::kickoff_storage_bloat_cleanup::<T>())
+                // Schedule stale StakingHotkeys relationship cleanup. It runs after storage GC
+                // and uses only otherwise-unused on_idle weight; normal operations stay enabled.
+                .saturating_add(migrations::migrate_cleanup_staking_hotkeys::kickoff_staking_hotkeys_cleanup::<T>());
             weight
         }
 
@@ -259,6 +262,27 @@ mod hooks {
                     migrations::migrate_storage_bloat_v2::continue_storage_bloat_cleanup::<T>(
                         limit.saturating_sub(weight),
                     ),
+                );
+            }
+
+            // StakingHotkeys cleanup depends on storage GC having removed zero legacy Alpha rows.
+            // It is otherwise independent and does not block or gate any runtime operation.
+            let storage_bloat_cursor_read = T::DbWeight::get().reads(1);
+            let storage_bloat_in_progress = if !seed_in_progress
+                && weight
+                    .saturating_add(storage_bloat_cursor_read)
+                    .all_lt(limit)
+            {
+                weight.saturating_accrue(storage_bloat_cursor_read);
+                migrations::migrate_storage_bloat_v2::StorageBloatCleanupMigration::<T>::exists()
+            } else {
+                true
+            };
+            if !seed_in_progress && !storage_bloat_in_progress && weight.all_lt(limit) {
+                weight.saturating_accrue(
+                    migrations::migrate_cleanup_staking_hotkeys::continue_staking_hotkeys_cleanup::<
+                        T,
+                    >(limit.saturating_sub(weight)),
                 );
             }
 

--- a/pallets/subtensor/src/migrations/migrate_cleanup_staking_hotkeys.rs
+++ b/pallets/subtensor/src/migrations/migrate_cleanup_staking_hotkeys.rs
@@ -1,0 +1,249 @@
+use super::*;
+use codec::{Decode, DecodeWithMemTracking, Encode};
+use frame_support::{storage_alias, traits::Get, weights::Weight};
+use scale_info::TypeInfo;
+use scale_info::prelude::string::String;
+use sp_std::collections::btree_set::BTreeSet;
+use sp_std::vec::Vec;
+
+pub const MIGRATION_NAME: &[u8] = b"migrate_cleanup_staking_hotkeys";
+
+/// Persistent progress for the bounded `StakingHotkeys` cleanup.
+///
+/// The current row's hotkeys are stored as independent candidates so a pass can remove a
+/// bounded subset from the latest on-chain vector. This avoids overwriting hotkeys added by
+/// normal staking operations while the migration is running.
+#[derive(Encode, Decode, DecodeWithMemTracking, Clone, PartialEq, Eq, Debug, TypeInfo)]
+pub struct StakingHotkeysCleanupProgress {
+    /// Hashed key of the last fully processed `StakingHotkeys` row.
+    pub after: Option<Vec<u8>>,
+    /// SCALE-encoded coldkey for a row that is only partially processed.
+    pub coldkey: Option<Vec<u8>>,
+    /// SCALE-encoded hotkeys from that row which still need classification.
+    pub remaining_hotkeys: Vec<Vec<u8>>,
+    pub rows_scanned: u64,
+    pub relationships_scanned: u64,
+    pub relationships_removed: u64,
+    pub vector_writes: u64,
+}
+
+#[storage_alias]
+pub type StakingHotkeysCleanupMigration<T: Config> =
+    StorageValue<Pallet<T>, StakingHotkeysCleanupProgress, OptionQuery>;
+
+fn candidate_weight<T: Config>() -> Weight {
+    // One prefix probe in each share map plus one BasketClaimed read. The predicate may
+    // short-circuit, but charging all three reads keeps each candidate conservatively bounded.
+    T::DbWeight::get().reads(3)
+}
+
+fn vector_rewrite_weight<T: Config>() -> Weight {
+    T::DbWeight::get().reads_writes(1, 1)
+}
+
+fn row_load_weight<T: Config>() -> Weight {
+    // Iterating the next StakingHotkeys row performs one backend read.
+    T::DbWeight::get().reads(1)
+}
+
+/// A conservative keep predicate for one hotkey/coldkey relationship.
+///
+/// Any stored share row is retained, including a zero-valued legacy row. The storage-bloat
+/// migration runs first and clears zero legacy rows, while treating an unexpected remaining row
+/// as live makes this cleanup fail safe. A basket watermark is also sufficient to retain the
+/// relationship because zero-root-stake claimants still need to be discoverable by claims and
+/// coldkey swaps.
+fn relationship_must_remain<T: Config>(hotkey: &T::AccountId, coldkey: &T::AccountId) -> bool {
+    AlphaV2::<T>::iter_prefix((hotkey, coldkey))
+        .next()
+        .is_some()
+        || Alpha::<T>::iter_prefix((hotkey, coldkey)).next().is_some()
+        || BasketClaimed::<T>::get(hotkey, coldkey) != 0
+}
+
+/// Starts the cleanup without scanning `StakingHotkeys` in the runtime-upgrade block.
+pub fn kickoff_staking_hotkeys_cleanup<T: Config>() -> Weight {
+    let mut weight = T::DbWeight::get().reads(2);
+    if HasMigrationRun::<T>::get(MIGRATION_NAME) || StakingHotkeysCleanupMigration::<T>::exists() {
+        return weight;
+    }
+
+    StakingHotkeysCleanupMigration::<T>::put(StakingHotkeysCleanupProgress {
+        after: None,
+        coldkey: None,
+        remaining_hotkeys: Vec::new(),
+        rows_scanned: 0,
+        relationships_scanned: 0,
+        relationships_removed: 0,
+        vector_writes: 0,
+    });
+    weight.saturating_accrue(T::DbWeight::get().writes(1));
+    log::info!(
+        "Migration '{}' scheduled for bounded on_idle execution",
+        String::from_utf8_lossy(MIGRATION_NAME)
+    );
+    weight
+}
+
+/// Continues the cleanup without exceeding `limit`.
+///
+/// Normal operations remain enabled. Each batch removes candidates from the latest stored
+/// vector, so stake or hotkeys added between passes are never overwritten by an old snapshot.
+pub fn continue_staking_hotkeys_cleanup<T: Config>(limit: Weight) -> Weight {
+    // Cursor read plus either cursor persistence, or completion marker + cursor removal.
+    let pass_overhead = T::DbWeight::get().reads_writes(1, 2);
+    if !pass_overhead.all_lte(limit) {
+        return Weight::zero();
+    }
+
+    let Some(mut progress) = StakingHotkeysCleanupMigration::<T>::get() else {
+        return T::DbWeight::get().reads(1);
+    };
+    let work_limit = limit.saturating_sub(pass_overhead);
+    let mut work_weight = Weight::zero();
+    let mut finished = false;
+
+    loop {
+        if progress.coldkey.is_none() {
+            // Reserve a possible write as well: an encoded empty vector is removed immediately
+            // after it is read, without carrying an ambiguous empty-row cursor across blocks.
+            let row_load_reserve =
+                row_load_weight::<T>().saturating_add(T::DbWeight::get().writes(1));
+            if !work_weight
+                .saturating_add(row_load_reserve)
+                .all_lte(work_limit)
+            {
+                break;
+            }
+
+            // Drop the iterator before this row can be mutated below. Altering a map while one
+            // of its iterators is alive has undefined iteration results.
+            let next = {
+                let mut iter = match progress.after.as_ref() {
+                    Some(raw) => StakingHotkeys::<T>::iter_from(raw.clone()),
+                    None => StakingHotkeys::<T>::iter(),
+                };
+                iter.next()
+            };
+            work_weight.saturating_accrue(row_load_weight::<T>());
+
+            let Some((coldkey, hotkeys)) = next else {
+                finished = true;
+                break;
+            };
+
+            if hotkeys.is_empty() {
+                let empty_row_write = T::DbWeight::get().writes(1);
+                StakingHotkeys::<T>::remove(&coldkey);
+                work_weight.saturating_accrue(empty_row_write);
+                progress.after = Some(StakingHotkeys::<T>::hashed_key_for(&coldkey));
+                progress.rows_scanned = progress.rows_scanned.saturating_add(1);
+                progress.vector_writes = progress.vector_writes.saturating_add(1);
+                continue;
+            }
+
+            progress.coldkey = Some(coldkey.encode());
+            progress.remaining_hotkeys =
+                hotkeys.into_iter().map(|hotkey| hotkey.encode()).collect();
+        }
+
+        let Some(encoded_coldkey) = progress.coldkey.as_ref() else {
+            continue;
+        };
+        let Ok(coldkey) = T::AccountId::decode(&mut &encoded_coldkey[..]) else {
+            log::error!(
+                "Migration '{}' found an undecodable coldkey cursor; stopping this pass",
+                String::from_utf8_lossy(MIGRATION_NAME)
+            );
+            break;
+        };
+
+        // Reserve enough room to rewrite the current vector if any processed candidate is stale.
+        let rewrite_weight = vector_rewrite_weight::<T>();
+        let mut removals: BTreeSet<T::AccountId> = BTreeSet::new();
+        let mut processed_any = false;
+
+        while let Some(encoded_hotkey) = progress.remaining_hotkeys.last() {
+            if !work_weight
+                .saturating_add(candidate_weight::<T>())
+                .saturating_add(rewrite_weight)
+                .all_lte(work_limit)
+            {
+                break;
+            }
+
+            let encoded_hotkey = encoded_hotkey.clone();
+            progress.remaining_hotkeys.pop();
+            let Ok(hotkey) = T::AccountId::decode(&mut &encoded_hotkey[..]) else {
+                // The candidate came from a successfully decoded StakingHotkeys vector. If the
+                // persisted cursor is ever corrupted, preserving this relationship is safer than
+                // deleting an account we cannot identify.
+                log::error!(
+                    "Migration '{}' found an undecodable hotkey candidate; preserving it",
+                    String::from_utf8_lossy(MIGRATION_NAME)
+                );
+                processed_any = true;
+                progress.relationships_scanned = progress.relationships_scanned.saturating_add(1);
+                work_weight.saturating_accrue(candidate_weight::<T>());
+                continue;
+            };
+
+            if !relationship_must_remain::<T>(&hotkey, &coldkey) {
+                removals.insert(hotkey);
+            }
+            processed_any = true;
+            progress.relationships_scanned = progress.relationships_scanned.saturating_add(1);
+            work_weight.saturating_accrue(candidate_weight::<T>());
+        }
+
+        if !removals.is_empty() {
+            let mut removed = 0_u64;
+            StakingHotkeys::<T>::mutate_exists(&coldkey, |maybe_hotkeys| {
+                if let Some(hotkeys) = maybe_hotkeys {
+                    let before = hotkeys.len();
+                    hotkeys.retain(|hotkey| !removals.contains(hotkey));
+                    removed =
+                        u64::try_from(before.saturating_sub(hotkeys.len())).unwrap_or(u64::MAX);
+                    if hotkeys.is_empty() {
+                        *maybe_hotkeys = None;
+                    }
+                }
+            });
+            work_weight.saturating_accrue(rewrite_weight);
+            progress.relationships_removed = progress.relationships_removed.saturating_add(removed);
+            progress.vector_writes = progress.vector_writes.saturating_add(1);
+        }
+
+        if progress.remaining_hotkeys.is_empty() {
+            progress.after = Some(StakingHotkeys::<T>::hashed_key_for(&coldkey));
+            progress.coldkey = None;
+            progress.rows_scanned = progress.rows_scanned.saturating_add(1);
+            continue;
+        }
+
+        if !processed_any {
+            break;
+        }
+
+        // The current row was only partially classified. Persist its remaining candidates and
+        // resume from the latest vector on the next idle pass.
+        break;
+    }
+
+    if finished {
+        HasMigrationRun::<T>::insert(MIGRATION_NAME, true);
+        StakingHotkeysCleanupMigration::<T>::kill();
+        log::info!(
+            "Migration '{}' completed: scanned {} rows / {} relationships, removed {} relationships with {} vector writes",
+            String::from_utf8_lossy(MIGRATION_NAME),
+            progress.rows_scanned,
+            progress.relationships_scanned,
+            progress.relationships_removed,
+            progress.vector_writes,
+        );
+    } else {
+        StakingHotkeysCleanupMigration::<T>::put(progress);
+    }
+
+    pass_overhead.saturating_add(work_weight)
+}

--- a/pallets/subtensor/src/migrations/mod.rs
+++ b/pallets/subtensor/src/migrations/mod.rs
@@ -7,6 +7,7 @@ use sp_io::storage::clear_prefix;
 pub mod migrate_associated_evm_address_index;
 pub mod migrate_auto_stake_destination;
 pub mod migrate_backfill_historical_alpha_burned;
+pub mod migrate_cleanup_staking_hotkeys;
 pub mod migrate_cleanup_swap_v3;
 pub mod migrate_clear_deprecated_registration_maps;
 pub mod migrate_clear_orphan_subnet_identities_v3;

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -634,6 +634,27 @@ impl<T: Config> Pallet<T> {
         }
     }
 
+    /// Remove a staking-hotkey association once the pair has no stake left anywhere.
+    ///
+    /// A non-zero basket watermark also keeps the association alive. In particular, an
+    /// unstaked root claimant can have a negative watermark representing basket shares that
+    /// still need to be claimed or moved during a coldkey swap.
+    pub(crate) fn maybe_remove_staking_hotkey(hotkey: &T::AccountId, coldkey: &T::AccountId) {
+        let has_stake = Self::alpha_iter_prefix((hotkey, coldkey)).next().is_some();
+        if has_stake || BasketClaimed::<T>::get(hotkey, coldkey) != 0 {
+            return;
+        }
+
+        StakingHotkeys::<T>::mutate_exists(coldkey, |maybe_hotkeys| {
+            if let Some(hotkeys) = maybe_hotkeys {
+                hotkeys.retain(|staking_hotkey| staking_hotkey != hotkey);
+                if hotkeys.is_empty() {
+                    *maybe_hotkeys = None;
+                }
+            }
+        });
+    }
+
     /// Swaps TAO for the alpha token on the subnet.
     ///
     /// Updates TaoIn, AlphaIn, and AlphaOut
@@ -868,13 +889,7 @@ impl<T: Config> Pallet<T> {
             }
         }
 
-        // Step 3: Update StakingHotkeys if the hotkey's total alpha, across all subnets, is zero
-        // TODO const: fix.
-        // if Self::get_stake(hotkey, coldkey) == 0 {
-        //     StakingHotkeys::<T>::mutate(coldkey, |hotkeys| {
-        //         hotkeys.retain(|k| k != hotkey);
-        //     });
-        // }
+        Self::maybe_remove_staking_hotkey(hotkey, coldkey);
 
         // Record TAO outflow
         Self::record_tao_outflow(
@@ -1124,13 +1139,7 @@ impl<T: Config> Pallet<T> {
             Error::<T>::AmountTooLow
         );
 
-        // Step 3: Update StakingHotkeys if the hotkey's total alpha, across all subnets, is zero
-        // TODO: fix.
-        // if Self::get_stake(hotkey, coldkey) == 0 {
-        //     StakingHotkeys::<T>::mutate(coldkey, |hotkeys| {
-        //         hotkeys.retain(|k| k != hotkey);
-        //     });
-        // }
+        Self::maybe_remove_staking_hotkey(origin_hotkey, origin_coldkey);
 
         if netuid.is_root() {
             Self::touch_root_stake_age(destination_coldkey, destination_hotkey);

--- a/pallets/subtensor/src/tests/locks.rs
+++ b/pallets/subtensor/src/tests/locks.rs
@@ -2218,6 +2218,9 @@ fn test_do_transfer_stake_same_subnet_transfers_lock_to_destination_coldkey() {
             transfer_amount,
         ));
 
+        assert!(!StakingHotkeys::<Test>::contains_key(coldkey_sender));
+        assert_eq!(StakingHotkeys::<Test>::get(coldkey_receiver), vec![hotkey]);
+
         let expected_sender_lock = roll_forward_lock(
             sender_lock_before,
             SubtensorModule::get_current_block_as_u64(),

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -7104,3 +7104,116 @@ fn test_storage_bloat_cleanup_preserves_root_age_when_hold_is_enabled() {
         );
     });
 }
+
+#[test]
+fn test_staking_hotkeys_cleanup_is_bounded_and_preserves_live_relationships() {
+    use crate::migrations::migrate_cleanup_staking_hotkeys::{
+        MIGRATION_NAME, StakingHotkeysCleanupMigration, continue_staking_hotkeys_cleanup,
+        kickoff_staking_hotkeys_cleanup,
+    };
+
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(100);
+        let all_stale_coldkey = U256::from(101);
+        let empty_coldkey = U256::from(102);
+        let stale = U256::from(200);
+        let legacy = U256::from(201);
+        let v2 = U256::from(202);
+        let basket = U256::from(203);
+        let other_stale = U256::from(204);
+        let netuid = NetUid::from(1);
+
+        StakingHotkeys::<Test>::insert(coldkey, vec![stale, legacy, v2, basket]);
+        StakingHotkeys::<Test>::insert(all_stale_coldkey, vec![other_stale]);
+        StakingHotkeys::<Test>::insert(empty_coldkey, Vec::<U256>::new());
+        Alpha::<Test>::insert((legacy, coldkey, netuid), U64F64::from_num(1));
+        AlphaV2::<Test>::insert((v2, coldkey, netuid), share_pool::SafeFloat::from(1_u64));
+        BasketClaimed::<Test>::insert(basket, coldkey, -1);
+
+        let kickoff_weight = kickoff_staking_hotkeys_cleanup::<Test>();
+        assert!(!kickoff_weight.is_zero());
+        assert!(StakingHotkeysCleanupMigration::<Test>::exists());
+
+        let before_tiny_pass = StakingHotkeysCleanupMigration::<Test>::get().unwrap();
+        let tiny_limit = <Test as Config>::DbWeight::get().reads_writes(1, 1);
+        assert!(continue_staking_hotkeys_cleanup::<Test>(tiny_limit).is_zero());
+        assert_eq!(
+            StakingHotkeysCleanupMigration::<Test>::get().unwrap(),
+            before_tiny_pass,
+            "a pass below fixed overhead must not advance the cursor"
+        );
+
+        // This budget admits at most one relationship plus a possible vector rewrite per pass.
+        let limit = <Test as Config>::DbWeight::get().reads_writes(6, 3);
+        let mut passes = 0;
+        while StakingHotkeysCleanupMigration::<Test>::exists() {
+            let used = continue_staking_hotkeys_cleanup::<Test>(limit);
+            assert!(used.all_lte(limit));
+            passes += 1;
+            assert!(passes < 20, "bounded cleanup did not converge");
+        }
+
+        assert!(passes > 1, "test must exercise resumable progress");
+        assert_eq!(
+            StakingHotkeys::<Test>::get(coldkey),
+            vec![legacy, v2, basket]
+        );
+        assert!(!StakingHotkeys::<Test>::contains_key(all_stale_coldkey));
+        assert!(!StakingHotkeys::<Test>::contains_key(empty_coldkey));
+        assert!(HasMigrationRun::<Test>::get(MIGRATION_NAME));
+
+        // Completion is idempotent across later runtime upgrades.
+        kickoff_staking_hotkeys_cleanup::<Test>();
+        assert!(!StakingHotkeysCleanupMigration::<Test>::exists());
+    });
+}
+
+#[test]
+fn test_staking_hotkeys_cleanup_preserves_stake_added_between_passes() {
+    use crate::migrations::migrate_cleanup_staking_hotkeys::{
+        StakingHotkeysCleanupMigration, continue_staking_hotkeys_cleanup,
+        kickoff_staking_hotkeys_cleanup,
+    };
+
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(300);
+        let revived = U256::from(400);
+        let stale_one = U256::from(401);
+        let stale_two = U256::from(402);
+        let added_later = U256::from(403);
+        let netuid = NetUid::from(1);
+
+        StakingHotkeys::<Test>::insert(coldkey, vec![revived, stale_one, stale_two]);
+        kickoff_staking_hotkeys_cleanup::<Test>();
+
+        let limit = <Test as Config>::DbWeight::get().reads_writes(6, 3);
+        let first_used = continue_staking_hotkeys_cleanup::<Test>(limit);
+        assert!(first_used.all_lte(limit));
+        assert!(StakingHotkeysCleanupMigration::<Test>::exists());
+
+        // Both a snapshotted candidate and a newly appended relationship become live while the
+        // migration cursor is paused. Neither may be overwritten by the old row snapshot.
+        AlphaV2::<Test>::insert(
+            (revived, coldkey, netuid),
+            share_pool::SafeFloat::from(1_u64),
+        );
+        AlphaV2::<Test>::insert(
+            (added_later, coldkey, netuid),
+            share_pool::SafeFloat::from(1_u64),
+        );
+        StakingHotkeys::<Test>::mutate(coldkey, |hotkeys| hotkeys.push(added_later));
+
+        let mut passes = 0;
+        while StakingHotkeysCleanupMigration::<Test>::exists() {
+            let used = continue_staking_hotkeys_cleanup::<Test>(limit);
+            assert!(used.all_lte(limit));
+            passes += 1;
+            assert!(passes < 20, "bounded cleanup did not converge");
+        }
+
+        assert_eq!(
+            StakingHotkeys::<Test>::get(coldkey),
+            vec![revived, added_later]
+        );
+    });
+}

--- a/pallets/subtensor/src/tests/staking.rs
+++ b/pallets/subtensor/src/tests/staking.rs
@@ -4777,6 +4777,7 @@ fn test_unstake_from_subnet_low_amount() {
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &coldkey, netuid),
             AlphaBalance::ZERO,
         );
+        assert!(!StakingHotkeys::<Test>::contains_key(coldkey));
     });
 }
 
@@ -5128,6 +5129,79 @@ fn test_increase_stake_for_hotkey_and_coldkey_on_subnet_adds_to_staking_hotkeys_
         assert!(StakingHotkeys::<Test>::contains_key(coldkey1));
         // check entry has hotkey
         assert!(StakingHotkeys::<Test>::get(coldkey1).contains(&hotkey));
+    });
+}
+
+#[test]
+fn test_maybe_remove_staking_hotkey_only_removes_empty_relationships() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let other_hotkey = U256::from(3);
+        let first_netuid = NetUid::from(1);
+        let second_netuid = NetUid::from(2);
+        let stake = AlphaBalance::from(100_000_u64);
+
+        SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey,
+            &coldkey,
+            first_netuid,
+            stake,
+        );
+        SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey,
+            &coldkey,
+            second_netuid,
+            stake,
+        );
+        SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &other_hotkey,
+            &coldkey,
+            first_netuid,
+            stake,
+        );
+
+        SubtensorModule::decrease_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey,
+            &coldkey,
+            first_netuid,
+            stake,
+        );
+        SubtensorModule::maybe_remove_staking_hotkey(&hotkey, &coldkey);
+        assert!(StakingHotkeys::<Test>::get(coldkey).contains(&hotkey));
+
+        SubtensorModule::decrease_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey,
+            &coldkey,
+            second_netuid,
+            stake,
+        );
+        SubtensorModule::maybe_remove_staking_hotkey(&hotkey, &coldkey);
+        assert_eq!(StakingHotkeys::<Test>::get(coldkey), vec![other_hotkey]);
+
+        SubtensorModule::decrease_stake_for_hotkey_and_coldkey_on_subnet(
+            &other_hotkey,
+            &coldkey,
+            first_netuid,
+            stake,
+        );
+        SubtensorModule::maybe_remove_staking_hotkey(&other_hotkey, &coldkey);
+        assert!(!StakingHotkeys::<Test>::contains_key(coldkey));
+    });
+}
+
+#[test]
+fn test_maybe_remove_staking_hotkey_preserves_basket_claimant() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+
+        StakingHotkeys::<Test>::insert(coldkey, vec![hotkey]);
+        BasketClaimed::<Test>::insert(hotkey, coldkey, -1);
+
+        SubtensorModule::maybe_remove_staking_hotkey(&hotkey, &coldkey);
+
+        assert_eq!(StakingHotkeys::<Test>::get(coldkey), vec![hotkey]);
     });
 }
 


### PR DESCRIPTION
## Summary

Clean up stale `StakingHotkeys` associations when a hotkey/coldkey pair no longer has stake.

## Changes

- Added `maybe_remove_staking_hotkey`.
- Invoked cleanup after:
  - Fully unstaking from a subnet.
  - Transferring stake within a subnet.
- Retain associations when:
  - The pair still has stake on another subnet.
  - A nonzero basket watermark must remain discoverable for claims or coldkey swaps.
- Remove the storage map entry when its hotkey vector becomes empty.
- Added unit and integration coverage for unstaking, transfers, multi-subnet stake, and basket claimants.

## Testing

```text
cargo test --package pallet-subtensor --lib

1438 passed
9 ignored
0 failed
```

`cargo fmt --all -- --check` and `git diff --check` also pass.