### PR TITLE
Add all-hotkeys stake exit workflow

### DIFF
--- a/docs/guides/staking.mdx
+++ b/docs/guides/staking.mdx
@@ -51,6 +51,21 @@ Exit with [`remove-stake`](/docs/tx/remove-stake), or exit everything at once
 with [`unstake-all`](/docs/tx/unstake-all). Quote the exit the same way you
 quote the entry:
 
+```bash
+# One hotkey, across every subnet
+btcli stake unstake-all --hotkey 5F... --dry-run
+
+# Every live position held by the coldkey, across all hotkeys and subnets
+btcli stake unstake-all --all-hotkeys --dry-run
+btcli stake unstake-all --all-hotkeys -w my_coldkey
+```
+
+The multi-hotkey form discovers hotkeys from live non-zero chain positions,
+deduplicates hotkeys that appear on several subnets, and submits the resulting
+`unstake_all` calls atomically. A Staking proxy cannot wrap the required
+`Utility.batch_all` call on the current runtime; use a direct signer or a broader
+proxy type such as NonTransfer, or invoke the single-hotkey form separately.
+
 ```python
 quote = await client.prices.quote_unstake(netuid=1, amount_alpha=50)  # TAO out, fee, slippage
 await client.execute(bt.RemoveStake(hotkey_ss58="5F...", netuid=1, amount_alpha="all"), wallet)

--- a/docs/migration.mdx
+++ b/docs/migration.mdx
@@ -686,7 +686,8 @@ with exit code 1** instead of hanging; missing required options exit 2.
 | `stake add --amount` | `stake add` / `tx add-stake --amount-tao` |
 | `stake remove --amount` | `stake remove` / `tx remove-stake --amount-alpha` (accepts `all`) |
 | `stake remove --all` | `tx unstake-all` / `tx unstake-all-alpha` |
-| `stake list` / `move` / `transfer` / `swap` | same names (single hotkey per call; `--include-hotkeys`/`--exclude-hotkeys`/`--all-hotkeys` batching is gone — loop in your script) |
+| `stake remove --all --all-hotkeys` | `stake unstake-all --all-hotkeys` |
+| `stake list` / `move` / `transfer` / `swap` | same names (single hotkey per call; multi-hotkey selectors remain unavailable for these operations) |
 | `stake auto` / `set-auto` | same names |
 | `stake set-claim` / `process-claim` | `btcli root claim` / `btcli tx claim-root-with-hotkey --hotkey ...` (per-validator; `claim_root(subnets)` kept for old clients — see [Root Reborn](/docs/guides/root-reborn)) |
 | `stake child get/set/revoke/take` | same names (`child set` takes `--children` as JSON pairs) |

--- a/sdk/python/bittensor/cli/commands/stake.py
+++ b/sdk/python/bittensor/cli/commands/stake.py
@@ -25,6 +25,7 @@ from ..helpers import (
     netuid_groups,
     split_dust,
 )
+from ..stake_exit import mount_stake_exit_commands
 from ..tx import intent_command
 
 app = typer.Typer(no_args_is_help=True, help="Query and manage stake.")
@@ -45,10 +46,10 @@ for _alias, _op in (
     ("transfer", "transfer_stake"),
     ("swap", "swap_stake"),
     ("burn", "stake_burn"),
-    ("unstake-all", "unstake_all"),
-    ("unstake-all-alpha", "unstake_all_alpha"),
 ):
     app.command(_alias, rich_help_panel=PANEL_MOVE)(intent_command(_op))
+
+mount_stake_exit_commands(app, PANEL_MOVE)
 
 
 @app.command(rich_help_panel=PANEL_POSITIONS)

--- a/sdk/python/bittensor/cli/stake_exit.py
+++ b/sdk/python/bittensor/cli/stake_exit.py
@@ -1,0 +1,222 @@
+"""High-level stake exit commands built from the single-hotkey intents.
+
+The transaction catalog stays one-call-per-intent. The human-facing ``stake``
+group adds one target selector: ``--all-hotkeys`` discovers live positions and
+adapts the existing intent into an atomic batch.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import typer
+
+from .. import config as cfg
+from ..intents import Batch, UnstakeAll, UnstakeAllAlpha
+from ..intents.base import Intent
+from ..intents.proxy import ProxyTypeChoice
+from ..settings import tx_docs_url
+from .context import AppContext, address_cli_name, ctx_of, ss58_param_help
+from .globals import PANEL_EXECUTION, with_tx_globals
+from .prompt import fill_missing, interactive
+from .stake_picker import stake_source_spec
+
+
+class _StakeExitBatch(Batch):
+    """Atomic bulk exit with the same submission policy as its child intents."""
+
+    mev_shield_default = True
+
+
+def _position_kind(include_root: bool) -> str:
+    return "live non-zero position" if include_root else "live non-zero alpha position outside root"
+
+
+def _command_help(intent_cls: type[Intent], include_root: bool) -> str:
+    return (
+        f"{intent_cls.describe()}\n\n"
+        "Use `--hotkey` for one hotkey, or `--all-hotkeys` to sweep every "
+        f"hotkey with a {_position_kind(include_root)} for the coldkey. Multiple "
+        "hotkeys execute atomically in one transaction. The multi-hotkey form "
+        "cannot use a Staking proxy because that proxy type cannot wrap "
+        "Utility.batch_all on the current runtime; sign directly or use a broader "
+        "proxy type such as NonTransfer.\n\n"
+        f"Docs: {tx_docs_url(intent_cls.op)}"
+    )
+
+
+def _live_hotkeys(app_ctx: AppContext, owner: str, include_root: bool) -> list[str]:
+    positions = app_ctx.run(lambda client: client.read("stake_for_coldkey", coldkey_ss58=owner))
+    return list(
+        dict.fromkeys(
+            position.hotkey
+            for position in positions
+            if position.stake.rao > 0 and (include_root or position.netuid != 0)
+        )
+    )
+
+
+def _stake_owner(app_ctx: AppContext, proxy_for: Optional[str]) -> str:
+    """Resolve the coldkey whose live positions ``--all-hotkeys`` should sweep."""
+    effective_proxy = proxy_for
+    if effective_proxy is None:
+        configured = cfg.get("proxy_for")
+        effective_proxy = str(configured) if configured else None
+    if effective_proxy not in (None, "self"):
+        owner = app_ctx.resolve_address("proxy_for", effective_proxy)
+        if owner is not None:
+            return owner
+
+    if app_ctx.uses_external_signer():
+        signer_ref = app_ctx.signer_address or cfg.get("signer_address")
+        if signer_ref:
+            owner = app_ctx.resolve_address("coldkey_ss58", str(signer_ref))
+        elif app_ctx.uses_ledger_signer():
+            owner = app_ctx.ledger_signer().ss58_address
+        elif app_ctx.uses_vault_signer():
+            owner = app_ctx.vault_signer().ss58_address
+        else:
+            app_ctx.output.error(
+                "cannot inspect stake before selecting the extension account",
+                help="pass --signer-address or --proxy-for",
+            )
+            raise typer.Exit(2)
+        if owner is not None:
+            return owner
+
+    owner = app_ctx.resolve_address("coldkey_ss58", app_ctx.wallet_name)
+    if owner is None:
+        app_ctx.output.error(f"wallet {app_ctx.wallet_name!r} has no usable coldkey")
+        raise typer.Exit(1)
+    return owner
+
+
+def _proxy_options(
+    app_ctx: AppContext,
+    proxy_for: Optional[str],
+    force_proxy_type: Optional[ProxyTypeChoice],
+) -> tuple[Optional[str], Optional[str]]:
+    """Normalize proxy CLI values before handing them to ``AppContext.submit``."""
+    resolved_proxy = (
+        proxy_for
+        if proxy_for in (None, "self")
+        else app_ctx.resolve_address("proxy_for", proxy_for)
+    )
+    resolved_type = str(force_proxy_type.value) if force_proxy_type is not None else None
+    return resolved_proxy, resolved_type
+
+
+def _select_hotkeys(
+    app_ctx: AppContext,
+    hotkey_ss58: Optional[str],
+    all_hotkeys: bool,
+    proxy_for: Optional[str],
+    include_root: bool,
+) -> list[str]:
+    if all_hotkeys:
+        owner = _stake_owner(app_ctx, proxy_for)
+        hotkeys = _live_hotkeys(app_ctx, owner, include_root)
+        if not hotkeys:
+            kind = "stake" if include_root else "alpha stake outside root"
+            app_ctx.output.error(
+                f"coldkey {owner} has no {kind}",
+                help="`btcli stake list` shows every position",
+            )
+            raise typer.Exit(1)
+        return hotkeys
+
+    if (
+        hotkey_ss58 is None
+        and not app_ctx.assume_yes
+        and not app_ctx.uses_external_signer()
+        and interactive(app_ctx)
+    ):
+        values = {"hotkey_ss58": None, "proxy_for": proxy_for}
+        fill_missing(app_ctx, [stake_source_spec("hotkey_ss58", None)], values)
+        hotkey_ss58 = values["hotkey_ss58"]
+    resolved = app_ctx.resolve_address("hotkey_ss58", hotkey_ss58)
+    if resolved is None:
+        app_ctx.output.error(
+            "missing hotkey",
+            help="pass `--hotkey <HOTKEY>` or `--all-hotkeys`",
+        )
+        raise typer.Exit(2)
+    return [resolved]
+
+
+def _submit(
+    app_ctx: AppContext,
+    intent_cls: type[Intent],
+    include_root: bool,
+    hotkey_ss58: Optional[str],
+    all_hotkeys: bool,
+    proxy_for: Optional[str],
+    force_proxy_type: Optional[ProxyTypeChoice],
+) -> None:
+    if all_hotkeys and hotkey_ss58 is not None:
+        app_ctx.output.error("choose only one of `--hotkey` or `--all-hotkeys`")
+        raise typer.Exit(2)
+
+    resolved_proxy, resolved_proxy_type = _proxy_options(app_ctx, proxy_for, force_proxy_type)
+    hotkeys = _select_hotkeys(app_ctx, hotkey_ss58, all_hotkeys, proxy_for, include_root)
+    intents = [intent_cls.from_args({"hotkey_ss58": hotkey}) for hotkey in hotkeys]
+    intent = intents[0] if len(intents) == 1 else _StakeExitBatch(intents=intents)
+    app_ctx.submit(
+        intent,
+        proxy_for=resolved_proxy,
+        force_proxy_type=resolved_proxy_type,
+    )
+
+
+def _command(intent_cls: type[Intent], include_root: bool):
+    @with_tx_globals
+    def command(
+        ctx: typer.Context,
+        hotkey_ss58: Optional[str] = typer.Option(
+            None, address_cli_name("hotkey_ss58"), help=ss58_param_help("hotkey_ss58")
+        ),
+        all_hotkeys: bool = typer.Option(
+            False,
+            "--all-hotkeys",
+            help=f"Sweep every hotkey with a {_position_kind(include_root)} for this coldkey.",
+        ),
+        proxy_for: Optional[str] = typer.Option(
+            None,
+            "--proxy-for",
+            help=(
+                "Dispatch as this account via Proxy.proxy; pass `self` to bypass a "
+                "configured default."
+            ),
+            rich_help_panel=PANEL_EXECUTION,
+        ),
+        force_proxy_type: Optional[ProxyTypeChoice] = typer.Option(
+            None,
+            "--force-proxy-type",
+            help="Require this exact proxy type to be used (with --proxy-for).",
+            rich_help_panel=PANEL_EXECUTION,
+        ),
+    ):
+        _submit(
+            ctx_of(ctx),
+            intent_cls,
+            include_root,
+            hotkey_ss58,
+            all_hotkeys,
+            proxy_for,
+            force_proxy_type,
+        )
+
+    return command
+
+
+def mount_stake_exit_commands(app: typer.Typer, help_panel: str) -> None:
+    """Mount high-level single/all-hotkey variants on the ``stake`` group."""
+    for name, intent_cls, include_root in (
+        ("unstake-all", UnstakeAll, True),
+        ("unstake-all-alpha", UnstakeAllAlpha, False),
+    ):
+        app.command(
+            name,
+            rich_help_panel=help_panel,
+            help=_command_help(intent_cls, include_root),
+        )(_command(intent_cls, include_root))

--- a/sdk/python/tests/unit/test_cli.py
+++ b/sdk/python/tests/unit/test_cli.py
@@ -25,7 +25,7 @@ from bittensor.cli.root_helpers import RootPosition, position_columns, position_
 from bittensor.client import Client
 from bittensor.intents import REGISTRY
 from tests.harness.fake_substrate import FakeSubstrate
-from tests.harness.samples import BOB
+from tests.harness.samples import ALICE_HOT, BOB, BOB_HOT
 
 runner = CliRunner()
 
@@ -127,6 +127,17 @@ class TestOffline:
         assert result.exit_code == 0
         for op in ("add-stake", "transfer", "set-weights", "create-crowdloan"):
             assert op in result.output
+
+    def test_stake_unstake_all_exposes_bulk_selector_only_on_workflow(self):
+        result = invoke("stake", "unstake-all", "--help")
+        assert result.exit_code == 0
+        assert "--hotkey" in result.output
+        assert "--all-hotkeys" in result.output
+
+        primitive = invoke("tx", "unstake-all", "--help")
+        assert primitive.exit_code == 0
+        assert "--hotkey" in primitive.output
+        assert "--all-hotkeys" not in primitive.output
 
     def test_query_group_help(self):
         result = invoke("query", "--help")
@@ -407,6 +418,181 @@ class TestTransactions:
         call, _signer, _ = fake.submissions[-1]
         assert (call.module, call.function) == ("Balances", "transfer_keep_alive")
         assert call.params["value"] == 1_500_000_000
+
+    def test_stake_unstake_all_single_hotkey_keeps_direct_call(self, fake: FakeSubstrate):
+        result = invoke(
+            "--json",
+            "--yes",
+            "--no-mev-shield",
+            "stake",
+            "unstake-all",
+            "--hotkey",
+            BOB,
+        )
+
+        assert result.exit_code == 0, result.output
+        call = fake.last_call
+        assert (call.module, call.function) == ("SubtensorModule", "unstake_all")
+        assert call.params == {"hotkey": BOB}
+
+    @pytest.mark.parametrize(
+        ("command", "call_name", "expected_hotkeys"),
+        [
+            ("unstake-all", "unstake_all", [BOB, BOB_HOT, ALICE_HOT]),
+            ("unstake-all-alpha", "unstake_all_alpha", [BOB, ALICE_HOT]),
+        ],
+    )
+    def test_stake_unstake_all_hotkeys_batches_unique_live_positions(
+        self,
+        fake: FakeSubstrate,
+        wallet_dir: str,
+        command: str,
+        call_name: str,
+        expected_hotkeys: list[str],
+    ):
+        coldkey = wallets.open_wallet(_WALLET_NAME, "default", wallet_dir).coldkeypub.ss58_address
+        fake.seed("System", "Account", [coldkey], {"data": {"free": 2_500_000_000}})
+
+        def positions(params):
+            assert params == [coldkey]
+            return [
+                {
+                    "hotkey": BOB,
+                    "coldkey": coldkey,
+                    "netuid": 1,
+                    "stake": 1_000_000_000,
+                    "is_registered": True,
+                },
+                {
+                    "hotkey": BOB,
+                    "coldkey": coldkey,
+                    "netuid": 2,
+                    "stake": 2_000_000_000,
+                    "is_registered": True,
+                },
+                {
+                    "hotkey": BOB_HOT,
+                    "coldkey": coldkey,
+                    "netuid": 0,
+                    "stake": 4_000_000_000,
+                    "is_registered": True,
+                },
+                {
+                    "hotkey": ALICE_HOT,
+                    "coldkey": coldkey,
+                    "netuid": 4,
+                    "stake": 3_000_000_000,
+                    "is_registered": True,
+                },
+            ]
+
+        fake.seed_runtime("StakeInfoRuntimeApi", "get_stake_info_for_coldkey", positions)
+
+        result = invoke(
+            "--json",
+            "--yes",
+            "--no-mev-shield",
+            "stake",
+            command,
+            "--all-hotkeys",
+        )
+
+        assert result.exit_code == 0, result.output
+        call = fake.last_call
+        assert (call.module, call.function) == ("Utility", "batch_all")
+        assert [(child.function, child.params["hotkey"]) for child in call.params["calls"]] == [
+            (call_name, hotkey) for hotkey in expected_hotkeys
+        ]
+        if command == "unstake-all":
+            dry_run = invoke(
+                "--json",
+                "--dry-run",
+                "stake",
+                command,
+                "--all-hotkeys",
+            )
+            assert dry_run.exit_code == 0, dry_run.output
+            assert any("MEV-shielded" in effect for effect in json.loads(dry_run.output)["effects"])
+
+    def test_stake_unstake_all_rejects_conflicting_hotkey_selectors(self, fake: FakeSubstrate):
+        result = invoke(
+            "--json",
+            "--yes",
+            "stake",
+            "unstake-all",
+            "--hotkey",
+            BOB,
+            "--all-hotkeys",
+        )
+
+        assert result.exit_code == 2
+        assert "choose only one" in result.output
+        assert fake.submissions == []
+
+    def test_stake_unstake_all_reports_when_no_live_positions(
+        self, fake: FakeSubstrate, wallet_dir: str
+    ):
+        coldkey = wallets.open_wallet(_WALLET_NAME, "default", wallet_dir).coldkeypub.ss58_address
+        fake.seed_runtime(
+            "StakeInfoRuntimeApi",
+            "get_stake_info_for_coldkey",
+            [
+                {
+                    "hotkey": BOB,
+                    "coldkey": coldkey,
+                    "netuid": 1,
+                    "stake": 0,
+                    "is_registered": True,
+                }
+            ],
+        )
+
+        result = invoke(
+            "--json",
+            "--yes",
+            "stake",
+            "unstake-all",
+            "--all-hotkeys",
+        )
+
+        assert result.exit_code == 1
+        assert "has no stake" in result.output
+        assert fake.submissions == []
+
+    def test_stake_unstake_all_uses_configured_proxy_as_selection_owner(self, fake: FakeSubstrate):
+        config.set_value("proxy_for", BOB)
+
+        def positions(params):
+            assert params == [BOB]
+            return [
+                {
+                    "hotkey": BOB_HOT,
+                    "coldkey": BOB,
+                    "netuid": 1,
+                    "stake": 1_000_000_000,
+                    "is_registered": True,
+                }
+            ]
+
+        fake.seed_runtime("StakeInfoRuntimeApi", "get_stake_info_for_coldkey", positions)
+
+        result = invoke(
+            "--json",
+            "--yes",
+            "--no-mev-shield",
+            "stake",
+            "unstake-all",
+            "--all-hotkeys",
+        )
+
+        assert result.exit_code == 0, result.output
+        call = fake.last_call
+        assert (call.module, call.function) == ("Proxy", "proxy")
+        assert call.params["real"] == BOB
+        assert (call.params["call"].module, call.params["call"].function) == (
+            "SubtensorModule",
+            "unstake_all",
+        )
 
     def test_failed_extrinsic_exits_nonzero(self, fake: FakeSubstrate):
         from bittensor.result import ChainError, ExtrinsicResult

--- a/sdk/python/tests/unit/test_cli.py
+++ b/sdk/python/tests/unit/test_cli.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import re
 
 import pytest
 from typer.testing import CliRunner
@@ -129,15 +130,18 @@ class TestOffline:
             assert op in result.output
 
     def test_stake_unstake_all_exposes_bulk_selector_only_on_workflow(self):
+        ansi = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
         result = invoke("stake", "unstake-all", "--help")
         assert result.exit_code == 0
-        assert "--hotkey" in result.output
-        assert "--all-hotkeys" in result.output
+        workflow_help = ansi.sub("", result.output)
+        assert "--hotkey" in workflow_help
+        assert "--all-hotkeys" in workflow_help
 
         primitive = invoke("tx", "unstake-all", "--help")
         assert primitive.exit_code == 0
-        assert "--hotkey" in primitive.output
-        assert "--all-hotkeys" not in primitive.output
+        primitive_help = ansi.sub("", primitive.output)
+        assert "--hotkey" in primitive_help
+        assert "--all-hotkeys" not in primitive_help
 
     def test_query_group_help(self):
         result = invoke("query", "--help")


### PR DESCRIPTION
## Summary

- add `btcli stake unstake-all --all-hotkeys` and `unstake-all-alpha --all-hotkeys`
- discover live non-zero positions and deduplicate hotkeys across subnets
- keep the generated `btcli tx unstake-all` command as a one-hotkey primitive
- submit multiple hotkey exits atomically with `Utility.batch_all`
- document the migration path and current Staking-proxy limitation

Single-hotkey selections continue to use the direct runtime call. The alpha-only variant ignores root-only positions.

## Testing

- `.venv/bin/pytest -q` (`1107 passed, 2 skipped`)
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/ty check --exit-zero-on-warning bittensor`
- all codegen coverage, names, units, and namespace checks
- manual Finney validation: the all-hotkeys selector discovered a live position, submitted it MEV-shielded successfully, and the post-transaction stake query was empty