### PR TITLE
Bump bittensor-core to 0.1.4 to unblock the v448 PyPI release

### DIFF
--- a/sdk/bittensor-core-py/pyproject.toml
+++ b/sdk/bittensor-core-py/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 name = "bittensor-core"
 # Static (not read from Cargo.toml) so the release train can stamp PEP 440
 # rc/dev suffixes that cargo's semver would reject.
-version = "0.1.3"
+version = "0.1.4"
 description = "The chain-defined compute core for Bittensor clients: sp-core keys, keyfiles, drand timelock, ML-KEM, SCALE codec, and RFC-0078 metadata digest, built from the bittensor monorepo"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -165,7 +165,7 @@ dev = [
 
 [[package]]
 name = "bittensor-core"
-version = "0.1.3"
+version = "0.1.4"
 source = { directory = "../bittensor-core-py" }
 
 [[package]]


### PR DESCRIPTION
## Summary

- The v448 [release train run](https://github.com/RaoFoundation/subtensor/actions/runs/32500727119) failed at **Compute rc versions**: `bittensor-core 0.1.3 is already published; bump the base version.` The release-448 prep bumped the SDK to `11.2.0.dev0` but left `bittensor-core-py` at `0.1.3` (published with v445).
- Bumps `sdk/bittensor-core-py/pyproject.toml` to `0.1.4` and updates the matching entry in `sdk/python/uv.lock` (`uv lock --check` passes). The core crate has changed since 0.1.3 (price-protected cross-hotkey stake moves), so a new version is due regardless.

## After merging

Re-running the failed job will not work — it checks out the old commit. Instead:

1. Cancel run [32500727119](https://github.com/RaoFoundation/subtensor/actions/runs/32500727119) (it holds the `release-train` concurrency slot while waiting on the mainnet gate). **Do not approve its mainnet gate** — a release cut from that commit would try to republish core 0.1.3 in the stable channel.
2. Dispatch a fresh Release Train (`workflow_dispatch`) from `main`. Devnet/testnet deploys no-op via the spec_version guard, the rc publish picks up 0.1.4, and the mainnet proposal is made from the bumped commit.

Made with [Cursor](https://cursor.com)