### PR TITLE
sync bittensor-core 0.1.4 release versions

### DIFF
--- a/sdk/bittensor-core-py/pyproject.toml
+++ b/sdk/bittensor-core-py/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 name = "bittensor-core"
 # Static (not read from Cargo.toml) so the release train can stamp PEP 440
 # rc/dev suffixes that cargo's semver would reject.
-version = "0.1.3"
+version = "0.1.4"
 description = "The chain-defined compute core for Bittensor clients: sp-core keys, keyfiles, drand timelock, ML-KEM, SCALE codec, and RFC-0078 metadata digest, built from the bittensor monorepo"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     # Keys, keyfiles, timelock, ML-KEM crypto, and the SCALE codec/runtime
     # engine: the in-repo Rust core, built against the same crate revisions
     # as the runtime.
-    "bittensor-core>=0.1.3,<0.2.0",
+    "bittensor-core>=0.1.4,<0.2.0",
     # `btcli` terminal UI. The CLI is a first-class part of the package, so
     # its dependencies are unconditional.
     "typer>=0.12.0",

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -165,7 +165,7 @@ dev = [
 
 [[package]]
 name = "bittensor-core"
-version = "0.1.3"
+version = "0.1.4"
 source = { directory = "../bittensor-core-py" }
 
 [[package]]


### PR DESCRIPTION
## Motivation

The v448 Python SDK release requires `bittensor-core` 0.1.4, but the repository still declared and locked version 0.1.3 in several packaging files.

## Changes

- Bump the `bittensor-core` Python package version to 0.1.4.
- Raise the Python SDK dependency floor to `bittensor-core>=0.1.4`.
- Synchronize the local package entry in `sdk/python/uv.lock`.

## Behavioral impact

This changes package and dependency metadata only. It does not alter runtime behavior, APIs, storage, or chain state.

## Migration and spec version

No migration or runtime `spec_version` bump is required because no runtime code changes.

## Validation

- Confirmed all affected version declarations resolve to 0.1.4.
- `git diff --check` passes.
- Ruff checks were not run because the existing locked `uv` environment was unavailable.