### PR TITLE
Add finalized_block property to Subtensor/SyncClient

### DIFF
--- a/sdk/python/bittensor/_substrate.py
+++ b/sdk/python/bittensor/_substrate.py
@@ -120,6 +120,10 @@ class Substrate(Protocol):
         """Current chain block number."""
         ...
 
+    async def finalized_block_number(self) -> int:
+        """Current finalized chain block number."""
+        ...
+
     async def block_time(self) -> float:
         """Seconds per block, detected from the chain."""
         ...
@@ -404,6 +408,14 @@ class RpcSubstrate:
 
     async def block_number(self) -> int:
         return await self._read(lambda raw: raw.get_block_number(None))
+
+    async def finalized_block_number(self) -> int:
+        # A fresh read per call, like block_number: _known_finalized_height's
+        # TTL cache would answer the property with a stale height.
+        async def op(raw: SubstrateConnection) -> int:
+            return await raw.get_block_number(await raw.get_chain_finalised_head())
+
+        return await self._read(op)
 
     async def block_time(self) -> float:
         """Seconds per block, from the chain's ``Aura.SlotDuration`` constant.

--- a/sdk/python/bittensor/_subtensor.py
+++ b/sdk/python/bittensor/_subtensor.py
@@ -53,8 +53,8 @@ class Subtensor(SyncClient):
     of code. The first blocking call locks the instance into blocking mode;
     the first ``await`` locks it into async mode. Attribute *inspection* has
     no side effects (safe to repr, probe, or autocomplete a cold instance) —
-    except the chain-reading properties ``block``, ``time``, and
-    ``spec_version``, whose *evaluation* is a blocking read.
+    except the chain-reading properties ``block``, ``finalized_block``,
+    ``time``, and ``spec_version``, whose *evaluation* is a blocking read.
 
     Blocking mode needs no ``close()``: the connection opens on first call and
     is cleaned up when the instance is garbage collected (or at process exit).

--- a/sdk/python/bittensor/client.py
+++ b/sdk/python/bittensor/client.py
@@ -585,6 +585,10 @@ class Client:
         """Current chain block number."""
         return await self._substrate.block_number()
 
+    async def finalized_block(self) -> int:
+        """Latest finalized chain block number."""
+        return await self._substrate.finalized_block_number()
+
     async def spec_version(self) -> int:
         """The connected runtime's ``spec_version`` (at the chain head)."""
         return await self._substrate.spec_version()

--- a/sdk/python/bittensor/sync.py
+++ b/sdk/python/bittensor/sync.py
@@ -319,6 +319,12 @@ class SyncClient:
         return self._call(self._client.block())
 
     @property
+    def finalized_block(self) -> int:
+        """Latest finalized chain block number (always <= ``block``). Reads the
+        chain on every access."""
+        return self._call(self._client.finalized_block())
+
+    @property
     def time(self) -> datetime:
         """UTC timestamp of the current chain head block. Reads the chain on
         every access; ``timestamp(block=...)`` reads another block's time."""

--- a/sdk/python/tests/harness/fake_substrate.py
+++ b/sdk/python/tests/harness/fake_substrate.py
@@ -129,6 +129,7 @@ class FakeSubstrate:
         self.connected = False
         self.closed = False
         self.block = 100
+        self.finalized_block = 98
         self.runtime_spec_version = 300
 
         # (module, item) -> {params-tuple: value}
@@ -206,6 +207,9 @@ class FakeSubstrate:
 
     async def block_number(self) -> int:
         return self.block
+
+    async def finalized_block_number(self) -> int:
+        return self.finalized_block
 
     async def block_time(self) -> float:
         # Same derivation as production: the chain's Aura.SlotDuration constant.

--- a/sdk/python/tests/unit/test_finalized_block.py
+++ b/sdk/python/tests/unit/test_finalized_block.py
@@ -1,0 +1,40 @@
+"""The ``finalized_block`` read across every facade (issue #3068).
+
+Mirrors the ``block`` surface: an async method on ``Client``, a blocking
+property on ``SyncClient`` (inherited by ``Subtensor``), both reading the
+chain fresh on every access.
+"""
+
+from __future__ import annotations
+
+from bittensor._subtensor import Subtensor
+from bittensor.client import Client
+from bittensor.sync import SyncClient
+from tests.harness.fake_substrate import FakeSubstrate
+
+
+async def test_client_finalized_block_reads_finalized_head() -> None:
+    fake = FakeSubstrate()
+    client = Client("local", substrate=fake)
+    assert await client.finalized_block() == 98
+    assert await client.finalized_block() <= await client.block()
+
+
+def test_sync_client_finalized_block_property_reads_the_chain_every_access() -> None:
+    fake = FakeSubstrate()
+    client = SyncClient("local", substrate=fake)
+    try:
+        assert client.finalized_block <= client.block
+        # No caching: a moved finalized head must show up on the next access.
+        fake.finalized_block = 105
+        assert client.finalized_block == 105
+    finally:
+        client.close()
+
+
+def test_subtensor_finalized_block_property() -> None:
+    st = Subtensor("local", substrate=FakeSubstrate())
+    try:
+        assert st.finalized_block == 98
+    finally:
+        st.close()


### PR DESCRIPTION
## Description

Adds a read-only `finalized_block` property mirroring the existing `.block` property at every layer of the SDK:

- `Substrate` protocol + `RpcSubstrate`: new `finalized_block_number()` — resolves `chain_getFinalizedHead`, then reads the header number via the transport's existing `get_block_number()`. It is a **fresh read on every call**, like `block_number()`: reusing the transport's `_known_finalized_height()` TTL cache would answer the property up to 12s stale.
- `Client.finalized_block()` async method.
- `SyncClient.finalized_block` blocking property (`Subtensor` inherits it unchanged), so `bt.Subtensor().finalized_block` works as requested.

Two RPCs per read is the protocol floor (Substrate has no one-shot finalized-height RPC); as a side effect the number↔hash LRU caches get populated with finalized mappings, which are exactly the entries safe to cache.

## Related Issue(s)

- Closes #3068

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

None — purely additive. Note for anyone injecting custom `Substrate` implementations: the protocol gains one method (`finalized_block_number`); existing custom implementations only need it once they actually call the new surface. The in-repo `FakeSubstrate` test harness is updated in this PR.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` to ensure my code is formatted and linted correctly (Python-only change; `ruff check`/`ruff format --check` pass)
- [x] I have made corresponding changes to the documentation (docstrings; generated reference pages don't cover client properties)
- [x] My changes generate no new warnings (`ty check --exit-zero-on-warning bittensor` exits 0)
- [x] I have added tests that prove my fix is effective or that my feature works (`tests/unit/test_finalized_block.py`)
- [x] New and existing unit tests pass locally with my changes (1100 passed / 2 skipped; 3 pre-existing environment failures in `test_extension_bridge.py` reproduce on clean `main` — local SOCKS proxy)

## Additional Notes

The facade-parity invariant test (`tests/unit/test_facades.py::test_sync_facade_mirrors_async_surface`) now also pins the new method: an async `Client` member without its blocking twin fails CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
