### PR TITLE
Root claim accounts for amm concavity

### DIFF
--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -1950,9 +1950,11 @@ mod dispatches {
         /// Claims the root emissions for a coldkey across every validator it root-stakes to.
         ///
         /// Redemption is fund-level: for each validator, the staker's accrued entitlement is
-        /// redeemed as their pro-rata fraction of that basket (sold to TAO and staked on root).
-        /// The `subnets` argument is retained for call-data compatibility with pre-basket
-        /// clients; it is ignored — baskets have no per-subnet claim selection.
+        /// paid as their pro-rata fraction of the basket's full-liquidation NAV and staked on
+        /// root. The corresponding alpha fraction is sold; any concavity surplus over the
+        /// NAV-priced entitlement remains in the basket as root TAO for the other holders. The
+        /// `subnets` argument is retained for call-data compatibility with pre-basket clients;
+        /// it is ignored — baskets have no per-subnet claim selection.
         ///
         /// Prefer [`Pallet::claim_root_with_hotkey`] to claim a single validator.
         ///
@@ -1992,8 +1994,10 @@ mod dispatches {
         /// Claims the root emissions for a coldkey on one validator hotkey.
         ///
         /// Redemption is fund-level for that validator: the staker's accrued entitlement is
-        /// redeemed as their pro-rata fraction of each basket holding (sold to TAO and staked
-        /// on root). Other validators' accrued yield is left untouched.
+        /// paid as their pro-rata fraction of the basket's full-liquidation NAV and staked on
+        /// root. The corresponding alpha fraction is sold; any concavity surplus over the
+        /// NAV-priced entitlement remains in the basket as root TAO for the other holders.
+        /// Other validators' accrued yield is left untouched.
         ///
         /// # Arguments
         /// * `origin`: The signature of the caller's coldkey.

--- a/pallets/subtensor/src/staking/basket_views.rs
+++ b/pallets/subtensor/src/staking/basket_views.rs
@@ -10,11 +10,12 @@ use subtensor_runtime_common::NetUidStorageIndex;
 use subtensor_swap_interface::{Order, SwapHandler};
 
 impl<T: Config> Pallet<T> {
-    /// Realizable TAO value of `alpha` on `netuid`: the slippage-aware quote a full redemption
-    /// would fetch right now (net of fees), not the marked spot value `price * amount`. On a
-    /// thin pool a tiny buy can push spot arbitrarily high, letting a marked NAV grow without
-    /// bound (and saturate to `u64::MAX`); the realizable quote is bounded by the pool's TAO
-    /// reserve, so NAV computed from it matches what the fund could actually pay out.
+    /// Realizable TAO value of `alpha` on `netuid`: the slippage-aware quote a full basket
+    /// redemption would fetch right now, using the same fee-free protocol swap as the
+    /// money-moving claim path, not the marked spot value `price * amount`. On a thin pool a
+    /// tiny buy can push spot arbitrarily high, letting a marked NAV grow without bound (and
+    /// saturate to `u64::MAX`); the realizable quote is bounded by the pool's TAO reserve, so
+    /// NAV computed from it matches what the fund could actually pay out.
     pub fn realizable_tao_for_alpha(netuid: NetUid, alpha: u64) -> u64 {
         if alpha == 0 {
             return 0;
@@ -30,9 +31,15 @@ impl<T: Config> Pallet<T> {
         #[cfg(test)]
         crate::tests::mock::inc_basket_quote_ops();
         let order = GetTaoForAlpha::<T>::with_amount(alpha);
-        T::SwapInterface::sim_swap(netuid.into(), order)
-            .map(|res| res.amount_paid_out.to_u64())
-            .unwrap_or(0)
+        T::SwapInterface::swap(
+            netuid.into(),
+            order,
+            T::SwapInterface::min_price::<TaoBalance>(),
+            true,
+            true,
+        )
+        .map(|res| res.amount_paid_out.to_u64())
+        .unwrap_or(0)
     }
 
     /// Single source of truth for redemption sizing: a staker's owed shares are worth
@@ -62,9 +69,9 @@ impl<T: Config> Pallet<T> {
         Self::basket_payout_from(owed_shares.min(shares_total), nav, shares_total)
     }
 
-    /// Current realizable TAO value of a staker's unclaimed share of one subnet holding in a
-    /// validator's basket. This is a read-only projection of the same pro-rata holding amount
-    /// that [`Self::root_claim_for_hotkey`] would redeem.
+    /// Current TAO entitlement of a staker's unclaimed share of one subnet holding in a
+    /// validator's basket. Claims sell the corresponding pro-rata alpha amount, but pay this
+    /// full-liquidation-NAV fraction and retain any larger concavity surplus in the fund.
     pub fn get_basket_subnet_payout_tao(
         hotkey: &T::AccountId,
         coldkey: &T::AccountId,
@@ -83,8 +90,8 @@ impl<T: Config> Pallet<T> {
         let escrow = Self::get_beta_escrow_account_id();
         let holding =
             Self::get_stake_for_hotkey_and_coldkey_on_subnet(hotkey, &escrow, netuid).to_u64();
-        let redeemable_alpha = Self::mul_div_u64(holding, owed_shares, shares_total);
-        Self::realizable_tao_for_alpha(netuid, redeemable_alpha)
+        let slot_nav = Self::realizable_tao_for_alpha(netuid, holding);
+        Self::basket_payout_from(owed_shares, slot_nav, shares_total)
     }
 
     /// Total TAO a coldkey would realize by redeeming every beta basket it holds across all of

--- a/pallets/subtensor/src/staking/claim_root.rs
+++ b/pallets/subtensor/src/staking/claim_root.rs
@@ -533,12 +533,13 @@ impl<T: Config> Pallet<T> {
 
     /// Claims (redeems) a staker's share of a validator's basket.
     ///
-    /// Redemption is fund-level and purely proportional: the staker's owed shares define a
-    /// fraction `f = owed / P` of the fund, and exactly that fraction of *every* holding is
-    /// redeemed — subnet alpha is sold to TAO (the staker bears slippage), the root-slot portion
-    /// is reassigned as root stake directly (no swap). Because every claim preserves the fund's
-    /// composition, claims and (future) validator-directed rebalancing never interfere. All
-    /// realized TAO is staked on root for the staker.
+    /// Redemption is fund-level and NAV-proportional: the staker's owed shares define a
+    /// fraction `f = owed / P` of the fund's full-liquidation NAV. Exactly that fraction of
+    /// every holding's alpha is removed and sold, but the claimant receives at most `f` of
+    /// that holding's pre-sale realizable value. A concave AMM curve makes selling `f` of a
+    /// holding realize more than `f` of the proceeds from selling the whole holding; that
+    /// surplus is retained in the fund's root (TAO cash) slot for the remaining shareholders.
+    /// The root-slot portion is reassigned directly because it is already TAO.
     ///
     /// Before redeeming, the fund's orphaned dust holdings (subnets outside the
     /// validator's current weight vector) are consolidated into its root slot (see
@@ -584,10 +585,20 @@ impl<T: Config> Pallet<T> {
         outcome.rows = holdings.len() as u32;
 
         // Dust check against the estimated payout (owed fraction of the marked NAV).
-        // Same valuation as `get_validator_basket_nav_tao`, reusing the holdings read.
-        let nav: u64 = holdings.iter().fold(0u64, |acc, (netuid, alpha)| {
-            acc.saturating_add(Self::realizable_tao_for_alpha(*netuid, alpha.to_u64()))
-        });
+        // Keep each slot's pre-sale value as well as the total: redemption caps every
+        // slot independently at the same NAV fraction. Without that cap, selling a raw
+        // alpha fraction on a concave AMM curve overpays the first redeemer and transfers
+        // the loss to the remaining shareholders.
+        let valued_holdings: Vec<(NetUid, AlphaBalance, u64)> = holdings
+            .into_iter()
+            .map(|(netuid, alpha)| {
+                let value = Self::realizable_tao_for_alpha(netuid, alpha.to_u64());
+                (netuid, alpha, value)
+            })
+            .collect();
+        let nav: u64 = valued_holdings
+            .iter()
+            .fold(0u64, |acc, (_, _, value)| acc.saturating_add(*value));
         let estimated_payout: u64 = Self::basket_payout_from(owed_shares, nav, shares_total);
         if !ignore_minimum_condition
             && I96F32::saturating_from_num(estimated_payout)
@@ -607,14 +618,12 @@ impl<T: Config> Pallet<T> {
         // shareholders (e.g. 99/100 of a 1-alpha position → floor 0, then the leftover
         // 1-share holder owns the whole unit). Same posture as the all-zero-take rollback
         // below — leave the watermark untouched. Worthless rows (realizable 0) are ignored.
-        for (netuid, slot_alpha) in holdings.iter() {
+        for (_, slot_alpha, slot_value) in valued_holdings.iter() {
             let alpha = slot_alpha.to_u64();
             if alpha == 0 {
                 continue;
             }
-            if Self::mul_div_u64(alpha, owed_shares, shares_total) == 0
-                && Self::realizable_tao_for_alpha(*netuid, alpha) > 0
-            {
+            if Self::mul_div_u64(alpha, owed_shares, shares_total) == 0 && *slot_value > 0 {
                 return Ok(outcome);
             }
         }
@@ -629,9 +638,10 @@ impl<T: Config> Pallet<T> {
             // a stake reassignment (no new TAO on root), while subnet sells realize new TAO that
             // must also be credited to the root reserves.
             let mut root_slot_tao: u64 = 0;
-            let mut swapped_tao: u64 = 0;
+            let mut claimant_swapped_tao: u64 = 0;
+            let mut retained_swapped_tao: u64 = 0;
 
-            for (netuid, slot_alpha) in holdings.iter() {
+            for (netuid, slot_alpha, slot_value) in valued_holdings.iter() {
                 // This staker's pro-rata slice of the holding: slot_alpha * owed / P.
                 let take: u64 = Self::mul_div_u64(slot_alpha.to_u64(), owed_shares, shares_total);
                 if take == 0 {
@@ -663,10 +673,27 @@ impl<T: Config> Pallet<T> {
                     *total = total.saturating_add(tao);
                 });
 
-                swapped_tao = swapped_tao.saturating_add(tao.to_u64());
+                // Shares are minted and quoted against full-liquidation NAV. Selling a raw
+                // alpha fraction on a concave AMM curve realizes more than the same NAV
+                // fraction, so pay only the priced entitlement and retain the surplus as
+                // fund cash. Otherwise a permissionless deposit followed by a claim can
+                // extract the difference from earlier holders.
+                let slot_entitlement =
+                    Self::basket_payout_from(owed_shares, *slot_value, shares_total);
+                let realized_tao = tao.to_u64();
+                // A final claimant has no remaining holders to retain a surplus for. Give
+                // them every realized rao so no root cash is stranded behind zero shares.
+                let claimant_tao = if owed_shares == shares_total {
+                    realized_tao
+                } else {
+                    realized_tao.min(slot_entitlement)
+                };
+                claimant_swapped_tao = claimant_swapped_tao.saturating_add(claimant_tao);
+                retained_swapped_tao =
+                    retained_swapped_tao.saturating_add(realized_tao.saturating_sub(claimant_tao));
             }
 
-            let total_tao: u64 = root_slot_tao.saturating_add(swapped_tao);
+            let total_tao: u64 = root_slot_tao.saturating_add(claimant_swapped_tao);
 
             // Nothing was actually realized (every per-holding take floored to zero, or the
             // swaps returned zero TAO). The marked estimate above can be positive while the raw
@@ -677,16 +704,31 @@ impl<T: Config> Pallet<T> {
                 return TransactionOutcome::Rollback(Ok(0));
             }
 
-            // Stake the redeemed TAO on root for the staker. Only the swapped portion is new TAO
-            // on root (the root-slot portion was already counted in the root reserves).
+            // The sale surplus still belongs to the fund. It already landed in the root
+            // subnet account, so represent it as escrow-owned root stake before burning the
+            // claimant's shares. Together, the remaining alpha and this cash retain the
+            // unclaimed fraction of the pre-sale liquidation NAV (modulo integer floors).
+            if retained_swapped_tao > 0 {
+                Self::increase_stake_for_hotkey_and_coldkey_on_subnet(
+                    hotkey,
+                    &escrow,
+                    NetUid::ROOT,
+                    retained_swapped_tao.into(),
+                );
+            }
+
+            // Stake the redeemed TAO on root for the staker. Only sold TAO is new on root;
+            // the root-slot portion was already counted in the root reserves. Credit both
+            // the claimant payout and the surplus retained by the fund.
             Self::increase_stake_for_hotkey_and_coldkey_on_subnet(
                 hotkey,
                 coldkey,
                 NetUid::ROOT,
                 total_tao.into(),
             );
-            if swapped_tao > 0 {
-                Self::credit_root_reserves(swapped_tao.into());
+            let total_swapped_tao = claimant_swapped_tao.saturating_add(retained_swapped_tao);
+            if total_swapped_tao > 0 {
+                Self::credit_root_reserves(total_swapped_tao.into());
             }
 
             // Claimed root stake must start (or refresh) the unlock hold, same as a

--- a/pallets/subtensor/src/tests/stake_into_basket.rs
+++ b/pallets/subtensor/src/tests/stake_into_basket.rs
@@ -222,6 +222,76 @@ fn test_stake_into_basket_does_not_dilute_existing_holders() {
     });
 }
 
+/// Regression: a direct depositor cannot capture the concavity premium from selling a
+/// proportional alpha slice. Shares are minted against full-liquidation NAV, so the claim
+/// pays that same NAV-priced fraction and retains any larger raw sale proceeds as fund cash.
+/// The remaining holder therefore keeps their pre-claim marked value.
+#[test]
+fn test_stake_into_basket_claim_retains_concavity_surplus_for_existing_holders() {
+    new_test_ext(1).execute_with(|| {
+        let (_owner, hotkey, netuid) = setup_stake_in_env();
+        set_root_weights_direct(&hotkey, 0, &[(netuid, u16::MAX)]);
+
+        // Make the pool deliberately thin so the old raw-alpha-fraction redemption
+        // overpayment is large and this test is sensitive to the exploit.
+        SubnetTAO::<Test>::insert(netuid, TaoBalance::from(100_000_000u64));
+        SubnetAlphaIn::<Test>::insert(netuid, AlphaBalance::from(100_000_000u64));
+
+        let alice = U256::from(2001);
+        let bob = U256::from(2002);
+        let alice_deposit = 50_000_000u64;
+        let bob_deposit = 10_000_000u64;
+        add_balance_to_coldkey_account(&alice, TaoBalance::from(2 * alice_deposit));
+        add_balance_to_coldkey_account(&bob, TaoBalance::from(2 * bob_deposit));
+
+        assert_ok!(SubtensorModule::do_stake_into_basket(
+            alice,
+            hotkey,
+            alice_deposit.into(),
+        ));
+        assert_ok!(SubtensorModule::do_stake_into_basket(
+            bob,
+            hotkey,
+            bob_deposit.into(),
+        ));
+
+        let alice_payout_before = SubtensorModule::get_basket_payout_tao(&hotkey, &alice);
+        let bob_payout_before = SubtensorModule::get_basket_payout_tao(&hotkey, &bob);
+        let bob_shares = SubtensorModule::get_basket_owed_shares(&hotkey, &bob);
+        let shares_total = fund_shares(&hotkey);
+        let holding = escrow_alpha(&hotkey, netuid);
+        let raw_take = SubtensorModule::mul_div_u64(holding, bob_shares, shares_total);
+        let uncapped_raw_sale = SubtensorModule::realizable_tao_for_alpha(netuid, raw_take);
+
+        assert!(
+            uncapped_raw_sale > bob_payout_before,
+            "test setup must expose the concavity premium: raw={uncapped_raw_sale}, nav-priced={bob_payout_before}"
+        );
+        assert_eq!(
+            SubtensorModule::get_basket_subnet_payout_tao(&hotkey, &bob, netuid),
+            bob_payout_before,
+            "subnet payout view must quote the same NAV-priced entitlement as claim"
+        );
+
+        assert_ok!(SubtensorModule::claim_root_with_hotkey(
+            RuntimeOrigin::signed(bob),
+            hotkey
+        ));
+
+        let bob_received = root_stake_of(&hotkey, &bob);
+        assert!(
+            bob_received <= bob_payout_before,
+            "claim paid more than the depositor's NAV-priced entitlement: {bob_received} > {bob_payout_before}"
+        );
+
+        let alice_payout_after = SubtensorModule::get_basket_payout_tao(&hotkey, &alice);
+        assert!(
+            alice_payout_after.saturating_add(ROUNDING_EPS) >= alice_payout_before,
+            "earlier holder lost value across the deposit/claim cycle: before={alice_payout_before}, after={alice_payout_after}",
+        );
+    });
+}
+
 /// Input validation: nonexistent hotkey, a hotkey that exists but is not on root,
 /// dust amounts, and insufficient balance are rejected before any state changes.
 #[test]

--- a/pallets/subtensor/src/tests/stake_into_basket.rs
+++ b/pallets/subtensor/src/tests/stake_into_basket.rs
@@ -6,7 +6,9 @@ use crate::tests::claim_root::{
     set_root_weights_direct, zero_claim_threshold,
 };
 use crate::tests::mock::*;
-use crate::{BasketClaimed, DefaultMinStake, Error, StakingHotkeys, SubnetAlphaIn, SubnetTAO};
+use crate::{
+    BasketClaimed, DefaultMinStake, Error, StakingHotkeys, SubnetAlphaIn, SubnetTAO, TotalStake,
+};
 use approx::assert_abs_diff_eq;
 use frame_support::traits::Get;
 use frame_support::{assert_noop, assert_ok};
@@ -288,6 +290,125 @@ fn test_stake_into_basket_claim_retains_concavity_surplus_for_existing_holders()
         assert!(
             alice_payout_after.saturating_add(ROUNDING_EPS) >= alice_payout_before,
             "earlier holder lost value across the deposit/claim cycle: before={alice_payout_before}, after={alice_payout_after}",
+        );
+    });
+}
+
+/// Regression for interleaved accounting after a concavity-capped claim: the retained sale
+/// surplus becomes root cash, the first claimant's newly received root stake earns only a
+/// subsequent dividend, and both the old and newly accrued shares can then drain the fund
+/// without stranding cash or changing TotalStake.
+#[test]
+fn test_retained_concavity_cash_balances_with_new_root_entitlement() {
+    new_test_ext(1).execute_with(|| {
+        let (owner, hotkey, netuid) = setup_stake_in_env();
+        set_root_weights_direct(&hotkey, 0, &[(netuid, u16::MAX)]);
+
+        // A thin pool makes Bob's partial alpha sale realize a measurable concavity surplus.
+        SubnetTAO::<Test>::insert(netuid, TaoBalance::from(100_000_000u64));
+        SubnetAlphaIn::<Test>::insert(netuid, AlphaBalance::from(100_000_000u64));
+        mock_increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey,
+            &owner,
+            netuid,
+            10_000_000u64.into(),
+        );
+
+        let alice = U256::from(2001);
+        let bob = U256::from(2002);
+        let alice_deposit = 50_000_000u64;
+        let bob_deposit = 10_000_000u64;
+        add_balance_to_coldkey_account(&alice, TaoBalance::from(2 * alice_deposit));
+        add_balance_to_coldkey_account(&bob, TaoBalance::from(2 * bob_deposit));
+        assert_ok!(SubtensorModule::do_stake_into_basket(
+            alice,
+            hotkey,
+            alice_deposit.into(),
+        ));
+        assert_ok!(SubtensorModule::do_stake_into_basket(
+            bob,
+            hotkey,
+            bob_deposit.into(),
+        ));
+
+        // From this point onward claims and dividend deployment only move existing stake.
+        let total_stake_before_claims = TotalStake::<Test>::get();
+        let bob_first_quote = SubtensorModule::get_basket_payout_tao(&hotkey, &bob);
+        let bob_root_before = root_stake_of(&hotkey, &bob);
+        assert_ok!(SubtensorModule::claim_root_with_hotkey(
+            RuntimeOrigin::signed(bob),
+            hotkey
+        ));
+        let bob_first_gain = root_stake_of(&hotkey, &bob).saturating_sub(bob_root_before);
+        assert!(bob_first_gain <= bob_first_quote);
+        assert_eq!(
+            SubtensorModule::get_basket_owed_shares(&hotkey, &bob),
+            0,
+            "claim payout must not retroactively recreate Bob's consumed entitlement"
+        );
+
+        let retained_root = escrow_alpha(&hotkey, NetUid::ROOT);
+        assert!(
+            retained_root > 0,
+            "partial claim must retain a measurable concavity surplus as root cash"
+        );
+        let alice_before_dividend = SubtensorModule::get_basket_payout_tao(&hotkey, &alice);
+
+        // Bob's claimed root stake now legitimately earns a new dividend. The retained escrow
+        // root slot earns its own fraction unminted, so Alice's pre-existing shares are not
+        // diluted when Bob receives the newly minted entitlement.
+        SubtensorModule::distribute_emission(
+            netuid,
+            AlphaBalance::ZERO,
+            AlphaBalance::ZERO,
+            5_000_000u64.into(),
+            AlphaBalance::ZERO,
+        );
+        flush_baskets();
+
+        assert!(
+            SubtensorModule::get_basket_owed_shares(&hotkey, &bob) > 0,
+            "Bob's root stake must earn shares from the later dividend"
+        );
+        let alice_after_dividend = SubtensorModule::get_basket_payout_tao(&hotkey, &alice);
+        assert!(
+            alice_after_dividend.saturating_add(ROUNDING_EPS) >= alice_before_dividend,
+            "newly minted root entitlement diluted the retained cash belonging to Alice"
+        );
+        assert_shares_fully_owed(&hotkey, &[alice, bob], ROUNDING_EPS);
+
+        let nav = SubtensorModule::get_validator_basket_nav_tao(&hotkey).to_u64();
+        let owed_value = alice_after_dividend
+            .saturating_add(SubtensorModule::get_basket_payout_tao(&hotkey, &bob));
+        assert_abs_diff_eq!(owed_value, nav, epsilon = ROUNDING_EPS);
+
+        // Alice redeems the old position, then Bob redeems his later-earned shares as the final
+        // holder. The latter must receive all remaining alpha and retained root cash.
+        assert_ok!(SubtensorModule::claim_root_with_hotkey(
+            RuntimeOrigin::signed(alice),
+            hotkey
+        ));
+        assert_ok!(SubtensorModule::claim_root_with_hotkey(
+            RuntimeOrigin::signed(bob),
+            hotkey
+        ));
+
+        assert!(
+            escrow_alpha(&hotkey, netuid) <= 10,
+            "subnet holding remained after the final claim"
+        );
+        assert!(
+            escrow_alpha(&hotkey, NetUid::ROOT) <= 10,
+            "retained root cash remained after the final claim"
+        );
+        assert!(
+            fund_shares(&hotkey) <= 10,
+            "shares remained after final claim"
+        );
+        assert_eq!(
+            TotalStake::<Test>::get(),
+            total_stake_before_claims,
+            "claim/dividend interleaving changed TotalStake"
         );
     });
 }


### PR DESCRIPTION
## Motivation

Basket shares are priced against the basket’s fee-free full-liquidation NAV. On a concave AMM curve, selling a proportional alpha slice realizes more than the same proportional fraction of the proceeds from liquidating the entire holding. Paying all of that realized TAO to an early claimant lets a deposit-and-claim cycle extract value from existing basket holders.

## Changes

- Value basket holdings using the same fee-free rollback swap configuration as the money-moving claim path.
- Calculate each claimant’s entitlement as their share of each holding’s full-liquidation NAV.
- Sell the corresponding proportional alpha slice, pay no more than its NAV-priced entitlement, and retain any concavity surplus as escrow-owned root stake for remaining shareholders.
- Preserve all realized proceeds for the final claimant so no cash remains behind after all shares are redeemed.
- Align basket payout views and dispatch documentation with this behavior.
- Add a regression test demonstrating that a direct depositor cannot capture the concavity premium at an earlier holder’s expense.

## Files of interest

- `pallets/subtensor/src/staking/basket_views.rs`
- `pallets/subtensor/src/staking/claim_root.rs`
- `pallets/subtensor/src/tests/stake_into_basket.rs`
- `pallets/subtensor/src/macros/dispatches.rs`

## Behavioral impact

Claims remain proportional to the basket’s full-liquidation NAV. Any excess produced by partially selling alpha on the concave AMM curve remains in the basket’s root cash slot rather than being transferred to the current claimant.

## Migration and runtime version

No storage migration is required. The PR targets `release-v450`, for which the automated per-network `spec_version` check does not apply.

## Testing

Added `test_stake_into_basket_claim_retains_concavity_surplus_for_existing_holders`, covering the thin-pool deposit/claim extraction scenario, view consistency, claimant payout capping, and preservation of the earlier holder’s value.