### PR TITLE
Add WTAO ERC-20 contract to monorepo

### DIFF
--- a/contracts/wtao/.gitignore
+++ b/contracts/wtao/.gitignore
@@ -1,0 +1,17 @@
+node_modules
+
+# Hardhat files and other artifacts
+/cache
+/artifacts
+deployed-contract.json
+
+# TypeChain files
+/typechain
+/typechain-types
+
+# solidity-coverage files
+/coverage
+/coverage.json
+
+# secrets and other local configs
+config.ts

--- a/contracts/wtao/LICENSE
+++ b/contracts/wtao/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Opentensor
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/contracts/wtao/README.md
+++ b/contracts/wtao/README.md
@@ -1,0 +1,28 @@
+# WTAO Contract
+
+## Description
+
+The WTAO contract is an ERC-20 token implementation that wraps the native TAO token, deployed on the Subtensor mainnet. It allows users to deposit TAO into the contract and mint an equivalent amount of wrapped TAO tokens (WTAO), which can be used as a tradable asset on the blockchain. The contract enables users to withdraw TAO by burning the corresponding amount of WTAO tokens, with the transaction being recorded via Deposit and Withdrawal events. The contract tracks its TAO balance, which accumulates from user deposits, and allows external users to check this balance through the getContractETHBalance function. The contract initializes with the name "Wrapped TAO" and the symbol "WTAO", and it follows the ERC-20 token standard, providing a seamless mechanism for wrapping and unwrapping TAO tokens. Notably, it does not collect any additional fees and is neither owned nor controlled by any party, ensuring a decentralized and trustless operation.
+
+## Deployment info
+
+### Deployed contract address
+
+```
+0x312bD9165550C964a37ca33d6d55779d953eC566
+```
+
+### Deployer address
+
+H160:
+0x6ce97D4154A0FD893ED6FB6aB5A7B20F98340DE2
+
+ss58 mirror:
+5GQ9R3hCR2DDZSk2ytYppNhkjfaFtexzt6SmxPG7wrfSGENN
+
+## Running tests locally
+
+```
+yarn install
+yarn run test
+```

--- a/contracts/wtao/config-example.ts
+++ b/contracts/wtao/config-example.ts
@@ -1,0 +1,17 @@
+// PROTECT YOUR PRIVATE KEYS WELL, NEVER COMMIT THEM TO GITHUB OR SHARE WITH ANYONE
+import { BigNumberish } from "ethers";
+
+const ethPrivateKey: string =
+  "0000000000000000000000000000000000000000000000000000000000000001";
+
+const subSeed: string = "//Alice"; // this can be found in the hotkey file, "secretSeed"
+
+const env: string = "local"; // local, testnet, mainnet
+const netuid: BigNumberish = "0x99"; //local = 0x2, testnet = 0x15B, mainnet = tbd
+
+export const config = {
+  ethPrivateKey,
+  env,
+  netuid,
+  subSeed,
+};

--- a/contracts/wtao/contracts/IWTAO.sol
+++ b/contracts/wtao/contracts/IWTAO.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface Wrapper {
+    // Event for depositing TAO, same as in WETH
+    event Deposit(address indexed dst, uint wad);
+    // Event for withdrawing TAO, same as in WETH
+    event Withdrawal(address indexed src, uint wad);
+
+    /**
+     * @dev Allows users to deposit TAO into the contract and receive an equivalent amount of wrapped tokens.
+     * 
+     * The contract will mint the corresponding amount of wrapped tokens (ERC20) to the sender's address,
+     * based on the amount of TAO sent with the transaction. The deposited TAO is stored within the contract.
+     *
+     * Requirements:
+     * - The caller must send a non-zero amount of TAO (msg.value > 0).
+     *
+     * Emits a `Deposit` event indicating the user address and the amount deposited.
+     *
+     * @notice This function mints wrapped tokens corresponding to the TAO sent.
+     */
+    function deposit() external payable;
+
+    /**
+     * @dev Allows users to withdraw TAO by burning an equivalent amount of wrapped tokens (WTAO).
+     * 
+     * This function allows the caller to burn a specified amount of wrapped tokens (WTAO) from their balance,
+     * and in return, the equivalent amount of TAO is transferred to the caller.
+     *
+     * Requirements:
+     * - The caller must have a sufficient balance of wrapped tokens to burn (balanceOf(msg.sender) >= amount).
+     * - The contract must have enough TAO balance to fulfill the withdrawal.
+     *
+     * Emits a `Withdrawal` event indicating the user address and the amount withdrawn.
+     *
+     * @param amount The amount of wrapped tokens (WTAO) to burn and the corresponding TAO to withdraw.
+     */
+    function withdraw(uint amount) external;
+}
+
+interface IWTAO is IERC20, Wrapper {}

--- a/contracts/wtao/contracts/WTAO.sol
+++ b/contracts/wtao/contracts/WTAO.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "./IWTAO.sol";
+
+contract WTAO is ERC20, Wrapper {
+    /**
+     * @dev Initializes the Wrapped TAO (WTAO) ERC20 token contract.
+     * 
+     * This constructor sets the name and symbol of the token to "Wrapped TAO" and "WTAO", respectively.
+     * It calls the constructor of the ERC20 token standard to initialize the token with the provided name and symbol.
+     *
+     * Requirements:
+     * - No arguments are required for the constructor as it directly initializes the ERC20 token with the name 
+     *   "Wrapped TAO" and the symbol "WTAO".
+     * 
+     * The contract is deployed with these default values, and the total supply will be minted when users deposit TAO.
+     */
+    constructor() ERC20("Wrapped TAO", "WTAO") {}
+
+    /**
+     * @dev Allows users to deposit TAO into the contract and receive an equivalent amount of wrapped tokens.
+     * 
+     * The contract will mint the corresponding amount of wrapped tokens (ERC20) to the sender's address,
+     * based on the amount of TAO sent with the transaction. The deposited TAO is stored within the contract.
+     *
+     * Requirements:
+     * - The caller must send a non-zero amount of TAO (msg.value > 0).
+     *
+     * Emits a `Deposit` event indicating the user address and the amount deposited.
+     *
+     * @notice This function mints wrapped tokens corresponding to the TAO sent.
+     */
+    function deposit() external payable {
+        require(msg.value > 0, "Must send TAO to deposit");
+
+        _mint(msg.sender, msg.value);
+        emit Deposit(msg.sender, msg.value);
+    }
+
+    /**
+     * @dev Allows users to withdraw TAO by burning an equivalent amount of wrapped tokens (WTAO).
+     * 
+     * This function allows the caller to burn a specified amount of wrapped tokens (WTAO) from their balance,
+     * and in return, the equivalent amount of TAO is transferred to the caller.
+     *
+     * Requirements:
+     * - The caller must have a sufficient balance of wrapped tokens to burn (balanceOf(msg.sender) >= amount).
+     * - The contract must have enough TAO balance to fulfill the withdrawal.
+     *
+     * Emits a `Withdrawal` event indicating the user address and the amount withdrawn.
+     *
+     * @param amount The amount of wrapped tokens (WTAO) to burn and the corresponding TAO to withdraw.
+     */
+    function withdraw(uint256 amount) external {
+        require(balanceOf(msg.sender) >= amount, "Insufficient balance");
+
+        _burn(msg.sender, amount);
+        payable(msg.sender).transfer(amount);
+        emit Withdrawal(msg.sender, amount);
+    }
+
+    /**
+     * @dev Returns the balance of TAO held by the contract.
+     * 
+     * This function allows external callers to check the total amount of TAO stored in the contract.
+     * It is primarily used for tracking the contract's TAO balance, which is accumulated from user deposits.
+     *
+     * @return uint256 The amount of TAO (in wei, specifically 1e-18) currently held by the contract.
+     */
+    function getContractETHBalance() external view returns (uint256) {
+        return address(this).balance;
+    }
+}

--- a/contracts/wtao/hardhat.config.ts
+++ b/contracts/wtao/hardhat.config.ts
@@ -1,0 +1,28 @@
+import { HardhatUserConfig } from "hardhat/config";
+import "@nomicfoundation/hardhat-toolbox";
+import "@nomicfoundation/hardhat-verify";
+import { config } from "./config";
+
+const hardhatConfig: HardhatUserConfig = {
+  solidity: "0.8.24",
+  defaultNetwork: "local",
+  networks: {
+    mainnet: {
+      url: "https://entrypoint-finney.opentensor.ai",
+      accounts: [config.ethPrivateKey],
+    },
+    subevm: {
+      url: "https://test.chain.opentensor.ai",
+      accounts: [config.ethPrivateKey],
+    },
+    local: {
+      url: "http://127.0.0.1:9944",
+      accounts: [config.ethPrivateKey],
+    },
+  },
+  mocha: {
+    timeout: 300000,
+  },
+};
+
+export default hardhatConfig;

--- a/contracts/wtao/package.json
+++ b/contracts/wtao/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "wtao",
+  "version": "1.0.0",
+  "description": "Wrapped TAO on Bittensor",
+  "scripts": {
+    "build": "npx hardhat compile",
+    "deploy-local": "npx hardhat run scripts/deploy.ts --network local",
+    "deploy-testnet": "npx hardhat run scripts/deploy.ts --network subevm",
+    "test": "REPORT_GAS=true npx hardhat test --network local",
+    "deposit-local": "npx hardhat run scripts/deposit/main --network local",
+    "withdraw-local": "npx hardhat run scripts/withdrawal.ts --network local",
+    "balance-local": "npx hardhat run scripts/get-balance.ts --network local",
+    "balance-testnet": "npx hardhat run scripts/get-balance.ts --network subevm"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "@nomicfoundation/hardhat-chai-matchers": "^2.0.7",
+    "@nomicfoundation/hardhat-ethers": "^3.0.8",
+    "@nomicfoundation/hardhat-network-helpers": "^1.0.11",
+    "@nomicfoundation/hardhat-toolbox": "^3.0.0",
+    "@nomicfoundation/hardhat-verify": "^1.0.0",
+    "@openzeppelin/contracts": "5.0.1",
+    "@typechain/ethers-v6": "^0.4.0",
+    "@typechain/hardhat": "^8.0.0",
+    "@types/chai": "^4.3.19",
+    "@types/mocha": "^10.0.7",
+    "@types/node": "^22.5.4",
+    "bignumber.js": "^9.1.0",
+    "chai": "^4.2.0",
+    "ethers": "^6.13.2",
+    "hardhat": "^2.19.4",
+    "hardhat-gas-reporter": "^1.0.8",
+    "node-json-db": "^2.3.1",
+    "solidity-coverage": "^0.8.13",
+    "ts-node": "^10.9.2",
+    "typechain": "^8.3.2",
+    "typescript": "^5.3.3"
+  }
+}

--- a/contracts/wtao/scripts/deploy.ts
+++ b/contracts/wtao/scripts/deploy.ts
@@ -1,0 +1,19 @@
+import { ethers } from "hardhat";
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+  const wtao = await ethers.deployContract("WTAO", { gasLimit: 2000000, from: deployer.address });
+  await wtao.waitForDeployment();
+
+  // Make an initial deposit to cover ED
+  await wtao.deposit({ gasLimit: 2000000, from: deployer.address, value: ethers.parseEther("0.0001") });
+
+  console.log(
+    `WTAO contract deployed to ${wtao.target}`
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/contracts/wtao/test/wrapper.ts
+++ b/contracts/wtao/test/wrapper.ts
@@ -1,0 +1,69 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { HardhatEthersProvider } from "@nomicfoundation/hardhat-ethers/internal/hardhat-ethers-provider";
+import { WTAO } from "../typechain-types/contracts/WTAO";
+import BigNumber from 'bignumber.js';
+BigNumber.config({ DECIMAL_PLACES: 0, ROUNDING_MODE: BigNumber.ROUND_DOWN, EXPONENTIAL_AT: 255 });
+
+describe("WTAO contract", function () {
+  let sutContract: WTAO;
+  let gasPrice: BigNumber;
+  let provider: HardhatEthersProvider;
+  let caller: any;
+  let gasParameters: {
+    gasLimit: ethers.BigNumber,
+    gasPrice: ethers.BigNumber,
+  } = {
+    gasLimit: 2000000,
+    gasPrice: ethers.parseUnits("20", "gwei"),
+  };
+
+  before(async () => {
+    provider = ethers.provider;
+    [caller] = await ethers.getSigners();
+    sutContract = await ethers.deployContract("WTAO", { ...gasParameters});
+    await sutContract.waitForDeployment();
+    console.log(`Contract deployed at address: ${await sutContract.getAddress()}`);
+  });
+
+  it("Deposit TAO", async () => {
+    const balanceBefore = await provider.getBalance(caller.address);
+    const tx = await sutContract.deposit({ ...gasParameters, value: ethers.parseEther("0.1") });
+
+    // Wait for the transaction to be mined
+    await tx.wait();
+
+    // Check user WTAO balance
+    const wtaoBalance = await sutContract.balanceOf(caller);
+    expect(wtaoBalance).to.be.eq(ethers.parseEther("0.1"));
+
+    // Check that TAO is stored in the contract (less 500 rao existential deposit 
+    // that we don't see on the EVM side)
+    const tvlBalance = await sutContract.getContractETHBalance();
+    expect(tvlBalance).to.be.eq(ethers.parseEther("0.1") - 500_000_000_000n);
+
+    // Check that user balance decreased
+    const balanceAfter = await provider.getBalance(caller.address);
+    expect(balanceBefore - balanceAfter).to.be.gte(ethers.parseEther("0.1"));
+  });
+
+  it("Withdraw TAO", async () => {
+    const balanceBefore = await provider.getBalance(caller.address);
+    const tx = await sutContract.withdraw(ethers.parseEther("0.1"), { ...gasParameters});
+
+    // Wait for the transaction to be mined
+    await tx.wait();
+
+    // Check user WTAO balance
+    const wtaoBalance = await sutContract.balanceOf(caller);
+    expect(wtaoBalance).to.be.eq(0);
+
+    // Check that TAO is stored in the contract
+    const tvlBalance = await sutContract.getContractETHBalance();
+    expect(tvlBalance).to.be.eq(0);
+
+    // Check that user balance increased
+    const balanceAfter = await provider.getBalance(caller.address);
+    expect(balanceAfter - balanceBefore).to.be.gte(0);
+  });
+});

--- a/contracts/wtao/tsconfig.json
+++ b/contracts/wtao/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  }
+}


### PR DESCRIPTION
## Summary

- Vendor the WTAO ERC-20 wrapper under `contracts/wtao`
- Include the Solidity contracts, Hardhat configuration, deployment script, tests, and locked dependencies
- Preserve the upstream `opentensor/wtao` snapshot at commit `49d1e44a6232a2200fa9bfdb006eeec9c73090fb` byte-for-byte

## Testing

- Verified all vendored files match their upstream Git blob hashes
- `git diff --check`
- Hardhat tests were not run because dependencies are not installed locally