### PR TITLE
fix(sdk): validate dry-run affordability

### DIFF
--- a/sdk/python/bittensor/executor.py
+++ b/sdk/python/bittensor/executor.py
@@ -27,6 +27,7 @@ from .balance import Balance
 from .fee_filters import COLDKEY_FEE_WARNING, charges_coldkey_fee
 from .intents import Intent, Plan, Policy, list_tools
 from .intents import build as build_intent
+from .intents._affordability import SpendProfile, affordability_blocks, planned_fee_payer
 from .intents.base import BuiltCall, IntentPreflight
 from .intents.proxy import check_proxy_type
 from .result import (
@@ -237,13 +238,13 @@ def _intent_accounts(
     wallet: WalletLike,
     proxy_for: Optional[str] = None,
 ) -> tuple[str, str]:
-    """Return ``(dispatch_origin, fee_payer)`` for a fully wrapped intent."""
-    fee_payer = public_view(wallet, intent.signer).ss58_address
+    """Return ``(dispatch_origin, signer_address)`` for a wrapped intent."""
+    signer_address = public_view(wallet, intent.signer).ss58_address
     if proxy_for is not None:
-        return proxy_for, fee_payer
+        return proxy_for, signer_address
     origin_view = _intent_origin_view(substrate, intent, wallet, proxy_for)
     dispatch_origin = public_view(origin_view, intent.semantic_intent().signer).ss58_address
-    return dispatch_origin, fee_payer
+    return dispatch_origin, signer_address
 
 
 def _with_nested_dispatch_failure(result: ExtrinsicResult) -> ExtrinsicResult:
@@ -693,18 +694,27 @@ class Executor:
                 proxy_for=proxy_for,
                 proxy_type=proxy_type,
             )
-        dispatch_origin, fee_payer = _intent_accounts(
+        dispatch_origin, signer_address = _intent_accounts(
             self.substrate,
             intent,
             wallet,
             proxy_for,
         )
-        return await intent.preflight(
+        fee_payer, fee_payer_block = await planned_fee_payer(
+            self.substrate,
+            proxy_for=proxy_for,
+            signer_address=signer_address,
+            proxy_is_outer=intent.semantic_intent() is intent,
+        )
+        preview = await intent.preflight(
             self.substrate,
             dispatch_origin,
             fee_payer,
             call=call,
         )
+        if fee_payer_block is not None:
+            preview.blocks.append(fee_payer_block)
+        return preview
 
     async def plan(
         self,
@@ -733,11 +743,19 @@ class Executor:
             proxy_type=proxy_type,
         )
         pub = self._public_keypair(wallet, intent.signer)
-        _origin, signer_address = _intent_accounts(self.substrate, intent, wallet, proxy_for)
-        preflight = await self._preflight(
-            intent,
-            wallet,
+        dispatch_origin, signer_address = _intent_accounts(
+            self.substrate, intent, wallet, proxy_for
+        )
+        fee_payer, fee_payer_block = await planned_fee_payer(
+            self.substrate,
             proxy_for=proxy_for,
+            signer_address=signer_address,
+            proxy_is_outer=intent.semantic_intent() is intent,
+        )
+        preflight = await intent.preflight(
+            self.substrate,
+            dispatch_origin,
+            fee_payer,
             call=call,
         )
         warnings: list[str] = list(preflight.warnings)
@@ -753,8 +771,28 @@ class Executor:
         effects = list(preflight.effects)
         if proxy_for is not None:
             effects.append(f"dispatched via proxy as {proxy_for} (signed by {signer_address})")
-        violations = self._violations(intent, fee, policy)
+        semantic_intent = intent.semantic_intent()
+        spend_profile = preflight.spend_profile
+        if spend_profile.total is None:
+            spend_profile = SpendProfile.from_spend(
+                semantic_intent.spend(),
+                preserve=semantic_intent.preserves_dispatch_origin(),
+            )
+        spend = spend_profile.total
+        active_policy = self._active_policy(policy)
+        violations = active_policy.check_resolved(intent, fee, spend) if active_policy else []
         violations.extend(preflight.blocks)
+        if fee_payer_block is not None and isinstance(spend, Balance):
+            violations.append(fee_payer_block)
+        violations.extend(
+            await affordability_blocks(
+                self.substrate,
+                profile=spend_profile,
+                fee=fee,
+                dispatch_origin=dispatch_origin,
+                fee_payer=fee_payer,
+            )
+        )
 
         return Plan(
             op=intent.op,
@@ -767,7 +805,7 @@ class Executor:
             violations=violations,
             call=call,
             extras=extras,
-            spend=intent.semantic_intent().spend(),
+            spend=spend,
             args={k: v for k, v in intent.to_dict().items() if k != "op"},
         )
 
@@ -930,13 +968,16 @@ class Executor:
         call, extras = await _compose_intent_call(
             self.substrate, intent, wallet, proxy_for=proxy_for, proxy_type=proxy_type
         )
-        dispatch_origin, fee_payer = _intent_accounts(self.substrate, intent, wallet, proxy_for)
-        preflight = await self._preflight(
-            intent,
-            wallet,
-            proxy_for=proxy_for,
+        dispatch_origin, signer_address = _intent_accounts(
+            self.substrate, intent, wallet, proxy_for
+        )
+        preflight = await intent.preflight(
+            self.substrate,
+            dispatch_origin,
+            signer_address,
             call=call,
         )
+        fee_payer = signer_address
         fee = preflight.estimated_fee
         active = self._active_policy(policy)
         if active is not None and active.max_fee_tao is not None and fee is None:

--- a/sdk/python/bittensor/intents/_affordability.py
+++ b/sdk/python/bittensor/intents/_affordability.py
@@ -1,0 +1,155 @@
+"""Free-balance requirements for planned TAO spends."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+from .._generated import constants, storage
+from ..balance import Balance
+from ._money import UNBOUNDED, Spend
+
+if TYPE_CHECKING:
+    from .._substrate import Substrate
+
+
+@dataclass(frozen=True)
+class SpendProfile:
+    """Bounded TAO spend and the latest prefix that must preserve the account.
+
+    ``preserve_through`` is the cumulative spend immediately after a
+    keep-alive child. Keeping the prefix instead of a batch-wide boolean avoids
+    reserving the existential deposit after later expendable children.
+    """
+
+    total: Spend = None
+    preserve_through: Optional[Balance] = None
+
+    @classmethod
+    def from_spend(cls, spend: Spend, *, preserve: bool = False) -> "SpendProfile":
+        return cls(
+            total=spend,
+            preserve_through=spend if preserve and isinstance(spend, Balance) else None,
+        )
+
+    @classmethod
+    def combine(cls, profiles: Iterable["SpendProfile"]) -> "SpendProfile":
+        total = Balance.from_rao(0)
+        preserve_through: Optional[Balance] = None
+        bounded = False
+        for profile in profiles:
+            if profile.total is UNBOUNDED:
+                return cls(total=UNBOUNDED)
+            if not isinstance(profile.total, Balance):
+                continue
+            if profile.preserve_through is not None:
+                candidate = total + profile.preserve_through
+                if preserve_through is None or candidate > preserve_through:
+                    preserve_through = candidate
+            total += profile.total
+            bounded = True
+        return cls(total=total if bounded else None, preserve_through=preserve_through)
+
+
+async def planned_fee_payer(
+    substrate: "Substrate",
+    *,
+    proxy_for: Optional[str],
+    signer_address: str,
+    proxy_is_outer: bool,
+) -> tuple[str, Optional[str]]:
+    """Resolve the payer selected by the runtime's outer proxy wrapper."""
+    if proxy_for is None or not proxy_is_outer:
+        return signer_address, None
+    try:
+        delegates = await substrate.query_map(*storage.Proxy.RealPaysFee, [proxy_for])
+    except Exception as error:
+        return (
+            signer_address,
+            f"could not verify which proxy account pays the transaction fee: {error}",
+        )
+    opted_in = any(str(delegate) == signer_address for delegate, _value in delegates)
+    return (proxy_for if opted_in else signer_address), None
+
+
+async def affordability_blocks(
+    substrate: "Substrate",
+    *,
+    profile: SpendProfile,
+    fee: Optional[Balance],
+    dispatch_origin: str,
+    fee_payer: str,
+) -> list[str]:
+    """Return hard stops when a bounded spend cannot be funded.
+
+    The semantic spend belongs to ``dispatch_origin`` while the outer
+    extrinsic fee belongs to ``fee_payer``. They are usually the same account,
+    but proxy and multisig execution deliberately separate them.
+    """
+    if not isinstance(profile.total, Balance):
+        return []
+    if fee is None:
+        return ["could not verify affordability because the transaction fee is unavailable"]
+
+    spends: dict[str, int] = defaultdict(int)
+    fees: dict[str, int] = defaultdict(int)
+    parts: dict[str, list[str]] = defaultdict(list)
+    spends[dispatch_origin] += profile.total.rao
+    parts[dispatch_origin].append(f"spend {profile.total}")
+    fees[fee_payer] += fee.rao
+    parts[fee_payer].append(f"fee ~{fee}")
+
+    accounts = list(dict.fromkeys([dispatch_origin, fee_payer]))
+    reads = [substrate.query(*storage.System.Account, [account]) for account in accounts]
+    reads.append(substrate.constant(*constants.Balances.ExistentialDeposit))
+    try:
+        results = await asyncio.gather(*reads)
+    except Exception as error:
+        return [f"could not verify free TAO for this spend: {error}"]
+    states = results[: len(accounts)]
+    deposit = int(results[-1])
+
+    blocks = []
+    for address, state in zip(accounts, states):
+        data = (state or {}).get("data") or {}
+        free = int(data.get("free") or 0)
+        frozen = max(0, int(data.get("frozen") or 0) - int(data.get("reserved") or 0))
+        spend_rao = spends[address]
+        fee_rao = fees[address]
+
+        # Transaction payment withdraws the fee first with
+        # ``Preservation::Preserve``. The semantic call then spends from its
+        # dispatch origin and may or may not preserve that account. Both
+        # intermediate and final balance constraints must hold.
+        after_fee_floor = max(frozen, deposit) if fee_rao else frozen
+        fee_stage_needed = fee_rao + after_fee_floor
+        semantic_stage_needed = fee_rao + spend_rao + frozen
+        semantic_floor = frozen
+        if address == dispatch_origin and profile.preserve_through is not None:
+            preserve_floor = max(frozen, deposit)
+            preserve_needed = fee_rao + profile.preserve_through.rao + preserve_floor
+            if preserve_needed > semantic_stage_needed:
+                semantic_stage_needed = preserve_needed
+                semantic_floor = preserve_floor
+        needed = max(fee_stage_needed, semantic_stage_needed)
+        if free < needed:
+            reasons = list(parts[address])
+            floor = after_fee_floor if fee_stage_needed >= semantic_stage_needed else semantic_floor
+            if floor:
+                label = (
+                    "existential deposit"
+                    if floor == deposit and deposit >= frozen
+                    else "frozen balance"
+                )
+                reasons.append(f"{label} {Balance.from_rao(floor)}")
+            blocks.append(
+                f"free TAO ({Balance.from_rao(free)}) for {address} is below "
+                f"the required {Balance.from_rao(needed)} ({' + '.join(reasons)})"
+            )
+    return blocks
+
+
+__all__ = ["SpendProfile", "affordability_blocks", "planned_fee_payer"]

--- a/sdk/python/bittensor/intents/base.py
+++ b/sdk/python/bittensor/intents/base.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal, Optional
 
 from ..balance import Balance
 from ..result import BittensorError
+from ._affordability import SpendProfile
 from ._money import Spend
 
 if TYPE_CHECKING:
@@ -132,6 +133,10 @@ class IntentPreflight:
     # Stage heading for ``facts`` in the review card: "Fees" for cost
     # breakdowns, "Quote" for simulated swap outcomes (what you receive).
     facts_title: str = "Fees"
+    # Chain-resolved TAO spend and keep-alive sequencing. Static intents get
+    # this from ``Intent.spend``; dynamic-price intents resolve it here so the
+    # plan's effects, policy, and affordability all share one state read.
+    spend_profile: SpendProfile = field(default_factory=SpendProfile)
 
 
 @dataclass
@@ -223,6 +228,9 @@ class Intent(ABC):
             effects=list(await self.effects(substrate, dispatch_origin)),
             warnings=list(await self.warnings(substrate, dispatch_origin)),
             blocks=list(await self.blocks(substrate, dispatch_origin)),
+            spend_profile=SpendProfile.from_spend(
+                self.spend(), preserve=self.preserves_dispatch_origin()
+            ),
         )
 
     async def wrap_call(self, substrate: "Substrate", wallet: "Any", call: Any):
@@ -307,6 +315,10 @@ class Intent(ABC):
         value leaves.
         """
         return None
+
+    def preserves_dispatch_origin(self) -> bool:
+        """Whether TAO spend must leave the dispatch-origin account alive."""
+        return False
 
     def touches_netuids(self) -> list[int]:
         """Every netuid this intent acts on, for policy allowlists.

--- a/sdk/python/bittensor/intents/batch.py
+++ b/sdk/python/bittensor/intents/batch.py
@@ -9,15 +9,29 @@ the command for free like any other intent.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Any
 
 from .._generated import calls
 from ..balance import Balance
+from ._affordability import SpendProfile
 from ._money import UNBOUNDED, Spend
 from .base import BuiltCall, Intent, IntentPreflight
 from .registry import build as build_intent
 from .registry import register
+
+
+def _sum_spends(spends: Iterable[Spend]) -> Spend:
+    total = Balance.from_rao(0)
+    bounded = False
+    for spend in spends:
+        if spend is UNBOUNDED:
+            return UNBOUNDED
+        if spend is not None:
+            total += spend
+            bounded = True
+    return total if bounded else None
 
 
 @register
@@ -122,6 +136,7 @@ class Batch(Intent):
         required_free: Balance | None = None
         available_free: Balance | None = None
         estimated_fee: Balance | None = None
+        spend_profiles: list[SpendProfile] = []
         for index, child in enumerate(self._children):
             child_preflight = await child.preflight(
                 substrate, dispatch_origin, fee_payer, call=call
@@ -129,6 +144,7 @@ class Batch(Intent):
             effects.extend(f"[{index}] {item}" for item in child_preflight.effects)
             warnings.extend(f"[{index}] {item}" for item in child_preflight.warnings)
             blocks.extend(f"[{index}] {item}" for item in child_preflight.blocks)
+            spend_profiles.append(child_preflight.spend_profile)
             if child_preflight.required_free is not None and (
                 required_free is None or child_preflight.required_free.rao > required_free.rao
             ):
@@ -144,21 +160,13 @@ class Batch(Intent):
             required_free=required_free,
             available_free=available_free,
             estimated_fee=estimated_fee,
+            spend_profile=SpendProfile.combine(spend_profiles),
         )
 
     def spend(self) -> Spend:
         """Aggregate TAO spend across children; any unbounded child makes the
         whole batch unbounded."""
-        total = Balance.from_rao(0)
-        bounded = False
-        for child in self._children:
-            child_spend = child.spend()
-            if child_spend is UNBOUNDED:
-                return UNBOUNDED
-            if child_spend is not None:
-                total = total + child_spend
-                bounded = True
-        return total if bounded else None
+        return _sum_spends(child.spend() for child in self._children)
 
     def touches_netuids(self) -> list[int]:
         return sorted({netuid for child in self._children for netuid in child.touches_netuids()})

--- a/sdk/python/bittensor/intents/evm.py
+++ b/sdk/python/bittensor/intents/evm.py
@@ -73,6 +73,9 @@ class FundEvmKey(Intent):
             return UNBOUNDED
         return self.amount_tao
 
+    def preserves_dispatch_origin(self) -> bool:
+        return True
+
 
 @register
 @dataclass

--- a/sdk/python/bittensor/intents/governance.py
+++ b/sdk/python/bittensor/intents/governance.py
@@ -125,6 +125,9 @@ class StakeBurn(Intent):
     def spend(self) -> Spend:
         return self.amount_tao
 
+    def preserves_dispatch_origin(self) -> bool:
+        return True
+
 
 @register
 @dataclass

--- a/sdk/python/bittensor/intents/multisig.py
+++ b/sdk/python/bittensor/intents/multisig.py
@@ -374,6 +374,7 @@ class MultisigIntentAdapter(Intent):
             estimated_fee=semantic.estimated_fee,
             facts=[*semantic.facts, *dispatch.facts],
             facts_title=semantic.facts_title,
+            spend_profile=semantic.spend_profile,
         )
 
     def spend(self):

--- a/sdk/python/bittensor/intents/plan.py
+++ b/sdk/python/bittensor/intents/plan.py
@@ -49,6 +49,12 @@ class Policy:
         return ["raw call submission is disabled by policy (set allow_raw_calls=True)"]
 
     def check(self, intent: Intent, fee: Optional[Balance]) -> list[str]:
+        """Check policy against the intent's static spend declaration."""
+        semantic = intent.semantic_intent()
+        return self.check_resolved(semantic, fee, semantic.spend())
+
+    def check_resolved(self, intent: Intent, fee: Optional[Balance], spend: Spend) -> list[str]:
+        """Check policy using a chain-resolved spend from the planner."""
         intent = intent.semantic_intent()
         violations: list[str] = []
         if self.max_fee_tao is not None:
@@ -62,7 +68,6 @@ class Policy:
             elif fee > self.max_fee_tao:
                 violations.append(f"fee {fee} exceeds max_fee_tao {self.max_fee_tao}")
         if self.max_spend_tao is not None:
-            spend = intent.spend()
             if spend is UNBOUNDED:
                 violations.append(
                     f"{intent.op} spends an amount that cannot be bounded before "

--- a/sdk/python/bittensor/intents/registration.py
+++ b/sdk/python/bittensor/intents/registration.py
@@ -9,6 +9,7 @@ from typing import Any, Optional
 from .._generated import calls
 from .._generated import storage as st
 from ..balance import Balance
+from ._affordability import SpendProfile
 from ._money import UNBOUNDED, Spend
 from ._root_claim_fee import (
     quote_root_claim_fee,
@@ -243,6 +244,26 @@ class RootRegister(Intent):
             "lock none",
             "auto-childkey to every subnet owner unless opted out",
         ]
+
+    async def preflight(
+        self, substrate, dispatch_origin: str, fee_payer: str, *, call=None
+    ) -> IntentPreflight:
+        del dispatch_origin, fee_payer, call
+        burn, _lock = await neuron_registration_split(substrate, 0)
+        return IntentPreflight(
+            effects=[
+                self.summary(),
+                f"burn {burn} (recycled into issuance)",
+                "lock none",
+                "auto-childkey to every subnet owner unless opted out",
+            ],
+            warnings=[],
+            blocks=[],
+            spend_profile=SpendProfile.from_spend(burn, preserve=True),
+        )
+
+    def spend(self) -> Spend:
+        return UNBOUNDED
 
     def touches_netuids(self) -> list[int]:
         return [0]

--- a/sdk/python/bittensor/intents/staking.py
+++ b/sdk/python/bittensor/intents/staking.py
@@ -648,6 +648,9 @@ class AddStake(Intent):
             return UNBOUNDED
         return self.amount_tao
 
+    def preserves_dispatch_origin(self) -> bool:
+        return True
+
 
 @register
 @dataclass
@@ -998,6 +1001,9 @@ class AddStakeLimit(Intent):
         if self.amount_tao == ALL:
             return UNBOUNDED
         return self.amount_tao
+
+    def preserves_dispatch_origin(self) -> bool:
+        return True
 
 
 @register
@@ -1698,3 +1704,6 @@ class StakeIntoBasket(Intent):
         if self.amount_tao == ALL:
             return UNBOUNDED
         return self.amount_tao
+
+    def preserves_dispatch_origin(self) -> bool:
+        return True

--- a/sdk/python/bittensor/intents/transfer.py
+++ b/sdk/python/bittensor/intents/transfer.py
@@ -77,6 +77,9 @@ class Transfer(Intent):
             return UNBOUNDED
         return self.amount_tao
 
+    def preserves_dispatch_origin(self) -> bool:
+        return self.keep_alive
+
 
 @register
 @dataclass

--- a/sdk/python/tests/unit/test_affordability.py
+++ b/sdk/python/tests/unit/test_affordability.py
@@ -1,0 +1,346 @@
+"""Dry-run affordability across direct and delegated execution."""
+
+from __future__ import annotations
+
+import pytest
+
+from bittensor.balance import Balance
+from bittensor.client import Client
+from bittensor.intents.batch import Batch
+from bittensor.intents.plan import Policy
+from bittensor.intents.registration import RootRegister
+from bittensor.intents.staking import AddStake
+from bittensor.intents.transfer import Transfer
+from tests.harness.fake_substrate import FakeSubstrate
+from tests.harness.samples import ALICE, BOB, BOB_HOT, dev_wallet
+
+
+def _account(free: int, *, reserved: int = 0, frozen: int = 0) -> dict:
+    return {"data": {"free": free, "reserved": reserved, "frozen": frozen}}
+
+
+@pytest.fixture()
+def substrate() -> FakeSubstrate:
+    return FakeSubstrate()
+
+
+@pytest.fixture()
+def client(substrate: FakeSubstrate) -> Client:
+    return Client("local", substrate=substrate)
+
+
+def _stake() -> AddStake:
+    return AddStake(
+        hotkey_ss58=BOB_HOT,
+        netuid=0,
+        amount_tao=1,
+        slippage_protection=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_static_spend_blocks_zero_balance(client: Client):
+    plan = await client.plan(_stake(), dev_wallet())
+
+    assert not plan.ok
+    assert any("free TAO" in reason and "spend τ1" in reason for reason in plan.violations)
+
+
+@pytest.mark.asyncio
+async def test_static_spend_accepts_exact_spend_plus_fee(client: Client, substrate: FakeSubstrate):
+    deposit = int(await substrate.constant("Balances", "ExistentialDeposit"))
+    required = Balance.from_tao(1).rao + substrate.fee.rao + deposit
+    substrate.seed("System", "Account", [ALICE], _account(required))
+
+    plan = await client.plan(_stake(), dev_wallet())
+
+    assert plan.ok, plan.violations
+
+
+@pytest.mark.asyncio
+async def test_static_spend_accounts_for_frozen_balance(client: Client, substrate: FakeSubstrate):
+    frozen = 1_000
+    required = Balance.from_tao(1).rao + substrate.fee.rao + frozen
+    substrate.seed("System", "Account", [ALICE], _account(required - 1, frozen=frozen))
+
+    plan = await client.plan(_stake(), dev_wallet())
+
+    assert not plan.ok
+    assert any("frozen balance" in reason for reason in plan.violations)
+
+
+@pytest.mark.asyncio
+async def test_reserved_balance_offsets_the_total_frozen_floor(
+    client: Client, substrate: FakeSubstrate
+):
+    required = Balance.from_tao(1).rao + substrate.fee.rao
+    frozen = 1_000
+    reserved = 400
+    substrate.seed(
+        "System",
+        "Account",
+        [ALICE],
+        _account(required + frozen - reserved, reserved=reserved, frozen=frozen),
+    )
+
+    exact = await client.plan(_stake(), dev_wallet())
+    assert exact.ok, exact.violations
+
+    substrate.seed(
+        "System",
+        "Account",
+        [ALICE],
+        _account(required + frozen - reserved - 1, reserved=reserved, frozen=frozen),
+    )
+    short = await client.plan(_stake(), dev_wallet())
+    assert not short.ok
+    assert any("frozen balance" in reason for reason in short.violations)
+
+
+@pytest.mark.asyncio
+async def test_fee_withdrawal_preserves_existential_deposit(
+    client: Client, substrate: FakeSubstrate
+):
+    deposit = int(await substrate.constant("Balances", "ExistentialDeposit"))
+    transfer = Transfer(dest_ss58=BOB, amount_tao=Balance.from_rao(1), keep_alive=False)
+    substrate.seed(
+        "System",
+        "Account",
+        [ALICE],
+        _account(substrate.fee.rao + deposit - 1),
+    )
+
+    short = await client.plan(transfer, dev_wallet())
+
+    assert not short.ok
+    assert any("existential deposit" in reason for reason in short.violations)
+
+    substrate.seed("System", "Account", [ALICE], _account(substrate.fee.rao + deposit))
+    exact = await client.plan(transfer, dev_wallet())
+    assert exact.ok, exact.violations
+
+
+@pytest.mark.asyncio
+async def test_keep_alive_transfer_preserves_deposit_after_spend(
+    client: Client, substrate: FakeSubstrate
+):
+    deposit = int(await substrate.constant("Balances", "ExistentialDeposit"))
+    amount = Balance.from_tao(1)
+    transfer = Transfer(dest_ss58=BOB, amount_tao=amount, keep_alive=True)
+    required = substrate.fee.rao + amount.rao + deposit
+    substrate.seed("System", "Account", [ALICE], _account(required - 1))
+
+    short = await client.plan(transfer, dev_wallet())
+
+    assert not short.ok
+    assert any("existential deposit" in reason for reason in short.violations)
+
+    substrate.seed("System", "Account", [ALICE], _account(required))
+    exact = await client.plan(transfer, dev_wallet())
+    assert exact.ok, exact.violations
+
+
+@pytest.mark.asyncio
+async def test_allow_death_transfer_can_spend_the_post_fee_deposit(
+    client: Client, substrate: FakeSubstrate
+):
+    deposit = int(await substrate.constant("Balances", "ExistentialDeposit"))
+    amount = Balance.from_rao(deposit)
+    transfer = Transfer(dest_ss58=BOB, amount_tao=amount, keep_alive=False)
+    substrate.seed("System", "Account", [ALICE], _account(substrate.fee.rao + amount.rao))
+
+    plan = await client.plan(transfer, dev_wallet())
+
+    assert plan.ok, plan.violations
+
+
+@pytest.mark.asyncio
+async def test_root_registration_exposes_and_checks_dynamic_burn(
+    client: Client, substrate: FakeSubstrate
+):
+    burn = 2_000_000_000
+    deposit = int(await substrate.constant("Balances", "ExistentialDeposit"))
+    substrate.seed("SubtensorModule", "Burn", [0], burn)
+    substrate.seed(
+        "System",
+        "Account",
+        [ALICE],
+        _account(burn + substrate.fee.rao + deposit),
+    )
+
+    plan = await client.plan(RootRegister(), dev_wallet())
+
+    assert plan.ok, plan.violations
+    assert plan.to_dict()["spend_tao"] == pytest.approx(2.0)
+    capped = await client.plan(RootRegister(), dev_wallet(), policy=Policy(max_spend_tao=1))
+    assert any("spend τ2" in reason for reason in capped.violations)
+
+    substrate.seed(
+        "System",
+        "Account",
+        [ALICE],
+        _account(burn + substrate.fee.rao + deposit - 1),
+    )
+    short = await client.plan(RootRegister(), dev_wallet())
+    assert not short.ok
+    assert any("existential deposit" in reason for reason in short.violations)
+
+
+@pytest.mark.asyncio
+async def test_root_registration_uses_one_burn_snapshot(
+    client: Client, substrate: FakeSubstrate, monkeypatch
+):
+    original_query = substrate.query
+    burn_reads = 0
+
+    async def counted_query(module, item, params=None):
+        nonlocal burn_reads
+        if (module, item, params) == ("SubtensorModule", "Burn", [0]):
+            burn_reads += 1
+        return await original_query(module, item, params)
+
+    monkeypatch.setattr(substrate, "query", counted_query)
+    substrate.seed_default("System", "Account", _account(Balance.from_tao(10).rao))
+
+    plan = await client.plan(RootRegister(), dev_wallet())
+
+    assert plan.ok, plan.violations
+    assert burn_reads == 1
+
+
+@pytest.mark.asyncio
+async def test_batch_only_preserves_the_prefix_that_needs_keep_alive(
+    client: Client, substrate: FakeSubstrate
+):
+    deposit = int(await substrate.constant("Balances", "ExistentialDeposit"))
+    first = Balance.from_rao(100)
+    last = Balance.from_rao(1_000)
+    batch = Batch(
+        intents=[
+            Transfer(dest_ss58=BOB, amount_tao=first, keep_alive=True),
+            Transfer(dest_ss58=BOB, amount_tao=last, keep_alive=False),
+        ]
+    )
+    required = first.rao + last.rao + substrate.fee.rao
+    assert first.rao + last.rao >= first.rao + deposit
+    substrate.seed("System", "Account", [ALICE], _account(required))
+
+    plan = await client.plan(batch, dev_wallet())
+
+    assert plan.ok, plan.violations
+
+
+@pytest.mark.asyncio
+async def test_batch_preserves_deposit_when_keep_alive_spend_is_last(
+    client: Client, substrate: FakeSubstrate
+):
+    deposit = int(await substrate.constant("Balances", "ExistentialDeposit"))
+    first = Balance.from_rao(1_000)
+    last = Balance.from_rao(100)
+    batch = Batch(
+        intents=[
+            Transfer(dest_ss58=BOB, amount_tao=first, keep_alive=False),
+            Transfer(dest_ss58=BOB, amount_tao=last, keep_alive=True),
+        ]
+    )
+    required = first.rao + last.rao + substrate.fee.rao + deposit
+    substrate.seed("System", "Account", [ALICE], _account(required - 1))
+
+    short = await client.plan(batch, dev_wallet())
+    assert not short.ok
+    assert any("existential deposit" in reason for reason in short.violations)
+
+    substrate.seed("System", "Account", [ALICE], _account(required))
+    exact = await client.plan(batch, dev_wallet())
+    assert exact.ok, exact.violations
+
+
+@pytest.mark.asyncio
+async def test_proxy_checks_origin_spend_and_delegate_fee_separately(
+    client: Client, substrate: FakeSubstrate
+):
+    deposit = int(await substrate.constant("Balances", "ExistentialDeposit"))
+    substrate.seed(
+        "System",
+        "Account",
+        [BOB],
+        _account(Balance.from_tao(1).rao + deposit),
+    )
+    substrate.seed("System", "Account", [ALICE], _account(substrate.fee.rao + deposit))
+
+    plan = await client.plan(_stake(), dev_wallet(), proxy_for=BOB)
+    assert plan.ok, plan.violations
+
+    substrate.seed("System", "Account", [ALICE], _account(substrate.fee.rao + deposit - 1))
+    short = await client.plan(_stake(), dev_wallet(), proxy_for=BOB)
+    assert not short.ok
+    assert any(ALICE in reason and "fee" in reason for reason in short.violations)
+
+    substrate.seed("System", "Account", [ALICE], _account(substrate.fee.rao + deposit))
+    substrate.seed(
+        "System",
+        "Account",
+        [BOB],
+        _account(Balance.from_tao(1).rao + deposit - 1),
+    )
+    short = await client.plan(_stake(), dev_wallet(), proxy_for=BOB)
+    assert not short.ok
+    assert any(BOB in reason and "spend" in reason for reason in short.violations)
+
+
+@pytest.mark.asyncio
+async def test_proxy_real_pays_fee_is_resolved_from_chain_state(
+    client: Client, substrate: FakeSubstrate
+):
+    deposit = int(await substrate.constant("Balances", "ExistentialDeposit"))
+    required = Balance.from_tao(1).rao + substrate.fee.rao + deposit
+    substrate.seed_map("Proxy", "RealPaysFee", [(ALICE, ())])
+    substrate.seed("System", "Account", [ALICE], _account(0))
+    substrate.seed("System", "Account", [BOB], _account(required))
+
+    plan = await client.plan(_stake(), dev_wallet(), proxy_for=BOB)
+
+    assert plan.ok, plan.violations
+    assert plan.signer_address == ALICE
+    assert any(f"signed by {ALICE}" in effect for effect in plan.effects)
+
+    substrate.seed("System", "Account", [BOB], _account(required - 1))
+    short = await client.plan(_stake(), dev_wallet(), proxy_for=BOB)
+    assert not short.ok
+    assert any(BOB in reason and "fee" in reason for reason in short.violations)
+
+
+@pytest.mark.asyncio
+async def test_bounded_spend_fails_closed_when_fee_is_unavailable(
+    client: Client, substrate: FakeSubstrate, monkeypatch
+):
+    substrate.seed("System", "Account", [ALICE], _account(Balance.from_tao(10).rao))
+
+    async def unavailable_fee(*_args, **_kwargs):
+        raise RuntimeError("payment info unavailable")
+
+    monkeypatch.setattr(substrate, "estimate_fee", unavailable_fee)
+
+    plan = await client.plan(_stake(), dev_wallet())
+
+    assert not plan.ok
+    assert any("transaction fee is unavailable" in reason for reason in plan.violations)
+
+
+@pytest.mark.asyncio
+async def test_bounded_spend_fails_closed_when_account_read_fails(
+    client: Client, substrate: FakeSubstrate, monkeypatch
+):
+    original_query = substrate.query
+
+    async def unavailable_account(module, item, params=None):
+        if (module, item) == ("System", "Account"):
+            raise RuntimeError("account storage unavailable")
+        return await original_query(module, item, params)
+
+    monkeypatch.setattr(substrate, "query", unavailable_account)
+
+    plan = await client.plan(_stake(), dev_wallet())
+
+    assert not plan.ok
+    assert any("could not verify free TAO" in reason for reason in plan.violations)

--- a/sdk/python/tests/unit/test_cli.py
+++ b/sdk/python/tests/unit/test_cli.py
@@ -59,6 +59,9 @@ def fake(tmp_path, monkeypatch, wallet_dir) -> FakeSubstrate:
     monkeypatch.setenv("BT_WALLET", _WALLET_NAME)
 
     substrate = FakeSubstrate()
+    substrate.seed_default(
+        "System", "Account", {"data": {"free": 10**18, "reserved": 0, "frozen": 0}}
+    )
 
     def make_client(network, **kwargs):
         return Client(network, substrate=substrate)
@@ -382,6 +385,19 @@ class TestRoot:
 
 
 class TestTransactions:
+    def test_root_register_dry_run_rejects_an_unfunded_wallet(self, fake: FakeSubstrate):
+        fake.seed_default("System", "Account", {"data": {"free": 0, "reserved": 0, "frozen": 0}})
+
+        result = invoke("--json", "--dry-run", "root", "register")
+
+        assert result.exit_code == 1, result.output
+        plan = json.loads(result.output)
+        assert plan["op"] == "root_register"
+        assert plan["spend_tao"] == 1.0
+        assert plan["ok"] is False
+        assert any("free TAO" in reason for reason in plan["violations"])
+        assert fake.submissions == []
+
     def test_dry_run_renders_plan_without_submitting(self, fake: FakeSubstrate):
         result = invoke(
             "--json",

--- a/sdk/python/tests/unit/test_intents_table.py
+++ b/sdk/python/tests/unit/test_intents_table.py
@@ -26,7 +26,11 @@ from tests.harness.samples import ALICE, ALICE_HOT, BOB, BOB_HOT, INTENT_SAMPLES
 
 @pytest.fixture()
 def substrate() -> FakeSubstrate:
-    return FakeSubstrate()
+    substrate = FakeSubstrate()
+    substrate.seed_default(
+        "System", "Account", {"data": {"free": 10**18, "reserved": 0, "frozen": 0}}
+    )
+    return substrate
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary

- resolve dynamic root-registration burn once during preflight and expose it as planned spend
- reject unaffordable bounded dry-runs before signing, including fee, frozen-balance, existential-deposit, proxy, multisig, and ordered-batch requirements
- enforce spend policies against the chain-resolved amount

## Validation

- Ruff lint and format checks
- focused dry-run, CLI, intent-table, and multisig tests: 622 passed
- full Python unit suite: 1,792 passed, 1 skipped
- live testnet root-register dry-run: reported 1 TAO spend plus fee and existential-deposit shortfall, returned ok false, and did not submit