### PR TITLE
fix(btcli): trim wallet balance decimals

### DIFF
--- a/sdk/python/bittensor/cli/commands/wallet.py
+++ b/sdk/python/bittensor/cli/commands/wallet.py
@@ -37,6 +37,7 @@ from ..helpers import (
     combine_root_yields,
     dust_note,
     filter_stakes,
+    format_balance,
     format_root_yield_value,
     has_root_yield_context,
     human_balance_fields,
@@ -1081,16 +1082,16 @@ def wallet_balance(
         shown = rows_data if show_empty else [r for r in rows_data if r["total_value_tao"] > 0]
         hidden = len(rows_data) - len(shown)
 
-        def _amount(display: object, tao: float) -> str:
-            return "—" if tao == 0 else str(display)
+        def _amount(display: Balance) -> str:
+            return "—" if display.rao == 0 else format_balance(display)
 
         table_rows = [
             [
                 r["wallet"] + (" (multisig)" if r["kind"] == "multisig" else ""),
-                _amount(r["free"], r["free_tao"]),
-                _amount(r["stake_value"], r["stake_value_tao"]),
-                _amount(r["beta_value"], r["beta_value_tao"]),
-                _amount(r["total_value"], r["total_value_tao"]),
+                _amount(r["free"]),
+                _amount(r["stake_value"]),
+                _amount(r["beta_value"]),
+                _amount(r["total_value"]),
                 r["coldkey"],
             ]
             for r in shown
@@ -1100,7 +1101,10 @@ def wallet_balance(
         by_coldkey = {r["coldkey"]: r for r in rows_data}
         grand_total = Balance(sum(int(r["total_value"].rao) for r in by_coldkey.values()))
         duplicates = len(rows_data) - len(by_coldkey)
-        footer = f"[bold]total[/bold] {grand_total}  [dim](alpha at spot; beta realizable"
+        footer = (
+            f"[bold]total[/bold] {format_balance(grand_total)}  "
+            "[dim](alpha at spot; beta realizable"
+        )
         if duplicates:
             footer += f"; {duplicates} duplicate-coldkey wallets counted once"
         footer += ")[/dim]"

--- a/sdk/python/bittensor/cli/helpers.py
+++ b/sdk/python/bittensor/cli/helpers.py
@@ -29,6 +29,16 @@ STAKE_VALUE_BASIS = "spot price; excludes slippage/fees of an actual unstake"
 DUST_VALUE_TAO = 0.001
 
 
+def format_balance(balance: Balance, decimals: int = 3) -> str:
+    """Format a balance for human CLI output without exposing rao precision.
+
+    ``Balance.__str__`` intentionally keeps all nine decimal places for exact
+    diagnostics and backwards compatibility. Human wallet summaries only need
+    millitao precision, while JSON output continues to carry the exact value.
+    """
+    return f"{balance.unit}{balance.decimal:,.{decimals}f}"
+
+
 def split_dust(records: list[dict]) -> tuple[list[dict], list[dict]]:
     """Split stake/delegation records into (kept, dust) by spot TAO value.
 
@@ -349,7 +359,7 @@ def human_balance_fields(row: dict) -> dict:
     basis string) is for JSON consumers."""
     fields = {
         "wallet": f"{row['wallet']} ({row['coldkey']})",
-        "free": row["free"],
+        "free": format_balance(row["free"]),
         "alpha": f"{row['stake_positions']} positions · {row['stake_subnets']} subnets",
     }
     beta_tokens = row.get("beta_tokens")
@@ -357,13 +367,14 @@ def human_balance_fields(row: dict) -> dict:
         validators = int(row.get("beta_validators") or 0)
         suffix = "validator" if validators == 1 else "validators"
         fields["beta"] = f"{beta_tokens:,.9f} β · {validators} {suffix}" if validators else "—"
-    fields["beta_value"] = f"{row['beta_value']}  (claimable root dividends)"
-    fields["alpha_value"] = f"{row['stake_value']}  (spot, excl. slippage/fees)"
+    fields["beta_value"] = f"{format_balance(row['beta_value'])}  (claimable root dividends)"
+    fields["alpha_value"] = f"{format_balance(row['stake_value'])}  (spot, excl. slippage/fees)"
     if row.get("locked_subnets"):
         fields["locked_value"] = (
-            f"{row['locked_value']}  ({row['locked_subnets']} subnets; part of alpha_value)"
+            f"{format_balance(row['locked_value'])}  "
+            f"({row['locked_subnets']} subnets; part of alpha_value)"
         )
-    fields["total_value"] = row["total_value"]
+    fields["total_value"] = format_balance(row["total_value"])
     fields["block"] = row["block"]
     return fields
 

--- a/sdk/python/tests/unit/test_cli.py
+++ b/sdk/python/tests/unit/test_cli.py
@@ -20,6 +20,7 @@ import bittensor.cli.context as cli_context
 from bittensor import RpcConnectionError, RpcPolicyError, __version__, config, wallets
 from bittensor.balance import Balance
 from bittensor.cli.call_names import resolve_builder_params
+from bittensor.cli.helpers import format_balance
 from bittensor.cli.main import app
 from bittensor.cli.output import Output
 from bittensor.cli.root_helpers import RootPosition, position_columns, position_rows
@@ -260,6 +261,9 @@ class TestQueries:
         payload = json.loads(result.output)
         assert payload["coldkey"] == BOB
         assert payload["free_tao"] == pytest.approx(2.5)
+
+    def test_wallet_balance_human_format_uses_three_decimals(self):
+        assert format_balance(Balance.from_rao(2_832_438_604_652)) == "τ2,832.439"
 
 
 class TestAddressResolution:


### PR DESCRIPTION
## Summary

- Format human `btcli wallet balance` amounts to three decimal places.
- Keep exact nine-decimal `Balance` formatting and JSON fields unchanged.
- Apply the same concise formatting to single-wallet details and the aggregate total.

## Verification

- `uv run --no-sync ruff check bittensor/cli/helpers.py bittensor/cli/commands/wallet.py tests/unit/test_cli.py`
- `uv run --no-sync ruff format --check bittensor/cli/helpers.py bittensor/cli/commands/wallet.py tests/unit/test_cli.py`
- `uv run --no-sync pytest tests/unit/test_cli.py -q` *(blocked: locked environment is missing `qrcode`)*