### PR TITLE
fix(limit-orders): retain linked outputs for 180 days

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 450,
+    spec_version: 451,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,
@@ -1330,8 +1330,8 @@ impl pallet_crowdloan::Config for Runtime {
 parameter_types! {
     pub const LimitOrdersPalletId: PalletId = PalletId(*b"bt/limit");
     pub const LimitOrdersMaxOrdersPerBatch: u32 = 100;
-    /// Provider records stay drawable for 7 days.
-    pub const LimitOrdersLinkedOutputTtl: u64 = 7 * 24 * 60 * 60 * 1000;
+    /// Provider records stay drawable for the 180-day advanced-order GTC lifetime.
+    pub const LimitOrdersLinkedOutputTtl: u64 = 180 * 24 * 60 * 60 * 1000;
 }
 
 pub struct LimitOrdersPalletHotkey;
@@ -2694,4 +2694,9 @@ fn test_into_evm_balance_overflow() {
 
     let result = SubtensorEvmBalanceConverter::into_evm_balance(substrate_balance);
     assert_eq!(result, Some(expected_evm_balance)); // Should return the scaled value
+}
+
+#[test]
+fn linked_output_ttl_covers_advanced_order_gtc_lifetime() {
+    assert_eq!(LimitOrdersLinkedOutputTtl::get(), 180 * 24 * 60 * 60 * 1000);
 }


### PR DESCRIPTION
## Summary
- raise `LimitOrdersLinkedOutputTtl` from 7 days to 180 days
- bump the runtime spec version from 450 to 451
- add a regression test pinning the advanced-order GTC lifetime

## Context
Advanced Orders 2.1 signs GTC orders for 180 days. Linked consumers can only draw a provider record while `LinkedOutputTtl` remains active, so the previous 7-day runtime value made the backend reject production linked SL/TP preparation.

Backend integration: https://github.com/tao-com-official/advanced-orders-backend/pull/182

Unconsumed provider records remain unprunable for longer, increasing maximum retention from 7 days to 180 days. Consumed records are still removed when the linked output is drawn.

## Verification
- `cargo fmt --all --check`
- `SKIP_WASM_BUILD=1 cargo test -p node-subtensor-runtime linked_output_ttl_covers_advanced_order_gtc_lifetime`