### PR TITLE
Runtime 451 hotfix: harden Root Reborn basket claims

### DIFF
--- a/pallets/subtensor/src/macros/errors.rs
+++ b/pallets/subtensor/src/macros/errors.rs
@@ -372,5 +372,8 @@ mod errors {
         /// destinations. Not enforced while the chain has fewer destinations than the cap
         /// demands.
         RootWeightCapExceeded,
+        /// A queued root-dividend deposit could not be settled. Operations which change
+        /// the hotkey's root claimant base must retry after the deposit becomes executable.
+        BasketDepositPending,
     }
 }

--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -803,5 +803,18 @@ mod events {
             /// Validator hotkey whose fund was stamped.
             hotkey: T::AccountId,
         },
+
+        /// A terminally untradeable basket alpha slice was explicitly written off. This is
+        /// distinct from a swap/transfer failure: only a pool too shallow to execute any sale
+        /// is eligible, and removing the exact slice preserves every holder's fund proportion.
+        /// Appended to preserve existing SCALE event indices.
+        BasketAlphaWrittenOff {
+            /// Validator hotkey whose basket held the alpha.
+            hotkey: T::AccountId,
+            /// Subnet whose pool was terminally too shallow.
+            netuid: NetUid,
+            /// Alpha removed from basket custody and recorded as burned.
+            alpha: AlphaBalance,
+        },
     }
 }

--- a/pallets/subtensor/src/staking/basket_flush.rs
+++ b/pallets/subtensor/src/staking/basket_flush.rs
@@ -55,19 +55,14 @@ impl<T: Config> Pallet<T> {
     /// alpha only — basket holdings are untouched). Root replacement calls this after
     /// dropping membership so churn cannot leave permanent straggler rows.
     ///
-    /// Returns `(work, last_key)`: the approximate quote work done (scan-priced into claim
-    /// weights by `root_claim_for_hotkey`) and the raw storage key of the hotkey's last
-    /// queue entry, which the drain stores as its cursor so a hotkey whose credits are all
-    /// deferred dust still gets skipped past instead of pinning the queue head.
+    /// Returns `(work, last_key, completed)`: the approximate quote work done (scan-priced
+    /// into claim weights by `root_claim_for_hotkey`), the raw storage key of the hotkey's
+    /// last queue entry, and whether every credit selected for this flush was settled. The
+    /// drain stores `last_key` as its cursor so a hotkey whose credits are all deferred dust
+    /// still gets skipped past instead of pinning the queue head.
     pub(crate) fn flush_basket_deposits_for_hotkey(
         hotkey: &T::AccountId,
-    ) -> (u64, Option<Vec<u8>>) {
-        // While the seed migration owns the basket maps every deposit waits. Epoch credits may
-        // accumulate in the pending queue, which starts draining after the cursor clears.
-        if crate::migrations::migrate_seed_beta_basket::seed_beta_basket_v2_in_progress::<T>() {
-            return (0, None);
-        }
-
+    ) -> (u64, Option<Vec<u8>>, bool) {
         let threshold: u64 =
             RootClaimableThreshold::<T>::get(NetUid::ROOT).saturating_to_num::<u64>();
         let on_root = Self::is_hotkey_registered_on_network(NetUid::ROOT, hotkey);
@@ -104,7 +99,7 @@ impl<T: Config> Pallet<T> {
             last_netuid.map(|netuid| PendingBasketDeposits::<T>::hashed_key_for(hotkey, netuid));
 
         if batch.is_empty() {
-            return (work, last_key);
+            return (work, last_key, true);
         }
         for (netuid, _) in batch.iter() {
             PendingBasketDeposits::<T>::remove(hotkey, netuid);
@@ -113,7 +108,10 @@ impl<T: Config> Pallet<T> {
         }
 
         work = work.saturating_add(Self::deposit_root_alpha_batch(hotkey, &batch));
-        (work, last_key)
+        let completed = batch
+            .iter()
+            .all(|(netuid, _)| !PendingBasketDeposits::<T>::contains_key(hotkey, netuid));
+        (work, last_key, completed)
     }
 
     /// The per-block queue drain: flush exactly one queued hotkey per block, round-robin
@@ -144,7 +142,7 @@ impl<T: Config> Pallet<T> {
         };
         drop(keys);
 
-        let (_work, last_key) = Self::flush_basket_deposits_for_hotkey(&hotkey);
+        let (_work, last_key, _) = Self::flush_basket_deposits_for_hotkey(&hotkey);
         match last_key {
             Some(last_key) => {
                 PendingBasketFlushCursor::<T>::put(last_key);
@@ -197,10 +195,12 @@ impl<T: Config> Pallet<T> {
     /// fund's own cash yield accrues to existing share holders through N/P instead of
     /// leaking to root stakers as free shares.
     ///
-    /// The whole operation is transactional: if any swap fails (or the deposit is dust), it is
-    /// rolled back and the original alpha is re-queued for a later flush (multi-credit batches
-    /// split into per-origin retries first). Dividends are recycled only when the validator
-    /// has no root stake to apportion against.
+    /// The whole operation is transactional. Unknown swap/accounting failures (or a dust mint)
+    /// roll back and re-queue the original alpha for a later flush, with multi-credit batches
+    /// split into per-origin retries first. A terminally shallow origin credit is recycled, and
+    /// a terminally shallow destination slice is retained as root cash, so one garbage subnet
+    /// cannot pin the hotkey's queue indefinitely. Dividends are also recycled when the
+    /// validator has no root stake to apportion against.
     ///
     /// Protocol-flow accounting is symmetric with redemption: the origin sell is booked as an
     /// outflow on the origin subnet and each redistribution buy as an inflow on its dest subnet,
@@ -228,8 +228,9 @@ impl<T: Config> Pallet<T> {
     /// batch. The batch is transactional as a whole; on soft failure a multi-credit batch
     /// splits into per-origin retries so one borked origin cannot sink healthy credits, and
     /// any credit that still fails is re-queued for a later flush (it may merge with future
-    /// dividends and become depositable). Credits are recycled only when demonstrably
-    /// unapportionable (no root stake) or when the seed migration owns the basket maps.
+    /// dividends and become depositable). Credits are recycled when demonstrably
+    /// unapportionable (no root stake), terminally untradeable, or when the seed migration owns
+    /// the basket maps.
     ///
     /// Returns the approximate quote work performed (holdings valued plus origin quotes),
     /// scan-priced into claim weights by callers that flush inside an extrinsic.
@@ -402,27 +403,51 @@ impl<T: Config> Pallet<T> {
         // Minting against this pre-sale baseline (with value_added = final − pre-sale) makes
         // the deposit bear that sale impact instead of taxing existing shareholders. A
         // non-positive transformation fails the dust check in the mint and rolls back.
-        let pre_sale_nav: u64 = Self::get_validator_basket_nav_tao(hotkey).to_u64();
+        let pre_sale_nav: u64 = Self::try_get_validator_basket_nav_tao(hotkey)?;
 
         // 1. Sell each origin credit for TAO, booked as protocol outflow (TAO left that
         // origin pool).
         let mut tao_total: u64 = 0;
+        let mut sold_any = false;
         for (origin_netuid, root_alpha) in batch {
             if root_alpha.is_zero() {
                 continue;
             }
-            let tao: TaoBalance = Self::swap_alpha_for_tao(
-                *origin_netuid,
-                *root_alpha,
-                T::SwapInterface::min_price::<TaoBalance>(),
-                true,
-            )?
-            .amount_paid_out;
+            match Self::try_realizable_tao_for_alpha(*origin_netuid, root_alpha.to_u64())? {
+                Some(_) => {}
+                None => {
+                    // This dividend cannot be sold on a terminally shallow origin. Recycling
+                    // the still-unassigned credit is preferable to pinning every later flush
+                    // for this hotkey behind the bad subnet.
+                    Self::recycle_subnet_alpha(*origin_netuid, *root_alpha);
+                    continue;
+                }
+            }
+            let tao = match Self::swap_basket_alpha_for_tao_chunks(*origin_netuid, *root_alpha) {
+                Ok(tao) => tao,
+                Err(err)
+                    if T::SwapInterface::classify_failure(&err)
+                        == subtensor_swap_interface::SwapFailureKind::TerminalLiquidity =>
+                {
+                    // The chunk helper is atomic, so a late terminal failure leaves the
+                    // entire credit untouched and safe to recycle here.
+                    Self::recycle_subnet_alpha(*origin_netuid, *root_alpha);
+                    continue;
+                }
+                Err(err) => return Err(err),
+            };
+            sold_any = true;
             Self::record_protocol_outflow(*origin_netuid, tao);
             if *origin_netuid != funding_netuid && !origin_netuid.is_root() {
                 Self::transfer_tao_from_subnet(*origin_netuid, &root_account, tao.into())?;
             }
             tao_total = tao_total.saturating_add(tao.to_u64());
+        }
+
+        // A batch made exclusively of terminal garbage has been disposed of successfully;
+        // there is no value against which to mint fund shares.
+        if !sold_any {
+            return Ok(());
         }
 
         // 2. Deploy the TAO across the basket per the weight vector. `deploy_tao_into_basket`
@@ -472,9 +497,10 @@ impl<T: Config> Pallet<T> {
         escrow_root: u64,
     ) -> DispatchResult {
         let escrow = Self::get_beta_escrow_account_id();
-        let nav_before: u64 = Self::get_validator_basket_nav_tao(hotkey).to_u64();
+        let nav_before: u64 = Self::try_get_validator_basket_nav_tao(hotkey)?;
 
         let mut value_added: u64 = 0;
+        let mut accumulated_any = false;
         for (origin_netuid, root_alpha) in batch {
             if root_alpha.is_zero() {
                 continue;
@@ -482,7 +508,17 @@ impl<T: Config> Pallet<T> {
             let held_before: u64 =
                 Self::get_stake_for_hotkey_and_coldkey_on_subnet(hotkey, &escrow, *origin_netuid)
                     .to_u64();
-            let origin_before: u64 = Self::realizable_tao_for_alpha(*origin_netuid, held_before);
+            let origin_before =
+                match Self::try_realizable_tao_for_alpha(*origin_netuid, held_before)? {
+                    Some(value) => value,
+                    None => {
+                        // Do not add fresh dividends to a holding which is already terminally
+                        // untradeable. The credit has not been assigned to a staker yet, so recycle
+                        // it rather than manufacturing shares with a zero mark.
+                        Self::recycle_subnet_alpha(*origin_netuid, *root_alpha);
+                        continue;
+                    }
+                };
 
             Self::increase_stake_for_hotkey_and_coldkey_on_subnet(
                 hotkey,
@@ -495,10 +531,30 @@ impl<T: Config> Pallet<T> {
             let held_after: u64 =
                 Self::get_stake_for_hotkey_and_coldkey_on_subnet(hotkey, &escrow, *origin_netuid)
                     .to_u64();
-            value_added = value_added.saturating_add(
-                Self::realizable_tao_for_alpha(*origin_netuid, held_after)
-                    .saturating_sub(origin_before),
-            );
+            let origin_after = match Self::try_realizable_tao_for_alpha(*origin_netuid, held_after)?
+            {
+                Some(value) => value,
+                None => {
+                    // Adding the credit crossed into terminal territory. Undo only the amount
+                    // actually assigned to the holding, recycle the whole unassigned credit,
+                    // and leave the pre-existing position untouched.
+                    let assigned = held_after.saturating_sub(held_before);
+                    Self::decrease_stake_for_hotkey_and_coldkey_on_subnet(
+                        hotkey,
+                        &escrow,
+                        *origin_netuid,
+                        assigned.into(),
+                    );
+                    Self::recycle_subnet_alpha(*origin_netuid, *root_alpha);
+                    continue;
+                }
+            };
+            accumulated_any = true;
+            value_added = value_added.saturating_add(origin_after.saturating_sub(origin_before));
+        }
+
+        if !accumulated_any {
+            return Ok(());
         }
 
         Self::mint_basket_dividend_shares(hotkey, nav_before, value_added, total_root, escrow_root)

--- a/pallets/subtensor/src/staking/basket_views.rs
+++ b/pallets/subtensor/src/staking/basket_views.rs
@@ -6,6 +6,8 @@
 //! deposit share pricing, redemption sizing, and what dashboards report can never diverge.
 
 use super::*;
+use frame_support::storage::{TransactionOutcome, with_transaction};
+use sp_runtime::DispatchError;
 use subtensor_runtime_common::NetUidStorageIndex;
 use subtensor_swap_interface::{Order, SwapHandler};
 
@@ -17,29 +19,73 @@ impl<T: Config> Pallet<T> {
     /// saturate to `u64::MAX`); the realizable quote is bounded by the pool's TAO reserve, so
     /// NAV computed from it matches what the fund could actually pay out.
     pub fn realizable_tao_for_alpha(netuid: NetUid, alpha: u64) -> u64 {
+        Self::try_realizable_tao_for_alpha(netuid, alpha)
+            .ok()
+            .flatten()
+            .unwrap_or(0)
+    }
+
+    /// Fallible money-moving valuation. `Ok(None)` means the pool is terminally too shallow to
+    /// realize even one atomic unit and the holding may be explicitly written off. Unknown or
+    /// accounting failures remain `Err`; callers must not silently mark them to zero.
+    pub(crate) fn try_realizable_tao_for_alpha(
+        netuid: NetUid,
+        alpha: u64,
+    ) -> Result<Option<u64>, DispatchError> {
         if alpha == 0 {
-            return 0;
+            return Ok(Some(0));
         }
-        // Root holdings are TAO held 1:1; nothing to swap.
-        if netuid.is_root() {
-            return alpha;
-        }
-        // Stable-mechanism subnets redeem 1:1 (mirrors `swap_alpha_for_tao`).
-        if SubnetMechanism::<T>::get(netuid) != 1 {
-            return alpha;
+        if netuid.is_root() || SubnetMechanism::<T>::get(netuid) != 1 {
+            return Ok(Some(alpha));
         }
         #[cfg(test)]
         crate::tests::mock::inc_basket_quote_ops();
-        let order = GetTaoForAlpha::<T>::with_amount(alpha);
-        T::SwapInterface::swap(
-            netuid.into(),
-            order,
-            T::SwapInterface::min_price::<TaoBalance>(),
-            true,
-            true,
-        )
-        .map(|res| res.amount_paid_out.to_u64())
-        .unwrap_or(0)
+
+        let maximum = T::SwapInterface::max_swap_input::<GetTaoForAlpha<T>>(netuid).to_u64();
+        let quote = if alpha <= maximum {
+            // Preserve the cheap single-swap simulation for ordinary holdings. Only an
+            // oversized position needs the sequential reserve updates of the rollback overlay.
+            let order = GetTaoForAlpha::<T>::with_amount(alpha);
+            T::SwapInterface::swap(
+                netuid.into(),
+                order,
+                T::SwapInterface::min_price::<TaoBalance>(),
+                true,
+                true,
+            )
+            .map(|result| result.amount_paid_out)
+        } else {
+            with_transaction(|| {
+                TransactionOutcome::Rollback(Self::swap_basket_alpha_for_tao_chunks(
+                    netuid,
+                    alpha.into(),
+                ))
+            })
+        };
+        match quote {
+            Ok(tao) => Ok(Some(tao.to_u64())),
+            Err(err)
+                if T::SwapInterface::classify_failure(&err)
+                    == subtensor_swap_interface::SwapFailureKind::TerminalLiquidity =>
+            {
+                Ok(None)
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Fallible NAV for share pricing and claims. Terminal garbage contributes zero; every
+    /// unknown valuation error aborts the money-moving operation.
+    pub(crate) fn try_get_validator_basket_nav_tao(
+        hotkey: &T::AccountId,
+    ) -> Result<u64, DispatchError> {
+        let mut nav = 0u64;
+        for (netuid, alpha) in Self::get_basket_holdings(hotkey) {
+            if let Some(value) = Self::try_realizable_tao_for_alpha(netuid, alpha.to_u64())? {
+                nav = nav.saturating_add(value);
+            }
+        }
+        Ok(nav)
     }
 
     /// Single source of truth for redemption sizing: a staker's owed shares are worth

--- a/pallets/subtensor/src/staking/claim_root.rs
+++ b/pallets/subtensor/src/staking/claim_root.rs
@@ -401,8 +401,7 @@ impl<T: Config> Pallet<T> {
         );
         // Deposit queued dividend credits first so the share mint below prices against
         // the fund's full, current NAV.
-        let (_, _, flush_completed) = Self::flush_basket_deposits_for_hotkey(&hotkey);
-        ensure!(flush_completed, Error::<T>::BasketDepositPending);
+        Self::flush_basket_deposits_for_hotkey(&hotkey);
         ensure!(tao >= DefaultMinStake::<T>::get(), Error::<T>::AmountTooLow);
         ensure!(
             Self::can_remove_balance_from_coldkey_account(&coldkey, tao.into()),
@@ -580,11 +579,10 @@ impl<T: Config> Pallet<T> {
 
         // Deposit any queued dividend credits first so the claim redeems against the
         // fund's full, current state. The flush work is scan-priced into the outcome.
-        let (flush_work, _, flush_completed) = Self::flush_basket_deposits_for_hotkey(hotkey);
+        let (flush_work, _, _) = Self::flush_basket_deposits_for_hotkey(hotkey);
         outcome.rows = outcome
             .rows
             .saturating_add(u32::try_from(flush_work).unwrap_or(u32::MAX));
-        ensure!(flush_completed, Error::<T>::BasketDepositPending);
 
         let owed_shares: u64 = Self::get_basket_owed_shares(hotkey, coldkey);
         if owed_shares == 0 {

--- a/pallets/subtensor/src/staking/claim_root.rs
+++ b/pallets/subtensor/src/staking/claim_root.rs
@@ -9,7 +9,7 @@ use sp_std::collections::btree_map::BTreeMap;
 use sp_std::collections::btree_set::BTreeSet;
 use substrate_fixed::types::I96F32;
 use subtensor_runtime_common::{NetUidStorageIndex, clear_prefix_with_meter};
-use subtensor_swap_interface::SwapHandler;
+use subtensor_swap_interface::{SwapFailureKind, SwapHandler};
 
 /// A drained fund (shares outstanding but NAV marked at zero) may revive via a par mint
 /// only when the stale shares are rounding dust: at most `value / DRAINED_FUND_DUST_DIVISOR`
@@ -255,7 +255,7 @@ impl<T: Config> Pallet<T> {
     ) -> Result<(u64, u64), DispatchError> {
         let escrow = Self::get_beta_escrow_account_id();
         let weight_sum: u64 = valid.iter().map(|(_, w)| *w).sum();
-        let nav_before: u64 = Self::get_validator_basket_nav_tao(hotkey).to_u64();
+        let nav_before = Self::try_get_validator_basket_nav_tao(hotkey)?;
 
         let mut spent: u64 = 0;
         let last_idx = valid.len().saturating_sub(1);
@@ -304,13 +304,33 @@ impl<T: Config> Pallet<T> {
                 Self::credit_root_reserves(tao_s.into());
             } else {
                 let drop_fees = matches!(funding, BasketFunding::Protocol { .. });
-                let bought = Self::swap_tao_for_alpha(
+                let bought = match Self::swap_basket_tao_for_alpha_chunks(
                     *dest_netuid,
                     tao_s.into(),
-                    T::SwapInterface::max_price(),
                     drop_fees,
-                )?
-                .amount_paid_out;
+                ) {
+                    Ok(bought) => bought,
+                    Err(err)
+                        if drop_fees
+                            && T::SwapInterface::classify_failure(&err)
+                                == SwapFailureKind::TerminalLiquidity =>
+                    {
+                        // A protocol dividend must not be pinned forever by a validator weight
+                        // targeting a terminally shallow pool. Keep that slice as fund cash.
+                        let root_account = Self::get_subnet_account_id(NetUid::ROOT)
+                            .ok_or(Error::<T>::RootNetworkDoesNotExist)?;
+                        Self::transfer_tao_from_subnet(*dest_netuid, &root_account, tao_s.into())?;
+                        Self::increase_stake_for_hotkey_and_coldkey_on_subnet(
+                            hotkey,
+                            &escrow,
+                            NetUid::ROOT,
+                            tao_s.into(),
+                        );
+                        Self::credit_root_reserves(tao_s.into());
+                        continue;
+                    }
+                    Err(err) => return Err(err),
+                };
                 if bought.is_zero() {
                     // Dust slice whose swap rounds to zero alpha: a user deposit must not
                     // silently donate its TAO to the pool (mirrors `stake_into_subnet`'s
@@ -334,7 +354,7 @@ impl<T: Config> Pallet<T> {
             }
         }
 
-        let nav_after: u64 = Self::get_validator_basket_nav_tao(hotkey).to_u64();
+        let nav_after = Self::try_get_validator_basket_nav_tao(hotkey)?;
         Ok((nav_before, nav_after.saturating_sub(nav_before)))
     }
 
@@ -381,7 +401,8 @@ impl<T: Config> Pallet<T> {
         );
         // Deposit queued dividend credits first so the share mint below prices against
         // the fund's full, current NAV.
-        Self::flush_basket_deposits_for_hotkey(&hotkey);
+        let (_, _, flush_completed) = Self::flush_basket_deposits_for_hotkey(&hotkey);
+        ensure!(flush_completed, Error::<T>::BasketDepositPending);
         ensure!(tao >= DefaultMinStake::<T>::get(), Error::<T>::AmountTooLow);
         ensure!(
             Self::can_remove_balance_from_coldkey_account(&coldkey, tao.into()),
@@ -393,13 +414,14 @@ impl<T: Config> Pallet<T> {
             // Uncurated fund: mirror the fund — deploy pro-rata across current holdings by
             // realizable value (worthless rows carry no weight). Empty fund: nothing to
             // mirror, hold the deposit as the fund's root (TAO cash) slot.
-            valid = Self::get_basket_holdings(&hotkey)
-                .into_iter()
-                .filter_map(|(netuid, alpha)| {
-                    let value = Self::realizable_tao_for_alpha(netuid, alpha.to_u64());
-                    (value > 0).then_some((netuid, value))
-                })
-                .collect();
+            valid = Vec::new();
+            for (netuid, alpha) in Self::get_basket_holdings(&hotkey) {
+                if let Some(value) = Self::try_realizable_tao_for_alpha(netuid, alpha.to_u64())?
+                    && value > 0
+                {
+                    valid.push((netuid, value));
+                }
+            }
             if valid.is_empty() {
                 valid = vec![(NetUid::ROOT, 1)];
             }
@@ -537,7 +559,9 @@ impl<T: Config> Pallet<T> {
     /// that holding's pre-sale realizable value. A concave AMM curve makes selling `f` of a
     /// holding realize more than `f` of the proceeds from selling the whole holding; that
     /// surplus is retained in the fund's root (TAO cash) slot for the remaining shareholders.
-    /// The root-slot portion is reassigned directly because it is already TAO.
+    /// The root-slot portion is reassigned directly because it is already TAO. A holding on a
+    /// terminally shallow pool is removed as an explicit pro-rata write-off instead of aborting
+    /// healthy slots; unknown swap or accounting errors still roll back the claim.
     ///
     /// Before redeeming, the fund's orphaned dust holdings (subnets outside the
     /// validator's current weight vector) are consolidated into its root slot (see
@@ -556,10 +580,11 @@ impl<T: Config> Pallet<T> {
 
         // Deposit any queued dividend credits first so the claim redeems against the
         // fund's full, current state. The flush work is scan-priced into the outcome.
-        let (flush_work, _) = Self::flush_basket_deposits_for_hotkey(hotkey);
+        let (flush_work, _, flush_completed) = Self::flush_basket_deposits_for_hotkey(hotkey);
         outcome.rows = outcome
             .rows
             .saturating_add(u32::try_from(flush_work).unwrap_or(u32::MAX));
+        ensure!(flush_completed, Error::<T>::BasketDepositPending);
 
         let owed_shares: u64 = Self::get_basket_owed_shares(hotkey, coldkey);
         if owed_shares == 0 {
@@ -587,18 +612,20 @@ impl<T: Config> Pallet<T> {
         // slot independently at the same NAV fraction. Without that cap, selling a raw
         // alpha fraction on a concave AMM curve overpays the first redeemer and transfers
         // the loss to the remaining shareholders.
-        let valued_holdings: Vec<(NetUid, AlphaBalance, u64)> = holdings
-            .into_iter()
-            .map(|(netuid, alpha)| {
-                let value = Self::realizable_tao_for_alpha(netuid, alpha.to_u64());
-                (netuid, alpha, value)
-            })
-            .collect();
+        let mut valued_holdings: Vec<(NetUid, AlphaBalance, u64, bool)> = Vec::new();
+        for (netuid, alpha) in holdings {
+            match Self::try_realizable_tao_for_alpha(netuid, alpha.to_u64())? {
+                Some(value) => valued_holdings.push((netuid, alpha, value, false)),
+                None => valued_holdings.push((netuid, alpha, 0, true)),
+            }
+        }
+        let has_terminal_garbage = valued_holdings.iter().any(|(_, _, _, garbage)| *garbage);
         let nav: u64 = valued_holdings
             .iter()
-            .fold(0u64, |acc, (_, _, value)| acc.saturating_add(*value));
+            .fold(0u64, |acc, (_, _, value, _)| acc.saturating_add(*value));
         let estimated_payout: u64 = Self::basket_payout_from(owed_shares, nav, shares_total);
         if !ignore_minimum_condition
+            && !has_terminal_garbage
             && I96F32::saturating_from_num(estimated_payout)
                 < RootClaimableThreshold::<T>::get(NetUid::ROOT)
         {
@@ -607,7 +634,7 @@ impl<T: Config> Pallet<T> {
             );
             return Ok(outcome); // no-op
         }
-        if estimated_payout == 0 {
+        if estimated_payout == 0 && !has_terminal_garbage {
             return Ok(outcome);
         }
 
@@ -616,7 +643,7 @@ impl<T: Config> Pallet<T> {
         // shareholders (e.g. 99/100 of a 1-alpha position → floor 0, then the leftover
         // 1-share holder owns the whole unit). Same posture as the all-zero-take rollback
         // below — leave the watermark untouched. Worthless rows (realizable 0) are ignored.
-        for (_, slot_alpha, slot_value) in valued_holdings.iter() {
+        for (_, slot_alpha, slot_value, _) in valued_holdings.iter() {
             let alpha = slot_alpha.to_u64();
             if alpha == 0 {
                 continue;
@@ -638,8 +665,9 @@ impl<T: Config> Pallet<T> {
             let mut root_slot_tao: u64 = 0;
             let mut claimant_swapped_tao: u64 = 0;
             let mut retained_swapped_tao: u64 = 0;
+            let mut written_off: u32 = 0;
 
-            for (netuid, slot_alpha, slot_value) in valued_holdings.iter() {
+            for (netuid, slot_alpha, slot_value, terminal_garbage) in valued_holdings.iter() {
                 // This staker's pro-rata slice of the holding: slot_alpha * owed / P.
                 let take: u64 = Self::mul_div_u64(slot_alpha.to_u64(), owed_shares, shares_total);
                 if take == 0 {
@@ -660,9 +688,36 @@ impl<T: Config> Pallet<T> {
                     continue;
                 }
 
+                if *terminal_garbage {
+                    Self::burn_subnet_alpha(*netuid, take.into());
+                    Self::deposit_event(Event::BasketAlphaWrittenOff {
+                        hotkey: hotkey.clone(),
+                        netuid: *netuid,
+                        alpha: take.into(),
+                    });
+                    written_off = written_off.saturating_add(1);
+                    continue;
+                }
+
                 // Sell the slice to TAO.
                 let tao = match Self::sell_basket_alpha_for_root_tao(*netuid, take.into()) {
                     Ok(tao) => tao,
+                    Err(err)
+                        if T::SwapInterface::classify_failure(&err)
+                            == SwapFailureKind::TerminalLiquidity =>
+                    {
+                        // The sale helper rolls back all of its chunks on failure. The stake
+                        // decrease above remains in this outer transaction, so the exact slice
+                        // can be written off without disturbing any healthy slot.
+                        Self::burn_subnet_alpha(*netuid, take.into());
+                        Self::deposit_event(Event::BasketAlphaWrittenOff {
+                            hotkey: hotkey.clone(),
+                            netuid: *netuid,
+                            alpha: take.into(),
+                        });
+                        written_off = written_off.saturating_add(1);
+                        continue;
+                    }
                     Err(err) => return TransactionOutcome::Rollback(Err(err)),
                 };
 
@@ -698,7 +753,7 @@ impl<T: Config> Pallet<T> {
             // alpha takes floor to zero (high-price, tiny-alpha holdings), so this must NOT
             // settle: roll back and leave the watermark untouched, otherwise the staker's owed
             // shares would be burned for a zero payout.
-            if total_tao == 0 {
+            if total_tao == 0 && written_off == 0 {
                 return TransactionOutcome::Rollback(Ok(0));
             }
 
@@ -718,12 +773,14 @@ impl<T: Config> Pallet<T> {
             // Stake the redeemed TAO on root for the staker. Only sold TAO is new on root;
             // the root-slot portion was already counted in the root reserves. Credit both
             // the claimant payout and the surplus retained by the fund.
-            Self::increase_stake_for_hotkey_and_coldkey_on_subnet(
-                hotkey,
-                coldkey,
-                NetUid::ROOT,
-                total_tao.into(),
-            );
+            if total_tao > 0 {
+                Self::increase_stake_for_hotkey_and_coldkey_on_subnet(
+                    hotkey,
+                    coldkey,
+                    NetUid::ROOT,
+                    total_tao.into(),
+                );
+            }
             let total_swapped_tao = claimant_swapped_tao.saturating_add(retained_swapped_tao);
             if total_swapped_tao > 0 {
                 Self::credit_root_reserves(total_swapped_tao.into());
@@ -732,11 +789,17 @@ impl<T: Config> Pallet<T> {
             // Claimed root stake must start (or refresh) the unlock hold, same as a
             // direct add_stake on root — otherwise JIT snipers can deposit → epoch →
             // claim → immediate remove_stake.
-            Self::touch_root_stake_age(coldkey, hotkey);
+            if total_tao > 0 {
+                Self::touch_root_stake_age(coldkey, hotkey);
+            }
 
             // The staker's root stake just grew; rebase their claimed watermark so the new stake
             // does not retroactively inflate their claimable.
-            Self::add_stake_adjust_root_claimed_for_hotkey_and_coldkey(hotkey, coldkey, total_tao);
+            if total_tao > 0 {
+                Self::add_stake_adjust_root_claimed_for_hotkey_and_coldkey(
+                    hotkey, coldkey, total_tao,
+                );
+            }
 
             // Consume the claimed shares and advance the watermark.
             let remaining = BasketShares::<T>::mutate(hotkey, |p| {
@@ -810,10 +873,25 @@ impl<T: Config> Pallet<T> {
             if netuid.is_root() || curated.contains(&netuid) {
                 continue;
             }
-            if Self::realizable_tao_for_alpha(netuid, alpha.to_u64()) < threshold
-                && Self::convert_basket_holding_to_root(hotkey, &escrow, netuid)
-            {
-                swept = swept.saturating_add(1);
+            match Self::try_realizable_tao_for_alpha(netuid, alpha.to_u64()) {
+                Ok(Some(value)) if value < threshold => {
+                    if Self::convert_basket_holding_to_root(hotkey, &escrow, netuid) {
+                        swept = swept.saturating_add(1);
+                    }
+                }
+                // A terminally shallow pool cannot recover merely by retrying this sell.
+                // Convert the row through the same explicit write-off path used by claims.
+                Ok(None) => {
+                    if Self::convert_basket_holding_to_root(hotkey, &escrow, netuid) {
+                        swept = swept.saturating_add(1);
+                    }
+                }
+                Ok(Some(_)) => {}
+                Err(err) => {
+                    // Unknown failures remain retryable: do not silently value or delete the
+                    // holding as zero.
+                    log::warn!("Error valuing basket holding for dust conversion: {err:?}");
+                }
             }
         }
         swept
@@ -1090,8 +1168,9 @@ impl<T: Config> Pallet<T> {
     ///
     /// Escrow alpha is sold once per fund and held as root stake under the same escrow.
     /// Fund shares, rates, and watermarks are untouched — NAV is continuous across the
-    /// conversion (minus slippage). Best-effort: a failed swap is logged and the slot is
-    /// left for generic teardown. Returns `(done, next_cursor)`.
+    /// conversion (minus slippage). A terminally shallow holding is explicitly written off;
+    /// any unknown failure is logged and leaves the slot for generic teardown. Returns
+    /// `(done, next_cursor)`.
     pub fn convert_subnet_basket_holdings_to_root(
         netuid: NetUid,
         weight_meter: &mut WeightMeter,
@@ -1135,6 +1214,16 @@ impl<T: Config> Pallet<T> {
             return false;
         }
 
+        let terminal_garbage =
+            match Self::try_realizable_tao_for_alpha(netuid, holding_alpha.to_u64()) {
+                Ok(Some(_)) => false,
+                Ok(None) => true,
+                Err(err) => {
+                    log::error!("Error valuing basket holding before conversion: {err:?}");
+                    return false;
+                }
+            };
+
         with_transaction(|| {
             Self::decrease_stake_for_hotkey_and_coldkey_on_subnet(
                 hotkey,
@@ -1143,8 +1232,35 @@ impl<T: Config> Pallet<T> {
                 holding_alpha,
             );
 
+            if terminal_garbage {
+                // The position is economically unusable and no executable sale exists. Remove
+                // it explicitly instead of allowing one bad subnet to pin claim/dissolution
+                // progress forever. This is a proportional loss to the fund as a whole.
+                Self::burn_subnet_alpha(netuid, holding_alpha);
+                Self::deposit_event(Event::BasketAlphaWrittenOff {
+                    hotkey: hotkey.clone(),
+                    netuid,
+                    alpha: holding_alpha,
+                });
+                return TransactionOutcome::Commit(Ok::<(), DispatchError>(()));
+            }
+
             let tao = match Self::sell_basket_alpha_for_root_tao(netuid, holding_alpha) {
                 Ok(tao) => tao,
+                Err(err)
+                    if T::SwapInterface::classify_failure(&err)
+                        == SwapFailureKind::TerminalLiquidity =>
+                {
+                    // A late shallow-pool failure is safe to write off because the sale
+                    // helper atomically rolled back every attempted chunk.
+                    Self::burn_subnet_alpha(netuid, holding_alpha);
+                    Self::deposit_event(Event::BasketAlphaWrittenOff {
+                        hotkey: hotkey.clone(),
+                        netuid,
+                        alpha: holding_alpha,
+                    });
+                    return TransactionOutcome::Commit(Ok::<(), DispatchError>(()));
+                }
                 Err(err) => {
                     log::error!("Error converting basket holding to root: {err:?}");
                     return TransactionOutcome::Rollback(Err(err));
@@ -1178,23 +1294,128 @@ impl<T: Config> Pallet<T> {
         netuid: NetUid,
         alpha: AlphaBalance,
     ) -> Result<TaoBalance, DispatchError> {
-        let out = Self::swap_alpha_for_tao(
-            netuid,
-            alpha,
-            T::SwapInterface::min_price::<TaoBalance>(),
-            true,
-        )
-        .inspect_err(|err| log::error!("Error swapping basket alpha for TAO: {err:?}"))?;
+        let tao = Self::swap_basket_alpha_for_tao_chunks(netuid, alpha)
+            .inspect_err(|err| log::warn!("Unable to swap basket alpha for TAO: {err:?}"))?;
 
         let root_subnet_account_id =
             Self::get_subnet_account_id(NetUid::ROOT).ok_or(Error::<T>::RootNetworkDoesNotExist)?;
 
-        Self::transfer_tao_from_subnet(netuid, &root_subnet_account_id, out.amount_paid_out.into())
+        Self::transfer_tao_from_subnet(netuid, &root_subnet_account_id, tao.into())
             .inspect_err(|err| log::error!("Error transferring basket TAO from subnet: {err:?}"))?;
 
-        Self::record_protocol_outflow(netuid, out.amount_paid_out);
+        Self::record_protocol_outflow(netuid, tao);
 
-        Ok(out.amount_paid_out)
+        Ok(tao)
+    }
+
+    /// Execute a fee-free protocol alpha sale in reserve-bounded chunks. This is both the
+    /// money-moving implementation and the engine used under a rollback overlay for NAV quotes,
+    /// so an oversized full holding is valued exactly as it would be liquidated.
+    pub(crate) fn swap_basket_alpha_for_tao_chunks(
+        netuid: NetUid,
+        alpha: AlphaBalance,
+    ) -> Result<TaoBalance, DispatchError> {
+        with_transaction(|| {
+            let result = (|| {
+                if alpha.is_zero() {
+                    return Ok(TaoBalance::ZERO);
+                }
+                if SubnetMechanism::<T>::get(netuid) != 1 {
+                    return Self::swap_alpha_for_tao(
+                        netuid,
+                        alpha,
+                        T::SwapInterface::min_price::<TaoBalance>(),
+                        true,
+                    )
+                    .map(|out| out.amount_paid_out);
+                }
+
+                let mut remaining = alpha.to_u64();
+                let mut total_tao = 0u64;
+                while remaining > 0 {
+                    let maximum =
+                        T::SwapInterface::max_swap_input::<GetTaoForAlpha<T>>(netuid).to_u64();
+                    // Let the engine return its concrete failure when the input reserve is zero.
+                    let chunk = if maximum == 0 {
+                        remaining
+                    } else {
+                        remaining.min(maximum)
+                    };
+                    let out = Self::swap_alpha_for_tao(
+                        netuid,
+                        chunk.into(),
+                        T::SwapInterface::min_price::<TaoBalance>(),
+                        true,
+                    )?;
+                    let consumed = out
+                        .amount_paid_in
+                        .to_u64()
+                        .saturating_add(out.fee_paid.to_u64());
+                    ensure!(consumed > 0, Error::<T>::AmountTooLow);
+                    remaining = remaining.saturating_sub(consumed);
+                    total_tao = total_tao.saturating_add(out.amount_paid_out.to_u64());
+                }
+                Ok(total_tao.into())
+            })();
+            match result {
+                Ok(tao) => TransactionOutcome::Commit(Ok(tao)),
+                Err(err) => TransactionOutcome::Rollback(Err(err)),
+            }
+        })
+    }
+
+    /// Buy basket alpha in reserve-bounded chunks for oversized protocol/user deployments.
+    pub(crate) fn swap_basket_tao_for_alpha_chunks(
+        netuid: NetUid,
+        tao: TaoBalance,
+        drop_fees: bool,
+    ) -> Result<AlphaBalance, DispatchError> {
+        with_transaction(|| {
+            let result = (|| {
+                if tao.is_zero() {
+                    return Ok(AlphaBalance::ZERO);
+                }
+                if SubnetMechanism::<T>::get(netuid) != 1 {
+                    return Self::swap_tao_for_alpha(
+                        netuid,
+                        tao,
+                        T::SwapInterface::max_price(),
+                        drop_fees,
+                    )
+                    .map(|out| out.amount_paid_out);
+                }
+
+                let mut remaining = tao.to_u64();
+                let mut total_alpha = 0u64;
+                while remaining > 0 {
+                    let maximum =
+                        T::SwapInterface::max_swap_input::<GetAlphaForTao<T>>(netuid).to_u64();
+                    let chunk = if maximum == 0 {
+                        remaining
+                    } else {
+                        remaining.min(maximum)
+                    };
+                    let out = Self::swap_tao_for_alpha(
+                        netuid,
+                        chunk.into(),
+                        T::SwapInterface::max_price(),
+                        drop_fees,
+                    )?;
+                    let consumed = out
+                        .amount_paid_in
+                        .to_u64()
+                        .saturating_add(out.fee_paid.to_u64());
+                    ensure!(consumed > 0, Error::<T>::AmountTooLow);
+                    remaining = remaining.saturating_sub(consumed);
+                    total_alpha = total_alpha.saturating_add(out.amount_paid_out.to_u64());
+                }
+                Ok(total_alpha.into())
+            })();
+            match result {
+                Ok(alpha) => TransactionOutcome::Commit(Ok(alpha)),
+                Err(err) => TransactionOutcome::Rollback(Err(err)),
+            }
+        })
     }
 
     /// Drop a dissolving subnet's entries from the LEGACY per-subnet claimable rates. The

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -828,7 +828,8 @@ impl<T: Config> Pallet<T> {
             if enforce_root_hold {
                 Self::ensure_root_stake_unlocked(coldkey, hotkey)?;
             }
-            Self::flush_basket_deposits_for_hotkey(hotkey);
+            let (_, _, flush_completed) = Self::flush_basket_deposits_for_hotkey(hotkey);
+            ensure!(flush_completed, Error::<T>::BasketDepositPending);
         }
 
         // Refuse to strip conviction-locked or collateral-bonded alpha even when
@@ -944,7 +945,8 @@ impl<T: Config> Pallet<T> {
         // pending dividend credits before the new stake lands, so it can't capture
         // flushable dividends earned before it arrived.
         if netuid.is_root() {
-            Self::flush_basket_deposits_for_hotkey(hotkey);
+            let (_, _, flush_completed) = Self::flush_basket_deposits_for_hotkey(hotkey);
+            ensure!(flush_completed, Error::<T>::BasketDepositPending);
         }
 
         // Transfer TAO from coldkey to the subnet account.
@@ -1070,9 +1072,16 @@ impl<T: Config> Pallet<T> {
         // Root stake moves claimant base on both hotkeys: settle queued basket deposits
         // on each side first (see `stake_into_subnet` / `unstake_from_subnet`).
         if netuid.is_root() {
-            Self::flush_basket_deposits_for_hotkey(origin_hotkey);
+            let (_, _, origin_flush_completed) =
+                Self::flush_basket_deposits_for_hotkey(origin_hotkey);
+            ensure!(origin_flush_completed, Error::<T>::BasketDepositPending);
             if destination_hotkey != origin_hotkey {
-                Self::flush_basket_deposits_for_hotkey(destination_hotkey);
+                let (_, _, destination_flush_completed) =
+                    Self::flush_basket_deposits_for_hotkey(destination_hotkey);
+                ensure!(
+                    destination_flush_completed,
+                    Error::<T>::BasketDepositPending
+                );
             }
         }
 

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -828,8 +828,7 @@ impl<T: Config> Pallet<T> {
             if enforce_root_hold {
                 Self::ensure_root_stake_unlocked(coldkey, hotkey)?;
             }
-            let (_, _, flush_completed) = Self::flush_basket_deposits_for_hotkey(hotkey);
-            ensure!(flush_completed, Error::<T>::BasketDepositPending);
+            Self::flush_basket_deposits_for_hotkey(hotkey);
         }
 
         // Refuse to strip conviction-locked or collateral-bonded alpha even when
@@ -945,8 +944,7 @@ impl<T: Config> Pallet<T> {
         // pending dividend credits before the new stake lands, so it can't capture
         // flushable dividends earned before it arrived.
         if netuid.is_root() {
-            let (_, _, flush_completed) = Self::flush_basket_deposits_for_hotkey(hotkey);
-            ensure!(flush_completed, Error::<T>::BasketDepositPending);
+            Self::flush_basket_deposits_for_hotkey(hotkey);
         }
 
         // Transfer TAO from coldkey to the subnet account.
@@ -1072,16 +1070,9 @@ impl<T: Config> Pallet<T> {
         // Root stake moves claimant base on both hotkeys: settle queued basket deposits
         // on each side first (see `stake_into_subnet` / `unstake_from_subnet`).
         if netuid.is_root() {
-            let (_, _, origin_flush_completed) =
-                Self::flush_basket_deposits_for_hotkey(origin_hotkey);
-            ensure!(origin_flush_completed, Error::<T>::BasketDepositPending);
+            Self::flush_basket_deposits_for_hotkey(origin_hotkey);
             if destination_hotkey != origin_hotkey {
-                let (_, _, destination_flush_completed) =
-                    Self::flush_basket_deposits_for_hotkey(destination_hotkey);
-                ensure!(
-                    destination_flush_completed,
-                    Error::<T>::BasketDepositPending
-                );
+                Self::flush_basket_deposits_for_hotkey(destination_hotkey);
             }
         }
 

--- a/pallets/subtensor/src/tests/basket_flush.rs
+++ b/pallets/subtensor/src/tests/basket_flush.rs
@@ -14,13 +14,13 @@ use crate::tests::claim_root::{
 use crate::tests::mock::*;
 use crate::{
     BasketShares, IsNetworkMember, Keys, PendingBasketDeposits, PendingBasketFlushCursor,
-    RootClaimableThreshold, SubnetAlphaOut, Uids,
+    RootClaimableThreshold, SubnetAlphaIn, SubnetAlphaOut, SubnetTAO, Uids,
 };
 use frame_support::assert_ok;
 use sp_core::U256;
 use sp_std::collections::btree_set::BTreeSet;
 use substrate_fixed::types::I96F32;
-use subtensor_runtime_common::{NetUid, Token};
+use subtensor_runtime_common::{AlphaBalance, NetUid, TaoBalance, Token};
 
 /// Storage iteration order of distinct hotkeys currently in the pending-deposit map.
 fn pending_hotkey_order() -> Vec<U256> {
@@ -355,8 +355,9 @@ fn test_flush_happy_path_ops_bounded_for_curated_batch() {
         queue_credit(&hotkey, origin_b, credit_alpha);
 
         reset_basket_op_counters();
-        let (work, _) = SubtensorModule::flush_basket_deposits_for_hotkey(&hotkey);
+        let (work, _, completed) = SubtensorModule::flush_basket_deposits_for_hotkey(&hotkey);
 
+        assert!(completed);
         assert!(fund_shares(&hotkey) > 0);
         assert!(escrow_alpha(&hotkey, dest) > 0);
         assert!(!PendingBasketDeposits::<Test>::contains_key(
@@ -436,8 +437,9 @@ fn test_flush_failure_path_requeues_and_splits() {
             .collect();
 
         reset_basket_op_counters();
-        let (work, _) = SubtensorModule::flush_basket_deposits_for_hotkey(&hotkey);
+        let (work, _, completed) = SubtensorModule::flush_basket_deposits_for_hotkey(&hotkey);
 
+        assert!(!completed);
         assert_eq!(BasketShares::<Test>::get(hotkey), 0);
         for netuid in origins {
             assert_eq!(
@@ -466,6 +468,37 @@ fn test_flush_failure_path_requeues_and_splits() {
         );
         // Pre-deposit removes + re-queue writes after each singleton failure.
         assert_eq!(basket_write_ops(), credits.saturating_mul(2));
+    });
+}
+
+/// A dividend credit from a terminally shallow pool is recycled and removed instead of being
+/// re-queued forever. Because it never entered the fund, no shares or basket holding are minted.
+#[test]
+fn test_flush_terminal_origin_recycles_credit_without_pinning_queue() {
+    new_test_ext(1).execute_with(|| {
+        SubtensorModule::set_tao_weight(u64::MAX);
+        zero_claim_threshold();
+
+        let coldkey = U256::from(2001);
+        let hotkey = U256::from(3001);
+        let netuid = setup_root_validator(hotkey, coldkey, 1);
+        let alpha_out_before = SubnetAlphaOut::<Test>::get(netuid);
+
+        // Alpha -> TAO cannot execute once its TAO output reserve is below the engine floor.
+        SubnetTAO::<Test>::insert(
+            netuid,
+            TaoBalance::from(u64::from(SwapMinimumReserve::get()) - 1),
+        );
+        SubnetAlphaIn::<Test>::insert(netuid, AlphaBalance::from(1_000_000u64));
+        queue_credit(&hotkey, netuid, 1_000u64);
+
+        let (_, _, completed) = SubtensorModule::flush_basket_deposits_for_hotkey(&hotkey);
+
+        assert!(completed);
+        assert!(!PendingBasketDeposits::<Test>::contains_key(hotkey, netuid));
+        assert_eq!(escrow_alpha(&hotkey, netuid), 0);
+        assert_eq!(BasketShares::<Test>::get(hotkey), 0);
+        assert_eq!(SubnetAlphaOut::<Test>::get(netuid), alpha_out_before);
     });
 }
 

--- a/pallets/subtensor/src/tests/claim_root.rs
+++ b/pallets/subtensor/src/tests/claim_root.rs
@@ -3,10 +3,12 @@
 use crate::tests::mock::*;
 use crate::weights::WeightInfo;
 use crate::{
-    BasketClaimed, BasketRate, BasketShares, BurnIncreaseMult, DefaultMinRootClaimAmount, Error,
-    Keys, MAX_ROOT_CLAIM_THRESHOLD, NetworksAdded, NumStakingColdkeys, RootClaimableThreshold,
+    BasketClaimed, BasketRate, BasketRedeemedTao, BasketShares, BurnIncreaseMult,
+    DefaultMinRootClaimAmount, Error, Keys, MAX_ROOT_CLAIM_THRESHOLD, NetworksAdded,
+    NumStakingColdkeys, PendingBasketDeposits, RootAlphaDividendsPerSubnet, RootClaimableThreshold,
     StakingColdkeys, StakingColdkeysByIndex, StakingHotkeys, SubnetAlphaIn, SubnetMovingPrice,
-    SubnetProtocolFlow, SubnetTAO, SubnetworkN, Tempo, TotalStake, Uids, Weights,
+    SubnetOwnerHotkey, SubnetProtocolFlow, SubnetTAO, SubnetworkN, Tempo, TotalStake, Uids,
+    Weights,
 };
 use approx::assert_abs_diff_eq;
 use frame_support::dispatch::{DispatchClass, GetDispatchInfo, RawOrigin};
@@ -16,7 +18,7 @@ use frame_support::{assert_err, assert_noop, assert_ok};
 use sp_core::U256;
 use sp_runtime::DispatchError;
 use sp_std::collections::btree_set::BTreeSet;
-use substrate_fixed::types::{I96F32, U64F64};
+use substrate_fixed::types::{I96F32, U64F64, U96F32};
 use subtensor_runtime_common::{AlphaBalance, NetUid, NetUidStorageIndex, TaoBalance, Token};
 
 // =============================================================================
@@ -440,6 +442,109 @@ fn test_root_basket_accumulates_in_place_without_weights() {
         assert!(
             SubtensorModule::get_basket_owed_shares(&hotkey, &coldkey) > 0,
             "staker must accrue fund shares"
+        );
+    });
+}
+
+#[test]
+fn test_subnet_owner_root_validator_dividend_is_basketed_and_claimable() {
+    new_test_ext(1).execute_with(|| {
+        let owner_coldkey = U256::from(1101);
+        let owner_hotkey = U256::from(1102);
+        let netuid = add_dynamic_network(&owner_hotkey, &owner_coldkey);
+        remove_owner_registration_stake(netuid);
+        fund_pool(netuid);
+        zero_claim_threshold();
+
+        // Model the reported identity collision explicitly: this single hotkey owns the
+        // subnet, is a neuron on that subnet, and is also a root validator. Owner immunity
+        // applies to its miner incentive, but must not apply to its Root Reborn dividend.
+        register_on_root(&owner_hotkey, 0);
+        assert_eq!(SubnetOwnerHotkey::<Test>::get(netuid), owner_hotkey);
+        assert!(Uids::<Test>::contains_key(netuid, owner_hotkey));
+        assert!(Uids::<Test>::contains_key(NetUid::ROOT, owner_hotkey));
+
+        mock_increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &owner_hotkey,
+            &owner_coldkey,
+            NetUid::ROOT,
+            2_000_000u64.into(),
+        );
+
+        // Use zero validator take so the complete Root Reborn dividend belongs to the
+        // root staker and the basket-side accounting can be asserted exactly.
+        crate::Delegates::<Test>::insert(owner_hotkey, sp_runtime::PerU16::from_parts(0));
+
+        let miner_incentive = 100_000u64;
+        let root_reborn_dividend = 1_000_000u64;
+        let issued =
+            SubtensorModule::mint_alpha(netuid, (miner_incentive + root_reborn_dividend).into());
+        SubtensorModule::resolve_to_alpha_out(issued);
+
+        let burned_before = pallet_alpha_assets::AlphaBurned::<Test>::get(netuid);
+        let recycled_before = pallet_alpha_assets::AlphaRecycled::<Test>::get(netuid);
+
+        let mut incentives = alloc::collections::BTreeMap::new();
+        incentives.insert(owner_hotkey, miner_incentive.into());
+        let mut root_dividends = alloc::collections::BTreeMap::new();
+        root_dividends.insert(owner_hotkey, U96F32::from_num(root_reborn_dividend));
+
+        SubtensorModule::distribute_dividends_and_incentives(
+            netuid,
+            AlphaBalance::ZERO,
+            incentives,
+            alloc::collections::BTreeMap::new(),
+            root_dividends,
+        );
+
+        // This is the distinction the bug report misses: the owner-directed miner incentive
+        // is burned by the owner-immunity rule, while the Root Reborn dividend is preserved
+        // verbatim in the pending basket queue.
+        assert_eq!(
+            pallet_alpha_assets::AlphaBurned::<Test>::get(netuid),
+            burned_before.saturating_add(miner_incentive.into())
+        );
+        assert_eq!(
+            pallet_alpha_assets::AlphaRecycled::<Test>::get(netuid),
+            recycled_before
+        );
+        assert_eq!(
+            RootAlphaDividendsPerSubnet::<Test>::get(netuid, owner_hotkey),
+            root_reborn_dividend.into()
+        );
+        assert_eq!(
+            PendingBasketDeposits::<Test>::get(owner_hotkey, netuid),
+            root_reborn_dividend.into()
+        );
+
+        flush_baskets();
+
+        assert_eq!(
+            PendingBasketDeposits::<Test>::get(owner_hotkey, netuid),
+            AlphaBalance::ZERO
+        );
+        assert_eq!(
+            escrow_alpha(&owner_hotkey, netuid),
+            root_reborn_dividend,
+            "the owner's Root Reborn dividend must enter basket custody, not burn"
+        );
+        assert!(fund_shares(&owner_hotkey) > 0);
+        assert!(
+            SubtensorModule::get_basket_owed_shares(&owner_hotkey, &owner_coldkey) > 0,
+            "the owner coldkey must receive a claimable basket entitlement"
+        );
+
+        let root_stake_before = root_stake_of(&owner_hotkey, &owner_coldkey);
+        assert_ok!(SubtensorModule::claim_root_with_hotkey(
+            RuntimeOrigin::signed(owner_coldkey),
+            owner_hotkey
+        ));
+        assert!(root_stake_of(&owner_hotkey, &owner_coldkey) > root_stake_before);
+        assert!(BasketRedeemedTao::<Test>::get(owner_hotkey) > 0.into());
+        assert_eq!(
+            pallet_alpha_assets::AlphaBurned::<Test>::get(netuid),
+            burned_before.saturating_add(miner_incentive.into()),
+            "claiming the Root Reborn dividend must not add to burned alpha"
         );
     });
 }
@@ -3396,6 +3501,135 @@ fn test_root_basket_mixed_forfeit_claim_burns_nothing() {
         assert_eq!(escrow_alpha(&hotkey, netuid), alpha_before);
         assert_eq!(root_stake_of(&hotkey, &alice), alice_root_before);
         assert_eq!(BasketClaimed::<Test>::get(hotkey, alice), 0);
+    });
+}
+
+/// One terminally shallow subnet must not block redemption of the rest of a validator's
+/// basket. The claimant's exact pro-rata garbage slice is written off while the executable
+/// holding pays normally, leaving the same garbage-per-share ratio for the next holder.
+#[test]
+fn test_root_basket_claim_writes_off_only_claimants_terminal_garbage_slice() {
+    new_test_ext(1).execute_with(|| {
+        let owner_coldkey = U256::from(1001);
+        let hotkey = U256::from(1002);
+        let alice = U256::from(1003);
+        let bob = U256::from(1004);
+        let healthy = add_dynamic_network(&hotkey, &owner_coldkey);
+        let garbage = add_dynamic_network(&hotkey, &owner_coldkey);
+        remove_owner_registration_stake(healthy);
+        remove_owner_registration_stake(garbage);
+        fund_pool(healthy);
+
+        SubtensorModule::set_tao_weight(u64::MAX);
+        zero_claim_threshold();
+
+        // Alpha -> TAO requires the output (TAO) reserve to meet SwapMinimumReserve.
+        // This pool is therefore terminal for sales, independent of the sale amount.
+        SubnetTAO::<Test>::insert(
+            garbage,
+            TaoBalance::from(u64::from(SwapMinimumReserve::get()) - 1),
+        );
+        SubnetAlphaIn::<Test>::insert(garbage, AlphaBalance::from(1_000_000u64));
+
+        mock_increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey,
+            &alice,
+            NetUid::ROOT,
+            100u64.into(),
+        );
+        mock_increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey,
+            &bob,
+            NetUid::ROOT,
+            100u64.into(),
+        );
+        set_root_weights_direct(&hotkey, 0, &[(healthy, u16::MAX), (garbage, u16::MAX)]);
+
+        let escrow = SubtensorModule::get_beta_escrow_account_id();
+        mock_increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey,
+            &escrow,
+            healthy,
+            1_000_000u64.into(),
+        );
+        mock_increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey,
+            &escrow,
+            garbage,
+            1_000u64.into(),
+        );
+        BasketShares::<Test>::insert(hotkey, 200u64);
+        BasketRate::<Test>::insert(hotkey, I96F32::from_num(1));
+
+        let alice_root_before = root_stake_of(&hotkey, &alice);
+        assert_ok!(SubtensorModule::claim_root_with_hotkey(
+            RuntimeOrigin::signed(alice),
+            hotkey
+        ));
+
+        assert!(root_stake_of(&hotkey, &alice) > alice_root_before);
+        assert_eq!(fund_shares(&hotkey), 100);
+        assert_eq!(escrow_alpha(&hotkey, garbage), 500);
+        assert_eq!(SubtensorModule::get_basket_owed_shares(&hotkey, &bob), 100);
+    });
+}
+
+/// A full holding larger than the swap engine's one-call 1000x input-reserve guard is still
+/// executable in reserve-bounded chunks. Its valuation and the money-moving claim must use
+/// the same chunk sequence, rather than treating `SwapInputTooLarge` as a zero-valued slot.
+#[test]
+fn test_root_basket_claim_chunks_oversized_executable_holding() {
+    new_test_ext(1).execute_with(|| {
+        let owner_coldkey = U256::from(1001);
+        let hotkey = U256::from(1002);
+        let coldkey = U256::from(1003);
+        let netuid = add_dynamic_network(&hotkey, &owner_coldkey);
+        remove_owner_registration_stake(netuid);
+        // A liquid high-price pool keeps ample TAO output reserve even after selling more
+        // than 1000x its alpha input reserve. This isolates the engine's per-call input guard
+        // from a genuinely terminal reserve condition.
+        SubnetTAO::<Test>::insert(netuid, TaoBalance::from(1_000_000_000_000_000u64));
+        SubnetAlphaIn::<Test>::insert(netuid, AlphaBalance::from(1_000_000_000u64));
+        let subnet_account = SubtensorModule::get_subnet_account_id(netuid).unwrap();
+        add_balance_to_coldkey_account(&subnet_account, TaoBalance::from(1_000_000_000_000_000u64));
+
+        SubtensorModule::set_tao_weight(u64::MAX);
+        zero_claim_threshold();
+        mock_increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey,
+            &coldkey,
+            NetUid::ROOT,
+            1u64.into(),
+        );
+        set_root_weights_direct(&hotkey, 0, &[(netuid, u16::MAX)]);
+
+        let alpha_reserve = SubnetAlphaIn::<Test>::get(netuid).to_u64();
+        let oversized = alpha_reserve.saturating_mul(1_100);
+        let escrow = SubtensorModule::get_beta_escrow_account_id();
+        SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey,
+            &escrow,
+            netuid,
+            oversized.into(),
+        );
+        BasketShares::<Test>::insert(hotkey, 1u64);
+        BasketRate::<Test>::insert(hotkey, I96F32::from_num(1));
+
+        assert!(
+            SubtensorModule::try_realizable_tao_for_alpha(netuid, oversized)
+                .expect("oversized quote must not fail")
+                .expect("deep pool is not terminal")
+                > 0
+        );
+        let root_before = root_stake_of(&hotkey, &coldkey);
+        assert_ok!(SubtensorModule::claim_root_with_hotkey(
+            RuntimeOrigin::signed(coldkey),
+            hotkey
+        ));
+
+        assert!(root_stake_of(&hotkey, &coldkey) > root_before);
+        assert_eq!(escrow_alpha(&hotkey, netuid), 0);
+        assert_eq!(fund_shares(&hotkey), 0);
     });
 }
 

--- a/pallets/subtensor/src/tests/epoch.rs
+++ b/pallets/subtensor/src/tests/epoch.rs
@@ -3945,9 +3945,16 @@ fn regression_liquid_alpha_event_indices_are_append_only() {
     .encode();
     let consensus_mode =
         Event::<Test>::LiquidAlphaConsensusModeSet(netuid, ConsensusMode::Auto).encode();
+    let basket_writeoff = Event::<Test>::BasketAlphaWrittenOff {
+        hotkey: U256::from(1),
+        netuid,
+        alpha: AlphaBalance::from(1),
+    }
+    .encode();
 
     assert_eq!(prior_tail[0], 145);
     assert_eq!(consensus_mode[0], 146);
+    assert_eq!(basket_writeoff[0], 148);
 }
 
 #[test]

--- a/pallets/swap/src/pallet/impls.rs
+++ b/pallets/swap/src/pallet/impls.rs
@@ -11,7 +11,7 @@ use sp_runtime::traits::AccountIdConversion;
 use substrate_fixed::types::U64F64;
 use subtensor_runtime_common::{AlphaBalance, NetUid, SubnetInfo, TaoBalance, Token, TokenReserve};
 use subtensor_swap_interface::{
-    DefaultPriceLimit, Order as OrderT, SwapEngine, SwapHandler, SwapResult,
+    DefaultPriceLimit, Order as OrderT, SwapEngine, SwapFailureKind, SwapHandler, SwapResult,
 };
 
 use super::pallet::*;
@@ -558,6 +558,23 @@ impl<T: Config> SwapHandler for Pallet<T> {
 
             // Static subnet, alpha == tao
             _ => u64::from(tao_amount).into(),
+        }
+    }
+
+    fn max_swap_input<O: OrderT>(netuid: NetUid) -> O::PaidIn
+    where
+        Self: SwapEngine<O>,
+    {
+        O::ReserveIn::reserve(netuid).saturating_mul(MAX_SWAP_INPUT_RESERVE_MULTIPLIER.into())
+    }
+
+    fn classify_failure(error: &DispatchError) -> SwapFailureKind {
+        if *error == Error::<T>::SwapInputTooLarge.into() {
+            SwapFailureKind::InputTooLarge
+        } else if *error == Error::<T>::ReservesTooLow.into() {
+            SwapFailureKind::TerminalLiquidity
+        } else {
+            SwapFailureKind::Other
         }
     }
 }

--- a/primitives/swap-interface/src/lib.rs
+++ b/primitives/swap-interface/src/lib.rs
@@ -11,6 +11,16 @@ use subtensor_runtime_common::{AlphaBalance, NetUid, TaoBalance, Token};
 
 mod order;
 
+/// Coarse failure classification for protocol-owned basket operations. Callers may recover from
+/// an oversized input by chunking, and may explicitly write off a terminally untradeable asset;
+/// every other error remains fatal so accounting/transfer failures are never mistaken for dust.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SwapFailureKind {
+    InputTooLarge,
+    TerminalLiquidity,
+    Other,
+}
+
 pub trait SwapEngine<O: Order>: DefaultPriceLimit<O::PaidIn, O::PaidOut> {
     fn swap(
         netuid: NetUid,
@@ -53,6 +63,18 @@ pub trait SwapHandler {
     fn clear_protocol_liquidity(netuid: NetUid, weight_meter: &mut WeightMeter) -> bool;
     fn init_swap(netuid: NetUid, maybe_price: Option<U64F64>);
     fn get_alpha_amount_for_tao(netuid: NetUid, tao_amount: TaoBalance) -> AlphaBalance;
+
+    /// Maximum conservative gross input accepted by one swap for this order. Protocol basket
+    /// swaps drop fees, so the input-reserve multiple is exact for their use. Larger operations
+    /// must be executed in sequential chunks so each chunk observes the reserves left by the
+    /// previous one.
+    fn max_swap_input<O: Order>(netuid: NetUid) -> O::PaidIn
+    where
+        Self: SwapEngine<O>;
+
+    /// Classify a swap error without making callers depend on a concrete swap pallet's module
+    /// error indices.
+    fn classify_failure(error: &DispatchError) -> SwapFailureKind;
 }
 
 /// Combined swap + balance execution interface for limit orders.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 450,
+    spec_version: 451,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Summary

Hotfix release for runtime spec 451. This release hardens Root Reborn basket settlement so terminal or oversized liquidity on one subnet does not block healthy claims, and adds regression coverage for subnet-owner rewards.

## Changes

- Distinguishes terminal basket-liquidity failures from unexpected swap and accounting errors.
- Uses fallible realizable-NAV valuation in money-moving paths.
- Executes oversized basket swaps atomically in reserve-bounded chunks.
- Writes off only a claimant's proportional terminal alpha slice while allowing healthy basket holdings to settle.
- Applies terminal-liquidity handling to deferred deposits, dust consolidation, and subnet dissolution.
- Recycles terminal origin credits and retains terminal destination allocations as root cash.
- Adds end-to-end coverage proving subnet-owner hotkeys retain and can claim their Root Reborn rewards.
- Removes the seed-migration early return from eager per-hotkey basket flushing; the scheduled drain and deposit-engine migration checks remain.
- Bumps `spec_version` from 450 to 451.

## Behavioral impact

- A terminal or oversized basket holding no longer prevents settlement of otherwise healthy holdings.
- Unknown swap, transfer, valuation, and accounting failures continue to fail closed or remain queued for retry.
- `BasketAlphaWrittenOff` is appended to the event enum without shifting existing event indices.

## Compatibility and migration

- Runtime `spec_version`: 451.
- No new storage migration is introduced by this hotfix.

## Validation

- Root-claim test module: 57 passed.
- Basket-flush tests: 11 passed.
- Event-index append-only regression passed.
- `cargo fmt --check --all` passed.
- `git diff --check` passed.

## Included work

- #3127

