### PR TITLE
Restore the RootWeights proxy

### DIFF
--- a/common/src/proxy.rs
+++ b/common/src/proxy.rs
@@ -36,7 +36,7 @@ pub enum ProxyType {
     Registration,
     Transfer,
     SmallTransfer,
-    RootWeights, // Deprecated
+    RootWeights,
     ChildKeys,
     SudoUncheckedSetCode,
     SwapHotkey,
@@ -99,10 +99,7 @@ impl From<ProxyType> for u8 {
 
 impl ProxyType {
     pub fn is_deprecated(&self) -> bool {
-        matches!(
-            self,
-            Self::Triumvirate | Self::Senate | Self::Governance | Self::RootWeights
-        )
+        matches!(self, Self::Triumvirate | Self::Senate | Self::Governance)
     }
 }
 

--- a/runtime/src/proxy_filters/call_groups.rs
+++ b/runtime/src/proxy_filters/call_groups.rs
@@ -433,6 +433,14 @@ call_filter_group!(
     [RuntimeCall::SubtensorModule(SubtensorCall::start_call),]
 );
 
+// Root basket curation. Kept separate so `RootWeights` grants only this call.
+call_filter_group!(
+    RootWeightsCalls,
+    [RuntimeCall::SubtensorModule(
+        SubtensorCall::set_root_weights
+    ),]
+);
+
 // Residual pallet-subtensor calls that no proxy needs to grant on their own:
 // weights, serving, delegate-take, alpha lock/burn/preferences, network
 // registration, childkey admin, account association, tempo control, voting
@@ -441,7 +449,6 @@ call_filter_group!(
     SubtensorCommonCalls,
     [
         RuntimeCall::SubtensorModule(SubtensorCall::set_weights),
-        RuntimeCall::SubtensorModule(SubtensorCall::set_root_weights),
         RuntimeCall::SubtensorModule(SubtensorCall::set_mechanism_weights),
         RuntimeCall::SubtensorModule(SubtensorCall::batch_set_weights),
         RuntimeCall::SubtensorModule(SubtensorCall::commit_weights),
@@ -693,6 +700,7 @@ type SubtensorSplitCalls = (
     RootClaimCalls,
     SubnetIdentityCalls,
     SubnetActivationCalls,
+    RootWeightsCalls,
     SubtensorCommonCalls,
 );
 

--- a/runtime/src/proxy_filters/mod.rs
+++ b/runtime/src/proxy_filters/mod.rs
@@ -15,7 +15,7 @@ use crate::RuntimeCall;
 //
 // Each proxy type's permission set is an *additive* union of whole call groups
 // from `call_groups`. A call a proxy does not list is denied. `Any` allows
-// everything; the deprecated proxies allow nothing.
+// everything; the deprecated governance proxies allow nothing.
 //
 // `Contains` for a tuple is logical OR (any member matches), so these aliases
 // read as "allow if the call is in any of these groups".
@@ -65,6 +65,7 @@ type NonTransferAllowed = (
     RootClaimCalls,
     SubnetIdentityCalls,
     SubnetActivationCalls,
+    RootWeightsCalls,
     SubtensorCommonCalls,
 );
 
@@ -80,6 +81,7 @@ type NonFungibleAllowed = (
     RootClaimCalls,
     SubnetIdentityCalls,
     SubnetActivationCalls,
+    RootWeightsCalls,
     SubtensorCommonCalls,
 );
 
@@ -99,6 +101,7 @@ type NonCriticalAllowed = (
     RootClaimCalls,
     SubnetIdentityCalls,
     SubnetActivationCalls,
+    RootWeightsCalls,
     SubtensorCommonCalls,
 );
 
@@ -117,11 +120,9 @@ pub(crate) fn proxy_type_filter(proxy_type: &ProxyType, call: &RuntimeCall) -> b
         ProxyType::SwapHotkey => HotkeySwapCalls::contains(call),
         ProxyType::SubnetLeaseBeneficiary => SubnetLeaseAllowed::contains(call),
         ProxyType::RootClaim => RootClaimCalls::contains(call),
+        ProxyType::RootWeights => RootWeightsCalls::contains(call),
         ProxyType::SudoUncheckedSetCode => SudoSetCodeCalls::contains(call),
-        ProxyType::Triumvirate
-        | ProxyType::Senate
-        | ProxyType::Governance
-        | ProxyType::RootWeights => false,
+        ProxyType::Triumvirate | ProxyType::Senate | ProxyType::Governance => false,
     }
 }
 
@@ -183,11 +184,11 @@ fn proxy_filter_mode(proxy_type: ProxyType) -> FilterMode {
         ProxyType::SwapHotkey => FilterMode::Allow(HotkeySwapCalls::call_infos()),
         ProxyType::SubnetLeaseBeneficiary => FilterMode::Allow(SubnetLeaseAllowed::call_infos()),
         ProxyType::RootClaim => FilterMode::Allow(RootClaimCalls::call_infos()),
+        ProxyType::RootWeights => FilterMode::Allow(RootWeightsCalls::call_infos()),
         ProxyType::SudoUncheckedSetCode => FilterMode::Allow(SudoSetCodeCalls::call_infos()),
-        ProxyType::Triumvirate
-        | ProxyType::Senate
-        | ProxyType::Governance
-        | ProxyType::RootWeights => FilterMode::Allow(Vec::new()),
+        ProxyType::Triumvirate | ProxyType::Senate | ProxyType::Governance => {
+            FilterMode::Allow(Vec::new())
+        }
     }
 }
 
@@ -287,11 +288,11 @@ mod tests {
     #[test]
     fn any_allows_everything_and_deprecated_allow_nothing() {
         assert_eq!(allowed_calls(ProxyType::Any), all_runtime_calls());
+        assert!(!ProxyType::RootWeights.is_deprecated());
         for deprecated in [
             ProxyType::Triumvirate,
             ProxyType::Senate,
             ProxyType::Governance,
-            ProxyType::RootWeights,
         ] {
             assert!(allowed_calls(deprecated).is_empty());
         }
@@ -513,6 +514,10 @@ mod tests {
                 "SubtensorModule::claim_root",
                 "SubtensorModule::claim_root_with_hotkey",
             ])
+        );
+        assert_eq!(
+            allowed_calls(ProxyType::RootWeights),
+            expected(&["SubtensorModule::set_root_weights"])
         );
         assert_eq!(
             allowed_calls(ProxyType::SudoUncheckedSetCode),


### PR DESCRIPTION
## Problem

`set_root_weights` is currently available through `Any`, `NonTransfer`, `NonFungible`, and `NonCritical`, but each of those proxy types grants substantially broader authority than root basket curation alone. The stable `RootWeights` proxy type still exists at index 12, but it is marked deprecated and its filter denies every call, so users cannot delegate this operation narrowly.

## Root cause

When proxy filtering was reorganized into additive call groups, `set_root_weights` was placed in the broad residual Subtensor call group while `RootWeights` remained grouped with deprecated deny-all proxy types. That preserved the encoded proxy index but removed its original useful behavior.

## Fix

- Reactivate `RootWeights` without changing its stable on-chain index.
- Give it an explicit call group containing only `SubtensorModule::set_root_weights`.
- Expose the same one-call allowlist through proxy filter metadata and stop reporting the type as deprecated.
- Preserve the existing permissions of `Any`, `NonTransfer`, `NonFungible`, and `NonCritical` by including the new call group in their additive policies.
- Cover the active status and exact one-call allowlist in the proxy filter tests.

## Validation

- `cargo fmt --check --all`
- `git diff --check`

Rust builds and tests are left to CI under the repository's quick-preflight policy. This runtime-affecting change requires release handling through a spec version newer than mainnet or the corresponding no-bump label.
