### PR TITLE
Bump spec_version to 452

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 451,
+    spec_version: 452,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Summary
- Bump `spec_version` from 451 to 452 so the current `main` tip (v451 plus the precompile frame alignment) can ride one Release Train.
- Trains 37 and 38 were cancelled so this train is not blocked on the leftover 451 mainnet gate.

## Test plan
- [ ] Release Train builds wasm once at spec 452
- [ ] Devnet deploy is not skipped (`452 >` on-chain)
- [ ] Testnet deploy follows after the usual environment gate


Made with [Cursor](https://cursor.com)