### PR TITLE
add `SetRootWeights` proxy

### DIFF
--- a/common/src/proxy.rs
+++ b/common/src/proxy.rs
@@ -42,6 +42,8 @@ pub enum ProxyType {
     SwapHotkey,
     SubnetLeaseBeneficiary,
     RootClaim,
+    /// Root basket curation (`set_root_weights`) only.
+    SetRootWeights,
 }
 
 impl TryFrom<u8> for ProxyType {
@@ -67,6 +69,7 @@ impl TryFrom<u8> for ProxyType {
             15 => Ok(Self::SwapHotkey),
             16 => Ok(Self::SubnetLeaseBeneficiary),
             17 => Ok(Self::RootClaim),
+            18 => Ok(Self::SetRootWeights),
             _ => Err(()),
         }
     }
@@ -93,6 +96,7 @@ impl From<ProxyType> for u8 {
             ProxyType::SwapHotkey => 15,
             ProxyType::SubnetLeaseBeneficiary => 16,
             ProxyType::RootClaim => 17,
+            ProxyType::SetRootWeights => 18,
         }
     }
 }

--- a/docs/guides/proxies.mdx
+++ b/docs/guides/proxies.mdx
@@ -63,6 +63,7 @@ Prefer the narrowest type that covers the job:
   [`register_limit`](/code/pallets/subtensor/src/macros/dispatches.rs#L2242-L2249)).
 * **ChildKeys** — [`set_children`](/code/pallets/subtensor/src/macros/dispatches.rs#L1093-L1101) and [`set_childkey_take`](/code/pallets/subtensor/src/macros/dispatches.rs#L935-L945);
   **RootClaim** — [`claim_root`](/code/pallets/subtensor/src/macros/dispatches.rs#L1905-L1939) and [`claim_root_with_hotkey`](/code/pallets/subtensor/src/macros/dispatches.rs#L1941-L1970).
+* **SetRootWeights** — root basket curation through `set_root_weights` only.
 * **Owner** — subnet-owner admin calls; **NonCritical** — everything except
   registrations, coldkey swaps, and subnet dissolution;
   **SubnetLeaseBeneficiary** — the lease-scoped subset of owner calls.

--- a/docs/tx/add-proxy.mdx
+++ b/docs/tx/add-proxy.mdx
@@ -21,7 +21,7 @@ only to keys you control or fully trust.
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
 | `delegate_ss58` | string | yes | Key that will be allowed to sign for this account. |
-| `proxy_type` | string | no | Scope of calls the delegation covers. One of: Any, Owner, NonCritical, NonTransfer, Senate, NonFungible, Triumvirate, Governance, Staking, Registration, Transfer, SmallTransfer, RootWeights, ChildKeys, SudoUncheckedSetCode, SwapHotkey, SubnetLeaseBeneficiary, RootClaim. Triumvirate, Senate, Governance, and RootWeights are deprecated on the current runtime: they deny all calls, so a proxy of those types can dispatch nothing. Prefer the narrowest type that covers your use; Any can do everything the account can, including transfers. |
+| `proxy_type` | string | no | Scope of calls the delegation covers. One of: Any, Owner, NonCritical, NonTransfer, Senate, NonFungible, Triumvirate, Governance, Staking, Registration, Transfer, SmallTransfer, RootWeights, ChildKeys, SudoUncheckedSetCode, SwapHotkey, SubnetLeaseBeneficiary, RootClaim, SetRootWeights. Triumvirate, Senate, Governance, and RootWeights are deprecated on the current runtime: they deny all calls, so a proxy of those types can dispatch nothing. SetRootWeights permits only set_root_weights. Prefer the narrowest type that covers your use; Any can do everything the account can, including transfers. |
 | `delay` | integer | no | Announcement delay in blocks: the delegate must announce each call and wait this long before executing it, giving you time to veto. 0 executes immediately. |
 
 Address parameters (`--hotkey`, `--coldkey`, `--dest`, ...) accept a raw ss58

--- a/docs/tx/create-pure-proxy.mdx
+++ b/docs/tx/create-pure-proxy.mdx
@@ -21,7 +21,7 @@ the pure proxy and anything it holds.
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| `proxy_type` | string | no | Scope of calls the delegation covers. One of: Any, Owner, NonCritical, NonTransfer, Senate, NonFungible, Triumvirate, Governance, Staking, Registration, Transfer, SmallTransfer, RootWeights, ChildKeys, SudoUncheckedSetCode, SwapHotkey, SubnetLeaseBeneficiary, RootClaim. Triumvirate, Senate, Governance, and RootWeights are deprecated on the current runtime: they deny all calls, so a proxy of those types can dispatch nothing. Prefer the narrowest type that covers your use; Any can do everything the account can, including transfers. |
+| `proxy_type` | string | no | Scope of calls the delegation covers. One of: Any, Owner, NonCritical, NonTransfer, Senate, NonFungible, Triumvirate, Governance, Staking, Registration, Transfer, SmallTransfer, RootWeights, ChildKeys, SudoUncheckedSetCode, SwapHotkey, SubnetLeaseBeneficiary, RootClaim, SetRootWeights. Triumvirate, Senate, Governance, and RootWeights are deprecated on the current runtime: they deny all calls, so a proxy of those types can dispatch nothing. SetRootWeights permits only set_root_weights. Prefer the narrowest type that covers your use; Any can do everything the account can, including transfers. |
 | `delay` | integer | no | Announcement delay in blocks: the delegate must announce each call and wait this long before executing it, giving you time to veto. 0 executes immediately. |
 | `index` | integer | no | Disambiguator so one signer can create several pure proxies in one block; also part of the derived address. Keep 0 unless batching. |
 

--- a/runtime/src/proxy_filters/call_groups.rs
+++ b/runtime/src/proxy_filters/call_groups.rs
@@ -418,6 +418,14 @@ call_filter_group!(
     ]
 );
 
+// Curating a validator's root basket.
+call_filter_group!(
+    RootWeightsCalls,
+    [RuntimeCall::SubtensorModule(
+        SubtensorCall::set_root_weights
+    ),]
+);
+
 // A subnet's public identity and token symbol.
 call_filter_group!(
     SubnetIdentityCalls,
@@ -441,7 +449,6 @@ call_filter_group!(
     SubtensorCommonCalls,
     [
         RuntimeCall::SubtensorModule(SubtensorCall::set_weights),
-        RuntimeCall::SubtensorModule(SubtensorCall::set_root_weights),
         RuntimeCall::SubtensorModule(SubtensorCall::set_mechanism_weights),
         RuntimeCall::SubtensorModule(SubtensorCall::batch_set_weights),
         RuntimeCall::SubtensorModule(SubtensorCall::commit_weights),

--- a/runtime/src/proxy_filters/mod.rs
+++ b/runtime/src/proxy_filters/mod.rs
@@ -63,6 +63,7 @@ type NonTransferAllowed = (
     CriticalNetworkCalls,
     ChildKeyCalls,
     RootClaimCalls,
+    RootWeightsCalls,
     SubnetIdentityCalls,
     SubnetActivationCalls,
     SubtensorCommonCalls,
@@ -78,6 +79,7 @@ type NonFungibleAllowed = (
     CriticalNetworkCalls,
     ChildKeyCalls,
     RootClaimCalls,
+    RootWeightsCalls,
     SubnetIdentityCalls,
     SubnetActivationCalls,
     SubtensorCommonCalls,
@@ -97,6 +99,7 @@ type NonCriticalAllowed = (
     HotkeySwapCalls,
     ChildKeyCalls,
     RootClaimCalls,
+    RootWeightsCalls,
     SubnetIdentityCalls,
     SubnetActivationCalls,
     SubtensorCommonCalls,
@@ -117,6 +120,7 @@ pub(crate) fn proxy_type_filter(proxy_type: &ProxyType, call: &RuntimeCall) -> b
         ProxyType::SwapHotkey => HotkeySwapCalls::contains(call),
         ProxyType::SubnetLeaseBeneficiary => SubnetLeaseAllowed::contains(call),
         ProxyType::RootClaim => RootClaimCalls::contains(call),
+        ProxyType::SetRootWeights => RootWeightsCalls::contains(call),
         ProxyType::SudoUncheckedSetCode => SudoSetCodeCalls::contains(call),
         ProxyType::Triumvirate
         | ProxyType::Senate
@@ -152,7 +156,8 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
                 | ProxyType::SudoUncheckedSetCode
                 | ProxyType::SwapHotkey
                 | ProxyType::SubnetLeaseBeneficiary
-                | ProxyType::RootClaim,
+                | ProxyType::RootClaim
+                | ProxyType::SetRootWeights,
             ) => true,
             (ProxyType::Transfer, ProxyType::SmallTransfer) => true,
             _ => false,
@@ -183,6 +188,7 @@ fn proxy_filter_mode(proxy_type: ProxyType) -> FilterMode {
         ProxyType::SwapHotkey => FilterMode::Allow(HotkeySwapCalls::call_infos()),
         ProxyType::SubnetLeaseBeneficiary => FilterMode::Allow(SubnetLeaseAllowed::call_infos()),
         ProxyType::RootClaim => FilterMode::Allow(RootClaimCalls::call_infos()),
+        ProxyType::SetRootWeights => FilterMode::Allow(RootWeightsCalls::call_infos()),
         ProxyType::SudoUncheckedSetCode => FilterMode::Allow(SudoSetCodeCalls::call_infos()),
         ProxyType::Triumvirate
         | ProxyType::Senate
@@ -238,6 +244,7 @@ mod tests {
         string::{String, ToString},
         vec,
     };
+    use codec::Encode;
     use frame_support::traits::GetCallMetadata;
     use subtensor_runtime_common::CallInfo;
 
@@ -287,6 +294,7 @@ mod tests {
     #[test]
     fn any_allows_everything_and_deprecated_allow_nothing() {
         assert_eq!(allowed_calls(ProxyType::Any), all_runtime_calls());
+        assert!(!ProxyType::SetRootWeights.is_deprecated());
         for deprecated in [
             ProxyType::Triumvirate,
             ProxyType::Senate,
@@ -295,6 +303,14 @@ mod tests {
         ] {
             assert!(allowed_calls(deprecated).is_empty());
         }
+    }
+
+    #[test]
+    fn set_root_weights_has_a_fresh_wire_index() {
+        assert_eq!(u8::from(ProxyType::RootWeights), 12);
+        assert_eq!(ProxyType::RootWeights.encode(), vec![12]);
+        assert_eq!(u8::from(ProxyType::SetRootWeights), 18);
+        assert_eq!(ProxyType::SetRootWeights.encode(), vec![18]);
     }
 
     // Broad proxies are specified subtractively here (all calls minus a few
@@ -398,6 +414,7 @@ mod tests {
             ProxyType::SwapHotkey,
             ProxyType::SubnetLeaseBeneficiary,
             ProxyType::RootClaim,
+            ProxyType::SetRootWeights,
         ]
         .into_iter()
         .collect::<BTreeSet<_>>();
@@ -513,6 +530,10 @@ mod tests {
                 "SubtensorModule::claim_root",
                 "SubtensorModule::claim_root_with_hotkey",
             ])
+        );
+        assert_eq!(
+            allowed_calls(ProxyType::SetRootWeights),
+            expected(&["SubtensorModule::set_root_weights"])
         );
         assert_eq!(
             allowed_calls(ProxyType::SudoUncheckedSetCode),

--- a/sdk/python/bittensor/intents/proxy.py
+++ b/sdk/python/bittensor/intents/proxy.py
@@ -37,6 +37,7 @@ PROXY_TYPES = (
     "SwapHotkey",
     "SubnetLeaseBeneficiary",
     "RootClaim",
+    "SetRootWeights",
 )
 
 
@@ -58,7 +59,8 @@ PROXY_TYPE_HELP = (
     + ", ".join(PROXY_TYPES)
     + ". Triumvirate, Senate, Governance, and RootWeights are deprecated on "
     "the current runtime: they deny all calls, so a proxy of those types can "
-    "dispatch nothing. Prefer the narrowest type that covers your use; Any "
+    "dispatch nothing. SetRootWeights permits only set_root_weights. Prefer the "
+    "narrowest type that covers your use; Any "
     "can do everything the account can, including transfers."
 )
 

--- a/website/apps/bittensor-website/public/catalog/intents.json
+++ b/website/apps/bittensor-website/public/catalog/intents.json
@@ -92,7 +92,7 @@
         },
         "proxy_type": {
           "type": "string",
-          "description": "Scope of calls the delegation covers. One of: Any, Owner, NonCritical, NonTransfer, Senate, NonFungible, Triumvirate, Governance, Staking, Registration, Transfer, SmallTransfer, RootWeights, ChildKeys, SudoUncheckedSetCode, SwapHotkey, SubnetLeaseBeneficiary, RootClaim. Triumvirate, Senate, Governance, and RootWeights are deprecated on the current runtime: they deny all calls, so a proxy of those types can dispatch nothing. Prefer the narrowest type that covers your use; Any can do everything the account can, including transfers."
+          "description": "Scope of calls the delegation covers. One of: Any, Owner, NonCritical, NonTransfer, Senate, NonFungible, Triumvirate, Governance, Staking, Registration, Transfer, SmallTransfer, RootWeights, ChildKeys, SudoUncheckedSetCode, SwapHotkey, SubnetLeaseBeneficiary, RootClaim, SetRootWeights. Triumvirate, Senate, Governance, and RootWeights are deprecated on the current runtime: they deny all calls, so a proxy of those types can dispatch nothing. SetRootWeights permits only set_root_weights. Prefer the narrowest type that covers your use; Any can do everything the account can, including transfers."
         },
         "delay": {
           "type": "integer",
@@ -871,7 +871,7 @@
       "properties": {
         "proxy_type": {
           "type": "string",
-          "description": "Scope of calls the delegation covers. One of: Any, Owner, NonCritical, NonTransfer, Senate, NonFungible, Triumvirate, Governance, Staking, Registration, Transfer, SmallTransfer, RootWeights, ChildKeys, SudoUncheckedSetCode, SwapHotkey, SubnetLeaseBeneficiary, RootClaim. Triumvirate, Senate, Governance, and RootWeights are deprecated on the current runtime: they deny all calls, so a proxy of those types can dispatch nothing. Prefer the narrowest type that covers your use; Any can do everything the account can, including transfers."
+          "description": "Scope of calls the delegation covers. One of: Any, Owner, NonCritical, NonTransfer, Senate, NonFungible, Triumvirate, Governance, Staking, Registration, Transfer, SmallTransfer, RootWeights, ChildKeys, SudoUncheckedSetCode, SwapHotkey, SubnetLeaseBeneficiary, RootClaim, SetRootWeights. Triumvirate, Senate, Governance, and RootWeights are deprecated on the current runtime: they deny all calls, so a proxy of those types can dispatch nothing. SetRootWeights permits only set_root_weights. Prefer the narrowest type that covers your use; Any can do everything the account can, including transfers."
         },
         "delay": {
           "type": "integer",


### PR DESCRIPTION
## Motivation

Operators need to delegate root-basket curation without granting a broader proxy scope. Reusing the deprecated `RootWeights` variant could unexpectedly reactivate existing delegations, so this change introduces a new proxy type with a fresh wire index.

## Changes

- Add `SetRootWeights` as proxy type index `18` while leaving deprecated `RootWeights` at index `12` deny-all.
- Restrict `SetRootWeights` to `SubtensorModule::set_root_weights`.
- Preserve the existing broad proxy behavior by moving `set_root_weights` into a dedicated call group included by the same broad filters.
- Expose the new type through runtime filter metadata and the Python SDK.
- Update proxy guides, transaction reference pages, and generated intent catalog data.
- Add tests for the stable SCALE index and exact allowed-call set.

## Behavioral and upgrade impact

This is a runtime-facing proxy enum and filter change and therefore takes effect with a runtime upgrade. It requires no storage migration. Existing `RootWeights` proxies remain deprecated and deny all calls; users must explicitly create or update a proxy using `SetRootWeights`.

## Validation

- Added unit assertions for wire indices and the `SetRootWeights` allowlist.
- `git diff --check` passes.
- Rust formatting could not be executed in the review environment because rustup attempted to write to a read-only locked environment.
- Python Ruff and generated-reference checks could not be executed because the existing environment does not provide `uv`.