### PR TITLE
release-453

### DIFF
--- a/pallets/drand/src/tests.rs
+++ b/pallets/drand/src/tests.rs
@@ -141,6 +141,42 @@ fn it_rejects_invalid_pulse_due_to_bad_signature() {
 }
 
 #[test]
+fn it_rejects_valid_signature_with_unbound_randomness() {
+    new_test_ext().execute_with(|| {
+        let alice = sp_keyring::Sr25519Keyring::Alice;
+        let block_number = 100_000_000;
+        System::set_block_number(block_number);
+
+        let info: BeaconInfoResponse = serde_json::from_str(DRAND_INFO_RESPONSE).unwrap();
+        let config_payload = BeaconConfigurationPayload {
+            block_number,
+            config: info.try_into_beacon_config().unwrap(),
+            public: alice.public(),
+        };
+        assert_ok!(Drand::set_beacon_config(
+            RuntimeOrigin::root(),
+            config_payload,
+            None
+        ));
+
+        let response: DrandResponseBody = serde_json::from_str(DRAND_PULSE).unwrap();
+        let mut pulse: Pulse = response.try_into_pulse().unwrap();
+        pulse.randomness[0] ^= 1;
+        let pulses_payload = PulsesPayload {
+            pulses: vec![pulse],
+            block_number,
+            public: alice.public(),
+        };
+
+        assert_noop!(
+            Drand::write_pulse(RuntimeOrigin::none(), pulses_payload, None),
+            Error::<Test>::PulseVerificationError
+        );
+        assert!(Pulses::<Test>::get(ROUND_NUMBER).is_none());
+    });
+}
+
+#[test]
 fn it_rejects_pulses_with_non_incremental_round_numbers() {
     new_test_ext().execute_with(|| {
         let block_number = 100_000_000;

--- a/pallets/drand/src/verifier.rs
+++ b/pallets/drand/src/verifier.rs
@@ -65,6 +65,14 @@ pub struct QuicknetVerifier;
 
 impl Verifier for QuicknetVerifier {
     fn verify(beacon_config: BeaconConfiguration, pulse: Pulse) -> Result<bool, String> {
+        // Quicknet derives the public randomness as SHA-256(signature). The BLS
+        // pairing authenticates the round, but it does not authenticate a
+        // separately supplied randomness field, so bind the two explicitly.
+        let expected_randomness = Sha256::digest(pulse.signature.as_slice());
+        if pulse.randomness.as_slice() != expected_randomness.as_slice() {
+            return Err("Randomness does not match the signature digest".into());
+        }
+
         // decode public key (pk)
         let pk =
             ArkScale::<G2AffineOpt>::decode(&mut beacon_config.public_key.into_inner().as_slice())

--- a/pallets/proxy/src/lib.rs
+++ b/pallets/proxy/src/lib.rs
@@ -258,14 +258,14 @@ pub mod pallet {
             force_proxy_type: Option<T::ProxyType>,
             call: Box<<T as Config>::RuntimeCall>,
         ) -> DispatchResultWithPostInfo {
-            let who = ensure_signed(origin)?;
+            let who = ensure_signed(origin.clone())?;
             let real = T::Lookup::lookup(real)?;
             let def = Self::find_proxy(&real, &who, force_proxy_type)?;
             ensure!(def.delay.is_zero(), Error::<T>::Unannounced);
 
             let weight = T::WeightInfo::proxy(T::MaxProxies::get())
                 .saturating_add(T::DbWeight::get().reads_writes(1, 1))
-                .saturating_add(Self::do_proxy(def, real, *call));
+                .saturating_add(Self::do_proxy(def, real, *call, origin));
 
             Ok(Some(weight).into())
         }
@@ -570,7 +570,7 @@ pub mod pallet {
             force_proxy_type: Option<T::ProxyType>,
             call: Box<<T as Config>::RuntimeCall>,
         ) -> DispatchResultWithPostInfo {
-            ensure_signed(origin)?;
+            ensure_signed(origin.clone())?;
             let delegate = T::Lookup::lookup(delegate)?;
             let real = T::Lookup::lookup(real)?;
             let def = Self::find_proxy(&real, &delegate, force_proxy_type)?;
@@ -586,7 +586,7 @@ pub mod pallet {
 
             let weight = T::WeightInfo::proxy_announced(T::MaxPending::get(), T::MaxProxies::get())
                 .saturating_add(T::DbWeight::get().reads_writes(1, 1))
-                .saturating_add(Self::do_proxy(def, real, *call));
+                .saturating_add(Self::do_proxy(def, real, *call, origin));
 
             Ok(Some(weight).into())
         }
@@ -1120,11 +1120,17 @@ impl<T: Config> Pallet<T> {
         def: ProxyDefinition<T::AccountId, T::ProxyType, BlockNumberFor<T>>,
         real: T::AccountId,
         call: <T as Config>::RuntimeCall,
+        inherited_origin: T::RuntimeOrigin,
     ) -> Weight {
         use frame::traits::{InstanceFilter as _, OriginTrait as _};
-        // This is a freshly authenticated new account, the origin restrictions doesn't apply.
+        // Authenticate the next real account without discarding restrictions inherited from an
+        // outer proxy. Every nested effect must pass all filters in the proxy chain.
         let mut origin: T::RuntimeOrigin = frame_system::RawOrigin::Signed(real.clone()).into();
         origin.add_filter(move |c: &<T as frame_system::Config>::RuntimeCall| {
+            if !inherited_origin.filter_call(c) {
+                return false;
+            }
+
             let c = <T as Config>::RuntimeCall::from_ref(c);
             // We make sure the proxy call does access this pallet to change modify proxies.
             match c.is_sub_type() {

--- a/pallets/proxy/src/tests.rs
+++ b/pallets/proxy/src/tests.rs
@@ -77,6 +77,7 @@ pub enum ProxyType {
     Any,
     JustTransfer,
     JustUtility,
+    JustProxy,
 }
 impl Default for ProxyType {
     fn default() -> Self {
@@ -94,6 +95,7 @@ impl frame::traits::InstanceFilter<RuntimeCall> for ProxyType {
                 )
             }
             ProxyType::JustUtility => matches!(c, RuntimeCall::Utility { .. }),
+            ProxyType::JustProxy => matches!(c, RuntimeCall::Proxy { .. }),
         }
     }
     fn is_superset(&self, o: &Self) -> bool {
@@ -712,6 +714,98 @@ fn filtering_works() {
             BalancesEvent::<Test>::Unreserved { who: 1, amount: 5 }.into(),
             ProxyEvent::ProxyExecuted { result: Ok(()) }.into(),
         ]);
+    });
+}
+
+#[test]
+fn nested_proxy_intersects_outer_and_inner_authority() {
+    new_test_ext().execute_with(|| {
+        Balances::make_free_balance_be(&5, 100);
+        // Account 2 may use proxy calls as account 1, while account 1 has
+        // unrestricted proxy authority over account 5.
+        assert_ok!(Proxy::add_proxy(
+            RuntimeOrigin::signed(1),
+            2,
+            ProxyType::JustProxy,
+            0
+        ));
+        assert_ok!(Proxy::add_proxy(
+            RuntimeOrigin::signed(5),
+            1,
+            ProxyType::Any,
+            0
+        ));
+
+        let victim_before = Balances::free_balance(5);
+        let recipient_before = Balances::free_balance(6);
+        let nested = RuntimeCall::Proxy(ProxyCall::new_call_variant_proxy(
+            5,
+            Some(ProxyType::Any),
+            Box::new(call_transfer(6, 10)),
+        ));
+
+        assert_ok!(Proxy::proxy(
+            RuntimeOrigin::signed(2),
+            1,
+            Some(ProxyType::JustProxy),
+            Box::new(nested),
+        ));
+
+        assert_eq!(Balances::free_balance(5), victim_before);
+        assert_eq!(Balances::free_balance(6), recipient_before);
+        assert!(System::events().iter().any(|event| event.event
+            == RuntimeEvent::Proxy(ProxyEvent::ProxyExecuted {
+                result: Err(SystemError::CallFiltered.into()),
+            })));
+    });
+}
+
+#[test]
+fn nested_announced_proxy_intersects_outer_and_inner_authority() {
+    new_test_ext().execute_with(|| {
+        Balances::make_free_balance_be(&5, 100);
+        assert_ok!(Proxy::add_proxy(
+            RuntimeOrigin::signed(1),
+            2,
+            ProxyType::JustProxy,
+            0
+        ));
+        assert_ok!(Proxy::add_proxy(
+            RuntimeOrigin::signed(5),
+            1,
+            ProxyType::Any,
+            1
+        ));
+
+        let transfer = Box::new(call_transfer(6, 10));
+        assert_ok!(Proxy::announce(
+            RuntimeOrigin::signed(1),
+            5,
+            BlakeTwo256::hash_of(&transfer)
+        ));
+        System::set_block_number(2);
+
+        let victim_before = Balances::free_balance(5);
+        let recipient_before = Balances::free_balance(6);
+        let nested = RuntimeCall::Proxy(ProxyCall::new_call_variant_proxy_announced(
+            1,
+            5,
+            Some(ProxyType::Any),
+            transfer,
+        ));
+        assert_ok!(Proxy::proxy(
+            RuntimeOrigin::signed(2),
+            1,
+            Some(ProxyType::JustProxy),
+            Box::new(nested),
+        ));
+
+        assert_eq!(Balances::free_balance(5), victim_before);
+        assert_eq!(Balances::free_balance(6), recipient_before);
+        assert!(System::events().iter().any(|event| event.event
+            == RuntimeEvent::Proxy(ProxyEvent::ProxyExecuted {
+                result: Err(SystemError::CallFiltered.into()),
+            })));
     });
 }
 

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -1331,6 +1331,7 @@ mod dispatches {
         /// * `AmountTooLow`: The TAO-equivalent of the transfer is below the minimum stake requirement.
         /// * `TransferDisallowed`: Transfers are disabled on the origin or destination subnet.
         /// * `StakeUnavailable`: The remaining stake would not cover the locked amount on the origin subnet.
+        /// * `CannotUseSystemAccount`: The destination coldkey is the protocol-owned basket escrow.
         ///
         /// # Events
         /// May emit a `StakeTransferred` event on success.
@@ -2518,6 +2519,7 @@ mod dispatches {
         /// * `AmountTooLow`: The TAO-equivalent of the transfer is below the minimum stake requirement.
         /// * `TransferDisallowed`: Transfers are disabled on the origin or destination subnet.
         /// * `StakeUnavailable`: The remaining stake would not cover the locked amount on the origin subnet.
+        /// * `CannotUseSystemAccount`: The destination coldkey is the protocol-owned basket escrow.
         ///
         /// # Events
         /// May emit a `StakeAndHotkeyTransferred` event on success.

--- a/pallets/subtensor/src/staking/stake_utils.rs
+++ b/pallets/subtensor/src/staking/stake_utils.rs
@@ -1393,6 +1393,14 @@ impl<T: Config> Pallet<T> {
             Self::ensure_beta_basket_seed_idle()?;
         }
 
+        // The beta escrow is protocol-owned custody for basket holdings. Allowing user stake
+        // transitions into it would create holdings without matching basket shares and can block
+        // legitimate claims, particularly for same-subnet transfers that have no minimum amount.
+        ensure!(
+            *destination_coldkey != Self::get_beta_escrow_account_id(),
+            Error::<T>::CannotUseSystemAccount
+        );
+
         // Ensure stake transition is actually happening
         if origin_coldkey == destination_coldkey && origin_hotkey == destination_hotkey {
             ensure!(origin_netuid != destination_netuid, Error::<T>::SameNetuid);

--- a/pallets/subtensor/src/subnets/subnet.rs
+++ b/pallets/subtensor/src/subnets/subnet.rs
@@ -239,6 +239,7 @@ impl<T: Config> Pallet<T> {
             ensure!(lock_id != u32::MAX, Error::<T>::LockIdOverFlow);
 
             Self::lock_network_registration_cost(&coldkey, lock_amount.into(), lock_id)?;
+            Self::create_account_if_non_existent(&coldkey, hotkey)?;
             NetworkRegistrationLockId::<T>::set(lock_id.saturating_add(1));
 
             let median_subnet_alpha_price = Self::get_median_subnet_alpha_price();
@@ -253,6 +254,8 @@ impl<T: Config> Pallet<T> {
                 lock_id,
             };
             NetworkRegistrationQueue::<T>::mutate(|queue| queue.push(info));
+            Self::set_network_last_lock(lock_amount);
+            Self::set_network_last_lock_block(current_block);
             Self::deposit_event(Event::NetworkRegistrationQueued {
                 coldkey: coldkey.clone(),
                 hotkey: hotkey.clone(),
@@ -349,10 +352,13 @@ impl<T: Config> Pallet<T> {
         log::debug!("actual_tao_lock_amount: {actual_tao_lock_amount:?}");
 
         // --- 3. Set the lock amount for use to determine pricing.
-        Self::set_network_last_lock(actual_tao_lock_amount);
-        Self::set_network_last_lock_block(current_block);
-        weight.saturating_accrue(db_weight.reads(1));
-        weight.saturating_accrue(db_weight.writes(2));
+        // Deferred registrations update pricing when they are queued.
+        if lock_id.is_none() {
+            Self::set_network_last_lock(actual_tao_lock_amount);
+            Self::set_network_last_lock_block(current_block);
+            weight.saturating_accrue(db_weight.reads(1));
+            weight.saturating_accrue(db_weight.writes(2));
+        }
 
         // --- 4. Add the caller to the neuron set.
         let hotkey_is_new = !Self::hotkey_account_exists(hotkey);

--- a/pallets/subtensor/src/tests/move_stake.rs
+++ b/pallets/subtensor/src/tests/move_stake.rs
@@ -2323,6 +2323,44 @@ fn test_transfer_stake_same_netuid_not_rate_limited() {
 }
 
 #[test]
+fn test_transfer_stake_rejects_beta_escrow_destination() {
+    new_test_ext(1).execute_with(|| {
+        let subnet_owner_coldkey = U256::from(1001);
+        let subnet_owner_hotkey = U256::from(1002);
+        let netuid = add_dynamic_network(&subnet_owner_hotkey, &subnet_owner_coldkey);
+
+        let origin_coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let stake_amount = DefaultMinStake::<Test>::get();
+
+        let _ = SubtensorModule::create_account_if_non_existent(&origin_coldkey, &hotkey);
+        add_balance_to_coldkey_account(&origin_coldkey, stake_amount);
+        SubtensorModule::stake_into_subnet(
+            &hotkey,
+            &origin_coldkey,
+            netuid,
+            stake_amount,
+            <Test as Config>::SwapInterface::max_price(),
+            false,
+        )
+        .unwrap();
+
+        let escrow = SubtensorModule::get_beta_escrow_account_id();
+        assert_noop!(
+            SubtensorModule::do_transfer_stake(
+                RuntimeOrigin::signed(origin_coldkey),
+                escrow,
+                hotkey,
+                netuid,
+                netuid,
+                1.into(),
+            ),
+            Error::<Test>::CannotUseSystemAccount
+        );
+    });
+}
+
+#[test]
 fn test_transfer_stake_doesnt_limit_destination_coldkey() {
     new_test_ext(1).execute_with(|| {
         let subnet_owner_coldkey = U256::from(1001);

--- a/pallets/subtensor/src/tests/networks.rs
+++ b/pallets/subtensor/src/tests/networks.rs
@@ -3130,6 +3130,7 @@ fn register_network_fails_without_balance_and_does_not_write_owner_alpha_state()
         );
 
         assert!(!SubtensorModule::if_subnet_exist(would_be_netuid));
+        assert!(!SubtensorModule::hotkey_account_exists(&hot));
         assert_eq!(TotalNetworks::<Test>::get(), 0);
         assert_eq!(
             SubnetAlphaIn::<Test>::get(would_be_netuid),
@@ -3505,7 +3506,7 @@ fn register_network_queues_when_waiting_for_dissolve_cleanup() {
         SubnetLimit::<Test>::put(2u16);
 
         let n1 = add_dynamic_network(&U256::from(9102), &U256::from(9101));
-        let _n2 = add_dynamic_network(&U256::from(9202), &U256::from(9201));
+        let n2 = add_dynamic_network(&U256::from(9202), &U256::from(9201));
 
         assert_ok!(SubtensorModule::do_dissolve_network(n1));
         assert!(DissolveCleanupQueue::<Test>::get().contains(&n1));
@@ -3526,7 +3527,57 @@ fn register_network_queues_when_waiting_for_dissolve_cleanup() {
         assert_eq!(NetworkRegistrationQueue::<Test>::get().len(), 1);
         assert_eq!(NetworkRegistrationQueue::<Test>::get()[0].coldkey, cold);
         assert_eq!(TotalNetworks::<Test>::get(), 1);
-        assert!(!SubtensorModule::hotkey_account_exists(&hot));
+        assert!(SubtensorModule::coldkey_owns_hotkey(&cold, &hot));
+
+        SubtensorModule::set_burn(n2, TaoBalance::ZERO);
+        assert_err!(
+            SubtensorModule::burned_register(RuntimeOrigin::signed(U256::from(9303)), n2, hot,),
+            Error::<Test>::NonAssociatedColdKey,
+        );
+    });
+}
+
+#[test]
+fn queued_network_registration_reserves_new_hotkey_for_payer() {
+    new_test_ext(0).execute_with(|| {
+        SubnetLimit::<Test>::put(2u16);
+
+        let dissolving = add_dynamic_network(&U256::from(9352), &U256::from(9351));
+        let existing = add_dynamic_network(&U256::from(9362), &U256::from(9361));
+        assert_ok!(SubtensorModule::do_dissolve_network(dissolving));
+
+        let payer = U256::from(9371);
+        let rival = U256::from(9372);
+        let hotkey = U256::from(9373);
+        let lock_amount = SubtensorModule::get_network_lock_cost();
+        add_balance_to_coldkey_account(&payer, lock_amount.saturating_mul(2.into()).into());
+
+        assert_ok!(SubtensorModule::do_register_network(
+            RuntimeOrigin::signed(payer),
+            &hotkey,
+            1,
+            None,
+        ));
+        assert_eq!(NetworkRegistrationQueue::<Test>::get().len(), 1);
+        assert!(SubtensorModule::coldkey_owns_hotkey(&payer, &hotkey));
+
+        // A later registration attempt cannot acquire the already-reserved hotkey.
+        assert_ok!(SubtensorModule::create_account_if_non_existent(
+            &rival, &hotkey
+        ));
+        assert!(SubtensorModule::coldkey_owns_hotkey(&payer, &hotkey));
+        assert!(!SubtensorModule::coldkey_owns_hotkey(&rival, &hotkey));
+
+        DissolveCleanupQueue::<Test>::kill();
+        run_network_registration_queue();
+
+        let registered_netuid = NetworksAdded::<Test>::iter()
+            .find(|(netuid, added)| *added && *netuid != existing)
+            .map(|(netuid, _)| netuid)
+            .expect("queued registration should create a subnet");
+        assert_eq!(SubnetOwner::<Test>::get(registered_netuid), payer);
+        assert_eq!(SubnetOwnerHotkey::<Test>::get(registered_netuid), hotkey);
+        assert!(SubtensorModule::coldkey_owns_hotkey(&payer, &hotkey));
     });
 }
 
@@ -3601,6 +3652,94 @@ fn register_network_prune_registers_registration_queued() {
         assert!(NetworkRegistrationQueue::<Test>::get().len() == 1);
         assert!(DissolveCleanupQueue::<Test>::get().contains(&n1));
         assert!(!NetworksAdded::<Test>::get(n1));
+    });
+}
+
+#[test]
+fn queued_network_registration_consumes_rate_limit() {
+    new_test_ext(0).execute_with(|| {
+        SubnetLimit::<Test>::put(2u16);
+        NetworkRateLimit::<Test>::put(100u64);
+
+        let n1 = add_dynamic_network(&U256::from(10_102), &U256::from(10_101));
+        let n2 = add_dynamic_network(&U256::from(10_202), &U256::from(10_201));
+
+        let current_block = SubtensorModule::get_network_immunity_period() + 100;
+        System::set_block_number(current_block);
+        Emission::<Test>::insert(n1, vec![AlphaBalance::from(1)]);
+        Emission::<Test>::insert(n2, vec![AlphaBalance::from(1_000)]);
+
+        let cold = U256::from(10_301);
+        let lock_amount = SubtensorModule::get_network_lock_cost();
+        add_balance_to_coldkey_account(&cold, lock_amount.saturating_mul(10.into()).into());
+
+        assert_ok!(SubtensorModule::do_register_network(
+            RuntimeOrigin::signed(cold),
+            &U256::from(10_302),
+            1,
+            None,
+        ));
+        assert_err!(
+            SubtensorModule::do_register_network(
+                RuntimeOrigin::signed(cold),
+                &U256::from(10_303),
+                1,
+                None,
+            ),
+            Error::<Test>::NetworkTxRateLimitExceeded,
+        );
+
+        assert_eq!(NetworkRegistrationQueue::<Test>::get().len(), 1);
+        assert_eq!(DissolveCleanupQueue::<Test>::get().len(), 1);
+        assert!(NetworksAdded::<Test>::get(n2));
+        assert_eq!(SubtensorModule::get_network_last_lock(), lock_amount);
+        assert_eq!(
+            SubtensorModule::get_network_last_lock_block(),
+            current_block
+        );
+
+        DissolveCleanupQueue::<Test>::kill();
+        System::set_block_number(current_block + 50);
+        SubtensorModule::process_network_registration_queue();
+
+        assert!(NetworkRegistrationQueue::<Test>::get().is_empty());
+        assert_eq!(SubtensorModule::get_network_last_lock(), lock_amount);
+        assert_eq!(
+            SubtensorModule::get_network_last_lock_block(),
+            current_block
+        );
+    });
+}
+
+#[test]
+fn set_new_network_state_without_lock_id_updates_lock_pricing() {
+    new_test_ext(1).execute_with(|| {
+        let current_block = 123;
+        System::set_block_number(current_block);
+
+        let cold = U256::from(10_001);
+        let hot = U256::from(10_002);
+        let lock_amount = SubtensorModule::get_network_lock_cost();
+        add_balance_to_coldkey_account(&cold, lock_amount.saturating_mul(2.into()).into());
+
+        SubtensorModule::set_network_last_lock(lock_amount.saturating_add(1.into()));
+        SubtensorModule::set_network_last_lock_block(current_block - 1);
+
+        assert_ok!(SubtensorModule::set_new_network_state(
+            &cold,
+            &hot,
+            1,
+            None,
+            lock_amount,
+            SubtensorModule::get_median_subnet_alpha_price(),
+            None,
+        ));
+
+        assert_eq!(SubtensorModule::get_network_last_lock(), lock_amount);
+        assert_eq!(
+            SubtensorModule::get_network_last_lock_block(),
+            current_block
+        );
     });
 }
 
@@ -3830,7 +3969,7 @@ fn process_network_registration_queue_waits_for_cleanup_completion() {
         SubtensorModule::process_network_registration_queue();
 
         assert_eq!(NetworkRegistrationQueue::<Test>::get().len(), 1);
-        assert!(!SubtensorModule::hotkey_account_exists(&hot));
+        assert!(SubtensorModule::coldkey_owns_hotkey(&cold, &hot));
         assert_eq!(TotalNetworks::<Test>::get(), 1);
 
         // Once cleanup completes, the same call releases the registration.
@@ -3885,7 +4024,7 @@ fn process_network_registration_queue_processes_one_entry_per_call() {
         SubtensorModule::process_network_registration_queue();
         assert_eq!(NetworkRegistrationQueue::<Test>::get().len(), 1);
         assert!(SubtensorModule::hotkey_account_exists(&hot_a));
-        assert!(!SubtensorModule::hotkey_account_exists(&hot_b));
+        assert!(SubtensorModule::hotkey_account_exists(&hot_b));
         assert_eq!(NetworkRegistrationQueue::<Test>::get()[0].coldkey, cold_b);
 
         // Second call processes the remaining entry.

--- a/precompiles/src/balance_transfer.rs
+++ b/precompiles/src/balance_transfer.rs
@@ -1,5 +1,7 @@
+use alloc::format;
 use core::marker::PhantomData;
 
+use fp_evm::{ExitError, PrecompileFailure};
 use frame_support::dispatch::{DispatchInfo, GetDispatchInfo, PostDispatchInfo};
 use frame_support::traits::IsSubType;
 use frame_system::RawOrigin;
@@ -77,14 +79,32 @@ where
             return Ok(());
         }
 
+        let caller = handle.caller_account_id::<R>();
         let dest = R::AccountId::from(address.0).into();
 
-        let call = pallet_balances::Call::<R>::transfer_allow_death {
-            dest,
-            value: amount_sub.unique_saturated_into(),
-        };
+        let call = <R as frame_system::Config>::RuntimeCall::from(
+            pallet_balances::Call::<R>::transfer_allow_death {
+                dest,
+                value: amount_sub.unique_saturated_into(),
+            },
+        );
 
-        handle.try_dispatch_runtime_call::<R, _>(call, RawOrigin::Signed(Self::account_id()))
+        // Frontier has already moved msg.value from the mapped caller into this precompile's
+        // account, so the balance dispatch must continue to spend from the precompile account.
+        // Apply the existing centralized swap guard to the true caller before that dispatch.
+        handle.record_db_reads::<R>(2)?;
+        pallet_subtensor::CheckColdkeySwap::<R>::check(&caller, &call).map_err(|error| {
+            PrecompileFailure::Error {
+                exit_status: ExitError::Other(
+                    format!("dispatch execution failed: {error:?}").into(),
+                ),
+            }
+        })?;
+
+        handle.try_dispatch_runtime_call::<R, <R as frame_system::Config>::RuntimeCall>(
+            call,
+            RawOrigin::Signed(Self::account_id()),
+        )
     }
 
     #[precompile::public("transferKeepAlive(bytes32,uint256)")]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 452,
+    spec_version: 453,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/tests/precompiles.rs
+++ b/runtime/tests/precompiles.rs
@@ -1,16 +1,19 @@
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::expect_used)]
 
+use codec::Encode;
 use fp_evm::{Context, ExitError, PrecompileFailure, PrecompileResult};
 use node_subtensor_runtime::{BuildStorage, Runtime, RuntimeGenesisConfig, System};
-use pallet_evm::{BalanceConverter, PrecompileSet};
+use pallet_evm::{AddressMapping, BalanceConverter, PrecompileSet};
 use precompile_utils::solidity::encode_with_selector;
 use precompile_utils::testing::MockHandle;
 use sp_core::{H160, H256, U256};
-use sp_runtime::traits::Hash;
+use sp_runtime::traits::{Hash, StaticLookup};
 use std::collections::BTreeSet;
-use subtensor_precompiles::{BalanceTransferPrecompile, PrecompileExt, Precompiles};
-use subtensor_runtime_common::TaoBalance;
+use subtensor_precompiles::{
+    BalanceTransferPrecompile, PrecompileExt, Precompiles, ProxyPrecompile,
+};
+use subtensor_runtime_common::{ProxyType, TaoBalance};
 
 type AccountId = <Runtime as frame_system::Config>::AccountId;
 
@@ -116,17 +119,20 @@ fn balance_transfer_precompile_respects_dispatch_guard_policy() {
         let precompiles = Precompiles::<Runtime>::new();
         let precompile_addr = addr_from_index(BalanceTransferPrecompile::<Runtime>::INDEX);
         let dispatch_account: AccountId = BalanceTransferPrecompile::<Runtime>::account_id();
+        let caller = addr_from_index(1);
+        let caller_account =
+            <Runtime as pallet_evm::Config>::AddressMapping::into_account_id(caller);
         let destination_raw = H256::repeat_byte(8);
         let destination_account: AccountId = destination_raw.0.into();
 
-        let amount = 100;
+        let amount = 1_000;
         add_balance_to_coldkey_account(&dispatch_account, 1_000_000_u64.into());
 
         let replacement_coldkey = AccountId::from([9u8; 32]);
         let replacement_hash =
             <Runtime as frame_system::Config>::Hashing::hash_of(&replacement_coldkey);
         pallet_subtensor::ColdkeySwapAnnouncements::<Runtime>::insert(
-            &dispatch_account,
+            &caller_account,
             (System::block_number(), replacement_hash),
         );
 
@@ -138,7 +144,7 @@ fn balance_transfer_precompile_respects_dispatch_guard_policy() {
         let result = execute_precompile(
             &precompiles,
             precompile_addr,
-            addr_from_index(1),
+            caller,
             encode_with_selector(selector_u32("transfer(bytes32)"), (destination_raw,)),
             evm_apparent_value_from_substrate(amount),
         );
@@ -163,5 +169,85 @@ fn balance_transfer_precompile_respects_dispatch_guard_policy() {
             pallet_balances::Pallet::<Runtime>::free_balance(&destination_account);
         assert_eq!(source_balance_after, source_balance_before);
         assert_eq!(destination_balance_after, destination_balance_before);
+    });
+}
+
+#[test]
+fn proxy_precompile_preserves_outer_filter_across_nested_proxy() {
+    new_test_ext().execute_with(|| {
+        let precompiles = Precompiles::<Runtime>::new();
+        let precompile_addr = addr_from_index(ProxyPrecompile::<Runtime>::INDEX);
+        let caller = addr_from_index(2);
+        let attacker = <Runtime as pallet_evm::Config>::AddressMapping::into_account_id(caller);
+        let intermediate = AccountId::from([0x11; 32]);
+        let victim = AccountId::from([0x22; 32]);
+        let recipient = AccountId::from([0x33; 32]);
+
+        add_balance_to_coldkey_account(&intermediate, 1_000_000_000_000_u64.into());
+        add_balance_to_coldkey_account(&victim, 1_000_000_000_000_u64.into());
+        pallet_subtensor_proxy::Pallet::<Runtime>::add_proxy_delegate(
+            &intermediate,
+            attacker,
+            ProxyType::NonTransfer,
+            0,
+        )
+        .unwrap();
+        pallet_subtensor_proxy::Pallet::<Runtime>::add_proxy_delegate(
+            &victim,
+            intermediate.clone(),
+            ProxyType::Any,
+            0,
+        )
+        .unwrap();
+
+        let amount = TaoBalance::from(10_000_u64);
+        let transfer = node_subtensor_runtime::RuntimeCall::Balances(pallet_balances::Call::<
+            Runtime,
+        >::transfer_allow_death {
+            dest: recipient.clone().into(),
+            value: amount,
+        });
+        let nested = node_subtensor_runtime::RuntimeCall::Proxy(pallet_subtensor_proxy::Call::<
+            Runtime,
+        >::proxy {
+            real: <<Runtime as frame_system::Config>::Lookup as StaticLookup>::Source::from(
+                victim.clone(),
+            ),
+            force_proxy_type: Some(ProxyType::Any),
+            call: Box::new(transfer),
+        });
+        let intermediate_word = H256::from_slice(intermediate.as_ref());
+        let victim_before = pallet_balances::Pallet::<Runtime>::free_balance(&victim);
+        let recipient_before = pallet_balances::Pallet::<Runtime>::free_balance(&recipient);
+
+        let result = execute_precompile(
+            &precompiles,
+            precompile_addr,
+            caller,
+            encode_with_selector(
+                selector_u32("proxyCall(bytes32,uint8[],uint8[])"),
+                (
+                    intermediate_word,
+                    vec![u8::from(ProxyType::NonTransfer)],
+                    nested.encode(),
+                ),
+            ),
+            U256::zero(),
+        )
+        .expect("expected proxy call to route to the precompile");
+        result.expect("the outer proxy dispatch itself should complete");
+
+        assert_eq!(
+            pallet_balances::Pallet::<Runtime>::free_balance(&victim),
+            victim_before
+        );
+        assert_eq!(
+            pallet_balances::Pallet::<Runtime>::free_balance(&recipient),
+            recipient_before
+        );
+        assert_eq!(
+            pallet_subtensor_proxy::LastCallResult::<Runtime>::get(&victim),
+            Some(Err(frame_system::Error::<Runtime>::CallFiltered.into()))
+        );
     });
 }


### PR DESCRIPTION
## Motivation

Release 453 collects runtime hardening fixes for randomness verification, nested proxy authorization, deferred subnet registration, protected coldkey transfers, and beta basket escrow custody.

## Changes

- Bind drand Quicknet randomness to `SHA-256(signature)` before accepting a pulse.
- Preserve inherited origin filters across nested direct and announced proxy calls.
- Reserve queued subnet-registration hotkeys for the paying coldkey and consume registration pricing/rate-limit state when the request is queued.
- Avoid updating registration pricing a second time when a queued registration is finalized.
- Reject stake transfers into the protocol-owned beta basket escrow account.
- Apply the coldkey-swap dispatch guard to the true EVM caller in the balance-transfer precompile.
- Bump the runtime `spec_version` from 452 to 453.

## Files of interest

- `pallets/drand/src/verifier.rs`
- `pallets/proxy/src/lib.rs`
- `pallets/subtensor/src/subnets/subnet.rs`
- `pallets/subtensor/src/staking/stake_utils.rs`
- `precompiles/src/balance_transfer.rs`
- `runtime/src/lib.rs`

## Behavioral impact

Invalid drand responses with signature-independent randomness are rejected. Nested proxies cannot gain permissions excluded by an outer proxy. Deferred subnet registrations reserve their hotkeys and affect registration timing/pricing immediately. User stake cannot be transferred into basket escrow without corresponding shares. EVM balance transfers initiated by a coldkey undergoing a protected swap are blocked consistently with native dispatches.

## Migration and runtime version

No storage migration is required. This release bumps `spec_version` to 453.

## Validation

Targeted regression tests cover altered drand randomness, nested direct and announced proxies, queued-registration ownership and rate limiting, beta escrow stake-transfer rejection, and precompile guard behavior. Full compilation and test execution are left to CI.