### PR TITLE
fix(runtime): allow transfer_stake through the contracts CallFilter

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1407,6 +1407,16 @@ impl Contains<RuntimeCall> for ContractCallFilter {
     fn contains(call: &RuntimeCall) -> bool {
         match call {
             RuntimeCall::Proxy(inner) => matches!(inner, pallet_proxy::Call::proxy { .. }),
+            // Since the proxy origin-filter inheritance fix (release 453), calls
+            // dispatched *inside* Proxy::proxy must also pass this filter. A
+            // contract holding an explicit user proxy delegation could
+            // previously execute transfer_stake on the user's behalf; allow
+            // that inner call again. Security is unchanged: the transfer still
+            // requires the user to have registered the contract as a proxy,
+            // and the inherited-filter fix keeps every other call blocked.
+            RuntimeCall::SubtensorModule(inner) => {
+                matches!(inner, pallet_subtensor::Call::transfer_stake { .. })
+            }
             _ => false,
         }
     }


### PR DESCRIPTION
## Context

Release 453's proxy fix (origin-filter inheritance in `do_proxy`) rightly closed the filter-laundering loophole — but it also broke a production escrow contract on this chain that executes deposits as:

```
call_runtime(Proxy::proxy(real = depositor, SubtensorModule::transfer_stake { .. }))
```

with an explicit proxy delegation registered by the depositor. Pre-453 the inner `transfer_stake` ran on a freshly authenticated origin; post-453 it must also pass `ContractCallFilter`, which only whitelists `Proxy::proxy` — so the inner call fails with `CallFiltered` inside `ProxyExecuted` and **every deposit reverts** (`TransferNotVerified` at the contract level). All inbound bridging has been down since the upgrade.

## Change

Whitelist the single inner call the flow needs: `SubtensorModule::transfer_stake`.

## Security

- The transfer still requires the user's **explicit proxy delegation** to the contract — no new capability is granted to contracts over arbitrary accounts.
- The 453 inherited-filter mechanism keeps working as intended for every other nested call.
- Direct `transfer_stake` dispatched by a contract as itself only moves the contract's own stake.

Happy to adjust scope (e.g. gate it further) if you prefer a narrower shape.

