### PR TITLE
Restore contract-proxied stake transfers

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 453,
+    spec_version: 454,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1407,6 +1407,16 @@ impl Contains<RuntimeCall> for ContractCallFilter {
     fn contains(call: &RuntimeCall) -> bool {
         match call {
             RuntimeCall::Proxy(inner) => matches!(inner, pallet_proxy::Call::proxy { .. }),
+            // Since the proxy origin-filter inheritance fix (release 453), calls
+            // dispatched *inside* Proxy::proxy must also pass this filter. A
+            // contract holding an explicit user proxy delegation could
+            // previously execute transfer_stake on the user's behalf; allow
+            // that inner call again. Security is unchanged: the transfer still
+            // requires the user to have registered the contract as a proxy,
+            // and the inherited-filter fix keeps every other call blocked.
+            RuntimeCall::SubtensorModule(inner) => {
+                matches!(inner, pallet_subtensor::Call::transfer_stake { .. })
+            }
             _ => false,
         }
     }


### PR DESCRIPTION
## Context

Release 453 fixed a proxy filter-laundering vulnerability by preserving inherited origin filters across nested proxy calls.

This also blocked legitimate contract deposit flows that execute:

```text
Contract::call_runtime(
    Proxy::proxy(
        real = depositor,
        SubtensorModule::transfer_stake { ... }
    )
)
```

The inner `transfer_stake` must now pass both the contract call filter and the user’s proxy-type filter. Because `ContractCallFilter` only permitted `Proxy::proxy`, these calls began failing with `CallFiltered`.

## Changes

- Allow `SubtensorModule::transfer_stake` through `ContractCallFilter`.
- Bump the runtime `spec_version` from 453 to 454.

## Security

This does not reintroduce the proxy vulnerability fixed in release 453.

The effective authorization remains the intersection of all inherited filters:

- The contract must be explicitly registered as the user’s proxy.
- The selected proxy type must permit `transfer_stake`.
- `NonTransfer` and `NonFungible` proxies continue to reject the transfer.
- `SmallTransfer` continues to enforce its amount limit.
- Other nested calls remain blocked.
- A direct contract-origin `transfer_stake` can only move stake owned by the contract account itself.

## Validation

- `cargo fmt --check --all`
- `git diff --check`