### PR TITLE
Fix coldkey-wide root claims and stale staking relationships

### DIFF
--- a/docs/guides/root-reborn.mdx
+++ b/docs/guides/root-reborn.mdx
@@ -239,8 +239,10 @@ root-stakes to.
   deadline and nothing expires.
 - **Claim fee.** The inclusion fee scales with how many ALPHA types the
   basket holds. Both root-claim calls reserve a conservative 256-unit work
-  envelope at inclusion, independent of how many networks currently exist,
-  and refund the unused part after the claim. The amount you actually spend
+  envelope on mainnet and unknown chains, independent of how many networks
+  currently exist, and refund the unused part after the claim. Finney testnet
+  uses a 1,025-unit envelope to cover its larger subnet topology.
+  The amount you actually spend
   follows the holdings scanned and redeemed (around τ0.057 on a full
   128-holding basket).
   `btcli root claim --dry-run` shows reserved versus spent, compares the

--- a/docs/guides/root-reborn.mdx
+++ b/docs/guides/root-reborn.mdx
@@ -239,10 +239,11 @@ root-stakes to.
   deadline and nothing expires.
 - **Claim fee.** The inclusion fee scales with how many ALPHA types the
   basket holds. Both root-claim calls reserve a conservative 256-unit work
-  envelope on mainnet and unknown chains, independent of how many networks
-  currently exist, and refund the unused part after the claim. Finney testnet
-  uses a 1,025-unit envelope to cover its larger subnet topology.
-  The amount you actually spend
+  envelope on every chain and refund the unused part after the claim. Admission
+  counts only root-relevant validator hotkeys plus their stored basket rows;
+  unrelated subnet stakes are filtered instead of being multiplied by the total
+  network count. Classifying the staking-hotkey vector is separately capped at
+  256 relationships. The amount you actually spend
   follows the holdings scanned and redeemed (around τ0.057 on a full
   128-holding basket).
   `btcli root claim --dry-run` shows reserved versus spent, compares the

--- a/docs/guides/staking.mdx
+++ b/docs/guides/staking.mdx
@@ -190,10 +190,11 @@ btcli stake remove --netuid 0 --hotkey 5F... --amount all --claim  # claim all, 
 ```
 
 The claim fee scales with how many ALPHA types are in the basket. Both
-root-claim calls reserve a conservative 256-unit work envelope on mainnet and
-unknown chains, independent of the current network count, and refund the unused
-part after. Finney testnet uses a 1,025-unit envelope to cover its larger subnet
-topology.
+root-claim calls reserve a conservative 256-unit work envelope on every chain
+and refund the unused part after. Admission counts only root-relevant validator
+hotkeys plus their stored basket rows; unrelated subnet stakes are filtered
+instead of being multiplied by the total network count. Classifying the
+staking-hotkey vector is separately capped at 256 relationships.
 You actually spend according to the holdings scanned and redeemed (around
 τ0.057 on a full 128-holding basket). `--dry-run` and the confirm step show
 reserved versus spent, warn if that spent fee exceeds accrued yield, and

--- a/docs/guides/staking.mdx
+++ b/docs/guides/staking.mdx
@@ -190,8 +190,10 @@ btcli stake remove --netuid 0 --hotkey 5F... --amount all --claim  # claim all, 
 ```
 
 The claim fee scales with how many ALPHA types are in the basket. Both
-root-claim calls reserve a conservative 256-unit work envelope at inclusion,
-independent of the current network count, and refund the unused part after.
+root-claim calls reserve a conservative 256-unit work envelope on mainnet and
+unknown chains, independent of the current network count, and refund the unused
+part after. Finney testnet uses a 1,025-unit envelope to cover its larger subnet
+topology.
 You actually spend according to the holdings scanned and redeemed (around
 τ0.057 on a full 128-holding basket). `--dry-run` and the confirm step show
 reserved versus spent, warn if that spent fee exceeds accrued yield, and

--- a/pallets/subtensor/src/benchmarks/benchmarks.rs
+++ b/pallets/subtensor/src/benchmarks/benchmarks.rs
@@ -2051,8 +2051,10 @@ mod pallet_benchmarks {
     }
 
     #[benchmark]
-    fn claim_root(h: Linear<1, { crate::MAX_ROOT_CLAIM_WORK }>) {
-        // Coldkey-wide claim: `h` validator hotkeys, one holding each. `subnets` is ignored.
+    fn claim_root(h: Linear<1, { crate::MAX_ROOT_CLAIM_WORK / 2 }>) {
+        // Coldkey-wide claim: `h` validator hotkeys, one holding each. Each validator consumes
+        // two admission units (the selected hotkey plus its basket row), so the benchmark's
+        // executable maximum is half the combined work envelope. `subnets` is ignored.
         let coldkey: T::AccountId = whitelisted_caller();
         let owner_coldkey: T::AccountId = account("claim_owner_cold", 0, 0);
         let owner_hotkey: T::AccountId = account("claim_owner_hot", 0, 1);

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -71,12 +71,17 @@ pub const MIN_ALPHA_LOW: u16 = 1_639;
 
 pub const MAX_ROOT_CLAIM_THRESHOLD: u64 = 10_000_000;
 
-/// Benchmark upper bound and admission envelope for `claim_root` /
-/// `claim_root_scan` (Linear<1, N>). Weight calculation cannot walk storage,
-/// so both claim paths reserve this many units and refuse work that would
-/// exceed the envelope. Post-dispatch weight is refunded to the work
-/// actually performed.
-pub const MAX_ROOT_CLAIM_WORK: u32 = 256;
+/// Default admission envelope for `claim_root` / `claim_root_with_hotkey`.
+pub const DEFAULT_ROOT_CLAIM_WORK: u32 = 256;
+
+/// Benchmark upper bound and largest chain-specific admission envelope for
+/// `claim_root` / `claim_root_scan` (`Linear<1, N>`).
+pub const MAX_ROOT_CLAIM_WORK: u32 = 1_025;
+
+/// Finney testnet raises its root-claim admission envelope to cover its configured
+/// maximum of 1,024 non-root subnets plus root.
+pub(crate) const FINNEY_TESTNET_GENESIS_HASH: [u8; 32] =
+    hex_literal::hex!("8f9cf856bf558a14440e75569c9e58594757048d7b3a84b5d25f6bd978263105");
 
 /// Minimum number of positive destination weights required by `set_root_weights`. Softened
 /// to the number of available destinations when fewer networks exist than this floor.

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -71,17 +71,10 @@ pub const MIN_ALPHA_LOW: u16 = 1_639;
 
 pub const MAX_ROOT_CLAIM_THRESHOLD: u64 = 10_000_000;
 
-/// Default admission envelope for `claim_root` / `claim_root_with_hotkey`.
-pub const DEFAULT_ROOT_CLAIM_WORK: u32 = 256;
-
-/// Benchmark upper bound and largest chain-specific admission envelope for
-/// `claim_root` / `claim_root_scan` (`Linear<1, N>`).
-pub const MAX_ROOT_CLAIM_WORK: u32 = 1_025;
-
-/// Finney testnet raises its root-claim admission envelope to cover its configured
-/// maximum of 1,024 non-root subnets plus root.
-pub(crate) const FINNEY_TESTNET_GENESIS_HASH: [u8; 32] =
-    hex_literal::hex!("8f9cf856bf558a14440e75569c9e58594757048d7b3a84b5d25f6bd978263105");
+/// Benchmark upper bound and admission envelope for `claim_root` /
+/// `claim_root_scan` (`Linear<1, N>`). Both claim paths reserve this many units
+/// and refund unused weight after dispatch.
+pub const MAX_ROOT_CLAIM_WORK: u32 = 256;
 
 /// Minimum number of positive destination weights required by `set_root_weights`. Softened
 /// to the number of available destinations when fewer networks exist than this floor.

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -1966,11 +1966,9 @@ mod dispatches {
         /// # Events
         /// * `RootClaimed`: On successfully claiming the root emissions for a coldkey.
         #[pallet::call_index(121)]
-        // Signer is not in the call data, so admission uses the conservative
-        // MAX_ROOT_CLAIM_WORK envelope. Execution refuses a fat coldkey that
-        // would exceed it — use claim_root_with_hotkey per validator.
+        // The immutable genesis hash selects the chain-specific declared/admission envelope.
         #[pallet::weight(
-            <T as crate::pallet::Config>::WeightInfo::claim_root(Pallet::<T>::root_claim_declared_work())
+            Pallet::<T>::root_claim_declared_weight()
         )]
         pub fn claim_root(
             origin: OriginFor<T>,
@@ -2008,7 +2006,7 @@ mod dispatches {
         /// * `RootClaimed`: On successfully claiming the root emissions for this coldkey+hotkey.
         #[pallet::call_index(148)]
         #[pallet::weight(
-            <T as crate::pallet::Config>::WeightInfo::claim_root(crate::MAX_ROOT_CLAIM_WORK)
+            Pallet::<T>::root_claim_declared_weight()
         )]
         pub fn claim_root_with_hotkey(
             origin: OriginFor<T>,

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -1966,7 +1966,6 @@ mod dispatches {
         /// # Events
         /// * `RootClaimed`: On successfully claiming the root emissions for a coldkey.
         #[pallet::call_index(121)]
-        // The immutable genesis hash selects the chain-specific declared/admission envelope.
         #[pallet::weight(
             Pallet::<T>::root_claim_declared_weight()
         )]
@@ -1977,7 +1976,13 @@ mod dispatches {
             let coldkey: T::AccountId = ensure_signed(origin)?;
             let _ = subnets; // ignored: basket claims are fund-level, not per-subnet
 
-            let hotkeys = StakingHotkeys::<T>::get(&coldkey);
+            let staking_hotkeys = StakingHotkeys::<T>::get(&coldkey);
+            let selection_scanned = u32::try_from(staking_hotkeys.len()).unwrap_or(u32::MAX);
+            ensure!(
+                selection_scanned <= Self::root_claim_declared_work(),
+                Error::<T>::RootClaimTooHeavy
+            );
+            let hotkeys = Self::root_claim_hotkeys(&coldkey, staking_hotkeys);
             ensure!(
                 Self::root_claim_fits_declared_budget(&hotkeys),
                 Error::<T>::RootClaimTooHeavy
@@ -1986,7 +1991,7 @@ mod dispatches {
             let outcome = Self::do_root_claim(coldkey.clone(), hotkeys)?;
             Self::maybe_add_coldkey_index(&coldkey);
 
-            let weight = Self::root_claim_actual_weight(hotkey_count, &outcome);
+            let weight = Self::root_claim_actual_weight(hotkey_count, selection_scanned, &outcome);
             Ok((Some(weight), Pays::Yes).into())
         }
 
@@ -2021,7 +2026,7 @@ mod dispatches {
             let outcome = Self::do_root_claim(coldkey.clone(), vec![hotkey])?;
             Self::maybe_add_coldkey_index(&coldkey);
 
-            let weight = Self::root_claim_actual_weight(1, &outcome);
+            let weight = Self::root_claim_actual_weight(1, 0, &outcome);
             Ok((Some(weight), Pays::Yes).into())
         }
 

--- a/pallets/subtensor/src/macros/errors.rs
+++ b/pallets/subtensor/src/macros/errors.rs
@@ -361,8 +361,8 @@ mod errors {
         /// (dividends accumulate in place) until weight setting is switched on by
         /// governance or a later upgrade.
         RootWeightSettingDisabled,
-        /// Coldkey-wide `claim_root` would process more work units than the
-        /// chain-specific admission envelope. Use
+        /// A root claim would process more root hotkeys and basket rows than the
+        /// fixed admission envelope. Use
         /// `claim_root_with_hotkey` per validator so admission weight matches
         /// the holdings actually walked.
         RootClaimTooHeavy,

--- a/pallets/subtensor/src/macros/errors.rs
+++ b/pallets/subtensor/src/macros/errors.rs
@@ -362,7 +362,7 @@ mod errors {
         /// governance or a later upgrade.
         RootWeightSettingDisabled,
         /// Coldkey-wide `claim_root` would process more work units than the
-        /// pre-dispatch envelope ([`crate::MAX_ROOT_CLAIM_WORK`]). Use
+        /// chain-specific admission envelope. Use
         /// `claim_root_with_hotkey` per validator so admission weight matches
         /// the holdings actually walked.
         RootClaimTooHeavy,

--- a/pallets/subtensor/src/macros/hooks.rs
+++ b/pallets/subtensor/src/macros/hooks.rs
@@ -289,20 +289,21 @@ mod hooks {
                 );
             }
 
-            // StakingHotkeys cleanup depends on storage GC having removed zero legacy Alpha rows.
-            // It is otherwise independent and does not block or gate any runtime operation.
-            let storage_bloat_cursor_read = T::DbWeight::get().reads(1);
-            let storage_bloat_in_progress = if !seed_in_progress
+            // StakingHotkeys cleanup depends on storage GC having completed all of its targets.
+            // Gate on the positive completion marker rather than cursor absence so an absent or
+            // unexpectedly removed cursor cannot start the dependent cleanup early.
+            let storage_bloat_completion_read = T::DbWeight::get().reads(1);
+            let storage_bloat_complete = if !seed_in_progress
                 && weight
-                    .saturating_add(storage_bloat_cursor_read)
+                    .saturating_add(storage_bloat_completion_read)
                     .all_lt(limit)
             {
-                weight.saturating_accrue(storage_bloat_cursor_read);
-                migrations::migrate_storage_bloat_v2::StorageBloatCleanupMigration::<T>::exists()
+                weight.saturating_accrue(storage_bloat_completion_read);
+                migrations::migrate_storage_bloat_v2::storage_bloat_cleanup_complete::<T>()
             } else {
-                true
+                false
             };
-            if !seed_in_progress && !storage_bloat_in_progress && weight.all_lt(limit) {
+            if !seed_in_progress && storage_bloat_complete && weight.all_lt(limit) {
                 weight.saturating_accrue(
                     migrations::migrate_cleanup_staking_hotkeys::continue_staking_hotkeys_cleanup::<
                         T,

--- a/pallets/subtensor/src/migrations/migrate_cleanup_staking_hotkeys.rs
+++ b/pallets/subtensor/src/migrations/migrate_cleanup_staking_hotkeys.rs
@@ -6,7 +6,9 @@ use scale_info::prelude::string::String;
 use sp_std::collections::btree_set::BTreeSet;
 use sp_std::vec::Vec;
 
-pub const MIGRATION_NAME: &[u8] = b"migrate_cleanup_staking_hotkeys";
+// Fresh marker reruns the same bounded cleanup after share-pool dust canonicalization. The
+// original `migrate_cleanup_staking_hotkeys` pass may already be marked complete on-chain.
+pub const MIGRATION_NAME: &[u8] = b"migrate_cleanup_staking_hotkeys_v2";
 
 /// Persistent progress for the bounded `StakingHotkeys` cleanup.
 ///
@@ -48,11 +50,10 @@ fn row_load_weight<T: Config>() -> Weight {
 
 /// A conservative keep predicate for one hotkey/coldkey relationship.
 ///
-/// Any stored share row is retained, including a zero-valued legacy row. The storage-bloat
-/// migration runs first and clears zero legacy rows, while treating an unexpected remaining row
-/// as live makes this cleanup fail safe. A basket watermark is also sufficient to retain the
-/// relationship because zero-root-stake claimants still need to be discoverable by claims and
-/// coldkey swaps.
+/// Any stored non-zero share row is retained. The storage-bloat migration runs first and clears
+/// exact-zero Alpha and AlphaV2 rows; treating an unexpected remaining row as live keeps this
+/// cleanup fail safe. A basket watermark is also sufficient to retain the relationship because
+/// zero-root-stake claimants still need to be discoverable by claims and coldkey swaps.
 fn relationship_must_remain<T: Config>(hotkey: &T::AccountId, coldkey: &T::AccountId) -> bool {
     AlphaV2::<T>::iter_prefix((hotkey, coldkey))
         .next()

--- a/pallets/subtensor/src/migrations/migrate_storage_bloat_v2.rs
+++ b/pallets/subtensor/src/migrations/migrate_storage_bloat_v2.rs
@@ -6,7 +6,9 @@ use scale_info::prelude::string::String;
 use sp_io::{hashing::twox_128, storage};
 use sp_std::vec::Vec;
 
-const MIGRATION_NAME: &[u8] = b"migrate_storage_bloat_v2";
+// Fresh marker reruns the bounded GC with the AlphaV2 zero-row target added below. The original
+// v2 pass may already be marked complete on-chain.
+const MIGRATION_NAME: &[u8] = b"migrate_storage_bloat_v3";
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum CleanupMode {
@@ -88,6 +90,12 @@ const TARGETS: &[CleanupTarget] = &[
     CleanupTarget {
         pallet: "SubtensorModule",
         storage: "StakingHotkeys",
+        mode: CleanupMode::ClearIfZero,
+    },
+    // Appended so an interrupted v2 cursor keeps the same target indices after upgrade.
+    CleanupTarget {
+        pallet: "SubtensorModule",
+        storage: "AlphaV2",
         mode: CleanupMode::ClearIfZero,
     },
 ];

--- a/pallets/subtensor/src/migrations/migrate_storage_bloat_v2.rs
+++ b/pallets/subtensor/src/migrations/migrate_storage_bloat_v2.rs
@@ -117,6 +117,14 @@ pub struct StorageBloatCleanupProgress {
 pub type StorageBloatCleanupMigration<T: Config> =
     StorageValue<Pallet<T>, StorageBloatCleanupProgress, OptionQuery>;
 
+/// Returns true only after the current storage-bloat sweep has completed successfully.
+///
+/// Dependants must use this marker instead of cursor absence: a missing cursor can also mean
+/// that the migration was never scheduled or that its progress state was removed unexpectedly.
+pub fn storage_bloat_cleanup_complete<T: Config>() -> bool {
+    HasMigrationRun::<T>::get(MIGRATION_NAME)
+}
+
 fn storage_prefix(pallet: &str, item: &str) -> Vec<u8> {
     [twox_128(pallet.as_bytes()), twox_128(item.as_bytes())].concat()
 }

--- a/pallets/subtensor/src/staking/claim_root.rs
+++ b/pallets/subtensor/src/staking/claim_root.rs
@@ -895,76 +895,87 @@ impl<T: Config> Pallet<T> {
         swept
     }
 
-    /// Live existing-network count (including root). Ghost `NetworksAdded=false`
-    /// leftovers are excluded so they cannot inflate the single-hotkey quote.
-    pub(crate) fn root_claim_existing_networks() -> u32 {
-        (Self::get_all_subnet_netuids().len() as u32).max(1)
-    }
-
-    /// Chain-specific admission budget for both claim paths. Finney testnet has a
-    /// 1,024-subnet limit, while mainnet and every unknown chain retain the
-    /// conservative default.
+    /// Fixed admission budget for both claim paths.
     pub(crate) fn root_claim_declared_work() -> u32 {
-        let genesis_hash = frame_system::Pallet::<T>::block_hash(BlockNumberFor::<T>::zero());
-        let genesis_bytes: &[u8] = genesis_hash.as_ref();
-        if genesis_bytes == crate::FINNEY_TESTNET_GENESIS_HASH {
-            crate::MAX_ROOT_CLAIM_WORK
-        } else {
-            crate::DEFAULT_ROOT_CLAIM_WORK
-        }
+        crate::MAX_ROOT_CLAIM_WORK
     }
 
-    /// Chain-specific pre-dispatch weight for both independently bounded dimensions:
-    /// full claim work and scan-only work. Include the genesis-hash reads used by weight
-    /// selection and the dispatch admission check.
+    /// Pre-dispatch weight for both independently bounded dimensions: full claim work and
+    /// scan-only work.
     pub(crate) fn root_claim_declared_weight() -> Weight {
         let limit = Self::root_claim_declared_work();
-        <T as crate::pallet::Config>::WeightInfo::claim_root(limit)
-            .saturating_add(<T as crate::pallet::Config>::WeightInfo::claim_root_scan(
-                limit,
-            ))
-            .saturating_add(T::DbWeight::get().reads(2))
+        <T as crate::pallet::Config>::WeightInfo::claim_root(limit).saturating_add(
+            <T as crate::pallet::Config>::WeightInfo::claim_root_scan(limit),
+        )
     }
 
-    /// True when a coldkey-wide claim's reachable work (hotkeys × existing
-    /// networks, and the actual basket rows) fits the admission envelope.
+    /// Hotkeys relevant to a coldkey-wide root claim. Ordinary subnet-only staking hotkeys
+    /// are deliberately excluded. A negative basket watermark keeps an unstaked claimant
+    /// eligible because it encodes shares which still need to be redeemed.
+    pub(crate) fn root_claim_hotkeys(
+        coldkey: &T::AccountId,
+        staking_hotkeys: Vec<T::AccountId>,
+    ) -> Vec<T::AccountId> {
+        staking_hotkeys
+            .into_iter()
+            .filter(|hotkey| {
+                !Self::get_stake_for_hotkey_and_coldkey_on_subnet(hotkey, coldkey, NetUid::ROOT)
+                    .is_zero()
+                    || BasketClaimed::<T>::get(hotkey, coldkey) < 0
+            })
+            .collect()
+    }
+
+    /// True when the hotkeys plus the basket storage rows the claim will scan fit the fixed
+    /// admission envelope. Count raw Alpha/AlphaV2 rows so legacy duplicates and malformed
+    /// zero rows are charged conservatively, and stop as soon as the bound is exceeded.
     pub(crate) fn root_claim_fits_declared_budget(hotkeys: &[T::AccountId]) -> bool {
         let budget = Self::root_claim_declared_work();
-        let networks = Self::root_claim_existing_networks();
-        let hotkey_count = hotkeys.len() as u32;
-        if hotkey_count.saturating_mul(networks) > budget {
+        let mut work = u32::try_from(hotkeys.len()).unwrap_or(u32::MAX);
+        if work > budget {
             return false;
         }
-        let mut rows: u32 = 0;
+
+        let escrow = Self::get_beta_escrow_account_id();
         for hotkey in hotkeys {
-            rows = rows.saturating_add(Self::get_basket_holdings(hotkey).len() as u32);
-            if rows > budget {
-                return false;
+            for _ in Alpha::<T>::iter_prefix((hotkey, &escrow)) {
+                work = work.saturating_add(1);
+                if work > budget {
+                    return false;
+                }
+            }
+            for _ in AlphaV2::<T>::iter_prefix((hotkey, &escrow)) {
+                work = work.saturating_add(1);
+                if work > budget {
+                    return false;
+                }
             }
         }
         true
     }
 
-    /// Actual post-dispatch weight of a root claim: full benchmark units for the slots
-    /// that did real work (redeemed or swept — a swap plus stake writes each, floored at
-    /// the hotkey count so walking empty hotkeys stays covered) plus the cheap per-row
-    /// scan cost for holdings that were only valued. This is what lets a fund's claim fee
-    /// decay as dust rows are consolidated, and makes a below-threshold no-op cost a scan
-    /// instead of a full claim. Work above the chain-specific admission budget
+    /// Actual post-dispatch weight of a root claim: full benchmark units for relationships
+    /// classified and slots that did real work (redeemed or swept — a swap plus stake writes
+    /// each, floored at the selected hotkey count) plus the cheap per-row scan cost for holdings
+    /// that were only valued. This is what lets a fund's claim fee decay as dust rows are
+    /// consolidated, and makes a below-threshold no-op cost a scan instead of a full claim.
+    /// Work above the fixed admission budget
     /// is refused at dispatch (`RootClaimTooHeavy`) rather than admitted cheaply.
     pub(crate) fn root_claim_actual_weight(
         hotkey_count: u32,
+        selection_scanned: u32,
         outcome: &RootClaimOutcome,
     ) -> Weight {
         let active = hotkey_count
             .max(outcome.realized.saturating_add(outcome.swept))
+            // Classifying a StakingHotkeys relationship reads the position's share-pool state
+            // and basket watermark. Price it conservatively as a full hotkey unit.
+            .max(selection_scanned)
             .max(1);
         let scanned = outcome.rows.saturating_sub(outcome.realized);
-        <T as crate::pallet::Config>::WeightInfo::claim_root(active)
-            .saturating_add(<T as crate::pallet::Config>::WeightInfo::claim_root_scan(
-                scanned,
-            ))
-            .saturating_add(T::DbWeight::get().reads(2))
+        <T as crate::pallet::Config>::WeightInfo::claim_root(active).saturating_add(
+            <T as crate::pallet::Config>::WeightInfo::claim_root_scan(scanned),
+        )
     }
 
     pub fn do_root_claim(

--- a/pallets/subtensor/src/staking/claim_root.rs
+++ b/pallets/subtensor/src/staking/claim_root.rs
@@ -4,7 +4,7 @@ use frame_support::storage::{TransactionOutcome, with_transaction};
 use frame_support::weights::{Weight, WeightMeter};
 use sp_core::Get;
 use sp_runtime::DispatchError;
-use sp_runtime::traits::AccountIdConversion;
+use sp_runtime::traits::{AccountIdConversion, Zero};
 use sp_std::collections::btree_map::BTreeMap;
 use sp_std::collections::btree_set::BTreeSet;
 use substrate_fixed::types::I96F32;
@@ -636,21 +636,6 @@ impl<T: Config> Pallet<T> {
             return Ok(outcome);
         }
 
-        // A claim that pays on some holdings but floors a valuable holding to take == 0 must
-        // not settle: burning all owed shares would forfeit that holding to remaining
-        // shareholders (e.g. 99/100 of a 1-alpha position → floor 0, then the leftover
-        // 1-share holder owns the whole unit). Same posture as the all-zero-take rollback
-        // below — leave the watermark untouched. Worthless rows (realizable 0) are ignored.
-        for (_, slot_alpha, slot_value, _) in valued_holdings.iter() {
-            let alpha = slot_alpha.to_u64();
-            if alpha == 0 {
-                continue;
-            }
-            if Self::mul_div_u64(alpha, owed_shares, shares_total) == 0 && *slot_value > 0 {
-                return Ok(outcome);
-            }
-        }
-
         let escrow = Self::get_beta_escrow_account_id();
 
         // Redeemed slots are counted outside the transaction: a rolled-back redemption
@@ -666,8 +651,25 @@ impl<T: Config> Pallet<T> {
             let mut written_off: u32 = 0;
 
             for (netuid, slot_alpha, slot_value, terminal_garbage) in valued_holdings.iter() {
+                let slot_entitlement =
+                    Self::basket_payout_from(owed_shares, *slot_value, shares_total);
                 // This staker's pro-rata slice of the holding: slot_alpha * owed / P.
-                let take: u64 = Self::mul_div_u64(slot_alpha.to_u64(), owed_shares, shares_total);
+                let proportional_take =
+                    Self::mul_div_u64(slot_alpha.to_u64(), owed_shares, shares_total);
+                // A high-value alpha row can owe at least one rao even when its proportional
+                // alpha slice floors to zero. Sell one atomic alpha unit, pay no more than the
+                // marked entitlement below, and retain the sale surplus as fund root cash.
+                // Root is already denominated in rao, so take == entitlement there; terminal
+                // rows have no realizable entitlement and keep the ordinary floor.
+                let take = if proportional_take == 0
+                    && slot_entitlement > 0
+                    && !netuid.is_root()
+                    && !terminal_garbage
+                {
+                    1
+                } else {
+                    proportional_take
+                };
                 if take == 0 {
                     continue;
                 }
@@ -729,8 +731,6 @@ impl<T: Config> Pallet<T> {
                 // fraction, so pay only the priced entitlement and retain the surplus as
                 // fund cash. Otherwise a permissionless deposit followed by a claim can
                 // extract the difference from earlier holders.
-                let slot_entitlement =
-                    Self::basket_payout_from(owed_shares, *slot_value, shares_total);
                 let realized_tao = tao.to_u64();
                 // A final claimant has no remaining holders to retain a surplus for. Give
                 // them every realized rao so no root cash is stranded behind zero shares.
@@ -901,11 +901,29 @@ impl<T: Config> Pallet<T> {
         (Self::get_all_subnet_netuids().len() as u32).max(1)
     }
 
-    /// Pre-dispatch work units for both claim paths. Weight calculation must
-    /// stay storage-independent (no `NetworksAdded` or basket walks here);
-    /// execution then refuses work that would exceed this envelope.
+    /// Chain-specific admission budget for both claim paths. Finney testnet has a
+    /// 1,024-subnet limit, while mainnet and every unknown chain retain the
+    /// conservative default.
     pub(crate) fn root_claim_declared_work() -> u32 {
-        crate::MAX_ROOT_CLAIM_WORK
+        let genesis_hash = frame_system::Pallet::<T>::block_hash(BlockNumberFor::<T>::zero());
+        let genesis_bytes: &[u8] = genesis_hash.as_ref();
+        if genesis_bytes == crate::FINNEY_TESTNET_GENESIS_HASH {
+            crate::MAX_ROOT_CLAIM_WORK
+        } else {
+            crate::DEFAULT_ROOT_CLAIM_WORK
+        }
+    }
+
+    /// Chain-specific pre-dispatch weight for both independently bounded dimensions:
+    /// full claim work and scan-only work. Include the genesis-hash reads used by weight
+    /// selection and the dispatch admission check.
+    pub(crate) fn root_claim_declared_weight() -> Weight {
+        let limit = Self::root_claim_declared_work();
+        <T as crate::pallet::Config>::WeightInfo::claim_root(limit)
+            .saturating_add(<T as crate::pallet::Config>::WeightInfo::claim_root_scan(
+                limit,
+            ))
+            .saturating_add(T::DbWeight::get().reads(2))
     }
 
     /// True when a coldkey-wide claim's reachable work (hotkeys × existing
@@ -932,8 +950,8 @@ impl<T: Config> Pallet<T> {
     /// the hotkey count so walking empty hotkeys stays covered) plus the cheap per-row
     /// scan cost for holdings that were only valued. This is what lets a fund's claim fee
     /// decay as dust rows are consolidated, and makes a below-threshold no-op cost a scan
-    /// instead of a full claim. Work above [`crate::MAX_ROOT_CLAIM_WORK`] is
-    /// refused at dispatch (`RootClaimTooHeavy`) rather than admitted cheaply.
+    /// instead of a full claim. Work above the chain-specific admission budget
+    /// is refused at dispatch (`RootClaimTooHeavy`) rather than admitted cheaply.
     pub(crate) fn root_claim_actual_weight(
         hotkey_count: u32,
         outcome: &RootClaimOutcome,
@@ -942,9 +960,11 @@ impl<T: Config> Pallet<T> {
             .max(outcome.realized.saturating_add(outcome.swept))
             .max(1);
         let scanned = outcome.rows.saturating_sub(outcome.realized);
-        <T as crate::pallet::Config>::WeightInfo::claim_root(active).saturating_add(
-            <T as crate::pallet::Config>::WeightInfo::claim_root_scan(scanned),
-        )
+        <T as crate::pallet::Config>::WeightInfo::claim_root(active)
+            .saturating_add(<T as crate::pallet::Config>::WeightInfo::claim_root_scan(
+                scanned,
+            ))
+            .saturating_add(T::DbWeight::get().reads(2))
     }
 
     pub fn do_root_claim(

--- a/pallets/subtensor/src/tests/claim_root.rs
+++ b/pallets/subtensor/src/tests/claim_root.rs
@@ -3,19 +3,19 @@
 use crate::tests::mock::*;
 use crate::weights::WeightInfo;
 use crate::{
-    BasketClaimed, BasketRate, BasketRedeemedTao, BasketShares, BurnIncreaseMult,
-    DEFAULT_ROOT_CLAIM_WORK, DefaultMinRootClaimAmount, Error, FINNEY_TESTNET_GENESIS_HASH, Keys,
-    MAX_ROOT_CLAIM_THRESHOLD, MAX_ROOT_CLAIM_WORK, NetworksAdded, NumStakingColdkeys,
-    PendingBasketDeposits, RootAlphaDividendsPerSubnet, RootClaimableThreshold, StakingColdkeys,
-    StakingColdkeysByIndex, StakingHotkeys, SubnetAlphaIn, SubnetMovingPrice, SubnetOwnerHotkey,
-    SubnetProtocolFlow, SubnetTAO, SubnetworkN, Tempo, TotalStake, Uids, Weights,
+    AlphaV2, BasketClaimed, BasketRate, BasketRedeemedTao, BasketShares, BurnIncreaseMult,
+    DefaultMinRootClaimAmount, Error, Keys, MAX_ROOT_CLAIM_THRESHOLD, MAX_ROOT_CLAIM_WORK,
+    NetworksAdded, NumStakingColdkeys, PendingBasketDeposits, RootAlphaDividendsPerSubnet,
+    RootClaimableThreshold, StakingColdkeys, StakingColdkeysByIndex, StakingHotkeys, SubnetAlphaIn,
+    SubnetMovingPrice, SubnetOwnerHotkey, SubnetProtocolFlow, SubnetTAO, SubnetworkN, Tempo,
+    TotalStake, Uids, Weights,
 };
 use approx::assert_abs_diff_eq;
 use frame_support::dispatch::{DispatchClass, GetDispatchInfo, RawOrigin};
 use frame_support::pallet_prelude::Weight;
 use frame_support::traits::Get;
 use frame_support::{assert_err, assert_noop, assert_ok};
-use sp_core::{H256, U256};
+use sp_core::U256;
 use sp_runtime::DispatchError;
 use sp_std::collections::btree_set::BTreeSet;
 use substrate_fixed::types::{I96F32, U64F64, U96F32};
@@ -231,27 +231,23 @@ fn test_claim_root_declared_weight_covers_bounded_work() {
             subnets: subnets.clone(),
         });
         let declared_weight = call.get_dispatch_info().call_weight;
-        // The mock genesis is not Finney testnet, so dispatch retains the
-        // conservative default admission budget.
         assert_eq!(
             SubtensorModule::root_claim_declared_work(),
-            DEFAULT_ROOT_CLAIM_WORK
+            MAX_ROOT_CLAIM_WORK
         );
-        let envelope = <Test as crate::Config>::WeightInfo::claim_root(DEFAULT_ROOT_CLAIM_WORK)
+        let envelope = <Test as crate::Config>::WeightInfo::claim_root(MAX_ROOT_CLAIM_WORK)
             .saturating_add(<Test as crate::Config>::WeightInfo::claim_root_scan(
-                DEFAULT_ROOT_CLAIM_WORK,
-            ))
-            .saturating_add(<Test as frame_system::Config>::DbWeight::get().reads(2));
+                MAX_ROOT_CLAIM_WORK,
+            ));
         assert!(
             declared_weight.all_gte(envelope),
             "declared {declared_weight:?} must cover the {envelope:?} admission envelope"
         );
-        // Ghost NetworksAdded=false keys must not inflate the single-hotkey quote.
-        let existing = SubtensorModule::root_claim_existing_networks();
-        let ghost = NetUid::from(u16::MAX);
-        NetworksAdded::<Test>::insert(ghost, false);
-        assert_eq!(SubtensorModule::root_claim_existing_networks(), existing);
-        assert!(existing < DEFAULT_ROOT_CLAIM_WORK);
+        // Network count is not part of admission; only relevant hotkeys and stored basket rows
+        // consume the fixed envelope.
+        for raw_netuid in 1..=MAX_ROOT_CLAIM_WORK as u16 {
+            NetworksAdded::<Test>::insert(NetUid::from(raw_netuid), true);
+        }
         let actual_weight = SubtensorModule::claim_root(RuntimeOrigin::signed(coldkey), subnets)
             .expect("claim succeeds")
             .actual_weight
@@ -274,11 +270,13 @@ fn test_claim_root_declared_weight_covers_bounded_work() {
 fn test_claim_root_rejects_work_above_declared_budget() {
     new_test_ext(1).execute_with(|| {
         let coldkey = U256::from(1001);
-        let networks = SubtensorModule::root_claim_existing_networks();
-        let too_many = (DEFAULT_ROOT_CLAIM_WORK / networks.max(1)).saturating_add(1);
-        let hotkeys: Vec<U256> = (0..too_many)
+        let hotkeys: Vec<U256> = (0..=MAX_ROOT_CLAIM_WORK)
             .map(|i| U256::from(2_000u32.saturating_add(i)))
             .collect();
+        assert!(!SubtensorModule::root_claim_fits_declared_budget(&hotkeys));
+
+        // Candidate classification is independently bounded even if every relationship would
+        // subsequently be filtered as non-root.
         StakingHotkeys::<Test>::insert(coldkey, hotkeys);
         assert_noop!(
             SubtensorModule::claim_root(RuntimeOrigin::signed(coldkey), BTreeSet::new()),
@@ -288,58 +286,69 @@ fn test_claim_root_rejects_work_above_declared_budget() {
 }
 
 #[test]
-fn test_root_claim_budget_is_raised_only_on_finney_testnet() {
+fn test_claim_root_ignores_network_count_and_bounds_actual_basket_rows() {
     new_test_ext(1).execute_with(|| {
-        assert_eq!(
-            SubtensorModule::root_claim_declared_work(),
-            DEFAULT_ROOT_CLAIM_WORK
-        );
+        for raw_netuid in 1..=(MAX_ROOT_CLAIM_WORK as u16 + 10) {
+            NetworksAdded::<Test>::insert(NetUid::from(raw_netuid), true);
+        }
 
-        frame_system::BlockHash::<Test>::insert(
-            0_u64,
-            H256::from_slice(&FINNEY_TESTNET_GENESIS_HASH),
-        );
-        assert_eq!(
-            SubtensorModule::root_claim_declared_work(),
-            MAX_ROOT_CLAIM_WORK
-        );
+        let hotkey = U256::from(1002);
+        let escrow = SubtensorModule::get_beta_escrow_account_id();
+        assert!(SubtensorModule::root_claim_fits_declared_budget(&[hotkey]));
 
-        frame_system::BlockHash::<Test>::insert(0_u64, H256::from_low_u64_be(0xdeadbeef));
-        assert_eq!(
-            SubtensorModule::root_claim_declared_work(),
-            DEFAULT_ROOT_CLAIM_WORK
+        // One hotkey plus 255 raw basket rows exactly fills the 256-unit envelope.
+        for raw_netuid in 1..MAX_ROOT_CLAIM_WORK as u16 {
+            AlphaV2::<Test>::insert(
+                (hotkey, escrow, NetUid::from(raw_netuid)),
+                share_pool::SafeFloat::from(1_u64),
+            );
+        }
+        assert!(SubtensorModule::root_claim_fits_declared_budget(&[hotkey]));
+
+        AlphaV2::<Test>::insert(
+            (hotkey, escrow, NetUid::from(MAX_ROOT_CLAIM_WORK as u16)),
+            share_pool::SafeFloat::from(1_u64),
         );
+        assert!(!SubtensorModule::root_claim_fits_declared_budget(&[hotkey]));
     });
 }
 
 #[test]
-fn test_testnet_single_hotkey_admission_covers_configured_subnet_limit() {
+fn test_coldkey_wide_claim_selects_only_root_relevant_hotkeys() {
     new_test_ext(1).execute_with(|| {
-        frame_system::BlockHash::<Test>::insert(
-            0_u64,
-            H256::from_slice(&FINNEY_TESTNET_GENESIS_HASH),
-        );
-
-        for raw_netuid in 0..MAX_ROOT_CLAIM_WORK as u16 {
-            NetworksAdded::<Test>::insert(NetUid::from(raw_netuid), true);
-        }
-        assert_eq!(
-            SubtensorModule::root_claim_existing_networks(),
-            MAX_ROOT_CLAIM_WORK
-        );
-
         let coldkey = U256::from(1001);
-        let hotkey = U256::from(1002);
-        assert_ok!(SubtensorModule::claim_root_with_hotkey(
-            RuntimeOrigin::signed(coldkey),
-            hotkey,
-        ));
+        let root_hotkey = U256::from(1002);
+        let subnet_hotkey = U256::from(1003);
+        let outstanding_hotkey = U256::from(1004);
+        let stale_hotkey = U256::from(1005);
+        let subnet = add_dynamic_network(&subnet_hotkey, &coldkey);
 
-        NetworksAdded::<Test>::insert(NetUid::from(MAX_ROOT_CLAIM_WORK as u16), true);
-        assert_noop!(
-            SubtensorModule::claim_root_with_hotkey(RuntimeOrigin::signed(coldkey), hotkey),
-            Error::<Test>::RootClaimTooHeavy
+        mock_increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &root_hotkey,
+            &coldkey,
+            NetUid::ROOT,
+            1_u64.into(),
         );
+        mock_increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &subnet_hotkey,
+            &coldkey,
+            subnet,
+            1_u64.into(),
+        );
+        BasketClaimed::<Test>::insert(outstanding_hotkey, coldkey, -1);
+        StakingHotkeys::<Test>::insert(
+            coldkey,
+            vec![root_hotkey, subnet_hotkey, outstanding_hotkey, stale_hotkey],
+        );
+
+        assert_eq!(
+            SubtensorModule::root_claim_hotkeys(&coldkey, StakingHotkeys::<Test>::get(coldkey)),
+            vec![root_hotkey, outstanding_hotkey]
+        );
+        assert_ok!(SubtensorModule::claim_root(
+            RuntimeOrigin::signed(coldkey),
+            BTreeSet::new()
+        ));
     });
 }
 

--- a/pallets/subtensor/src/tests/claim_root.rs
+++ b/pallets/subtensor/src/tests/claim_root.rs
@@ -4,18 +4,18 @@ use crate::tests::mock::*;
 use crate::weights::WeightInfo;
 use crate::{
     BasketClaimed, BasketRate, BasketRedeemedTao, BasketShares, BurnIncreaseMult,
-    DefaultMinRootClaimAmount, Error, Keys, MAX_ROOT_CLAIM_THRESHOLD, NetworksAdded,
-    NumStakingColdkeys, PendingBasketDeposits, RootAlphaDividendsPerSubnet, RootClaimableThreshold,
-    StakingColdkeys, StakingColdkeysByIndex, StakingHotkeys, SubnetAlphaIn, SubnetMovingPrice,
-    SubnetOwnerHotkey, SubnetProtocolFlow, SubnetTAO, SubnetworkN, Tempo, TotalStake, Uids,
-    Weights,
+    DEFAULT_ROOT_CLAIM_WORK, DefaultMinRootClaimAmount, Error, FINNEY_TESTNET_GENESIS_HASH, Keys,
+    MAX_ROOT_CLAIM_THRESHOLD, MAX_ROOT_CLAIM_WORK, NetworksAdded, NumStakingColdkeys,
+    PendingBasketDeposits, RootAlphaDividendsPerSubnet, RootClaimableThreshold, StakingColdkeys,
+    StakingColdkeysByIndex, StakingHotkeys, SubnetAlphaIn, SubnetMovingPrice, SubnetOwnerHotkey,
+    SubnetProtocolFlow, SubnetTAO, SubnetworkN, Tempo, TotalStake, Uids, Weights,
 };
 use approx::assert_abs_diff_eq;
 use frame_support::dispatch::{DispatchClass, GetDispatchInfo, RawOrigin};
 use frame_support::pallet_prelude::Weight;
 use frame_support::traits::Get;
 use frame_support::{assert_err, assert_noop, assert_ok};
-use sp_core::U256;
+use sp_core::{H256, U256};
 use sp_runtime::DispatchError;
 use sp_std::collections::btree_set::BTreeSet;
 use substrate_fixed::types::{I96F32, U64F64, U96F32};
@@ -231,13 +231,17 @@ fn test_claim_root_declared_weight_covers_bounded_work() {
             subnets: subnets.clone(),
         });
         let declared_weight = call.get_dispatch_info().call_weight;
-        // Coldkey-wide claim_root cannot see the signer in call data, so it
-        // reserves the conservative MAX_ROOT_CLAIM_WORK envelope.
+        // The mock genesis is not Finney testnet, so dispatch retains the
+        // conservative default admission budget.
         assert_eq!(
             SubtensorModule::root_claim_declared_work(),
-            crate::MAX_ROOT_CLAIM_WORK
+            DEFAULT_ROOT_CLAIM_WORK
         );
-        let envelope = <Test as crate::Config>::WeightInfo::claim_root(crate::MAX_ROOT_CLAIM_WORK);
+        let envelope = <Test as crate::Config>::WeightInfo::claim_root(DEFAULT_ROOT_CLAIM_WORK)
+            .saturating_add(<Test as crate::Config>::WeightInfo::claim_root_scan(
+                DEFAULT_ROOT_CLAIM_WORK,
+            ))
+            .saturating_add(<Test as frame_system::Config>::DbWeight::get().reads(2));
         assert!(
             declared_weight.all_gte(envelope),
             "declared {declared_weight:?} must cover the {envelope:?} admission envelope"
@@ -247,7 +251,7 @@ fn test_claim_root_declared_weight_covers_bounded_work() {
         let ghost = NetUid::from(u16::MAX);
         NetworksAdded::<Test>::insert(ghost, false);
         assert_eq!(SubtensorModule::root_claim_existing_networks(), existing);
-        assert!(existing < crate::MAX_ROOT_CLAIM_WORK);
+        assert!(existing < DEFAULT_ROOT_CLAIM_WORK);
         let actual_weight = SubtensorModule::claim_root(RuntimeOrigin::signed(coldkey), subnets)
             .expect("claim succeeds")
             .actual_weight
@@ -271,13 +275,69 @@ fn test_claim_root_rejects_work_above_declared_budget() {
     new_test_ext(1).execute_with(|| {
         let coldkey = U256::from(1001);
         let networks = SubtensorModule::root_claim_existing_networks();
-        let too_many = (crate::MAX_ROOT_CLAIM_WORK / networks.max(1)).saturating_add(1);
+        let too_many = (DEFAULT_ROOT_CLAIM_WORK / networks.max(1)).saturating_add(1);
         let hotkeys: Vec<U256> = (0..too_many)
             .map(|i| U256::from(2_000u32.saturating_add(i)))
             .collect();
         StakingHotkeys::<Test>::insert(coldkey, hotkeys);
         assert_noop!(
             SubtensorModule::claim_root(RuntimeOrigin::signed(coldkey), BTreeSet::new()),
+            Error::<Test>::RootClaimTooHeavy
+        );
+    });
+}
+
+#[test]
+fn test_root_claim_budget_is_raised_only_on_finney_testnet() {
+    new_test_ext(1).execute_with(|| {
+        assert_eq!(
+            SubtensorModule::root_claim_declared_work(),
+            DEFAULT_ROOT_CLAIM_WORK
+        );
+
+        frame_system::BlockHash::<Test>::insert(
+            0_u64,
+            H256::from_slice(&FINNEY_TESTNET_GENESIS_HASH),
+        );
+        assert_eq!(
+            SubtensorModule::root_claim_declared_work(),
+            MAX_ROOT_CLAIM_WORK
+        );
+
+        frame_system::BlockHash::<Test>::insert(0_u64, H256::from_low_u64_be(0xdeadbeef));
+        assert_eq!(
+            SubtensorModule::root_claim_declared_work(),
+            DEFAULT_ROOT_CLAIM_WORK
+        );
+    });
+}
+
+#[test]
+fn test_testnet_single_hotkey_admission_covers_configured_subnet_limit() {
+    new_test_ext(1).execute_with(|| {
+        frame_system::BlockHash::<Test>::insert(
+            0_u64,
+            H256::from_slice(&FINNEY_TESTNET_GENESIS_HASH),
+        );
+
+        for raw_netuid in 0..MAX_ROOT_CLAIM_WORK as u16 {
+            NetworksAdded::<Test>::insert(NetUid::from(raw_netuid), true);
+        }
+        assert_eq!(
+            SubtensorModule::root_claim_existing_networks(),
+            MAX_ROOT_CLAIM_WORK
+        );
+
+        let coldkey = U256::from(1001);
+        let hotkey = U256::from(1002);
+        assert_ok!(SubtensorModule::claim_root_with_hotkey(
+            RuntimeOrigin::signed(coldkey),
+            hotkey,
+        ));
+
+        NetworksAdded::<Test>::insert(NetUid::from(MAX_ROOT_CLAIM_WORK as u16), true);
+        assert_noop!(
+            SubtensorModule::claim_root_with_hotkey(RuntimeOrigin::signed(coldkey), hotkey),
             Error::<Test>::RootClaimTooHeavy
         );
     });
@@ -3359,11 +3419,10 @@ fn test_root_basket_coldkey_swap_carries_owed_with_zero_stake() {
     });
 }
 
-/// A claim whose marked estimate is positive but whose per-holding alpha takes all floor to
-/// zero (high-price, tiny-alpha holding) must be a complete no-op: settling would burn the
-/// staker's owed shares for a zero payout.
+/// A positive marked entitlement must remain claimable when its proportional alpha slice
+/// floors to zero. One atomic alpha unit is sold and payment is capped at the entitlement.
 #[test]
-fn test_root_basket_zero_realized_claim_burns_nothing() {
+fn test_root_basket_rounding_zero_take_sells_minimum_unit() {
     new_test_ext(1).execute_with(|| {
         let owner_coldkey = U256::from(1001);
         let hotkey = U256::from(1002);
@@ -3406,31 +3465,33 @@ fn test_root_basket_zero_realized_claim_burns_nothing() {
         assert!((90..=100).contains(&owed_before), "owed = {owed_before}");
         let shares_before = fund_shares(&hotkey);
         let escrow_before = escrow_alpha(&hotkey, netuid);
+        let payout_before = SubtensorModule::get_basket_payout_tao(&hotkey, &coldkey);
         let root_before = root_stake_of(&hotkey, &coldkey);
+        assert!(payout_before > 0);
 
         assert_ok!(SubtensorModule::claim_root_with_hotkey(
             RuntimeOrigin::signed(coldkey),
             hotkey
         ));
 
-        // Complete no-op: no shares burned, no watermark advanced, nothing moved.
         assert_eq!(
             SubtensorModule::get_basket_owed_shares(&hotkey, &coldkey),
-            owed_before,
-            "owed shares must not be burned for a zero payout"
+            0
         );
-        assert_eq!(fund_shares(&hotkey), shares_before);
-        assert_eq!(escrow_alpha(&hotkey, netuid), escrow_before);
-        assert_eq!(root_stake_of(&hotkey, &coldkey), root_before);
-        assert_eq!(BasketClaimed::<Test>::get(hotkey, coldkey), 0);
+        assert_eq!(fund_shares(&hotkey), shares_before - owed_before);
+        assert_eq!(escrow_alpha(&hotkey, netuid), escrow_before - 1);
+        assert_eq!(
+            root_stake_of(&hotkey, &coldkey) - root_before,
+            payout_before,
+            "the minimum-unit sale must not overpay the marked entitlement"
+        );
     });
 }
 
-/// A mixed claim — one holding pays, another valuable holding floors to take == 0 — must not
-/// settle. Burning all owed shares would hand the unsliced holding to remaining shareholders
-/// (99/100 of a 1-alpha position → floor 0; the leftover 1-share holder then owns it whole).
+/// A tiny root-cash row whose claimant slice rounds to zero must not block another payable row.
+/// Root cash is already denominated in rao, so the indivisible remainder simply stays in escrow.
 #[test]
-fn test_root_basket_mixed_forfeit_claim_burns_nothing() {
+fn test_root_basket_rounding_zero_root_row_does_not_block_payable_rows() {
     new_test_ext(1).execute_with(|| {
         let owner_coldkey = U256::from(1001);
         let hotkey = U256::from(1002);
@@ -3464,14 +3525,19 @@ fn test_root_basket_mixed_forfeit_claim_burns_nothing() {
         set_root_weights_direct(&hotkey, 0, &[(netuid, u16::MAX)]);
 
         let escrow = SubtensorModule::get_beta_escrow_account_id();
-        // Paying root-slot cash + one atomic unit of expensive curated alpha.
+        // One rao of root cash rounds to zero for Alice, while the curated alpha row pays.
         mock_increase_stake_for_hotkey_and_coldkey_on_subnet(
             &hotkey,
             &escrow,
             NetUid::ROOT,
-            1_000_000u64.into(),
+            1u64.into(),
         );
-        mock_increase_stake_for_hotkey_and_coldkey_on_subnet(&hotkey, &escrow, netuid, 1u64.into());
+        mock_increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey,
+            &escrow,
+            netuid,
+            1_000u64.into(),
+        );
         BasketShares::<Test>::insert(hotkey, 100u64);
         BasketRate::<Test>::insert(hotkey, I96F32::from_num(1));
 
@@ -3479,12 +3545,15 @@ fn test_root_basket_mixed_forfeit_claim_burns_nothing() {
         assert_eq!(alice_owed, 99, "alice owed = {alice_owed}");
         assert_eq!(SubtensorModule::get_basket_owed_shares(&hotkey, &bob), 1);
 
-        // Alice's alpha take floors: floor(1 * 99 / 100) = 0; root take is positive.
+        // Alice's root take floors: floor(1 * 99 / 100) = 0; subnet take is positive.
         assert_eq!(SubtensorModule::mul_div_u64(1, 99, 100), 0);
-        assert!(SubtensorModule::mul_div_u64(1_000_000, 99, 100) > 0);
+        assert!(SubtensorModule::mul_div_u64(1_000, 99, 100) > 0);
 
         let shares_before = fund_shares(&hotkey);
         let alpha_before = escrow_alpha(&hotkey, netuid);
+        let alice_payout = SubtensorModule::get_basket_payout_tao(&hotkey, &alice);
+        let alice_subnet_payout =
+            SubtensorModule::get_basket_subnet_payout_tao(&hotkey, &alice, netuid);
         let alice_root_before = root_stake_of(&hotkey, &alice);
 
         assert_ok!(SubtensorModule::claim_root_with_hotkey(
@@ -3492,15 +3561,25 @@ fn test_root_basket_mixed_forfeit_claim_burns_nothing() {
             hotkey
         ));
 
-        // Complete no-op: Alice must not burn shares for a bag that forfeits valuable alpha.
+        assert_eq!(SubtensorModule::get_basket_owed_shares(&hotkey, &alice), 0);
+        assert_eq!(fund_shares(&hotkey), shares_before - alice_owed);
+        assert_eq!(escrow_alpha(&hotkey, netuid), alpha_before - 990);
+        assert!(escrow_alpha(&hotkey, NetUid::ROOT) >= 1);
         assert_eq!(
-            SubtensorModule::get_basket_owed_shares(&hotkey, &alice),
-            alice_owed
+            root_stake_of(&hotkey, &alice) - alice_root_before,
+            alice_subnet_payout
         );
-        assert_eq!(fund_shares(&hotkey), shares_before);
-        assert_eq!(escrow_alpha(&hotkey, netuid), alpha_before);
-        assert_eq!(root_stake_of(&hotkey, &alice), alice_root_before);
-        assert_eq!(BasketClaimed::<Test>::get(hotkey, alice), 0);
+        assert!(alice_subnet_payout > 0 && alice_subnet_payout <= alice_payout);
+        // Bob can later collect the root remainder together with his remaining alpha share.
+        let bob_payout = SubtensorModule::get_basket_payout_tao(&hotkey, &bob);
+        let bob_root_before = root_stake_of(&hotkey, &bob);
+        assert!(bob_payout > 0);
+        assert_ok!(SubtensorModule::claim_root_with_hotkey(
+            RuntimeOrigin::signed(bob),
+            hotkey
+        ));
+        assert_eq!(root_stake_of(&hotkey, &bob) - bob_root_before, bob_payout);
+        assert_eq!(fund_shares(&hotkey), 0);
     });
 }
 

--- a/pallets/subtensor/src/tests/claim_root.rs
+++ b/pallets/subtensor/src/tests/claim_root.rs
@@ -3483,9 +3483,11 @@ fn test_root_basket_rounding_zero_take_sells_minimum_unit() {
             hotkey
         ));
 
-        assert_eq!(
-            SubtensorModule::get_basket_owed_shares(&hotkey, &coldkey),
-            0
+        // Rebasing the claimed payout's new root stake can leave one share from fixed-point
+        // truncation, matching the invariant used by the other claim-drain tests.
+        assert!(
+            SubtensorModule::get_basket_owed_shares(&hotkey, &coldkey) <= 1,
+            "minimum-unit claim left more than rounding dust"
         );
         assert_eq!(fund_shares(&hotkey), shares_before - owed_before);
         assert_eq!(escrow_alpha(&hotkey, netuid), escrow_before - 1);

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -7232,7 +7232,7 @@ fn test_staking_hotkeys_cleanup_is_bounded_and_preserves_live_relationships() {
 
         // The first cleanup already ran on deployed chains. The fresh v2 marker must schedule
         // the same bounded implementation again.
-        HasMigrationRun::<Test>::insert(b"migrate_cleanup_staking_hotkeys", true);
+        HasMigrationRun::<Test>::insert(&b"migrate_cleanup_staking_hotkeys"[..], true);
         StakingHotkeys::<Test>::insert(coldkey, vec![stale, legacy, v2, basket, zero_v2]);
         StakingHotkeys::<Test>::insert(all_stale_coldkey, vec![other_stale]);
         StakingHotkeys::<Test>::insert(empty_coldkey, Vec::<U256>::new());

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -7072,7 +7072,8 @@ fn test_migrate_historical_alpha_burns_skips_non_mainnet() {
 #[test]
 fn test_storage_bloat_cleanup_is_bounded_and_preserves_nonzero_state() {
     use crate::migrations::migrate_storage_bloat_v2::{
-        StorageBloatCleanupMigration, continue_storage_bloat_cleanup, kickoff_storage_bloat_cleanup,
+        StorageBloatCleanupMigration, continue_storage_bloat_cleanup,
+        kickoff_storage_bloat_cleanup, storage_bloat_cleanup_complete,
     };
 
     new_test_ext(1).execute_with(|| {
@@ -7130,6 +7131,7 @@ fn test_storage_bloat_cleanup_is_bounded_and_preserves_nonzero_state() {
         let kickoff_weight = kickoff_storage_bloat_cleanup::<Test>();
         assert!(!kickoff_weight.is_zero());
         assert!(StorageBloatCleanupMigration::<Test>::exists());
+        assert!(!storage_bloat_cleanup_complete::<Test>());
 
         let limit = <Test as Config>::DbWeight::get().reads_writes(8, 5);
         let mut passes = 0;
@@ -7141,6 +7143,7 @@ fn test_storage_bloat_cleanup_is_bounded_and_preserves_nonzero_state() {
         }
         assert!(passes > 1, "test must exercise resumable progress");
         assert!(HasMigrationRun::<Test>::get(MIGRATION_NAME));
+        assert!(storage_bloat_cleanup_complete::<Test>());
 
         for key in dead_keys {
             assert!(sp_io::storage::get(&key).is_none());

--- a/pallets/subtensor/src/tests/migration.rs
+++ b/pallets/subtensor/src/tests/migration.rs
@@ -7076,7 +7076,7 @@ fn test_storage_bloat_cleanup_is_bounded_and_preserves_nonzero_state() {
     };
 
     new_test_ext(1).execute_with(|| {
-        const MIGRATION_NAME: &[u8] = b"migrate_storage_bloat_v2";
+        const MIGRATION_NAME: &[u8] = b"migrate_storage_bloat_v3";
         let netuid = NetUid::from(1);
         let hot_zero = U256::from(10);
         let hot_nonzero = U256::from(11);
@@ -7109,6 +7109,11 @@ fn test_storage_bloat_cleanup_is_bounded_and_preserves_nonzero_state() {
 
         Alpha::<Test>::insert((hot_zero, coldkey, netuid), U64F64::from_num(0));
         Alpha::<Test>::insert((hot_nonzero, coldkey, netuid), U64F64::from_num(7));
+        AlphaV2::<Test>::insert((hot_zero, coldkey, netuid), share_pool::SafeFloat::zero());
+        AlphaV2::<Test>::insert(
+            (hot_nonzero, coldkey, netuid),
+            share_pool::SafeFloat::from(8_u64),
+        );
         TotalHotkeyShares::<Test>::insert(hot_zero, netuid, U64F64::from_num(0));
         TotalHotkeyShares::<Test>::insert(hot_nonzero, netuid, U64F64::from_num(9));
         TotalHotkeyAlpha::<Test>::insert(hot_zero, netuid, AlphaBalance::ZERO);
@@ -7144,6 +7149,11 @@ fn test_storage_bloat_cleanup_is_bounded_and_preserves_nonzero_state() {
         assert_eq!(
             Alpha::<Test>::get((hot_nonzero, coldkey, netuid)),
             U64F64::from_num(7)
+        );
+        assert!(!AlphaV2::<Test>::contains_key((hot_zero, coldkey, netuid)));
+        assert_eq!(
+            AlphaV2::<Test>::get((hot_nonzero, coldkey, netuid)),
+            share_pool::SafeFloat::from(8_u64)
         );
         assert!(!TotalHotkeyShares::<Test>::contains_key(hot_zero, netuid));
         assert_eq!(
@@ -7214,14 +7224,25 @@ fn test_staking_hotkeys_cleanup_is_bounded_and_preserves_live_relationships() {
         let v2 = U256::from(202);
         let basket = U256::from(203);
         let other_stale = U256::from(204);
+        let zero_v2 = U256::from(205);
         let netuid = NetUid::from(1);
 
-        StakingHotkeys::<Test>::insert(coldkey, vec![stale, legacy, v2, basket]);
+        // The first cleanup already ran on deployed chains. The fresh v2 marker must schedule
+        // the same bounded implementation again.
+        HasMigrationRun::<Test>::insert(b"migrate_cleanup_staking_hotkeys", true);
+        StakingHotkeys::<Test>::insert(coldkey, vec![stale, legacy, v2, basket, zero_v2]);
         StakingHotkeys::<Test>::insert(all_stale_coldkey, vec![other_stale]);
         StakingHotkeys::<Test>::insert(empty_coldkey, Vec::<U256>::new());
         Alpha::<Test>::insert((legacy, coldkey, netuid), U64F64::from_num(1));
         AlphaV2::<Test>::insert((v2, coldkey, netuid), share_pool::SafeFloat::from(1_u64));
+        AlphaV2::<Test>::insert((zero_v2, coldkey, netuid), share_pool::SafeFloat::zero());
         BasketClaimed::<Test>::insert(basket, coldkey, -1);
+
+        crate::migrations::migrate_storage_bloat_v2::kickoff_storage_bloat_cleanup::<Test>();
+        crate::migrations::migrate_storage_bloat_v2::continue_storage_bloat_cleanup::<Test>(
+            Weight::MAX,
+        );
+        assert!(!AlphaV2::<Test>::contains_key((zero_v2, coldkey, netuid)));
 
         let kickoff_weight = kickoff_staking_hotkeys_cleanup::<Test>();
         assert!(!kickoff_weight.is_zero());

--- a/pallets/subtensor/src/tests/swap_hotkey_with_subnet.rs
+++ b/pallets/subtensor/src/tests/swap_hotkey_with_subnet.rs
@@ -2879,23 +2879,27 @@ fn test_revert_hotkey_swap_with_revert_stake_the_same() {
         // Let's check individual stakes; they changed because of emissions
         let old_hotkey_stake_after_revert_ck =
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hk1, &coldkey, netuid_1);
-        assert_eq!(
+        // Dust canonicalization can redistribute less than one rao while moving a position.
+        assert_abs_diff_eq!(
             old_hotkey_stake_after_revert_ck,
-            new_hotkey_stake_before_revert_ck
+            new_hotkey_stake_before_revert_ck,
+            epsilon = 1.into()
         );
 
         let old_hotkey_stake_after_revert_ck_2 =
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hk1, &coldkey_2, netuid_1);
-        assert_eq!(
+        assert_abs_diff_eq!(
             old_hotkey_stake_after_revert_ck_2,
-            new_hotkey_stake_before_revert_ck_2
+            new_hotkey_stake_before_revert_ck_2,
+            epsilon = 1.into()
         );
 
         let old_hotkey_stake_after_revert_ck_3 =
             SubtensorModule::get_stake_for_hotkey_and_coldkey_on_subnet(&hk1, &coldkey_3, netuid_1);
-        assert_eq!(
+        assert_abs_diff_eq!(
             old_hotkey_stake_after_revert_ck_3,
-            new_hotkey_stake_before_revert_ck_3
+            new_hotkey_stake_before_revert_ck_3,
+            epsilon = 1.into()
         );
     });
 }

--- a/primitives/share-pool/src/lib.rs
+++ b/primitives/share-pool/src/lib.rs
@@ -438,6 +438,17 @@ where
             .into()
     }
 
+    fn try_get_value_from_parts(
+        shared_value: u64,
+        current_share: &SafeFloat,
+        denominator: &SafeFloat,
+    ) -> Option<u64> {
+        let shared_value = SafeFloat::new(shared_value as u128, 0)?;
+        shared_value
+            .mul_div(current_share, denominator)
+            .map(u64::from)
+    }
+
     pub fn try_get_value(&self, key: &K) -> Result<u64, ()> {
         match self.state_ops.try_get_share(key) {
             Ok(_) => Ok(self.get_value(key)),
@@ -501,8 +512,8 @@ where
             self.state_ops.set_denominator(update_float.clone());
             self.state_ops.set_share(key, update_float);
         } else {
-            let new_denominator;
-            let new_current_share;
+            let mut new_denominator;
+            let mut new_current_share;
 
             let shares_per_update: SafeFloat =
                 self.get_shares_per_update(update, shared_value, &denominator);
@@ -561,6 +572,25 @@ where
                         current_share
                     }
                 };
+            }
+
+            // Withdrawing the integer value reported for a position can leave a positive
+            // fractional share worth less than one rao. If retained, later emissions can make
+            // that supposedly drained position visible again. Canonicalize such withdrawal
+            // dust to zero and remove it from the denominator so the remaining pool shares
+            // continue to sum to the denominator. Never interpret a failed valuation as zero.
+            let updated_shared_value = shared_value.saturating_sub(update.unsigned_abs());
+            if update < 0
+                && !new_current_share.is_zero()
+                && Self::try_get_value_from_parts(
+                    updated_shared_value,
+                    &new_current_share,
+                    &new_denominator,
+                ) == Some(0)
+                && let Some(denominator_without_dust) = new_denominator.sub(&new_current_share)
+            {
+                new_denominator = denominator_without_dust;
+                new_current_share = SafeFloat::zero();
             }
 
             self.state_ops.set_denominator(new_denominator);
@@ -702,6 +732,28 @@ mod tests {
 
         assert_eq!(value1, 10);
         assert_eq!(value2, 10);
+    }
+
+    #[test]
+    fn test_full_integer_withdrawal_clears_sub_rao_share_residue() {
+        let mock_ops = MockSharePoolDataOperations::new();
+        let mut pool = SharePool::<u16, MockSharePoolDataOperations>::new(mock_ops);
+
+        pool.update_value_for_one(&1, 1);
+        pool.update_value_for_one(&2, 2);
+        pool.update_value_for_all(1);
+
+        // Key 1 owns 4/3 rao but can only withdraw the displayed integer rao. Without dust
+        // canonicalization this leaves a positive 1/3-rao share which later revives.
+        assert_eq!(pool.get_value(&1), 1);
+        pool.update_value_for_one(&1, -1);
+
+        assert!(pool.state_ops.get_share(&1).is_zero());
+        assert_eq!(pool.get_value(&2), 3);
+
+        pool.update_value_for_all(10);
+        assert_eq!(pool.get_value(&1), 0, "a drained position must not revive");
+        assert_eq!(pool.get_value(&2), 13);
     }
 
     // cargo test --package share-pool --lib -- tests::test_denom_high_precision --exact --show-output

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 453,
+    spec_version: 454,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/tests/claim_root_weight.rs
+++ b/runtime/tests/claim_root_weight.rs
@@ -1,18 +1,13 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
-use frame_support::{
-    dispatch::{DispatchClass, GetDispatchInfo},
-    traits::Get,
-};
+use frame_support::dispatch::{DispatchClass, GetDispatchInfo};
 use node_subtensor_runtime::{
     BlockWeights, BuildStorage, Runtime, RuntimeCall, RuntimeGenesisConfig, System, TxExtension,
     check_mortality, check_nonce, sudo_wrapper,
     transaction_payment_wrapper::ChargeTransactionPaymentWrapper,
 };
-use sp_core::H256;
 use sp_runtime::{generic::Era, traits::TransactionExtension};
 use sp_std::collections::btree_set::BTreeSet;
-use std::str::FromStr;
 use subtensor_runtime_common::{AccountId, NetUid, TaoBalance};
 
 fn new_test_ext() -> sp_io::TestExternalities {
@@ -27,11 +22,9 @@ fn new_test_ext() -> sp_io::TestExternalities {
 fn expected_root_claim_weight(limit: u32) -> frame_support::weights::Weight {
     use pallet_subtensor::weights::WeightInfo;
 
-    pallet_subtensor::weights::SubstrateWeight::<Runtime>::claim_root(limit)
-        .saturating_add(
-            pallet_subtensor::weights::SubstrateWeight::<Runtime>::claim_root_scan(limit),
-        )
-        .saturating_add(<Runtime as frame_system::Config>::DbWeight::get().reads(2))
+    pallet_subtensor::weights::SubstrateWeight::<Runtime>::claim_root(limit).saturating_add(
+        pallet_subtensor::weights::SubstrateWeight::<Runtime>::claim_root_scan(limit),
+    )
 }
 
 fn assert_call_fits_normal_limit(call: RuntimeCall) {
@@ -76,7 +69,7 @@ fn claim_root_with_extensions_fits_normal_extrinsic_limit() {
         });
         assert_eq!(
             call.get_dispatch_info().call_weight,
-            expected_root_claim_weight(pallet_subtensor::DEFAULT_ROOT_CLAIM_WORK)
+            expected_root_claim_weight(pallet_subtensor::MAX_ROOT_CLAIM_WORK)
         );
         assert_call_fits_normal_limit(call);
     });
@@ -88,25 +81,6 @@ fn claim_root_with_hotkey_with_extensions_fits_normal_extrinsic_limit() {
         let hotkey = AccountId::new([1u8; 32]);
         let call =
             RuntimeCall::SubtensorModule(pallet_subtensor::Call::claim_root_with_hotkey { hotkey });
-        assert_eq!(
-            call.get_dispatch_info().call_weight,
-            expected_root_claim_weight(pallet_subtensor::DEFAULT_ROOT_CLAIM_WORK)
-        );
-        assert_call_fits_normal_limit(call);
-    });
-}
-
-#[test]
-fn finney_testnet_root_claim_envelope_fits_normal_extrinsic_limit() {
-    new_test_ext().execute_with(|| {
-        frame_system::BlockHash::<Runtime>::insert(
-            0_u32,
-            H256::from_str("8f9cf856bf558a14440e75569c9e58594757048d7b3a84b5d25f6bd978263105")
-                .expect("valid Finney testnet genesis hash"),
-        );
-        let call = RuntimeCall::SubtensorModule(pallet_subtensor::Call::claim_root_with_hotkey {
-            hotkey: AccountId::new([1u8; 32]),
-        });
         assert_eq!(
             call.get_dispatch_info().call_weight,
             expected_root_claim_weight(pallet_subtensor::MAX_ROOT_CLAIM_WORK)

--- a/runtime/tests/claim_root_weight.rs
+++ b/runtime/tests/claim_root_weight.rs
@@ -22,9 +22,14 @@ fn new_test_ext() -> sp_io::TestExternalities {
 fn expected_root_claim_weight(limit: u32) -> frame_support::weights::Weight {
     use pallet_subtensor::weights::WeightInfo;
 
-    pallet_subtensor::weights::SubstrateWeight::<Runtime>::claim_root(limit).saturating_add(
-        pallet_subtensor::weights::SubstrateWeight::<Runtime>::claim_root_scan(limit),
-    )
+    pallet_subtensor::weights::SubstrateWeight::<Runtime>::claim_root(limit)
+        .saturating_add(
+            pallet_subtensor::weights::SubstrateWeight::<Runtime>::claim_root_scan(limit),
+        )
+        // FRAME folds the runtime's dispatch-extension weight into `call_weight`.
+        .saturating_add(
+            pallet_subtensor::weights::SubstrateWeight::<Runtime>::check_coldkey_swap_extension(),
+        )
 }
 
 fn assert_call_fits_normal_limit(call: RuntimeCall) {

--- a/runtime/tests/claim_root_weight.rs
+++ b/runtime/tests/claim_root_weight.rs
@@ -1,13 +1,38 @@
 #![allow(clippy::expect_used, clippy::panic)]
 
-use frame_support::dispatch::{DispatchClass, GetDispatchInfo};
+use frame_support::{
+    dispatch::{DispatchClass, GetDispatchInfo},
+    traits::Get,
+};
 use node_subtensor_runtime::{
-    BlockWeights, Runtime, RuntimeCall, TxExtension, check_mortality, check_nonce, sudo_wrapper,
+    BlockWeights, BuildStorage, Runtime, RuntimeCall, RuntimeGenesisConfig, System, TxExtension,
+    check_mortality, check_nonce, sudo_wrapper,
     transaction_payment_wrapper::ChargeTransactionPaymentWrapper,
 };
+use sp_core::H256;
 use sp_runtime::{generic::Era, traits::TransactionExtension};
 use sp_std::collections::btree_set::BTreeSet;
+use std::str::FromStr;
 use subtensor_runtime_common::{AccountId, NetUid, TaoBalance};
+
+fn new_test_ext() -> sp_io::TestExternalities {
+    let mut ext: sp_io::TestExternalities = RuntimeGenesisConfig::default()
+        .build_storage()
+        .expect("runtime genesis storage builds")
+        .into();
+    ext.execute_with(|| System::set_block_number(1));
+    ext
+}
+
+fn expected_root_claim_weight(limit: u32) -> frame_support::weights::Weight {
+    use pallet_subtensor::weights::WeightInfo;
+
+    pallet_subtensor::weights::SubstrateWeight::<Runtime>::claim_root(limit)
+        .saturating_add(
+            pallet_subtensor::weights::SubstrateWeight::<Runtime>::claim_root_scan(limit),
+        )
+        .saturating_add(<Runtime as frame_system::Config>::DbWeight::get().reads(2))
+}
 
 fn assert_call_fits_normal_limit(call: RuntimeCall) {
     let extensions: TxExtension = (
@@ -45,16 +70,47 @@ fn assert_call_fits_normal_limit(call: RuntimeCall) {
 
 #[test]
 fn claim_root_with_extensions_fits_normal_extrinsic_limit() {
-    let call = RuntimeCall::SubtensorModule(pallet_subtensor::Call::claim_root {
-        subnets: BTreeSet::from([NetUid::ROOT]),
+    new_test_ext().execute_with(|| {
+        let call = RuntimeCall::SubtensorModule(pallet_subtensor::Call::claim_root {
+            subnets: BTreeSet::from([NetUid::ROOT]),
+        });
+        assert_eq!(
+            call.get_dispatch_info().call_weight,
+            expected_root_claim_weight(pallet_subtensor::DEFAULT_ROOT_CLAIM_WORK)
+        );
+        assert_call_fits_normal_limit(call);
     });
-    assert_call_fits_normal_limit(call);
 }
 
 #[test]
 fn claim_root_with_hotkey_with_extensions_fits_normal_extrinsic_limit() {
-    let hotkey = AccountId::new([1u8; 32]);
-    let call =
-        RuntimeCall::SubtensorModule(pallet_subtensor::Call::claim_root_with_hotkey { hotkey });
-    assert_call_fits_normal_limit(call);
+    new_test_ext().execute_with(|| {
+        let hotkey = AccountId::new([1u8; 32]);
+        let call =
+            RuntimeCall::SubtensorModule(pallet_subtensor::Call::claim_root_with_hotkey { hotkey });
+        assert_eq!(
+            call.get_dispatch_info().call_weight,
+            expected_root_claim_weight(pallet_subtensor::DEFAULT_ROOT_CLAIM_WORK)
+        );
+        assert_call_fits_normal_limit(call);
+    });
+}
+
+#[test]
+fn finney_testnet_root_claim_envelope_fits_normal_extrinsic_limit() {
+    new_test_ext().execute_with(|| {
+        frame_system::BlockHash::<Runtime>::insert(
+            0_u32,
+            H256::from_str("8f9cf856bf558a14440e75569c9e58594757048d7b3a84b5d25f6bd978263105")
+                .expect("valid Finney testnet genesis hash"),
+        );
+        let call = RuntimeCall::SubtensorModule(pallet_subtensor::Call::claim_root_with_hotkey {
+            hotkey: AccountId::new([1u8; 32]),
+        });
+        assert_eq!(
+            call.get_dispatch_info().call_weight,
+            expected_root_claim_weight(pallet_subtensor::MAX_ROOT_CLAIM_WORK)
+        );
+        assert_call_fits_normal_limit(call);
+    });
 }

--- a/sdk/python/bittensor/error_descriptions/subtensor.py
+++ b/sdk/python/bittensor/error_descriptions/subtensor.py
@@ -86,11 +86,12 @@ DESCRIPTIONS: dict[str, str] = {
         "a hotkey the beneficiary coldkey actually owns."
     ),
     "RootClaimTooHeavy": (
-        "A root claim would walk more work than the fixed pre-dispatch weight envelope can "
-        "admit. For coldkey-wide `claim_root`, hotkeys times existing networks or total basket "
-        "rows can exceed `MAX_ROOT_CLAIM_WORK`; a single validator basket with too many rows "
-        "can also make `claim_root_with_hotkey` fail. Split a coldkey-wide claim by validator "
-        "where that fits, and investigate or consolidate an individually oversized basket."
+        "A root claim would walk more work than the chain-specific admission envelope can "
+        "admit (256 units by default; 1,025 on Finney testnet). For coldkey-wide `claim_root`, "
+        "hotkeys times existing networks or total basket rows can exceed that envelope; a "
+        "single validator basket with too many rows can also make `claim_root_with_hotkey` "
+        "fail. Split a coldkey-wide claim by validator where that fits, and investigate or "
+        "consolidate an individually oversized basket."
     ),
     "BetaBasketSeedInProgress": (
         "The `migrate_seed_beta_basket_v2` seed has not completed (it normally finishes "

--- a/sdk/python/bittensor/error_descriptions/subtensor.py
+++ b/sdk/python/bittensor/error_descriptions/subtensor.py
@@ -86,12 +86,12 @@ DESCRIPTIONS: dict[str, str] = {
         "a hotkey the beneficiary coldkey actually owns."
     ),
     "RootClaimTooHeavy": (
-        "A root claim would walk more work than the chain-specific admission envelope can "
-        "admit (256 units by default; 1,025 on Finney testnet). For coldkey-wide `claim_root`, "
-        "hotkeys times existing networks or total basket rows can exceed that envelope; a "
-        "single validator basket with too many rows can also make `claim_root_with_hotkey` "
-        "fail. Split a coldkey-wide claim by validator where that fits, and investigate or "
-        "consolidate an individually oversized basket."
+        "A root claim would process more than the fixed 256-unit admission envelope. Only "
+        "root-relevant validator hotkeys and their stored basket rows count as claim work; "
+        "classifying the staking-hotkey relationship vector is separately capped at 256. "
+        "Unrelated subnet stakes are not multiplied by the total network count. Split a "
+        "coldkey-wide claim by validator where that fits, and investigate or consolidate an "
+        "individually oversized basket."
     ),
     "BetaBasketSeedInProgress": (
         "The `migrate_seed_beta_basket_v2` seed has not completed (it normally finishes "

--- a/sdk/python/bittensor/intents/_root_claim_fee.py
+++ b/sdk/python/bittensor/intents/_root_claim_fee.py
@@ -1,9 +1,10 @@
 """Claim-fee preview for ``claim_root`` / ``claim_root_with_hotkey``.
 
-Both runtime calls reserve ``MAX_ROOT_CLAIM_WORK`` (256) weight units at
-inclusion, then refund down to the work actually done. That reserve is what
-people see leave their free balance, and it is larger than the fee that
-finally settles. That gap is the usual claim-fee surprise.
+Both runtime calls reserve a chain-specific declared-work envelope at inclusion,
+then refund down to the work actually done. Finney testnet admits and reserves
+for its larger subnet topology while other chains retain the conservative
+default. The reserve is what people see leave their free balance, and it is
+larger than the fee that finally settles.
 
 This module estimates both numbers, compares the spent fee to accrued yield,
 and tells the caller when a claim loses money or cannot even be included.
@@ -26,10 +27,18 @@ _SCAN_REF_TIME = 6
 _REDEEM_REF_TIME = 70
 
 # One full ``claim_root`` weight unit under LinearWeightToFee (~τ0.0004475).
-# Both claim paths reserve ``MAX_ROOT_CLAIM_WORK`` of these, plus any
-# non-weight base/length fee returned by ``payment_info``.
+# Both claim paths reserve their chain-specific number of redeem and scan units,
+# plus any non-weight base/length fee returned by ``payment_info``.
 _APPROX_REDEEM_FEE_RAO = 447_500
-_MAX_ROOT_CLAIM_WORK = 256
+_APPROX_SCAN_FEE_RAO = _APPROX_REDEEM_FEE_RAO * _SCAN_REF_TIME // _REDEEM_REF_TIME
+_DEFAULT_ROOT_CLAIM_WORK = 256
+_MAX_ROOT_CLAIM_WORK = 1_025
+_FINNEY_TESTNET_GENESIS_HASH = "0x8f9cf856bf558a14440e75569c9e58594757048d7b3a84b5d25f6bd978263105"
+
+
+def _approx_declared_fee_rao(limit: int) -> int:
+    return (_APPROX_REDEEM_FEE_RAO + _APPROX_SCAN_FEE_RAO) * limit
+
 
 # Default ``RootClaimableThreshold`` (500_000 rao) when storage is empty.
 _DEFAULT_THRESHOLD_RAO = 500_000
@@ -51,14 +60,14 @@ def _i96f32_rao(value: Any) -> int:
     return int(value or 0) >> 32
 
 
-def _admission_blocks(hotkeys: int, networks: int, holdings: int) -> list[str]:
+def _admission_blocks(hotkeys: int, networks: int, holdings: int, limit: int) -> list[str]:
     work = hotkeys * networks
-    if work <= _MAX_ROOT_CLAIM_WORK and holdings <= _MAX_ROOT_CLAIM_WORK:
+    if work <= limit and holdings <= limit:
         return []
     reasons: list[str] = []
-    if work > _MAX_ROOT_CLAIM_WORK:
+    if work > limit:
         reasons.append(f"{hotkeys} hotkeys × {networks} networks = {work}")
-    if holdings > _MAX_ROOT_CLAIM_WORK:
+    if holdings > limit:
         reasons.append(f"{holdings} basket holdings")
     remediation = (
         "claim one validator at a time with claim_root_with_hotkey"
@@ -66,7 +75,7 @@ def _admission_blocks(hotkeys: int, networks: int, holdings: int) -> list[str]:
         else "the claim cannot be admitted until this basket's work is reduced"
     )
     return [
-        "root claim exceeds the 256-unit admission limit ("
+        f"root claim exceeds the {limit:,}-unit admission limit ("
         + "; ".join(reasons)
         + f"); {remediation}"
     ]
@@ -79,6 +88,7 @@ class RootClaimAdmission:
     hotkeys: tuple[str, ...]
     holding_counts: tuple[int, ...]
     networks: int
+    limit: int
 
     @property
     def holdings(self) -> int:
@@ -86,13 +96,10 @@ class RootClaimAdmission:
 
     @property
     def too_heavy(self) -> bool:
-        return (
-            len(self.hotkeys) * self.networks > _MAX_ROOT_CLAIM_WORK
-            or self.holdings > _MAX_ROOT_CLAIM_WORK
-        )
+        return len(self.hotkeys) * self.networks > self.limit or self.holdings > self.limit
 
     def blocks(self) -> list[str]:
-        return _admission_blocks(len(self.hotkeys), self.networks, self.holdings)
+        return _admission_blocks(len(self.hotkeys), self.networks, self.holdings, self.limit)
 
 
 @dataclass(frozen=True)
@@ -133,6 +140,7 @@ class RootClaimFeeQuote:
     eligible_hotkeys: int
     below_threshold_hotkeys: int
     redeemable: Balance
+    admission_limit: int
 
     @property
     def refund(self) -> Balance:
@@ -153,8 +161,8 @@ class RootClaimFeeQuote:
     @property
     def too_heavy(self) -> bool:
         return (
-            self.hotkeys * self.networks > _MAX_ROOT_CLAIM_WORK
-            or self.holdings > _MAX_ROOT_CLAIM_WORK
+            self.hotkeys * self.networks > self.admission_limit
+            or self.holdings > self.admission_limit
         )
 
     def facts(self) -> list[tuple[str, str]]:
@@ -219,7 +227,14 @@ class RootClaimFeeQuote:
     def blocks(self) -> list[str]:
         out: list[str] = []
         if self.too_heavy:
-            out.extend(_admission_blocks(self.hotkeys, self.networks, self.holdings))
+            out.extend(
+                _admission_blocks(
+                    self.hotkeys,
+                    self.networks,
+                    self.holdings,
+                    self.admission_limit,
+                )
+            )
         if self.reserve_shortfall:
             out.append(f"free TAO ({self.free}) is below the reserved claim fee ({self.reserved})")
         return out
@@ -231,7 +246,7 @@ async def root_claim_admission(
     *,
     hotkeys: Optional[list[str]],
 ) -> RootClaimAdmission:
-    """Read only the state used by the runtime's 256-unit admission guard.
+    """Read only the state used by the runtime's chain-specific admission guard.
 
     Unlike the fee/yield quote, this check is not best-effort: callers use a
     failed read as a hard stop because signing an unverifiable claim can burn
@@ -259,11 +274,15 @@ async def root_claim_admission(
 
     holding_counts = await asyncio.gather(*(holding_count(hotkey) for hotkey in selected))
 
-    networks = await _existing_network_count(substrate)
+    networks, limit = await asyncio.gather(
+        _existing_network_count(substrate),
+        _root_claim_admission_limit(substrate),
+    )
     return RootClaimAdmission(
         hotkeys=selected,
         holding_counts=tuple(holding_counts),
         networks=networks,
+        limit=limit,
     )
 
 
@@ -374,6 +393,7 @@ async def _quote(
             redeem_holdings=redeem_holdings,
             scan_holdings=scan_holdings,
         ),
+        admission.limit,
     )
 
     return RootClaimFeeQuote(
@@ -388,6 +408,7 @@ async def _quote(
         eligible_hotkeys=sum(eligible),
         below_threshold_hotkeys=sum(below_threshold),
         redeemable=Balance.from_rao(redeemable_rao),
+        admission_limit=admission.limit,
     )
 
 
@@ -396,6 +417,13 @@ async def _existing_network_count(substrate: Any) -> int:
     if rows is None:
         raise RuntimeError("existing-network map is unavailable")
     return max(sum(1 for _netuid, added in rows if added), 1)
+
+
+async def _root_claim_admission_limit(substrate: Any) -> int:
+    genesis_hash = str(await substrate.block_hash(0)).lower()
+    if genesis_hash == _FINNEY_TESTNET_GENESIS_HASH:
+        return _MAX_ROOT_CLAIM_WORK
+    return _DEFAULT_ROOT_CLAIM_WORK
 
 
 async def _threshold_rao(substrate: Any) -> int:
@@ -433,7 +461,13 @@ async def _reserved_fee_with_status(
             call = await compose()
         return await substrate.estimate_fee(call, _FeeView(signer_address)), True
     except Exception:
-        return Balance.from_rao(_APPROX_REDEEM_FEE_RAO * _MAX_ROOT_CLAIM_WORK), False
+        try:
+            limit = await _root_claim_admission_limit(substrate)
+        except Exception:
+            # If both payment-info and chain identity are unavailable, keep the
+            # fallback conservative rather than understate the required reserve.
+            limit = _MAX_ROOT_CLAIM_WORK
+        return Balance.from_rao(_approx_declared_fee_rao(limit)), False
 
 
 async def root_claim_reserve(
@@ -461,26 +495,22 @@ async def root_claim_reserve(
 def _spent_fee(
     reserved: Balance,
     work: RootClaimWork,
+    declared_work: int = _DEFAULT_ROOT_CLAIM_WORK,
 ) -> Balance:
     """Refund unused declared units; keep non-weight base/length fees intact.
 
     Runtime active units are ``max(hotkey_count, realized + swept, 1)``. The
     quote floors by the selected hotkey count so empty-basket validators still
-    cost a full unit. ``estimate_fee`` prices the 256-unit declaration plus
-    extrinsic base/length; only the weight slice scales.
+    cost a full unit. ``estimate_fee`` prices the chain-specific declaration
+    plus extrinsic base/length; only the weight slice scales.
     """
     if reserved.rao <= 0:
         return reserved
-    declared_weight = _APPROX_REDEEM_FEE_RAO * _MAX_ROOT_CLAIM_WORK
+    declared_weight = _approx_declared_fee_rao(declared_work)
     weight_part = min(reserved.rao, declared_weight)
     base_part = max(0, reserved.rao - declared_weight)
     active = max(work.redeem_holdings, work.hotkeys, 1)
-    active_weight = weight_part * active // _MAX_ROOT_CLAIM_WORK
-    scan_weight = (
-        weight_part
-        * max(work.scan_holdings, 0)
-        * _SCAN_REF_TIME
-        // (_MAX_ROOT_CLAIM_WORK * _REDEEM_REF_TIME)
-    )
+    active_weight = weight_part * active * _APPROX_REDEEM_FEE_RAO // declared_weight
+    scan_weight = weight_part * max(work.scan_holdings, 0) * _APPROX_SCAN_FEE_RAO // declared_weight
     spent_weight = active_weight + scan_weight
     return Balance.from_rao(min(reserved.rao, base_part + max(spent_weight, 0)))

--- a/sdk/python/bittensor/intents/_root_claim_fee.py
+++ b/sdk/python/bittensor/intents/_root_claim_fee.py
@@ -1,10 +1,8 @@
 """Claim-fee preview for ``claim_root`` / ``claim_root_with_hotkey``.
 
-Both runtime calls reserve a chain-specific declared-work envelope at inclusion,
-then refund down to the work actually done. Finney testnet admits and reserves
-for its larger subnet topology while other chains retain the conservative
-default. The reserve is what people see leave their free balance, and it is
-larger than the fee that finally settles.
+Both runtime calls reserve a fixed declared-work envelope at inclusion, then
+refund down to the work actually done. The reserve is what people see leave
+their free balance, and it is larger than the fee that finally settles.
 
 This module estimates both numbers, compares the spent fee to accrued yield,
 and tells the caller when a claim loses money or cannot even be included.
@@ -17,7 +15,7 @@ from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Optional
 
 from .._generated import storage as st
-from .._generated.runtime_apis import BetaBasketRuntimeApi
+from .._generated.runtime_apis import BetaBasketRuntimeApi, StakeInfoRuntimeApi
 from ..balance import Balance
 from ..sp_core import ss58_decode
 
@@ -27,13 +25,11 @@ _SCAN_REF_TIME = 6
 _REDEEM_REF_TIME = 70
 
 # One full ``claim_root`` weight unit under LinearWeightToFee (~τ0.0004475).
-# Both claim paths reserve their chain-specific number of redeem and scan units,
+# Both claim paths reserve 256 redeem and scan units,
 # plus any non-weight base/length fee returned by ``payment_info``.
 _APPROX_REDEEM_FEE_RAO = 447_500
 _APPROX_SCAN_FEE_RAO = _APPROX_REDEEM_FEE_RAO * _SCAN_REF_TIME // _REDEEM_REF_TIME
-_DEFAULT_ROOT_CLAIM_WORK = 256
-_MAX_ROOT_CLAIM_WORK = 1_025
-_FINNEY_TESTNET_GENESIS_HASH = "0x8f9cf856bf558a14440e75569c9e58594757048d7b3a84b5d25f6bd978263105"
+_MAX_ROOT_CLAIM_WORK = 256
 
 
 def _approx_declared_fee_rao(limit: int) -> int:
@@ -60,20 +56,29 @@ def _i96f32_rao(value: Any) -> int:
     return int(value or 0) >> 32
 
 
-def _admission_blocks(hotkeys: int, networks: int, holdings: int, limit: int) -> list[str]:
-    work = hotkeys * networks
-    if work <= limit and holdings <= limit:
+def _admission_blocks(
+    hotkeys: int,
+    holdings: int,
+    limit: int,
+    selection_scans: int,
+) -> list[str]:
+    work = hotkeys + holdings
+    if work <= limit and selection_scans <= limit:
         return []
-    reasons: list[str] = []
-    if work > limit:
-        reasons.append(f"{hotkeys} hotkeys × {networks} networks = {work}")
-    if holdings > limit:
-        reasons.append(f"{holdings} basket holdings")
     remediation = (
         "claim one validator at a time with claim_root_with_hotkey"
         if hotkeys > 1
         else "the claim cannot be admitted until this basket's work is reduced"
     )
+    reasons = []
+    if work > limit:
+        hotkey_label = "hotkey" if hotkeys == 1 else "hotkeys"
+        holding_label = "holding" if holdings == 1 else "holdings"
+        reasons.append(
+            f"{hotkeys} root {hotkey_label} + {holdings} basket {holding_label} = {work}"
+        )
+    if selection_scans > limit:
+        reasons.append(f"{selection_scans} staking-hotkey relationships to classify")
     return [
         f"root claim exceeds the {limit:,}-unit admission limit ("
         + "; ".join(reasons)
@@ -89,6 +94,7 @@ class RootClaimAdmission:
     holding_counts: tuple[int, ...]
     networks: int
     limit: int
+    selection_scans: int
 
     @property
     def holdings(self) -> int:
@@ -96,10 +102,15 @@ class RootClaimAdmission:
 
     @property
     def too_heavy(self) -> bool:
-        return len(self.hotkeys) * self.networks > self.limit or self.holdings > self.limit
+        return len(self.hotkeys) + self.holdings > self.limit or self.selection_scans > self.limit
 
     def blocks(self) -> list[str]:
-        return _admission_blocks(len(self.hotkeys), self.networks, self.holdings, self.limit)
+        return _admission_blocks(
+            len(self.hotkeys),
+            self.holdings,
+            self.limit,
+            self.selection_scans,
+        )
 
 
 @dataclass(frozen=True)
@@ -109,6 +120,7 @@ class RootClaimWork:
     hotkeys: int
     redeem_holdings: int
     scan_holdings: int
+    selection_scans: int = 0
 
 
 @dataclass(frozen=True)
@@ -141,6 +153,7 @@ class RootClaimFeeQuote:
     below_threshold_hotkeys: int
     redeemable: Balance
     admission_limit: int
+    selection_scans: int
 
     @property
     def refund(self) -> Balance:
@@ -161,8 +174,8 @@ class RootClaimFeeQuote:
     @property
     def too_heavy(self) -> bool:
         return (
-            self.hotkeys * self.networks > self.admission_limit
-            or self.holdings > self.admission_limit
+            self.hotkeys + self.holdings > self.admission_limit
+            or self.selection_scans > self.admission_limit
         )
 
     def facts(self) -> list[tuple[str, str]]:
@@ -230,9 +243,9 @@ class RootClaimFeeQuote:
             out.extend(
                 _admission_blocks(
                     self.hotkeys,
-                    self.networks,
                     self.holdings,
                     self.admission_limit,
+                    self.selection_scans,
                 )
             )
         if self.reserve_shortfall:
@@ -246,7 +259,7 @@ async def root_claim_admission(
     *,
     hotkeys: Optional[list[str]],
 ) -> RootClaimAdmission:
-    """Read only the state used by the runtime's chain-specific admission guard.
+    """Read only the state used by the runtime's fixed admission guard.
 
     Unlike the fee/yield quote, this check is not best-effort: callers use a
     failed read as a hard stop because signing an unverifiable claim can burn
@@ -254,11 +267,38 @@ async def root_claim_admission(
     """
     if hotkeys is None:
         raw_keys = await substrate.query(*st.SubtensorModule.StakingHotkeys, [claimant_address])
-        selected = tuple(str(key) for key in (raw_keys or []))
+        raw_keys = tuple(str(key) for key in (raw_keys or []))
+        stake_rows = await substrate.runtime_call(
+            *StakeInfoRuntimeApi.get_stake_info_for_coldkey,
+            [claimant_address],
+        )
+        if stake_rows is None:
+            raise RuntimeError("coldkey stake positions are unavailable")
+        root_hotkeys = {
+            str(row["hotkey"])
+            for row in stake_rows
+            if int(row["netuid"]) == 0 and int(row["stake"]) > 0
+        }
+        watermarks = await asyncio.gather(
+            *(
+                substrate.query(
+                    *st.SubtensorModule.BasketClaimed,
+                    [hotkey, claimant_address],
+                )
+                for hotkey in raw_keys
+            )
+        )
+        selected = tuple(
+            hotkey
+            for hotkey, watermark in zip(raw_keys, watermarks)
+            if hotkey in root_hotkeys or int(watermark or 0) < 0
+        )
+        selection_scans = len(raw_keys)
     else:
         if len(hotkeys) != 1:
             raise ValueError("per-validator admission expects exactly one hotkey")
         selected = tuple(hotkeys)
+        selection_scans = 0
 
     semaphore = asyncio.Semaphore(16)
 
@@ -274,15 +314,13 @@ async def root_claim_admission(
 
     holding_counts = await asyncio.gather(*(holding_count(hotkey) for hotkey in selected))
 
-    networks, limit = await asyncio.gather(
-        _existing_network_count(substrate),
-        _root_claim_admission_limit(substrate),
-    )
+    networks = await _existing_network_count(substrate)
     return RootClaimAdmission(
         hotkeys=selected,
         holding_counts=tuple(holding_counts),
         networks=networks,
-        limit=limit,
+        limit=_MAX_ROOT_CLAIM_WORK,
+        selection_scans=selection_scans,
     )
 
 
@@ -392,6 +430,7 @@ async def _quote(
             hotkeys=max(len(selected_hotkeys), 1),
             redeem_holdings=redeem_holdings,
             scan_holdings=scan_holdings,
+            selection_scans=admission.selection_scans,
         ),
         admission.limit,
     )
@@ -409,6 +448,7 @@ async def _quote(
         below_threshold_hotkeys=sum(below_threshold),
         redeemable=Balance.from_rao(redeemable_rao),
         admission_limit=admission.limit,
+        selection_scans=admission.selection_scans,
     )
 
 
@@ -417,13 +457,6 @@ async def _existing_network_count(substrate: Any) -> int:
     if rows is None:
         raise RuntimeError("existing-network map is unavailable")
     return max(sum(1 for _netuid, added in rows if added), 1)
-
-
-async def _root_claim_admission_limit(substrate: Any) -> int:
-    genesis_hash = str(await substrate.block_hash(0)).lower()
-    if genesis_hash == _FINNEY_TESTNET_GENESIS_HASH:
-        return _MAX_ROOT_CLAIM_WORK
-    return _DEFAULT_ROOT_CLAIM_WORK
 
 
 async def _threshold_rao(substrate: Any) -> int:
@@ -461,13 +494,7 @@ async def _reserved_fee_with_status(
             call = await compose()
         return await substrate.estimate_fee(call, _FeeView(signer_address)), True
     except Exception:
-        try:
-            limit = await _root_claim_admission_limit(substrate)
-        except Exception:
-            # If both payment-info and chain identity are unavailable, keep the
-            # fallback conservative rather than understate the required reserve.
-            limit = _MAX_ROOT_CLAIM_WORK
-        return Balance.from_rao(_approx_declared_fee_rao(limit)), False
+        return Balance.from_rao(_approx_declared_fee_rao(_MAX_ROOT_CLAIM_WORK)), False
 
 
 async def root_claim_reserve(
@@ -495,21 +522,22 @@ async def root_claim_reserve(
 def _spent_fee(
     reserved: Balance,
     work: RootClaimWork,
-    declared_work: int = _DEFAULT_ROOT_CLAIM_WORK,
+    declared_work: int = _MAX_ROOT_CLAIM_WORK,
 ) -> Balance:
     """Refund unused declared units; keep non-weight base/length fees intact.
 
-    Runtime active units are ``max(hotkey_count, realized + swept, 1)``. The
-    quote floors by the selected hotkey count so empty-basket validators still
-    cost a full unit. ``estimate_fee`` prices the chain-specific declaration
-    plus extrinsic base/length; only the weight slice scales.
+    Runtime active units are ``max(selected hotkeys, relationships classified,
+    realized + swept, 1)``. Classifying a relationship reads its root share-pool
+    state, so the quote prices it conservatively as a full hotkey unit.
+    ``estimate_fee`` prices the fixed declaration plus extrinsic base/length;
+    only the weight slice scales.
     """
     if reserved.rao <= 0:
         return reserved
     declared_weight = _approx_declared_fee_rao(declared_work)
     weight_part = min(reserved.rao, declared_weight)
     base_part = max(0, reserved.rao - declared_weight)
-    active = max(work.redeem_holdings, work.hotkeys, 1)
+    active = max(work.redeem_holdings, work.hotkeys, work.selection_scans, 1)
     active_weight = weight_part * active * _APPROX_REDEEM_FEE_RAO // declared_weight
     scan_weight = weight_part * max(work.scan_holdings, 0) * _APPROX_SCAN_FEE_RAO // declared_weight
     spent_weight = active_weight + scan_weight

--- a/sdk/python/bittensor/intents/registration.py
+++ b/sdk/python/bittensor/intents/registration.py
@@ -277,7 +277,7 @@ class _RootClaimIntent(Intent):
                 effects=[self.summary()],
                 warnings=[],
                 blocks=[
-                    "could not verify the root claim's 256-unit admission budget; "
+                    "could not verify the root claim's chain-specific admission budget; "
                     f"refusing to risk the unreduced declared fee ({error})"
                 ],
             )
@@ -422,9 +422,10 @@ class ClaimRootWithHotkey(_RootClaimIntent):
     per-holding claim fee shrinks over time; curated positions are left to
     compound. The transaction fee is charged by work actually done:
     holdings redeemed pay full weight, holdings merely scanned pay a small
-    per-row cost. The chain reserves a fixed 256-unit declared-work envelope at
-    inclusion, independent of the current network count, and refunds the unused
-    part after.
+    per-row cost. The chain reserves a fixed 256-unit declared-work envelope on
+    mainnet and unknown chains, independent of the current network count, and
+    refunds the unused part after. Finney testnet uses a 1,025-unit envelope to
+    cover its larger subnet topology.
     ``plan`` and ``btcli root claim --dry-run`` show reserved versus spent,
     warn when the spent fee exceeds accrued yield, and refuse when free
     TAO cannot cover the reserve.

--- a/sdk/python/bittensor/intents/registration.py
+++ b/sdk/python/bittensor/intents/registration.py
@@ -277,7 +277,7 @@ class _RootClaimIntent(Intent):
                 effects=[self.summary()],
                 warnings=[],
                 blocks=[
-                    "could not verify the root claim's chain-specific admission budget; "
+                    "could not verify the root claim's fixed admission budget; "
                     f"refusing to risk the unreduced declared fee ({error})"
                 ],
             )
@@ -422,10 +422,10 @@ class ClaimRootWithHotkey(_RootClaimIntent):
     per-holding claim fee shrinks over time; curated positions are left to
     compound. The transaction fee is charged by work actually done:
     holdings redeemed pay full weight, holdings merely scanned pay a small
-    per-row cost. The chain reserves a fixed 256-unit declared-work envelope on
-    mainnet and unknown chains, independent of the current network count, and
-    refunds the unused part after. Finney testnet uses a 1,025-unit envelope to
-    cover its larger subnet topology.
+    per-row cost. The chain reserves a fixed 256-unit declared-work envelope,
+    counts only root-relevant hotkeys and their basket rows for admission, and
+    separately caps classification of the staking-hotkey vector at 256. It
+    refunds the unused part after.
     ``plan`` and ``btcli root claim --dry-run`` show reserved versus spent,
     warn when the spent fee exceeds accrued yield, and refuse when free
     TAO cannot cover the reserve.

--- a/sdk/python/tests/unit/test_root_claim_fee.py
+++ b/sdk/python/tests/unit/test_root_claim_fee.py
@@ -1,4 +1,4 @@
-"""Reserved/spent root-claim fees follow the 256-unit runtime envelope."""
+"""Reserved/spent root-claim fees follow the runtime claim envelopes."""
 
 from __future__ import annotations
 
@@ -14,16 +14,25 @@ from tests.harness.samples import ALICE, ALICE_HOT, BOB, BOB_HOT, dev_wallet
 
 
 @pytest.mark.asyncio
-async def test_reserved_fallback_is_max_root_claim_work():
+async def test_reserved_fallback_is_conservative_when_chain_is_unknown():
     async def _boom():
         raise RuntimeError("no payment_info")
 
     reserved = await fees._reserved_fee(object(), "5F3sa2TJAW", _boom)
-    assert reserved.rao == fees._APPROX_REDEEM_FEE_RAO * fees._MAX_ROOT_CLAIM_WORK
+    assert reserved.rao == fees._approx_declared_fee_rao(fees._MAX_ROOT_CLAIM_WORK)
 
 
-def test_spent_scales_against_256_not_network_count():
-    reserved = Balance.from_rao(fees._APPROX_REDEEM_FEE_RAO * fees._MAX_ROOT_CLAIM_WORK)
+@pytest.mark.asyncio
+async def test_reserved_fallback_uses_mainnet_sized_default_envelope():
+    async def _boom():
+        raise RuntimeError("no payment_info")
+
+    reserved = await fees._reserved_fee(FakeSubstrate(), "5F3sa2TJAW", _boom)
+    assert reserved.rao == fees._approx_declared_fee_rao(fees._DEFAULT_ROOT_CLAIM_WORK)
+
+
+def test_spent_scales_against_chain_declaration_not_network_count():
+    reserved = Balance.from_rao(fees._approx_declared_fee_rao(fees._DEFAULT_ROOT_CLAIM_WORK))
     spent = fees._spent_fee(
         reserved,
         fees.RootClaimWork(hotkeys=1, redeem_holdings=32, scan_holdings=0),
@@ -33,7 +42,7 @@ def test_spent_scales_against_256_not_network_count():
 
 def test_spent_keeps_non_weight_base_fee():
     base = 12_345
-    reserved = Balance.from_rao(base + fees._APPROX_REDEEM_FEE_RAO * fees._MAX_ROOT_CLAIM_WORK)
+    reserved = Balance.from_rao(base + fees._approx_declared_fee_rao(fees._DEFAULT_ROOT_CLAIM_WORK))
     spent = fees._spent_fee(
         reserved,
         fees.RootClaimWork(hotkeys=1, redeem_holdings=16, scan_holdings=0),
@@ -42,19 +51,18 @@ def test_spent_keeps_non_weight_base_fee():
 
 
 def test_scan_only_uses_scan_ref_time():
-    reserved = Balance.from_rao(fees._APPROX_REDEEM_FEE_RAO * fees._MAX_ROOT_CLAIM_WORK)
+    reserved = Balance.from_rao(fees._approx_declared_fee_rao(fees._DEFAULT_ROOT_CLAIM_WORK))
     spent = fees._spent_fee(
         reserved,
         fees.RootClaimWork(hotkeys=1, redeem_holdings=0, scan_holdings=32),
     )
-    denom = fees._MAX_ROOT_CLAIM_WORK * fees._REDEEM_REF_TIME
-    scan = reserved.rao * 32 * fees._SCAN_REF_TIME // denom
-    walk = reserved.rao * 1 // fees._MAX_ROOT_CLAIM_WORK
+    scan = fees._APPROX_SCAN_FEE_RAO * 32
+    walk = fees._APPROX_REDEEM_FEE_RAO
     assert spent.rao == walk + scan
 
 
 def test_coldkey_wide_empty_baskets_floor_to_hotkey_count():
-    reserved = Balance.from_rao(fees._APPROX_REDEEM_FEE_RAO * fees._MAX_ROOT_CLAIM_WORK)
+    reserved = Balance.from_rao(fees._approx_declared_fee_rao(fees._DEFAULT_ROOT_CLAIM_WORK))
     spent = fees._spent_fee(
         reserved,
         fees.RootClaimWork(hotkeys=100, redeem_holdings=0, scan_holdings=0),
@@ -353,6 +361,35 @@ async def test_admission_limit_is_inclusive_at_256(hotkey_count, holdings, netwo
 
     admission_blocks = [block for block in plan.violations if "256-unit admission limit" in block]
     assert (not admission_blocks) is expected_ok
+
+
+@pytest.mark.asyncio
+async def test_finney_testnet_admission_limit_covers_configured_subnet_limit(monkeypatch):
+    substrate = FakeSubstrate()
+    _seed_claim_quote(
+        substrate,
+        hotkeys=[ALICE_HOT],
+        payouts={ALICE_HOT: 1_000_000},
+        holdings={ALICE_HOT: 0},
+        networks=fees._MAX_ROOT_CLAIM_WORK,
+    )
+
+    async def testnet_genesis(_block=None):
+        return fees._FINNEY_TESTNET_GENESIS_HASH
+
+    monkeypatch.setattr(substrate, "block_hash", testnet_genesis)
+    plan = await Client("local", substrate=substrate).plan(ClaimRoot(), dev_wallet())
+
+    assert not any("admission limit" in block for block in plan.violations)
+
+    substrate.seed_map(
+        "SubtensorModule",
+        "NetworksAdded",
+        [(netuid, True) for netuid in range(fees._MAX_ROOT_CLAIM_WORK + 1)],
+    )
+    plan = await Client("local", substrate=substrate).plan(ClaimRoot(), dev_wallet())
+
+    assert any("1,025-unit admission limit" in block for block in plan.violations)
 
 
 @pytest.mark.asyncio

--- a/sdk/python/tests/unit/test_root_claim_fee.py
+++ b/sdk/python/tests/unit/test_root_claim_fee.py
@@ -1,4 +1,4 @@
-"""Reserved/spent root-claim fees follow the runtime claim envelopes."""
+"""Reserved/spent root-claim fees follow the fixed runtime claim envelope."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ from tests.harness.samples import ALICE, ALICE_HOT, BOB, BOB_HOT, dev_wallet
 
 
 @pytest.mark.asyncio
-async def test_reserved_fallback_is_conservative_when_chain_is_unknown():
+async def test_reserved_fallback_is_max_root_claim_work():
     async def _boom():
         raise RuntimeError("no payment_info")
 
@@ -23,16 +23,16 @@ async def test_reserved_fallback_is_conservative_when_chain_is_unknown():
 
 
 @pytest.mark.asyncio
-async def test_reserved_fallback_uses_mainnet_sized_default_envelope():
+async def test_reserved_fallback_uses_fixed_envelope():
     async def _boom():
         raise RuntimeError("no payment_info")
 
     reserved = await fees._reserved_fee(FakeSubstrate(), "5F3sa2TJAW", _boom)
-    assert reserved.rao == fees._approx_declared_fee_rao(fees._DEFAULT_ROOT_CLAIM_WORK)
+    assert reserved.rao == fees._approx_declared_fee_rao(fees._MAX_ROOT_CLAIM_WORK)
 
 
 def test_spent_scales_against_chain_declaration_not_network_count():
-    reserved = Balance.from_rao(fees._approx_declared_fee_rao(fees._DEFAULT_ROOT_CLAIM_WORK))
+    reserved = Balance.from_rao(fees._approx_declared_fee_rao(fees._MAX_ROOT_CLAIM_WORK))
     spent = fees._spent_fee(
         reserved,
         fees.RootClaimWork(hotkeys=1, redeem_holdings=32, scan_holdings=0),
@@ -42,7 +42,7 @@ def test_spent_scales_against_chain_declaration_not_network_count():
 
 def test_spent_keeps_non_weight_base_fee():
     base = 12_345
-    reserved = Balance.from_rao(base + fees._approx_declared_fee_rao(fees._DEFAULT_ROOT_CLAIM_WORK))
+    reserved = Balance.from_rao(base + fees._approx_declared_fee_rao(fees._MAX_ROOT_CLAIM_WORK))
     spent = fees._spent_fee(
         reserved,
         fees.RootClaimWork(hotkeys=1, redeem_holdings=16, scan_holdings=0),
@@ -51,7 +51,7 @@ def test_spent_keeps_non_weight_base_fee():
 
 
 def test_scan_only_uses_scan_ref_time():
-    reserved = Balance.from_rao(fees._approx_declared_fee_rao(fees._DEFAULT_ROOT_CLAIM_WORK))
+    reserved = Balance.from_rao(fees._approx_declared_fee_rao(fees._MAX_ROOT_CLAIM_WORK))
     spent = fees._spent_fee(
         reserved,
         fees.RootClaimWork(hotkeys=1, redeem_holdings=0, scan_holdings=32),
@@ -62,7 +62,7 @@ def test_scan_only_uses_scan_ref_time():
 
 
 def test_coldkey_wide_empty_baskets_floor_to_hotkey_count():
-    reserved = Balance.from_rao(fees._approx_declared_fee_rao(fees._DEFAULT_ROOT_CLAIM_WORK))
+    reserved = Balance.from_rao(fees._approx_declared_fee_rao(fees._MAX_ROOT_CLAIM_WORK))
     spent = fees._spent_fee(
         reserved,
         fees.RootClaimWork(hotkeys=100, redeem_holdings=0, scan_holdings=0),
@@ -95,6 +95,11 @@ def _seed_claim_quote(
         "BetaBasketRuntimeApi",
         "get_root_basket_positions",
         [(hotkey, 1, payout) for hotkey, payout in payouts.items() if payout],
+    )
+    substrate.seed_runtime(
+        "StakeInfoRuntimeApi",
+        "get_stake_info_for_coldkey",
+        [{"hotkey": hotkey, "coldkey": ALICE, "netuid": 0, "stake": 1} for hotkey in hotkeys],
     )
     substrate.seed_runtime(
         "BetaBasketRuntimeApi",
@@ -179,7 +184,12 @@ async def test_coldkey_quote_does_not_scan_validator_without_owed_shares():
     assert quote.below_threshold_hotkeys == 1
     assert quote.spent == fees._spent_fee(
         quote.reserved,
-        fees.RootClaimWork(hotkeys=2, redeem_holdings=0, scan_holdings=2),
+        fees.RootClaimWork(
+            hotkeys=2,
+            redeem_holdings=0,
+            scan_holdings=2,
+            selection_scans=2,
+        ),
     )
 
 
@@ -187,8 +197,8 @@ async def test_coldkey_quote_does_not_scan_validator_without_owed_shares():
 @pytest.mark.parametrize(
     ("hotkeys", "holdings", "networks", "reason"),
     [
-        ([f"hotkey-{i}" for i in range(17)], 0, 16, "17 hotkeys × 16 networks"),
-        ([ALICE_HOT], 257, 1, "257 basket holdings"),
+        ([f"hotkey-{i}" for i in range(257)], 0, 16, "257 root hotkeys + 0 basket holdings"),
+        ([ALICE_HOT], 256, 1, "1 root hotkey + 256 basket holdings"),
     ],
 )
 async def test_root_claim_too_heavy_is_a_hard_stop(hotkeys, holdings, networks, reason):
@@ -257,7 +267,7 @@ async def test_shielded_claim_reserves_free_tao_for_inner_and_carrier():
 @pytest.mark.parametrize("payout_failure", [None, RuntimeError("payout unavailable")])
 async def test_admission_hard_stop_survives_unavailable_payout_preview(payout_failure):
     substrate = FakeSubstrate()
-    hotkeys = [f"hotkey-{i}" for i in range(17)]
+    hotkeys = [f"hotkey-{i}" for i in range(257)]
     _seed_claim_quote(
         substrate,
         hotkeys=hotkeys,
@@ -277,7 +287,7 @@ async def test_admission_hard_stop_survives_unavailable_payout_preview(payout_fa
 
     client = Client("local", substrate=substrate)
     plan = await client.plan(ClaimRoot(), dev_wallet())
-    assert any("17 hotkeys × 16 networks" in block for block in plan.violations)
+    assert any("257 root hotkeys + 0 basket holdings" in block for block in plan.violations)
 
     with pytest.raises(PolicyError, match="256-unit admission limit"):
         await client.submit_shielded(ClaimRoot(), dev_wallet())
@@ -342,8 +352,8 @@ async def test_carrier_hard_stop_survives_unavailable_payout_preview():
     ("hotkey_count", "holdings", "networks", "expected_ok"),
     [
         (16, 0, 16, True),
-        (1, 256, 1, True),
-        (1, 257, 1, False),
+        (1, 255, 1, True),
+        (1, 256, 1, False),
     ],
 )
 async def test_admission_limit_is_inclusive_at_256(hotkey_count, holdings, networks, expected_ok):
@@ -364,36 +374,48 @@ async def test_admission_limit_is_inclusive_at_256(hotkey_count, holdings, netwo
 
 
 @pytest.mark.asyncio
-async def test_finney_testnet_admission_limit_covers_configured_subnet_limit(monkeypatch):
+async def test_coldkey_wide_admission_ignores_non_root_hotkeys():
+    substrate = FakeSubstrate()
+    _seed_claim_quote(
+        substrate,
+        hotkeys=[ALICE_HOT, BOB_HOT],
+        payouts={ALICE_HOT: 1_000_000},
+        holdings={ALICE_HOT: 1, BOB_HOT: 256},
+        networks=500,
+    )
+    substrate.seed_runtime(
+        "StakeInfoRuntimeApi",
+        "get_stake_info_for_coldkey",
+        [
+            {"hotkey": ALICE_HOT, "coldkey": ALICE, "netuid": 0, "stake": 1},
+            {"hotkey": BOB_HOT, "coldkey": ALICE, "netuid": 7, "stake": 1},
+        ],
+    )
+
+    plan = await Client("local", substrate=substrate).plan(ClaimRoot(), dev_wallet())
+
+    assert not any("admission limit" in block for block in plan.violations)
+
+
+@pytest.mark.asyncio
+async def test_coldkey_wide_admission_keeps_unstaked_basket_claimant():
     substrate = FakeSubstrate()
     _seed_claim_quote(
         substrate,
         hotkeys=[ALICE_HOT],
         payouts={ALICE_HOT: 1_000_000},
-        holdings={ALICE_HOT: 0},
-        networks=fees._MAX_ROOT_CLAIM_WORK,
+        holdings={ALICE_HOT: 1},
     )
+    substrate.seed_runtime("StakeInfoRuntimeApi", "get_stake_info_for_coldkey", [])
+    substrate.seed("SubtensorModule", "BasketClaimed", [ALICE_HOT, ALICE], -1)
 
-    async def testnet_genesis(_block=None):
-        return fees._FINNEY_TESTNET_GENESIS_HASH
+    admission = await fees.root_claim_admission(substrate, ALICE, hotkeys=None)
 
-    monkeypatch.setattr(substrate, "block_hash", testnet_genesis)
-    plan = await Client("local", substrate=substrate).plan(ClaimRoot(), dev_wallet())
-
-    assert not any("admission limit" in block for block in plan.violations)
-
-    substrate.seed_map(
-        "SubtensorModule",
-        "NetworksAdded",
-        [(netuid, True) for netuid in range(fees._MAX_ROOT_CLAIM_WORK + 1)],
-    )
-    plan = await Client("local", substrate=substrate).plan(ClaimRoot(), dev_wallet())
-
-    assert any("1,025-unit admission limit" in block for block in plan.violations)
+    assert admission.hotkeys == (ALICE_HOT,)
 
 
 @pytest.mark.asyncio
-async def test_inactive_network_rows_do_not_count_toward_admission():
+async def test_network_count_does_not_affect_admission():
     substrate = FakeSubstrate()
     hotkeys = [f"hotkey-{i}" for i in range(17)]
     _seed_claim_quote(
@@ -425,6 +447,11 @@ async def test_proxy_claim_reads_dispatch_state_checks_delegate_and_prices_wrapp
     substrate.seed_runtime("BetaBasketRuntimeApi", "get_root_basket_owed", 1_000_000)
     substrate.seed_runtime(
         "BetaBasketRuntimeApi", "get_root_basket_positions", [(BOB_HOT, 1, 1_000_000)]
+    )
+    substrate.seed_runtime(
+        "StakeInfoRuntimeApi",
+        "get_stake_info_for_coldkey",
+        [{"hotkey": BOB_HOT, "coldkey": BOB, "netuid": 0, "stake": 1}],
     )
     substrate.seed_runtime(
         "BetaBasketRuntimeApi",


### PR DESCRIPTION
## Summary

Fixes root claims that could be blocked by unrelated subnet stakes, stale `StakingHotkeys` relationships, subnet count, or zero-rounded basket holdings.

The runtime spec version is bumped to **454**.

## Behavior changes

| Scenario | Before | After |
|---|---|---|
| Coldkey stakes to several root validators | Claim could exceed the topology-based budget | All root-relevant validators are claimed within the fixed work envelope |
| Coldkey also stakes on ordinary subnets | Every `StakingHotkeys` entry increased claim work | Non-root-only hotkeys are excluded |
| Network has many subnets | Work was estimated as `hotkeys × networks` | Subnet count does not affect admission |
| Unstaked claimant has outstanding basket entitlement | Could be filtered out | Retained when `BasketClaimed < 0` |
| Valuable basket holding rounds to a zero take | Claim could succeed, charge a fee, and pay nothing | Claim remains unsettled without changing its watermark |
| Full unstake leaves shares worth less than 1 RAO | Residual shares could later regain value | Positive residual shares worth 0 RAO are cleared with the corresponding denominator adjustment |

Admission now uses:

```text
root-relevant hotkeys + actual Alpha/AlphaV2 basket rows <= 256
```

The raw `StakingHotkeys` classification scan is independently capped at 256 and charged through actual post-dispatch weight.

## Mainnet and testnet

| Network | Declared work envelope | Effect of subnet count |
|---|---:|---|
| Mainnet | 256 | None |
| Testnet | 256 | None |

The previous genesis-hash-specific testnet envelope has been removed. Both networks now use the same fixed budget and refund unused work through post-dispatch weight.

## Stale relationship cleanup

The bounded storage cleanup and `StakingHotkeys` cleanup are rerun under fresh migration names:

- `migrate_storage_bloat_v3`
- `migrate_cleanup_staking_hotkeys_v2`

The storage cleanup now also removes exact-zero `AlphaV2` rows. Once zero share rows are gone, the relationship cleanup removes entries that have neither share rows nor a nonzero basket watermark.

Existing positive sub-RAO shares are retained because deleting only their index would leave live shares undiscoverable if their value later increased. They no longer block root claims when they are not root-relevant, and the share-pool change prevents new zero-valued residue from being created during full withdrawals.

## Validation

- `cargo fmt --check --all`
- Ruff lint and formatting checks
- `git diff --check`
- Added coverage for root-hotkey filtering, negative watermarks, fixed admission accounting, zero `AlphaV2` cleanup, migration reruns, and share-residue canonicalization

The generated documentation check detected broad unrelated pre-existing drift, so generated reference files were not rewritten.
