### PR TITLE
CI: accept RUSTSEC-2026-0269 and patch fast-uri in the docs-preview lock

### DIFF
--- a/.github/docs-preview-vercel/package-lock.json
+++ b/.github/docs-preview-vercel/package-lock.json
@@ -2587,9 +2587,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/.github/docs-preview-vercel/package.json
+++ b/.github/docs-preview-vercel/package.json
@@ -22,6 +22,7 @@
     },
     "ajv": "8.18.0",
     "brace-expansion": "5.0.9",
+    "fast-uri": "3.1.7",
     "js-yaml": "4.3.1",
     "minimatch": "10.2.5",
     "path-to-regexp": "8.4.2",

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -72,6 +72,9 @@ jobs:
           # RUSTSEC-2026-0258: h2 unbounded empty DATA frames. Fix is
           #   >=0.4.16; we still carry 0.3.27 (no 0.3 patch) via hyper in the
           #   fork tree — revisit when that stack moves off h2 0.3.
+          # RUSTSEC-2026-0269: wasmtime 8.0.1 filesystem sandbox escape via
+          #   trailing slashes in WASI paths. We never expose a filesystem to
+          #   the runtime WASM; same pin as the wasmtime entries above.
           cargo audit --ignore RUSTSEC-2023-0091 \
                       --ignore RUSTSEC-2024-0438 \
                       --ignore RUSTSEC-2025-0009 \
@@ -103,4 +106,5 @@ jobs:
                       --ignore RUSTSEC-2025-0020 \
                       --ignore RUSTSEC-2026-0177 \
                       --ignore RUSTSEC-2026-0235 \
-                      --ignore RUSTSEC-2026-0258
+                      --ignore RUSTSEC-2026-0258 \
+                      --ignore RUSTSEC-2026-0269


### PR DESCRIPTION
Both checks fail on \`main\` today; nothing in the code changes.

## cargo audit
\`wasmtime 8.0.1\` (pinned by the polkadot-sdk fork's \`sc-executor\`, the same pin behind the existing wasmtime ignores) picked up [RUSTSEC-2026-0269](https://rustsec.org/advisories/RUSTSEC-2026-0269): a WASI filesystem sandbox escape via trailing slashes in paths. The runtime WASM is never given a filesystem, so the advisory is accepted next to the other wasmtime entries, with a comment. Fix upstream requires wasmtime >= 24, which comes only with a major SDK bump.

## Build PR docs preview
\`npm audit --audit-level=high\` flags \`fast-uri 3.1.5\` under the Vercel CLI tree (GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf, GHSA-jqff-g426-hqxp). Pinned \`fast-uri\` 3.1.7 through the existing \`overrides\` block, same pattern as the other entries there. Lockfile change is the one \`fast-uri\` entry.

Verified locally: \`actionlint\` on the workflow; \`cargo audit\` with the workflow's ignore list exits 0; \`npm ci --ignore-scripts\` then \`npm audit --audit-level=high --omit=dev\` report 0 vulnerabilities.

Made with [Cursor](https://cursor.com)