### PR TITLE
fix(cli): handle missing Exit and Abort on vendored typer._click.exceptions

### DIFF
--- a/sdk/python/bittensor/cli/prompt.py
+++ b/sdk/python/bittensor/cli/prompt.py
@@ -40,6 +40,11 @@ except ImportError:  # older typer uses the external click package
         exceptions as click_exceptions,
     )
 
+if not hasattr(click_exceptions, "Exit"):
+    click_exceptions.Exit = typer.Exit  # type: ignore[attr-defined]
+if not hasattr(click_exceptions, "Abort"):
+    click_exceptions.Abort = typer.Abort  # type: ignore[attr-defined]
+
 from .. import config as cfg
 from .. import wallets
 from .context import AppContext


### PR DESCRIPTION
### Summary
In modern versions of `typer` (>= 0.15.0/0.17+), `click` is vendored under `typer._click`. However, `Exit` and `Abort` exceptions are not exposed directly inside `typer._click.exceptions` (they exist under `typer.Exit` and `typer.Abort`).

When running interactive CLI flows (such as `btcli wallet create`), catching `click_exceptions.Exit` in `run_app()` raises:
```text
AttributeError: module 'typer._click.exceptions' has no attribute 'Exit'
```

### Changes
- Added attribute fallbacks on `click_exceptions` for `Exit` and `Abort` to point to `typer.Exit` and `typer.Abort` when not found on the vendored module.

### Testing
- Tested interactive CLI prompt flow on Python 3.12/3.14 with typer >= 0.17.
- Verified `btcli wallet create` finishes cleanly without raising `AttributeError`.