### PR TITLE
Decouple GitHub release publication from deployment approvals

### DIFF
--- a/.github/scripts/mainnet-release-state.py
+++ b/.github/scripts/mainnet-release-state.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Resolve the immutable finalized-mainnet release identity.
+
+This control-plane script deliberately contains no package or deployment logic.
+It is run from a trusted workflow checkout and fails closed on every ambiguous
+chain or GitHub response.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+import zipfile
+from pathlib import Path
+from typing import Any
+
+API = "https://api.github.com"
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+HASH_RE = re.compile(r"^0x[0-9a-f]{64}$")
+HEAD_RE = re.compile(r"^0x[0-9a-f]{64}$")
+ASSET_NAMES = (
+    "subtensor.wasm",
+    "subtensor-digest.json",
+    "proxy_proxy_blob.hex",
+    "pending-release.json",
+    "upgrade-manifest.json",
+)
+
+
+class StateError(RuntimeError):
+    pass
+
+
+class NotFound(StateError):
+    pass
+
+
+def env_required(name: str) -> str:
+    value = os.environ.get(name, "")
+    if not value:
+        raise StateError(f"{name} is required")
+    return value
+
+
+def json_object(raw: bytes, context: str) -> dict[str, Any]:
+    try:
+        value = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise StateError(f"{context} returned malformed JSON") from exc
+    if not isinstance(value, dict):
+        raise StateError(f"{context} returned a non-object")
+    return value
+
+
+def request_json(path: str, token: str) -> dict[str, Any]:
+    request = urllib.request.Request(
+        API + "/" + path.lstrip("/"),
+        headers={"Accept": "application/vnd.github+json", "Authorization": f"Bearer {token}", "User-Agent": "subtensor-release-state/1"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            if response.status != 200:
+                raise StateError(f"GitHub {path} returned HTTP {response.status}")
+            return json_object(response.read(), path)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            raise NotFound(path) from exc
+        raise StateError(f"GitHub {path} returned HTTP {exc.code}") from exc
+    except (urllib.error.URLError, TimeoutError) as exc:
+        raise StateError(f"GitHub {path} request failed") from exc
+
+
+def rpc(method: str, params: list[Any], endpoint: str) -> Any:
+    payload = json.dumps({"id": 1, "jsonrpc": "2.0", "method": method, "params": params}).encode()
+    request = urllib.request.Request(endpoint, data=payload, headers={"Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            if response.status != 200:
+                raise StateError(f"RPC {method} returned HTTP {response.status}")
+            value = json.loads(response.read())
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        raise StateError(f"RPC {method} failed") from exc
+    if not isinstance(value, dict) or value.get("error") is not None or "result" not in value:
+        raise StateError(f"RPC {method} returned an invalid result")
+    return value["result"]
+
+
+def finalized_identity(endpoint: str) -> tuple[int, str, str]:
+    head = rpc("chain_getFinalizedHead", [], endpoint)
+    if not isinstance(head, str) or HEAD_RE.fullmatch(head) is None:
+        raise StateError("finalized head is not a 32-byte block hash")
+    version = rpc("state_getRuntimeVersion", [head], endpoint)
+    if not isinstance(version, dict) or isinstance(version.get("specVersion"), bool) or not isinstance(version.get("specVersion"), int) or version["specVersion"] < 0:
+        raise StateError("runtime specVersion is not a non-negative integer")
+    code_hash = rpc("state_getStorageHash", ["0x3a636f6465", head], endpoint)
+    if not isinstance(code_hash, str) or HASH_RE.fullmatch(code_hash) is None:
+        raise StateError("runtime code hash is not a 32-byte hash")
+    return version["specVersion"], head, code_hash
+
+
+def local_spec() -> int:
+    text = Path("runtime/src/lib.rs").read_text(encoding="utf-8")
+    match = re.search(r"spec_version:\s*(\d+)", text)
+    if match is None:
+        raise StateError("could not parse local spec_version")
+    return int(match.group(1))
+
+
+def release_for_tag(repo: str, token: str, tag: str) -> dict[str, Any] | None:
+    try:
+        return request_json(f"repos/{repo}/releases/tags/{tag}", token)
+    except NotFound:
+        return None
+
+
+def require_tag(repo: str, token: str, tag: str) -> str:
+    ref = request_json(f"repos/{repo}/git/ref/tags/{tag}", token)
+    obj = ref.get("object")
+    if not isinstance(obj, dict) or obj.get("type") != "commit" or not isinstance(obj.get("sha"), str) or SHA_RE.fullmatch(obj["sha"]) is None:
+        raise StateError("release tag must be a lightweight Git tag resolving to a commit")
+    sha = obj["sha"]
+    compare = request_json(f"repos/{repo}/compare/{sha}...main", token)
+    if compare.get("status") not in ("ahead", "identical"):
+        raise StateError("release tag commit is not an ancestor of main")
+    return sha
+
+
+def mirror_matches(repo: str, token: str, sha: str) -> None:
+    ref = request_json(f"repos/{repo}/git/ref/heads/mainnet", token)
+    obj = ref.get("object")
+    if not isinstance(obj, dict) or obj.get("type") != "commit" or obj.get("sha") != sha:
+        raise StateError("protected mainnet mirror does not match release commit")
+
+
+def verify_final_assets(repo: str, token: str, release: dict[str, Any], spec: int, sha: str, code_hash: str) -> None:
+    assets = release.get("assets")
+    if not isinstance(assets, list):
+        raise StateError("final release assets are malformed")
+    by_name = {a.get("name"): a for a in assets if isinstance(a, dict)}
+    if any(name not in by_name for name in ASSET_NAMES):
+        raise StateError("final release is missing a verifier-required runtime asset")
+    with tempfile.TemporaryDirectory() as directory:
+        archive = Path(directory) / "runtime-assets.zip"
+        with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_STORED) as output:
+            for name in ASSET_NAMES:
+                asset_id = by_name[name].get("id")
+                if not isinstance(asset_id, int):
+                    raise StateError(f"asset {name} has no numeric id")
+                raw = download_asset(repo, token, asset_id)
+                output.writestr(name, raw)
+        command = [sys.executable, str(Path(__file__).with_name("verify-release-artifact.py")), str(archive), "--spec", str(spec), "--commit", sha, "--code-hash", code_hash]
+        result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False)
+        if result.returncode != 0:
+            raise StateError("final release runtime assets failed verification")
+
+
+def download_asset(repo: str, token: str, asset_id: int) -> bytes:
+    request = urllib.request.Request(
+        f"{API}/repos/{repo}/releases/assets/{asset_id}",
+        headers={"Accept": "application/octet-stream", "Authorization": f"Bearer {token}", "User-Agent": "subtensor-release-state/1"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            if response.status != 200:
+                raise StateError(f"release asset {asset_id} returned HTTP {response.status}")
+            return response.read()
+    except urllib.error.HTTPError as exc:
+        raise StateError(f"release asset {asset_id} returned HTTP {exc.code}") from exc
+    except (urllib.error.URLError, TimeoutError) as exc:
+        raise StateError(f"release asset {asset_id} download failed") from exc
+
+
+def resolve_artifact(spec: int, sha: str, code_hash: str, repo: str, token: str) -> int:
+    environment = os.environ | {"GITHUB_REPOSITORY": repo, "GH_TOKEN": token}
+    command = [str(Path(__file__).with_name("resolve-release-artifact.sh")), str(spec), sha, code_hash]
+    result = subprocess.run(command, env=environment, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False)
+    if result.returncode != 0 or not re.fullmatch(r"[0-9]+", result.stdout.strip()):
+        raise StateError("no trusted release-train artifact matches finalized identity")
+    return int(result.stdout.strip())
+
+
+def compute(mode: str) -> dict[str, Any]:
+    repo = env_required("GITHUB_REPOSITORY")
+    token = env_required("GH_TOKEN")
+    endpoint = env_required("MAINNET_HTTP")
+    spec, finalized_head, code_hash = finalized_identity(endpoint)
+    if spec > local_spec():
+        return {"eligible": False}
+    if spec <= 432:
+        command = ["gh", "release", "list", "--repo", repo, "--limit", "300", "--json", "tagName,isDraft,isPrerelease"]
+        result = subprocess.run(command, env=os.environ | {"GH_TOKEN": token}, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False)
+        if result.returncode != 0:
+            raise StateError("historical release lookup failed")
+        try:
+            releases = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise StateError("historical release lookup returned malformed JSON") from exc
+        if not isinstance(releases, list) or not any(
+            isinstance(release, dict)
+            and release.get("isDraft") is False
+            and release.get("isPrerelease") is False
+            and isinstance(release.get("tagName"), str)
+            and (release["tagName"] == f"v{spec}" or release["tagName"].endswith(f"-{spec}"))
+            for release in releases
+        ):
+            raise StateError(f"historical runtime v{spec} has no final GitHub release")
+        return {"eligible": False}
+    tag = f"v{spec}"
+    sha = require_tag(repo, token, tag)
+    release = release_for_tag(repo, token, tag)
+    release_needed = True
+    if release is not None:
+        draft = release.get("draft")
+        prerelease = release.get("prerelease")
+        if not isinstance(draft, bool) or not isinstance(prerelease, bool):
+            raise StateError("release draft/prerelease fields are malformed")
+        if release.get("target_commitish") != sha:
+            raise StateError("release target does not match immutable tag")
+        if not draft and not prerelease:
+            mirror_matches(repo, token, sha)
+            verify_final_assets(repo, token, release, spec, sha, code_hash)
+            release_needed = False
+    if mode == "published" and release_needed:
+        # Downstream publishers may run only after the independent metadata
+        # reconciler has finalized the exact GitHub release.
+        return {"eligible": False}
+    artifact_id = None
+    if release_needed:
+        artifact_id = resolve_artifact(spec, sha, code_hash, repo, token)
+    return {"eligible": True, "spec_version": spec, "release_tag": tag, "sha": sha, "code_hash": code_hash, "finalized_head": finalized_head, "release_needed": release_needed, "artifact_id": artifact_id}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=("metadata", "published"), required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args(argv)
+    target = Path(args.output)
+    try:
+        # Never let a failed invocation leave a stale successful selection.
+        target.unlink(missing_ok=True)
+        value = compute(args.mode)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        temporary = target.with_name(target.name + ".tmp")
+        temporary.write_text(json.dumps(value, separators=(",", ":")) + "\n", encoding="utf-8")
+        os.replace(temporary, target)
+        return 0
+    except (OSError, StateError) as exc:
+        print(f"mainnet release state unavailable: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/release-publication-state.py
+++ b/.github/scripts/release-publication-state.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""Check or record per-channel publication receipts for a finalized release.
+
+Each gated publication channel (Docker, Docker localnet, crates.io, website)
+leaves one independently named release asset, ``publication-<channel>.json``,
+on the exact final release after that channel's publication has been observed
+to succeed. The receipt is a completion record, never a release authorization:
+callers must already have validated runtime identity, tag, and mirror state.
+
+Usage:
+    release-publication-state.py check  --tag TAG --sha SHA --code-hash HASH --channel CHANNEL
+    release-publication-state.py record --tag TAG --sha SHA --code-hash HASH --channel CHANNEL
+
+Exit codes:
+    0  a valid receipt matching the requested identity exists (check), or the
+       receipt now exists and was verified by read-back (record)
+    1  the receipt is absent (explicit GitHub 404): safe to publish or retry
+    2  malformed or conflicting receipt, invalid arguments, or any API failure:
+       fail closed, never treat as absent
+
+Uses only the Python standard library and GitHub's REST API with
+``GITHUB_REPOSITORY`` and ``GH_TOKEN``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections.abc import Callable
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlencode
+from urllib.request import Request, urlopen
+
+API_BASE = "https://api.github.com"
+UPLOADS_BASE = "https://uploads.github.com"
+USER_AGENT = "subtensor-release-publication/1"
+SCHEMA_VERSION = 1
+RECEIPT_NAME_TEMPLATE = "publication-{channel}.json"
+CHANNELS = ("docker", "docker-localnet", "crates", "website")
+RECEIPT_KEYS = (
+    "schema",
+    "tag",
+    "sha",
+    "code_hash",
+    "channel",
+    "run_id",
+    "run_attempt",
+)
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+CODE_HASH_RE = re.compile(r"^0x[0-9a-f]{64}$")
+TAG_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._\-]{0,127}$")
+REPOSITORY_RE = re.compile(r"^[^/\s]+/[^/\s]+$")
+RUN_ID_RE = re.compile(r"^[0-9]{1,18}$")
+MAX_ASSET_SIZE = 1024 * 1024
+REQUEST_TIMEOUT = 30
+
+
+class ApiError(RuntimeError):
+    """GitHub could not provide authoritative state."""
+
+
+class AbsentReceipt(Exception):
+    """An explicit GitHub 404: the release or the receipt asset does not exist."""
+
+
+class ReceiptError(RuntimeError):
+    """A receipt asset exists but is malformed or conflicts with the request."""
+
+
+class GitHubClient:
+    """Minimal GitHub REST client; ``transport`` is injectable for tests."""
+
+    def __init__(
+        self,
+        token: str,
+        repository: str,
+        transport: Callable[[str, str, dict[str, str], bytes | None], tuple[int, bytes]] | None = None,
+    ) -> None:
+        self.token = token
+        self.repository = repository
+        self._transport = transport if transport is not None else self._http_transport
+
+    def _http_transport(
+        self, method: str, url: str, headers: dict[str, str], body: bytes | None
+    ) -> tuple[int, bytes]:
+        request = Request(url, data=body, headers=headers, method=method)
+        try:
+            with urlopen(request, timeout=REQUEST_TIMEOUT) as response:
+                return response.status, response.read(MAX_ASSET_SIZE + 1)
+        except HTTPError as error:
+            return error.code, error.read(MAX_ASSET_SIZE + 1)
+        except (OSError, URLError) as error:
+            raise ApiError(f"{method} {url} failed: {error}") from error
+
+    def request(
+        self,
+        method: str,
+        base: str,
+        path: str,
+        *,
+        query: dict[str, str] | None = None,
+        accept: str = "application/vnd.github+json",
+        content_type: str | None = None,
+        body: bytes | None = None,
+    ) -> tuple[int, bytes]:
+        owner, _, name = self.repository.partition("/")
+        url = f"{base}/repos/{quote(owner, safe='')}/{quote(name, safe='')}" + path
+        if query:
+            url += "?" + urlencode(query)
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+            "Accept": accept,
+            "User-Agent": USER_AGENT,
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if content_type is not None:
+            headers["Content-Type"] = content_type
+        status, data = self._transport(method, url, headers, body)
+        if len(data) > MAX_ASSET_SIZE:
+            raise ApiError(f"{method} {url} exceeded the response size limit")
+        return status, data
+
+    def get_release(self, tag: str) -> dict | None:
+        """Return the release for ``tag`` or None on an explicit 404."""
+        status, data = self.request(
+            "GET", API_BASE, f"/releases/tags/{quote(tag, safe='')}"
+        )
+        if status == 404:
+            return None
+        if status != 200:
+            raise ApiError(f"release lookup for tag {tag} returned HTTP {status}")
+        release = _parse_json_object(data, f"release lookup for tag {tag}")
+        if not isinstance(release.get("id"), int) or isinstance(release.get("id"), bool):
+            raise ApiError(f"release lookup for tag {tag} has no numeric id")
+        if not isinstance(release.get("assets"), list):
+            raise ApiError(f"release lookup for tag {tag} has no asset list")
+        return release
+
+    def download_asset(self, asset_id: int, name: str) -> bytes:
+        status, data = self.request(
+            "GET",
+            API_BASE,
+            f"/releases/assets/{asset_id}",
+            accept="application/octet-stream",
+        )
+        if status == 404:
+            raise AbsentReceipt(f"receipt asset {name} no longer exists")
+        if status != 200:
+            raise ApiError(f"download of asset {name} returned HTTP {status}")
+        return data
+
+    def upload_asset(self, release_id: int, name: str, content: bytes) -> None:
+        status, data = self.request(
+            "POST",
+            UPLOADS_BASE,
+            f"/releases/{release_id}/assets",
+            query={"name": name},
+            accept="application/vnd.github+json",
+            content_type="application/octet-stream",
+            body=content,
+        )
+        if status != 201:
+            raise ApiError(f"upload of asset {name} returned HTTP {status}")
+        uploaded = _parse_json_object(data, f"upload of asset {name}")
+        if uploaded.get("name") != name:
+            raise ApiError(f"upload of asset {name} recorded a different asset name")
+
+
+def _parse_json_object(data: bytes, context: str) -> dict:
+    try:
+        value = json.loads(data)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ApiError(f"{context} did not return valid JSON") from error
+    if not isinstance(value, dict):
+        raise ApiError(f"{context} did not return a JSON object")
+    return value
+
+
+def validate_identity(tag: str, sha: str, code_hash: str, channel: str) -> None:
+    if TAG_RE.fullmatch(tag) is None:
+        raise ValueError(f"invalid tag: {tag!r}")
+    if SHA_RE.fullmatch(sha) is None:
+        raise ValueError("sha must be a full lowercase 40-hex commit SHA")
+    if CODE_HASH_RE.fullmatch(code_hash) is None:
+        raise ValueError("code-hash must be a lowercase 0x-prefixed 64-hex runtime hash")
+    if channel not in CHANNELS:
+        raise ValueError(f"channel must be one of: {', '.join(CHANNELS)}")
+
+
+def receipt_name(channel: str) -> str:
+    return RECEIPT_NAME_TEMPLATE.format(channel=channel)
+
+
+def receipt_document(
+    tag: str, sha: str, code_hash: str, channel: str, run_id: int, run_attempt: int
+) -> bytes:
+    receipt = {
+        "schema": SCHEMA_VERSION,
+        "tag": tag,
+        "sha": sha,
+        "code_hash": code_hash,
+        "channel": channel,
+        "run_id": run_id,
+        "run_attempt": run_attempt,
+    }
+    return (json.dumps(receipt, separators=(",", ":")) + "\n").encode()
+
+
+def parse_receipt(
+    raw: bytes, tag: str, sha: str, code_hash: str, channel: str
+) -> dict:
+    """Parse one receipt asset; raise ReceiptError unless it matches exactly."""
+    try:
+        value = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ReceiptError(f"receipt for {channel} is not valid JSON") from error
+    if not isinstance(value, dict):
+        raise ReceiptError(f"receipt for {channel} is not a JSON object")
+    if sorted(value) != sorted(RECEIPT_KEYS):
+        raise ReceiptError(
+            f"receipt for {channel} has keys {sorted(value)}; expected exactly {sorted(RECEIPT_KEYS)}"
+        )
+    if value["schema"] is not SCHEMA_VERSION:
+        raise ReceiptError(f"receipt for {channel} has unsupported schema {value['schema']!r}")
+    for key in ("tag", "sha", "code_hash", "channel"):
+        if not isinstance(value[key], str):
+            raise ReceiptError(f"receipt for {channel} field {key!r} is not a string")
+    for key in ("run_id", "run_attempt"):
+        if not isinstance(value[key], int) or isinstance(value[key], bool) or value[key] <= 0:
+            raise ReceiptError(f"receipt for {channel} field {key!r} is not a positive integer")
+    if value["tag"] != tag or value["sha"] != sha or value["code_hash"] != code_hash:
+        raise ReceiptError(
+            f"receipt for {channel} records tag {value['tag']!r} sha {value['sha']!r} "
+            f"code_hash {value['code_hash']!r}; expected tag {tag!r} sha {sha!r} code_hash {code_hash!r}"
+        )
+    if value["channel"] != channel:
+        raise ReceiptError(f"receipt asset {receipt_name(channel)} records channel {value['channel']!r}")
+    return value
+
+
+def find_receipt_assets(release: dict, name: str) -> list[dict]:
+    assets = []
+    for asset in release["assets"]:
+        if not isinstance(asset, dict):
+            raise ApiError("release returned a malformed asset entry")
+        if asset.get("name") == name:
+            if not isinstance(asset.get("id"), int) or isinstance(asset.get("id"), bool):
+                raise ApiError(f"release asset {name} has no numeric id")
+            assets.append(asset)
+    return assets
+
+
+def require_environment(name: str) -> str:
+    value = os.environ.get(name, "")
+    if not value:
+        raise ApiError(f"{name} is not set")
+    return value
+
+
+def read_receipt(client: GitHubClient, tag: str, sha: str, code_hash: str, channel: str) -> dict | None:
+    """Return the matching receipt, None when explicitly absent, raise on conflict."""
+    release = client.get_release(tag)
+    if release is None:
+        raise AbsentReceipt(f"release {tag} does not exist")
+    name = receipt_name(channel)
+    assets = find_receipt_assets(release, name)
+    if not assets:
+        raise AbsentReceipt(f"release {tag} has no {name} asset")
+    receipts = [
+        parse_receipt(client.download_asset(asset["id"], name), tag, sha, code_hash, channel)
+        for asset in assets
+    ]
+    first = receipts[0]
+    for other in receipts[1:]:
+        if other != first:
+            raise ReceiptError(f"release {tag} has conflicting {name} assets")
+    return first
+
+
+def run_check(client: GitHubClient, tag: str, sha: str, code_hash: str, channel: str) -> int:
+    try:
+        receipt = read_receipt(client, tag, sha, code_hash, channel)
+    except AbsentReceipt as error:
+        print(f"receipt absent: {error}", file=sys.stderr)
+        return 1
+    except (ReceiptError, ApiError) as error:
+        print(f"could not verify publication receipt: {error}", file=sys.stderr)
+        return 2
+    print(
+        f"{receipt_name(channel)} already recorded on release {tag} "
+        f"(run {receipt['run_id']}.{receipt['run_attempt']})"
+    )
+    return 0
+
+
+def run_identities() -> tuple[int, int]:
+    run_id = os.environ.get("GITHUB_RUN_ID", "")
+    run_attempt = os.environ.get("GITHUB_RUN_ATTEMPT", "")
+    if RUN_ID_RE.fullmatch(run_id) is None or RUN_ID_RE.fullmatch(run_attempt) is None:
+        raise ApiError("GITHUB_RUN_ID and GITHUB_RUN_ATTEMPT must be positive integers")
+    return int(run_id), int(run_attempt)
+
+
+def run_record(client: GitHubClient, tag: str, sha: str, code_hash: str, channel: str) -> int:
+    name = receipt_name(channel)
+    try:
+        receipt = read_receipt(client, tag, sha, code_hash, channel)
+    except AbsentReceipt as error:
+        print(f"recording receipt: {error}")
+        try:
+            release = client.get_release(tag)
+            if release is None:
+                print(
+                    f"could not record publication receipt: release {tag} does not exist",
+                    file=sys.stderr,
+                )
+                return 2
+            run_id, run_attempt = run_identities()
+            content = receipt_document(tag, sha, code_hash, channel, run_id, run_attempt)
+            client.upload_asset(release["id"], name, content)
+            recorded = read_receipt(client, tag, sha, code_hash, channel)
+            if recorded is None:
+                print(f"could not record publication receipt: {name} missing after upload", file=sys.stderr)
+                return 2
+        except (AbsentReceipt, ReceiptError, ApiError) as error:
+            print(f"could not record publication receipt: {error}", file=sys.stderr)
+            return 2
+        print(f"recorded {name} on release {tag} (run {run_id}.{run_attempt})")
+        return 0
+    except (ReceiptError, ApiError) as error:
+        print(f"could not record publication receipt: {error}", file=sys.stderr)
+        return 2
+    print(
+        f"{name} already recorded on release {tag} "
+        f"(run {receipt['run_id']}.{receipt['run_attempt']}); nothing to do"
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None, *, transport=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    commands = parser.add_subparsers(dest="command", required=True)
+    for command in ("check", "record"):
+        subparser = commands.add_parser(command)
+        subparser.add_argument("--tag", required=True)
+        subparser.add_argument("--sha", required=True)
+        subparser.add_argument("--code-hash", required=True, dest="code_hash")
+        subparser.add_argument("--channel", required=True, choices=CHANNELS)
+    arguments = parser.parse_args(argv)
+    try:
+        validate_identity(arguments.tag, arguments.sha, arguments.code_hash, arguments.channel)
+    except ValueError as error:
+        print(f"invalid arguments: {error}", file=sys.stderr)
+        return 2
+    try:
+        repository = require_environment("GITHUB_REPOSITORY")
+        if REPOSITORY_RE.fullmatch(repository) is None:
+            raise ApiError(f"GITHUB_REPOSITORY is malformed: {repository!r}")
+        token = require_environment("GH_TOKEN")
+    except ApiError as error:
+        print(f"could not record or check publication receipt: {error}", file=sys.stderr)
+        return 2
+    client = GitHubClient(token, repository, transport=transport)
+    if arguments.command == "check":
+        return run_check(client, arguments.tag, arguments.sha, arguments.code_hash, arguments.channel)
+    return run_record(client, arguments.tag, arguments.sha, arguments.code_hash, arguments.channel)
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_mainnet_release_state.py
+++ b/.github/scripts/test_mainnet_release_state.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPT = Path(__file__).with_name("mainnet-release-state.py")
+spec = importlib.util.spec_from_file_location("mainnet_release_state", SCRIPT)
+assert spec and spec.loader
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+class DetectorTests(unittest.TestCase):
+    def run_cli(self, value, *, error=None):
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "state.json"
+            with patch.object(module, "compute", side_effect=error or (lambda mode: value)):
+                code = module.main(["--mode", "metadata", "--output", str(output)])
+            return code, output.read_text() if output.exists() else None
+
+    def test_historical_state_contains_only_eligible(self):
+        code, raw = self.run_cli({"eligible": False})
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(raw), {"eligible": False})
+
+    def test_success_writes_complete_identity(self):
+        value = {
+            "eligible": True,
+            "spec_version": 433,
+            "release_tag": "v433",
+            "sha": "a" * 40,
+            "code_hash": "0x" + "b" * 64,
+            "finalized_head": "0x" + "c" * 64,
+            "release_needed": True,
+            "artifact_id": 42,
+        }
+        code, raw = self.run_cli(value)
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(raw), value)
+
+    def test_failure_does_not_leave_usable_output(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "state.json"
+            output.write_text("old\n")
+            with patch.object(module, "compute", side_effect=module.StateError("bad RPC")):
+                code = module.main(["--mode", "published", "--output", str(output)])
+            self.assertEqual(code, 1)
+            self.assertFalse(output.exists())
+
+    def test_rpc_rejects_malformed_identity(self):
+        responses = iter([
+            "0x" + "a" * 64,
+            {"specVersion": "433"},
+        ])
+        with patch.object(module, "rpc", side_effect=lambda *args: next(responses)):
+            with self.assertRaises(module.StateError):
+                module.finalized_identity("https://fake")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_release_publication_state.py
+++ b/.github/scripts/test_release_publication_state.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Offline tests for release-publication-state.py using a fake HTTP transport.
+
+These tests never touch the network and never read real credentials: the
+GitHub client is constructed against a routing fake transport and the
+environment is patched for the duration of each test.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import unittest
+import urllib.parse
+from pathlib import Path
+from unittest.mock import patch
+
+_SCRIPT_PATH = Path(__file__).resolve().parent / "release-publication-state.py"
+_script_spec = importlib.util.spec_from_file_location("release_publication_state", _SCRIPT_PATH)
+assert _script_spec is not None and _script_spec.loader is not None
+rps = importlib.util.module_from_spec(_script_spec)
+sys.modules["release_publication_state"] = rps
+_script_spec.loader.exec_module(rps)
+
+
+REPOSITORY = "RaoFoundation/subtensor"
+TAG = "v433"
+SHA = "b" * 40
+CODE_HASH = "0x" + "c" * 64
+RUN_ID = 12345
+RUN_ATTEMPT = 2
+RECEIPT_NAME = "publication-docker.json"
+
+BASE_ENV = {
+    "GITHUB_REPOSITORY": REPOSITORY,
+    "GH_TOKEN": "fake-token",
+    "GITHUB_RUN_ID": str(RUN_ID),
+    "GITHUB_RUN_ATTEMPT": str(RUN_ATTEMPT),
+}
+
+
+def receipt_bytes(
+    *,
+    tag: str = TAG,
+    sha: str = SHA,
+    code_hash: str = CODE_HASH,
+    channel: str = "docker",
+    run_id: int = RUN_ID,
+    run_attempt: int = RUN_ATTEMPT,
+    extra: dict | None = None,
+    drop: str | None = None,
+    schema: int = 1,
+) -> bytes:
+    value = {
+        "schema": schema,
+        "tag": tag,
+        "sha": sha,
+        "code_hash": code_hash,
+        "channel": channel,
+        "run_id": run_id,
+        "run_attempt": run_attempt,
+    }
+    if drop is not None:
+        del value[drop]
+    if extra:
+        value.update(extra)
+    return (json.dumps(value) + "\n").encode()
+
+
+def release_payload(assets: list[dict], release_id: int = 900) -> bytes:
+    return json.dumps({"id": release_id, "tag_name": TAG, "assets": assets}).encode()
+
+
+def asset_payload(asset_id: int, name: str) -> dict:
+    return {"id": asset_id, "name": name}
+
+
+class FakeTransport:
+    """Routes expected GitHub API calls; rejects anything unexpected."""
+
+    def __init__(self) -> None:
+        self.routes: dict[tuple[str, str], tuple[int, bytes]] = {}
+        self.calls: list[tuple[str, str, bytes | None]] = []
+
+    def route(self, method: str, url: str, status: int, body: bytes) -> None:
+        self.routes[(method, url)] = (status, body)
+
+    def __call__(self, method: str, url: str, headers: dict, body: bytes | None) -> tuple[int, bytes]:
+        self.calls.append((method, url, body))
+        key = (method, url)
+        if key not in self.routes:
+            raise AssertionError(f"unexpected external call: {method} {url}")
+        return self.routes[key]
+
+    def upload_calls(self) -> list[tuple[str, bytes | None]]:
+        return [(url, body) for method, url, body in self.calls if method == "POST"]
+
+
+def release_url(tag: str = TAG) -> str:
+    return f"{rps.API_BASE}/repos/{REPOSITORY}/releases/tags/{tag}"
+
+
+def asset_url(asset_id: int) -> str:
+    return f"{rps.API_BASE}/repos/{REPOSITORY}/releases/assets/{asset_id}"
+
+
+def upload_url(name: str, release_id: int = 900) -> str:
+    return (
+        f"{rps.UPLOADS_BASE}/repos/{REPOSITORY}/releases/{release_id}/assets"
+        f"?{urllib.parse.urlencode({'name': name})}"
+    )
+
+
+def check_argv() -> list[str]:
+    return ["check", "--tag", TAG, "--sha", SHA, "--code-hash", CODE_HASH, "--channel", "docker"]
+
+
+def record_argv() -> list[str]:
+    return ["record", "--tag", TAG, "--sha", SHA, "--code-hash", CODE_HASH, "--channel", "docker"]
+
+
+class PublicationStateTestCase(unittest.TestCase):
+    def run_main(self, transport: FakeTransport, argv: list[str], env: dict[str, str] | None = None) -> int:
+        with patch.dict(os.environ, env if env is not None else BASE_ENV):
+            return rps.main(argv, transport=transport)
+
+    @staticmethod
+    def sequenced_transport(transport: FakeTransport, release_bodies: list[bytes]):
+        """Route repeated release lookups through an ordered response list."""
+        responses = iter(release_bodies)
+        original_transport = transport.__call__
+
+        def transport_fn(method, url, headers, body):
+            if (method, url) == ("GET", release_url()):
+                return 200, next(responses)
+            return original_transport(method, url, headers, body)
+
+        return transport_fn
+
+
+class CheckTests(PublicationStateTestCase):
+    def test_matching_receipt_exits_zero(self):
+        transport = FakeTransport()
+        transport.route("GET", release_url(), 200, release_payload([asset_payload(1, RECEIPT_NAME)]))
+        transport.route("GET", asset_url(1), 200, receipt_bytes())
+        self.assertEqual(self.run_main(transport, check_argv()), 0)
+        self.assertEqual(transport.upload_calls(), [])
+
+    def test_missing_release_is_absent_not_failure(self):
+        transport = FakeTransport()
+        transport.route("GET", release_url(), 404, b'{"message": "Not Found"}')
+        self.assertEqual(self.run_main(transport, check_argv()), 1)
+
+    def test_missing_receipt_asset_is_absent_not_failure(self):
+        transport = FakeTransport()
+        transport.route("GET", release_url(), 200, release_payload([asset_payload(1, "publication-website.json")]))
+        self.assertEqual(self.run_main(transport, check_argv()), 1)
+
+    def test_conflicting_receipt_fields_fail_closed(self):
+        for kwargs in (
+            {"sha": "a" * 40},
+            {"tag": "v432"},
+            {"code_hash": "0x" + "9" * 64},
+            {"channel": "website"},
+        ):
+            with self.subTest(conflict=kwargs):
+                transport = FakeTransport()
+                transport.route("GET", release_url(), 200, release_payload([asset_payload(1, RECEIPT_NAME)]))
+                transport.route("GET", asset_url(1), 200, receipt_bytes(**kwargs))
+                self.assertEqual(self.run_main(transport, check_argv()), 2)
+
+    def test_malformed_receipts_fail_closed(self):
+        for raw in (
+            b"not json",
+            b"[1, 2]",
+            receipt_bytes(extra={"surprise": True}),
+            receipt_bytes(drop="run_id"),
+            receipt_bytes(run_id=0),
+            receipt_bytes(run_attempt="2"),
+            receipt_bytes(schema=2),
+        ):
+            with self.subTest(raw=raw[:40]):
+                transport = FakeTransport()
+                transport.route("GET", release_url(), 200, release_payload([asset_payload(1, RECEIPT_NAME)]))
+                transport.route("GET", asset_url(1), 200, raw)
+                self.assertEqual(self.run_main(transport, check_argv()), 2)
+
+    def test_api_failure_is_not_treated_as_absent(self):
+        transport = FakeTransport()
+        transport.route("GET", release_url(), 403, b'{"message": "rate limited"}')
+        self.assertEqual(self.run_main(transport, check_argv()), 2)
+
+    def test_duplicate_identical_assets_are_accepted(self):
+        transport = FakeTransport()
+        transport.route(
+            "GET",
+            release_url(),
+            200,
+            release_payload([asset_payload(1, RECEIPT_NAME), asset_payload(2, RECEIPT_NAME)]),
+        )
+        transport.route("GET", asset_url(1), 200, receipt_bytes())
+        transport.route("GET", asset_url(2), 200, receipt_bytes())
+        self.assertEqual(self.run_main(transport, check_argv()), 0)
+
+    def test_duplicate_conflicting_assets_fail_closed(self):
+        transport = FakeTransport()
+        transport.route(
+            "GET",
+            release_url(),
+            200,
+            release_payload([asset_payload(1, RECEIPT_NAME), asset_payload(2, RECEIPT_NAME)]),
+        )
+        transport.route("GET", asset_url(1), 200, receipt_bytes())
+        transport.route("GET", asset_url(2), 200, receipt_bytes(run_id=RUN_ID + 1))
+        self.assertEqual(self.run_main(transport, check_argv()), 2)
+
+
+class RecordTests(PublicationStateTestCase):
+    def test_record_uploads_receipt_and_verifies_read_back(self):
+        transport = FakeTransport()
+        transport_fn = self.sequenced_transport(
+            transport,
+            [
+                release_payload([]),                                  # initial lookup
+                release_payload([]),                                  # re-fetch before upload
+                release_payload([asset_payload(1, RECEIPT_NAME)]),    # read-back
+            ],
+        )
+        transport.route("POST", upload_url(RECEIPT_NAME), 201, json.dumps({"name": RECEIPT_NAME}).encode())
+        transport.route("GET", asset_url(1), 200, receipt_bytes())
+        client = rps.GitHubClient("fake-token", REPOSITORY, transport=transport_fn)
+        with patch.dict(os.environ, BASE_ENV):
+            self.assertEqual(rps.run_record(client, TAG, SHA, CODE_HASH, "docker"), 0)
+        uploads = transport.upload_calls()
+        self.assertEqual(len(uploads), 1)
+        url, body = uploads[0]
+        self.assertEqual(url, upload_url(RECEIPT_NAME))
+        self.assertEqual(
+            json.loads(body),
+            {
+                "schema": 1,
+                "tag": TAG,
+                "sha": SHA,
+                "code_hash": CODE_HASH,
+                "channel": "docker",
+                "run_id": RUN_ID,
+                "run_attempt": RUN_ATTEMPT,
+            },
+        )
+
+    def test_second_record_is_idempotent_noop(self):
+        transport = FakeTransport()
+        transport.route("GET", release_url(), 200, release_payload([asset_payload(1, RECEIPT_NAME)]))
+        transport.route("GET", asset_url(1), 200, receipt_bytes())
+        self.assertEqual(self.run_main(transport, record_argv()), 0)
+        self.assertEqual(transport.upload_calls(), [])
+
+    def test_conflicting_receipt_rejects_record_without_upload(self):
+        transport = FakeTransport()
+        transport.route("GET", release_url(), 200, release_payload([asset_payload(1, RECEIPT_NAME)]))
+        transport.route("GET", asset_url(1), 200, receipt_bytes(sha="a" * 40))
+        self.assertEqual(self.run_main(transport, record_argv()), 2)
+        self.assertEqual(transport.upload_calls(), [])
+
+    def test_record_without_release_fails_closed(self):
+        transport = FakeTransport()
+        transport.route("GET", release_url(), 404, b'{"message": "Not Found"}')
+        self.assertEqual(self.run_main(transport, record_argv()), 2)
+        self.assertEqual(transport.upload_calls(), [])
+
+    def test_record_upload_failure_fails_closed(self):
+        transport = FakeTransport()
+        transport.route("GET", release_url(), 200, release_payload([]))
+        transport.route("POST", upload_url(RECEIPT_NAME), 422, b'{"message": "Unprocessable Entity"}')
+        self.assertEqual(self.run_main(transport, record_argv()), 2)
+        self.assertEqual(len(transport.upload_calls()), 1)
+
+    def test_record_read_back_mismatch_fails_closed(self):
+        transport = FakeTransport()
+        transport_fn = self.sequenced_transport(
+            transport,
+            [
+                release_payload([]),
+                release_payload([]),
+                release_payload([asset_payload(1, RECEIPT_NAME)]),
+            ],
+        )
+        transport.route("POST", upload_url(RECEIPT_NAME), 201, json.dumps({"name": RECEIPT_NAME}).encode())
+        transport.route("GET", asset_url(1), 200, receipt_bytes(sha="a" * 40))
+        client = rps.GitHubClient("fake-token", REPOSITORY, transport=transport_fn)
+        with patch.dict(os.environ, BASE_ENV):
+            self.assertEqual(rps.run_record(client, TAG, SHA, CODE_HASH, "docker"), 2)
+
+
+class ArgumentAndEnvironmentTests(PublicationStateTestCase):
+    def test_invalid_fields_exit_two_before_any_api_call(self):
+        transport = FakeTransport()
+        for argv in (
+            ["check", "--tag", "v 433", "--sha", SHA, "--code-hash", CODE_HASH, "--channel", "docker"],
+            ["check", "--tag", TAG, "--sha", "B" * 40, "--code-hash", CODE_HASH, "--channel", "docker"],
+            ["check", "--tag", TAG, "--sha", SHA, "--code-hash", "c" * 64, "--channel", "docker"],
+        ):
+            with self.subTest(argv=argv):
+                self.assertEqual(self.run_main(transport, argv), 2)
+        with self.subTest(argv="unknown channel"), self.assertRaises(SystemExit) as exited:
+            self.run_main(transport, ["check", "--tag", TAG, "--sha", SHA, "--code-hash", CODE_HASH, "--channel", "pypi"])
+        self.assertEqual(exited.exception.code, 2)
+        self.assertEqual(transport.calls, [])
+
+    def test_missing_environment_fails_closed_without_api_call(self):
+        transport = FakeTransport()
+        for env in (
+            {k: v for k, v in BASE_ENV.items() if k != "GITHUB_REPOSITORY"},
+            {k: v for k, v in BASE_ENV.items() if k != "GH_TOKEN"},
+            {**BASE_ENV, "GITHUB_REPOSITORY": "RaoFoundation/subtensor/extra"},
+        ):
+            with self.subTest(env=env):
+                self.assertEqual(self.run_main(transport, check_argv(), env=env), 2)
+        self.assertEqual(transport.calls, [])
+
+    def test_record_requires_run_identity_environment(self):
+        transport = FakeTransport()
+        transport.route("GET", release_url(), 200, release_payload([]))
+        env = {k: v for k, v in BASE_ENV.items() if k != "GITHUB_RUN_ID"}
+        self.assertEqual(self.run_main(transport, record_argv(), env=env), 2)
+        self.assertEqual(transport.upload_calls(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/reconcile-mainnet-release.yml
+++ b/.github/workflows/reconcile-mainnet-release.yml
@@ -1,0 +1,358 @@
+name: Reconcile Mainnet Release
+
+# Reconciles GitHub release metadata with finalized mainnet chain state
+# without the `mainnet` environment approval the watcher requires:
+#   1. Poll the finalized chain (same ten-minute cadence as
+#      watch-mainnet-release.yml) and detect a runtime whose immutable tag,
+#      provenance-verified release-train artifact, and commit ancestry agree.
+#   2. Point the protected mainnet mirror at the release commit through the
+#      GitHub Git refs API, using a short-lived token minted for the
+#      dedicated `subtensor-release-metadata` GitHub App.
+#   3. Attach the five verifier-required runtime assets and promote the
+#      pre-release to the final GitHub release.
+#
+# Disabled by default: every job requires BOTH `github.ref == 'refs/heads/main'`
+# and the repository variable `RELEASE_METADATA_AUTOMATION_ENABLED == 'true'`,
+# so a scheduled run before enablement, or a manual dispatch from any other
+# branch, is skipped before checkout, environment access, or token minting.
+# This is an independent reconciler: the gated publishers (PyPI, crates.io,
+# website) remain in watch-mainnet-release.yml and waiting approvals there
+# cannot hold this workflow's concurrency lock.
+#
+# Deliberately absent: any fallback to the shared mirror deploy key, a PAT,
+# or a less-protected environment. Enabling this workflow requires the
+# separately authorized `release-metadata` environment, the
+# `subtensor-release-metadata` GitHub App (Contents read/write, Metadata
+# read, no webhooks), and a mainnet-only mirror ruleset that grants this App
+# a bypass before mainnet is removed from `network-branch-mirrors (CI only)`.
+# Merging this workflow without that provisioning cutover would interrupt
+# GitHub release finalization; see the release publication PR.
+
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: reconcile-mainnet-release
+  cancel-in-progress: false
+
+env:
+  MAINNET_HTTP: https://entrypoint-finney.opentensor.ai:443
+
+permissions:
+  contents: read
+
+jobs:
+  detect:
+    name: Detect finalized mainnet release state
+    # Evaluated before any step runs: no checkout, environment access, or
+    # token minting happens unless the run is on main with automation
+    # explicitly enabled.
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      vars.RELEASE_METADATA_AUTOMATION_ENABLED == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      actions: read # list/download the release-train artifact
+    outputs:
+      eligible: ${{ steps.state.outputs.eligible }}
+      release_needed: ${{ steps.state.outputs.release_needed }}
+      spec_version: ${{ steps.state.outputs.spec_version }}
+      release_tag: ${{ steps.state.outputs.release_tag }}
+      sha: ${{ steps.state.outputs.sha }}
+      code_hash: ${{ steps.state.outputs.code_hash }}
+      finalized_head: ${{ steps.state.outputs.finalized_head }}
+      artifact_id: ${{ steps.state.outputs.artifact_id }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Control-plane scripts run from the trusted workflow revision on
+          # main; the checkout credential is never needed.
+          persist-credentials: false
+
+      - name: Resolve mainnet release state
+        id: state
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          python3 .github/scripts/mainnet-release-state.py \
+            --mode metadata --output state.json
+
+          if ! jq -e '.eligible == true' state.json > /dev/null; then
+            echo "Mainnet is not eligible for publication; nothing to do."
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "eligible=true" >> "$GITHUB_OUTPUT"
+          for key in release_needed spec_version release_tag sha code_hash finalized_head; do
+            echo "$key=$(jq -er --arg k "$key" '.[$k]' state.json)" >> "$GITHUB_OUTPUT"
+          done
+          echo "artifact_id=$(jq -r '.artifact_id // ""' state.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Log detected identity
+        if: steps.state.outputs.eligible == 'true'
+        env:
+          SPEC_VERSION: ${{ steps.state.outputs.spec_version }}
+          RELEASE_TAG: ${{ steps.state.outputs.release_tag }}
+          RELEASE_SHA: ${{ steps.state.outputs.sha }}
+          CODE_HASH: ${{ steps.state.outputs.code_hash }}
+          FINALIZED_HEAD: ${{ steps.state.outputs.finalized_head }}
+        run: |
+          echo "release tag:       $RELEASE_TAG"
+          echo "source sha:        $RELEASE_SHA"
+          echo "spec_version:      $SPEC_VERSION"
+          echo "runtime code hash: $CODE_HASH"
+          echo "finalized block:   $FINALIZED_HEAD"
+
+  publish:
+    name: Mirror mainnet and finalize the release
+    needs: detect
+    # Repeat the entry gate so no path reaches the release-metadata
+    # environment except an enabled run on main, and only for an eligible
+    # identity that still needs its release.
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      vars.RELEASE_METADATA_AUTOMATION_ENABLED == 'true' &&
+      needs.detect.outputs.eligible == 'true' &&
+      needs.detect.outputs.release_needed == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    # No reviewers and no wait timer by design: this environment exists to
+    # scope the dedicated App credentials, not to re-ask a human what the
+    # finalized chain state already answered.
+    environment: release-metadata
+    permissions:
+      contents: write # create/upload/promote the release
+      actions: read # download the release-train artifact
+    steps:
+      # Checked out at the workflow revision on main: every control-plane
+      # script below executes from trusted main, never from the release
+      # checkout. No source build happens in this job.
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Require release-metadata credentials
+        id: preflight
+        env:
+          APP_ID: ${{ vars.RELEASE_METADATA_APP_ID }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$APP_ID" ]]; then
+            echo "::error::vars.RELEASE_METADATA_APP_ID is not configured for the release-metadata environment; refusing to fall back to a less-protected credential."
+            exit 1
+          fi
+          echo "repo_name=${GITHUB_REPOSITORY#*/}" >> "$GITHUB_OUTPUT"
+
+      # Mint a short-lived token for the dedicated App, scoped to exactly
+      # this repository. It is used ONLY for the protected mainnet ref
+      # update below; release writes use the ordinary GITHUB_TOKEN. There is
+      # deliberately no fallback to the shared mirror deploy key.
+      - name: Mint release-metadata App token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ vars.RELEASE_METADATA_APP_ID }}
+          private-key: ${{ secrets.RELEASE_METADATA_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ steps.preflight.outputs.repo_name }}
+
+      - name: Download and verify the release-train artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SPEC_VERSION: ${{ needs.detect.outputs.spec_version }}
+          RELEASE_SHA: ${{ needs.detect.outputs.sha }}
+          CODE_HASH: ${{ needs.detect.outputs.code_hash }}
+          ARTIFACT_ID: ${{ needs.detect.outputs.artifact_id }}
+        run: |
+          set -euo pipefail
+          : "${ARTIFACT_ID:?detect job did not resolve a release artifact}"
+
+          gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/${ARTIFACT_ID}/zip" > artifact.zip
+          python3 .github/scripts/verify-release-artifact.py artifact.zip \
+            --spec "$SPEC_VERSION" \
+            --commit "$RELEASE_SHA" \
+            --code-hash "$CODE_HASH"
+          mkdir -p wasm
+          unzip -o artifact.zip -d wasm
+
+      - name: Recheck finalized identity before mirror mutation
+        id: recheck-before
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECTED_SPEC: ${{ needs.detect.outputs.spec_version }}
+          EXPECTED_SHA: ${{ needs.detect.outputs.sha }}
+          EXPECTED_CODE_HASH: ${{ needs.detect.outputs.code_hash }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/mainnet-release-state.py \
+            --mode metadata --output recheck-before.json
+          spec=$(jq -er '.spec_version' recheck-before.json)
+          sha=$(jq -er '.sha' recheck-before.json)
+          code_hash=$(jq -er '.code_hash' recheck-before.json)
+          if [[ "$spec" != "$EXPECTED_SPEC" || "$sha" != "$EXPECTED_SHA" || "$code_hash" != "$EXPECTED_CODE_HASH" ]]; then
+            echo "::error::Mainnet finalized identity moved since detection (spec=$spec sha=$sha); stopping without mutations. The next poll selects the newer release."
+            exit 1
+          fi
+          echo "release_needed=$(jq -r '.release_needed' recheck-before.json)" >> "$GITHUB_OUTPUT"
+
+      # Mirror first: if this protected ref update fails, the release stays a
+      # pre-release and the next scheduled run can retry safely. The App
+      # token lives only in this step's environment; it is never written to
+      # the checkout, a Git remote, or persisted credentials.
+      - name: Point the mainnet mirror at the release commit
+        if: steps.recheck-before.outputs.release_needed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RELEASE_SHA: ${{ needs.detect.outputs.sha }}
+        run: |
+          set -euo pipefail
+
+          ref_api="repos/$GITHUB_REPOSITORY/git/refs/heads/mainnet"
+          gh api -X PATCH "$ref_api" \
+            -f sha="$RELEASE_SHA" -F force=true > /dev/null
+
+          mirrored_sha=$(gh api --jq '.object.sha' "$ref_api")
+          if [[ "$mirrored_sha" != "$RELEASE_SHA" ]]; then
+            echo "::error::mainnet mirror is $mirrored_sha, expected $RELEASE_SHA"
+            exit 1
+          fi
+          echo "mainnet mirror verified at $mirrored_sha"
+
+      - name: Recheck finalized identity after mirror update
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECTED_SPEC: ${{ needs.detect.outputs.spec_version }}
+          EXPECTED_SHA: ${{ needs.detect.outputs.sha }}
+          EXPECTED_CODE_HASH: ${{ needs.detect.outputs.code_hash }}
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/mainnet-release-state.py \
+            --mode metadata --output recheck-after.json
+          spec=$(jq -er '.spec_version' recheck-after.json)
+          sha=$(jq -er '.sha' recheck-after.json)
+          code_hash=$(jq -er '.code_hash' recheck-after.json)
+          if [[ "$spec" != "$EXPECTED_SPEC" || "$sha" != "$EXPECTED_SHA" || "$code_hash" != "$EXPECTED_CODE_HASH" ]]; then
+            echo "::error::Mainnet finalized identity moved while this job ran (spec=$spec sha=$sha); stopping before final promotion. The next poll selects the newer release."
+            exit 1
+          fi
+
+      - name: Create or promote the release with runtime assets
+        id: finalize
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SPEC_VERSION: ${{ needs.detect.outputs.spec_version }}
+          RELEASE_SHA: ${{ needs.detect.outputs.sha }}
+          CODE_HASH: ${{ needs.detect.outputs.code_hash }}
+        run: |
+          set -euo pipefail
+          tag="v${SPEC_VERSION}"
+          # All five verifier-required assets, including upgrade-manifest.json,
+          # must be attached before promotion; none is optional at upload.
+          assets=(
+            wasm/subtensor.wasm
+            wasm/subtensor-digest.json
+            wasm/proxy_proxy_blob.hex
+            wasm/pending-release.json
+            wasm/upgrade-manifest.json
+          )
+
+          # The release train reserves this exact lightweight tag before
+          # submitting the multisig. Never accept an ambiguously named ref.
+          tag_json=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$tag")
+          tag_type=$(jq -er '.object.type' <<<"$tag_json")
+          [[ "$tag_type" = commit ]] \
+            || { echo "release tag $tag must be a lightweight Git tag, found $tag_type"; exit 1; }
+          tag_sha=$(jq -er '.object.sha' <<<"$tag_json")
+          [[ "$tag_sha" = "$RELEASE_SHA" ]] \
+            || { echo "tag $tag points at $tag_sha, expected $RELEASE_SHA"; exit 1; }
+
+          release_status=0
+          response=$(gh api --include \
+            "repos/$GITHUB_REPOSITORY/releases/tags/$tag" 2>release-error.txt) || release_status=$?
+          http_status=$(printf '%s\n' "$response" | sed -n '1s|HTTP/[^ ]* \([0-9]*\).*|\1|p')
+          release_json=$(printf '%s\n' "$response" | sed '1,/^[[:space:]]*$/d')
+          if [[ "$release_status" = 0 && "$http_status" = 200 ]]; then
+            is_prerelease=$(jq -er \
+              '.prerelease | if type == "boolean" then tostring else error("prerelease must be boolean") end' \
+              <<<"$release_json")
+            target_sha=$(jq -er \
+              '.target_commitish | strings | select(test("^[0-9a-f]{40}$"))' \
+              <<<"$release_json")
+            [[ "$target_sha" = "$RELEASE_SHA" ]] \
+              || { echo "release target $target_sha does not match $RELEASE_SHA"; exit 1; }
+
+            if [[ "$is_prerelease" = "false" ]]; then
+              # Another actor finalized the exact release while this job ran.
+              # Verify the final release against the finalized runtime
+              # (published mode also re-validates the mirror and the five
+              # attached assets) and return success without rewriting it.
+              python3 .github/scripts/mainnet-release-state.py \
+                --mode published --output already-final.json
+              jq -e '.eligible == true' already-final.json > /dev/null \
+                || { echo "::error::final release $tag does not match the finalized runtime; refusing to touch it"; exit 1; }
+              echo "changed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          elif [[ "$http_status" != 404 ]]; then
+            cat release-error.txt >&2
+            echo "::error::release lookup failed with HTTP $http_status"
+            exit 1
+          else
+            # Create only a pre-release here. If a later asset upload fails,
+            # the next run can safely resume instead of finding an
+            # incomplete final release.
+            gh release create "$tag" \
+              --repo "$GITHUB_REPOSITORY" \
+              --target "$RELEASE_SHA" \
+              --prerelease \
+              --title "Runtime ${SPEC_VERSION} (finalizing)" \
+              --notes "Runtime finalized on chain; release assets are being attached."
+          fi
+
+          notes=$(gh api "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+            -f tag_name="$tag" -f target_commitish="$RELEASE_SHA" --jq '.body' || true)
+          gh release upload "$tag" --repo "$GITHUB_REPOSITORY" --clobber "${assets[@]}"
+          gh release edit "$tag" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "Runtime ${SPEC_VERSION}" \
+            ${notes:+--notes "$notes"} \
+            --prerelease=false \
+            --latest
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Write run summary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SPEC_VERSION: ${{ needs.detect.outputs.spec_version }}
+          RELEASE_TAG: ${{ needs.detect.outputs.release_tag }}
+          RELEASE_SHA: ${{ needs.detect.outputs.sha }}
+          CODE_HASH: ${{ needs.detect.outputs.code_hash }}
+          FINALIZED_HEAD: ${{ needs.detect.outputs.finalized_head }}
+          CHANGED: ${{ steps.finalize.outputs.changed }}
+        run: |
+          set -euo pipefail
+          release_url=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/${RELEASE_TAG}" --jq '.html_url')
+          if [[ "$CHANGED" = "true" ]]; then
+            outcome="changed state (mainnet mirror updated, release finalized)"
+          else
+            outcome="verified existing state (no writes)"
+          fi
+          {
+            echo "## Reconcile Mainnet Release"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Release tag | \`${RELEASE_TAG}\` |"
+            echo "| Source SHA | \`${RELEASE_SHA}\` |"
+            echo "| Finalized block | \`${FINALIZED_HEAD}\` |"
+            echo "| Runtime code hash | \`${CODE_HASH}\` |"
+            echo "| Release URL | ${release_url} |"
+            echo "| Outcome | ${outcome} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/watch-mainnet-release.yml
+++ b/.github/workflows/watch-mainnet-release.yml
@@ -1,25 +1,21 @@
 name: Watch Mainnet Release
 
 # The mainnet upgrade is executed by the triumvirate signing the multisig
-# proposal submitted by the release train (release-train.yml). This watcher
-# polls the finalized chain state; once an upgrade executes, it cuts the
-# release. The immutable release tag, protected mainnet mirror, and finalized
-# runtime hash must all identify the same release-train commit. PyPI itself is
-# the terminal state for stable Python publication, so a later run can retry a
-# failed or partial upload:
-#   1. GitHub release v<spec_version>, with the srtool wasm + digest and
-#      multisig call data from the release train attached as assets
-#   2. Docker images via explicit dispatch of docker.yml and
+# proposal submitted by the release train (release-train.yml). GitHub release
+# finalization and mainnet mirror synchronization live in
+# reconcile-mainnet-release.yml; this watcher polls the finalized chain state
+# and, once the release is fully published (a final GitHub release whose
+# protected mainnet mirror matches), drives the gated publishers:
+#   1. Docker images via explicit dispatch of docker.yml and
 #      docker-localnet.yml (a release created with the default GITHUB_TOKEN
 #      does not emit `release: published`, so their `on: release` triggers
-#      never fire for releases cut by this workflow)
-#   3. Python SDK + bittensor-core wheels to PyPI
-#   4. Publishable Rust crates to crates.io
-#   5. Production website/docs deployment on Vercel
-#   6. Before finalizing the GitHub release, the `mainnet` branch is
-#      force-updated to the release-train commit, so it always contains the
-#      code running on mainnet (the devnet and testnet branches are updated by
-#      release-train.yml at deploy time)
+#      never fire for watcher-era releases)
+#   2. Python SDK + bittensor-core wheels to PyPI
+#   3. Publishable Rust crates to crates.io
+#   4. Production website/docs deployment on Vercel
+# Each non-Python channel records a `publication-<channel>` receipt on the
+# release after observing success, so scheduled polls skip completed channels
+# while failed, rejected, or cancelled ones remain eligible for retry.
 
 on:
   schedule:
@@ -34,150 +30,83 @@ env:
   MAINNET_HTTP: https://entrypoint-finney.opentensor.ai:443
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   check:
     name: Compare chain spec_version with main
+    # Scheduled runs execute on the default branch; a manual dispatch from any
+    # other ref must never reach the gated publishers below.
+    if: github.ref == 'refs/heads/main'
     runs-on: [self-hosted, fireactions-turbo-8]
     permissions:
       contents: read
-      actions: read # list/download the release-train artifact
+      actions: read # list/download release-train artifacts (identity check)
     outputs:
-      release_needed: ${{ steps.compare.outputs.release_needed }}
-      python_needed: ${{ steps.compare.outputs.python_needed }}
-      spec_version: ${{ steps.compare.outputs.spec_version }}
-      release_tag: ${{ steps.compare.outputs.release_tag }}
-      sha: ${{ steps.compare.outputs.sha }}
-      artifact_id: ${{ steps.compare.outputs.artifact_id }}
-      code_hash: ${{ steps.compare.outputs.code_hash }}
-      sdk_version: ${{ steps.compare.outputs.sdk_version }}
-      core_version: ${{ steps.compare.outputs.core_version }}
+      eligible: ${{ steps.state.outputs.eligible }}
+      spec_version: ${{ steps.state.outputs.spec_version }}
+      release_tag: ${{ steps.state.outputs.release_tag }}
+      sha: ${{ steps.state.outputs.sha }}
+      code_hash: ${{ steps.state.outputs.code_hash }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Compare mainnet with release state
-        id: compare
+      - name: Resolve finalized mainnet release identity
+        id: state
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-
-          local_spec=$(grep -Eo 'spec_version: *[0-9]+' runtime/src/lib.rs | head -n 1 | grep -Eo '[0-9]+')
-          : ${local_spec:?could not parse spec_version from runtime/src/lib.rs}
-
-          finalized_head=$(curl -sf -H "Content-Type: application/json" \
-            -d '{"id":1,"jsonrpc":"2.0","method":"chain_getFinalizedHead","params":[]}' \
-            "$MAINNET_HTTP" | jq -er \
-              '.result | strings | select(test("^0x[0-9a-f]{64}$"))')
-          runtime_request=$(jq -cn --arg block "$finalized_head" \
-            '{id: 1, jsonrpc: "2.0", method: "state_getRuntimeVersion", params: [$block]}')
-          chain_spec=$(curl -sf -H "Content-Type: application/json" \
-            -d "$runtime_request" "$MAINNET_HTTP" | jq -er '.result.specVersion')
-          code_hash_request=$(jq -cn --arg block "$finalized_head" \
-            '{id: 1, jsonrpc: "2.0", method: "state_getStorageHash",
-              params: ["0x3a636f6465", $block]}')
-          chain_code_hash=$(curl -sf -H "Content-Type: application/json" \
-            -d "$code_hash_request" "$MAINNET_HTTP" | jq -er \
-              '.result | strings | select(test("^0x[0-9a-f]{64}$"))')
-          [[ "$local_spec" =~ ^[0-9]+$ && "$chain_spec" =~ ^[0-9]+$ ]] \
-            || { echo "spec_version values must be integers"; exit 1; }
-
-          echo "main spec_version:     $local_spec"
-          echo "on-chain spec_version: $chain_spec"
-          echo "finalized block:       $finalized_head"
-          echo "runtime code hash:     $chain_code_hash"
-
-          if [ "$chain_spec" -gt "$local_spec" ]; then
-            echo "Main does not contain the on-chain runtime yet; refusing to publish."
-            echo "release_needed=false" >> "$GITHUB_OUTPUT"
-            echo "python_needed=false" >> "$GITHUB_OUTPUT"
+          python3 .github/scripts/mainnet-release-state.py \
+            --mode published --output release-state.json
+          if ! jq -e '.eligible == true' release-state.json > /dev/null; then
+            echo "No finalized release is ready for publication; nothing to do."
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          echo "spec_version=$chain_spec" >> "$GITHUB_OUTPUT"
-          echo "code_hash=$chain_code_hash" >> "$GITHUB_OUTPUT"
+          {
+            echo "eligible=true"
+            echo "spec_version=$(jq -er '.spec_version' release-state.json)"
+            echo "release_tag=$(jq -er '.release_tag' release-state.json)"
+            echo "sha=$(jq -er '.sha' release-state.json)"
+            echo "code_hash=$(jq -er '.code_hash' release-state.json)"
+          } >> "$GITHUB_OUTPUT"
 
-          # Old releases used several tag formats and predate automated stable
-          # Python publication. They are terminal historical state, not inputs
-          # to the immutable release flow below.
-          if [ "$chain_spec" -le 432 ]; then
-            release_tag=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 300 \
-              --json tagName,isDraft,isPrerelease \
-              | jq -r --arg exact "v${chain_spec}" --arg suffix "-${chain_spec}" \
-                '.[] |
-                 select(.isDraft == false and .isPrerelease == false) |
-                 select(.tagName == $exact or (.tagName | endswith($suffix))) |
-                 .tagName' \
-              | head -n 1)
-            : ${release_tag:?historical runtime v${chain_spec} has no final GitHub release}
-            echo "Historical release $release_tag is complete; Python was handled manually."
-            echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
-            echo "release_needed=false" >> "$GITHUB_OUTPUT"
-            echo "python_needed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+  # Python version discovery and PyPI completeness live in their own job so a
+  # failure here cannot block the independent Docker, crates, or website
+  # channels.
+  check-python:
+    name: Check stable Python publication state
+    needs: check
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      needs.check.result == 'success' &&
+      needs.check.outputs.eligible == 'true'
+    runs-on: [self-hosted, fireactions-turbo-8]
+    permissions:
+      contents: read
+    outputs:
+      python_needed: ${{ steps.python.outputs.python_needed }}
+      sdk_version: ${{ steps.python.outputs.sdk_version }}
+      core_version: ${{ steps.python.outputs.core_version }}
+    steps:
+      - uses: actions/checkout@v4
 
-          release_tag="v${chain_spec}"
-          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
-
-          # The release train reserves this exact lightweight tag before
-          # submitting the multisig. Never accept an ambiguously named branch.
-          tag_json=$(gh api \
-            "repos/$GITHUB_REPOSITORY/git/ref/tags/${release_tag}")
-          tag_type=$(jq -er '.object.type' <<<"$tag_json")
-          [ "$tag_type" = commit ] \
-            || { echo "release tag must be a lightweight Git tag, found $tag_type"; exit 1; }
-          release_sha=$(jq -er '.object.sha' <<<"$tag_json")
-          [[ "$release_sha" =~ ^[0-9a-f]{40}$ ]] \
-            || { echo "release tag did not resolve to a Git commit"; exit 1; }
-          status=$(gh api \
-            "repos/$GITHUB_REPOSITORY/compare/${release_sha}...main" --jq '.status')
-          case "$status" in
-            ahead|identical) ;;
-            *) echo "tagged commit $release_sha is not an ancestor of main"; exit 1 ;;
-          esac
-          echo "sha=$release_sha" >> "$GITHUB_OUTPUT"
-
-          release_needed=true
-          release_json=""
-          if release_json=$(gh api \
-              "repos/$GITHUB_REPOSITORY/releases/tags/${release_tag}" 2>/dev/null); then
-            is_draft=$(jq -er \
-              '.draft | if type == "boolean" then tostring else error("draft must be boolean") end' \
-              <<<"$release_json")
-            is_prerelease=$(jq -er \
-              '.prerelease | if type == "boolean" then tostring else error("prerelease must be boolean") end' \
-              <<<"$release_json")
-            if [ "$is_draft" = false ] && [ "$is_prerelease" = false ]; then
-              release_needed=false
-              target_sha=$(jq -er \
-                '.target_commitish | strings | select(test("^[0-9a-f]{40}$"))' \
-                <<<"$release_json")
-              [ "$target_sha" = "$release_sha" ] \
-                || { echo "release target $target_sha does not match tag $release_sha"; exit 1; }
-            fi
-          fi
-
-          # Once final, the independently protected mainnet branch must point
-          # to the tag before any downstream publication is considered.
-          if [ "$release_needed" = false ]; then
-            mainnet_json=$(gh api \
-              "repos/$GITHUB_REPOSITORY/git/ref/heads/mainnet")
-            mainnet_type=$(jq -er '.object.type' <<<"$mainnet_json")
-            [ "$mainnet_type" = commit ] \
-              || { echo "protected mainnet mirror did not resolve to a commit"; exit 1; }
-            mainnet_sha=$(jq -er '.object.sha' <<<"$mainnet_json")
-            [ "$release_sha" = "$mainnet_sha" ] \
-              || { echo "protected mainnet mirror $mainnet_sha does not match release commit $release_sha"; exit 1; }
-          fi
+      - name: Derive stable Python versions and check PyPI
+        id: python
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_SHA: ${{ needs.check.outputs.sha }}
+        run: |
+          set -euo pipefail
 
           # Derive the exact stable Python versions from the immutable tag,
           # never from the moving default branch or mutable release metadata.
           gh api -H "Accept: application/vnd.github.raw+json" \
-            "repos/$GITHUB_REPOSITORY/contents/sdk/python/pyproject.toml?ref=${release_sha}" \
+            "repos/$GITHUB_REPOSITORY/contents/sdk/python/pyproject.toml?ref=${RELEASE_SHA}" \
             > /tmp/release-sdk-pyproject.toml
           gh api -H "Accept: application/vnd.github.raw+json" \
-            "repos/$GITHUB_REPOSITORY/contents/sdk/bittensor-core-py/pyproject.toml?ref=${release_sha}" \
+            "repos/$GITHUB_REPOSITORY/contents/sdk/bittensor-core-py/pyproject.toml?ref=${RELEASE_SHA}" \
             > /tmp/release-core-pyproject.toml
           versions=$(python3 .github/scripts/release-python-versions.py \
             /tmp/release-sdk-pyproject.toml /tmp/release-core-pyproject.toml)
@@ -186,186 +115,325 @@ jobs:
           echo "sdk_version=$sdk_version" >> "$GITHUB_OUTPUT"
           echo "core_version=$core_version" >> "$GITHUB_OUTPUT"
 
-          if [ "$release_needed" = true ]; then
-            # The exact artifact is needed only until its bytes have been
-            # verified and attached to the final release.
-            artifact_id=$(.github/scripts/resolve-release-artifact.sh \
-              "$chain_spec" "$release_sha" "$chain_code_hash")
-            : ${artifact_id:?no artifact matches the immutable tag and finalized runtime}
-            echo "artifact_id=$artifact_id" >> "$GITHUB_OUTPUT"
-            python_needed=true
-          elif python3 .github/scripts/check-python-release.py \
+          if python3 .github/scripts/check-python-release.py \
               --sdk-version "$sdk_version" \
               --core-version "$core_version" \
               --repository "$GITHUB_REPOSITORY"; then
             echo "Stable Python packages are complete on PyPI."
-            python_needed=false
+            echo "python_needed=false" >> "$GITHUB_OUTPUT"
           else
             python_status=$?
             if [ "$python_status" -eq 1 ]; then
               echo "Stable Python publication is incomplete and will be retried."
-              python_needed=true
+              echo "python_needed=true" >> "$GITHUB_OUTPUT"
             else
               echo "PyPI could not provide authoritative release state."
               exit "$python_status"
             fi
           fi
 
-          echo "release_needed=$release_needed" >> "$GITHUB_OUTPUT"
-          echo "python_needed=$python_needed" >> "$GITHUB_OUTPUT"
-
-  release:
-    name: Cut GitHub release
+  publish-docker:
+    name: Dispatch production Docker image publishing
     needs: check
-    if: needs.check.outputs.release_needed == 'true'
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      needs.check.result == 'success' &&
+      needs.check.outputs.eligible == 'true'
+    timeout-minutes: 180
     runs-on: [self-hosted, fireactions-turbo-8]
-    # MIRROR_DEPLOY_KEY lives in the mainnet environment secrets; one
-    # approval of the run covers this and the publish jobs below.
-    environment: mainnet
     permissions:
-      contents: write # create the release
-      actions: read # download the release-train artifact
+      actions: write # dispatch docker.yml and observe its run
+      contents: write # upload the publication receipt
     steps:
-      # Checked out at the released commit with the mirror deploy key so the
-      # mainnet branch push below passes the network-branch-mirrors ruleset
-      # (the deploy key is its only bypass actor).
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.check.outputs.sha }}
-          ssh-key: ${{ secrets.MIRROR_DEPLOY_KEY }}
 
-      # The release train uploaded the deterministic srtool build and the
-      # multisig call data as the mainnet-upgrade-<spec> workflow artifact
-      # (90-day retention). Attach it to the release so the deterministic
-      # build evidence outlives the artifact and matches the convention of
-      # the pre-train releases (subtensor.wasm + subtensor-digest.json).
-      - name: Fetch release-train artifact
+      - name: Re-verify release identity before dispatch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECTED_SPEC_VERSION: ${{ needs.check.outputs.spec_version }}
+          EXPECTED_SHA: ${{ needs.check.outputs.sha }}
+          EXPECTED_CODE_HASH: ${{ needs.check.outputs.code_hash }}
         run: |
-          spec="${{ needs.check.outputs.spec_version }}"
-          artifact_id="${{ needs.check.outputs.artifact_id }}"
-          : ${artifact_id:?check job did not resolve a release artifact}
-          gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/${artifact_id}/zip" > artifact.zip
-          python3 .github/scripts/verify-release-artifact.py artifact.zip \
-            --spec "$spec" \
-            --commit "${{ needs.check.outputs.sha }}" \
-            --code-hash "${{ needs.check.outputs.code_hash }}"
-          mkdir -p wasm
-          unzip -o artifact.zip -d wasm
-          ls -la wasm
+          set -euo pipefail
+          # Runs from the trusted workflow revision on main. An approval must
+          # not dispatch image builds for an identity the chain no longer
+          # finalizes; stop and let the next scheduled run select it.
+          python3 .github/scripts/mainnet-release-state.py \
+            --mode published --output release-state.json
+          jq -e '.eligible == true' release-state.json > /dev/null \
+            || { echo "Release is no longer eligible for publication; stopping stale job."; exit 1; }
+          spec=$(jq -er '.spec_version' release-state.json)
+          sha=$(jq -er '.sha' release-state.json)
+          code_hash=$(jq -er '.code_hash' release-state.json)
+          [ "$spec" = "$EXPECTED_SPEC_VERSION" ] \
+            || { echo "Finalized spec $spec does not match selected $EXPECTED_SPEC_VERSION"; exit 1; }
+          [ "$sha" = "$EXPECTED_SHA" ] \
+            || { echo "Release commit $sha does not match selected $EXPECTED_SHA"; exit 1; }
+          [ "$code_hash" = "$EXPECTED_CODE_HASH" ] \
+            || { echo "Runtime hash $code_hash does not match selected $EXPECTED_CODE_HASH"; exit 1; }
 
-      # Mirror first. If this protected push fails, the proposal stays a
-      # pre-release and the next scheduled watcher run can retry safely.
-      - name: Point mainnet branch at released commit
+      - name: Check Docker publication receipt
+        id: receipt
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.check.outputs.release_tag }}
+          RELEASE_SHA: ${{ needs.check.outputs.sha }}
+          RELEASE_CODE_HASH: ${{ needs.check.outputs.code_hash }}
         run: |
-          release_sha="${{ needs.check.outputs.sha }}"
-          git push --force origin "${release_sha}:refs/heads/mainnet"
-          mirrored_sha=$(git ls-remote origin refs/heads/mainnet | awk '{print $1}')
-          [ "$mirrored_sha" = "$release_sha" ] \
-            || { echo "mainnet mirror is $mirrored_sha, expected $release_sha"; exit 1; }
+          set -euo pipefail
+          status=0
+          python3 .github/scripts/release-publication-state.py check \
+            --tag "$RELEASE_TAG" --sha "$RELEASE_SHA" \
+            --code-hash "$RELEASE_CODE_HASH" --channel docker || status=$?
+          case "$status" in
+            0)
+              echo "Docker images for $RELEASE_TAG are already recorded complete; skipping."
+              echo "already=true" >> "$GITHUB_OUTPUT"
+              ;;
+            1)
+              echo "No Docker receipt for $RELEASE_TAG; publication remains eligible."
+              echo "already=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Docker publication receipt could not be verified (exit $status); failing visibly."
+              exit "$status"
+              ;;
+          esac
 
-      - name: Create or promote release with runtime assets
+      # Dispatch at the release tag so docker.yml checks out and tags the
+      # exact released sha, even if main has moved on.
+      - name: Dispatch docker.yml at the release tag
+        if: steps.receipt.outputs.already != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPEC_VERSION: ${{ needs.check.outputs.spec_version }}
           RELEASE_SHA: ${{ needs.check.outputs.sha }}
         run: |
+          set -euo pipefail
           tag="v${SPEC_VERSION}"
-          assets=(
-            wasm/subtensor.wasm
-            wasm/subtensor-digest.json
-            wasm/proxy_proxy_blob.hex
-            wasm/pending-release.json
-          )
-          [ -f wasm/upgrade-manifest.json ] && assets+=(wasm/upgrade-manifest.json)
 
-          tag_json=$(gh api \
-            "repos/$GITHUB_REPOSITORY/git/ref/tags/$tag")
-          tag_type=$(jq -er '.object.type' <<<"$tag_json")
-          [ "$tag_type" = commit ] \
-            || { echo "release tag $tag must be a lightweight Git tag, found $tag_type"; exit 1; }
-          tag_sha=$(jq -er '.object.sha' <<<"$tag_json")
-          [ "$tag_sha" = "$RELEASE_SHA" ] \
-            || { echo "tag $tag points at $tag_sha, expected $RELEASE_SHA"; exit 1; }
+          list_matching_runs() {
+            gh run list --repo "$GITHUB_REPOSITORY" --workflow docker.yml \
+              --event workflow_dispatch --limit 100 \
+              --json databaseId,headBranch,headSha,status,conclusion,createdAt \
+              --jq "[.[] | select(.headBranch == \"$tag\" and .headSha == \"$RELEASE_SHA\")]"
+          }
 
-          # The release train published the proposal as a pre-release. Assets
-          # are re-uploaded from the exact artifact verified against finalized
-          # on-chain bytes, then the same release is promoted. A missing
-          # pre-release is recoverable, but an existing final release is not
-          # rewritten by a retry.
-          if release_json=$(gh api \
-              "repos/$GITHUB_REPOSITORY/releases/tags/$tag" 2>/dev/null); then
-            is_prerelease=$(jq -er \
-              '.prerelease | if type == "boolean" then tostring else error("prerelease must be boolean") end' \
-              <<<"$release_json")
-            [ "$is_prerelease" = true ] \
-              || { echo "release $tag is already final; refusing to rewrite it"; exit 1; }
-            target_sha=$(jq -er \
-              '.target_commitish | strings | select(test("^[0-9a-f]{40}$"))' \
-              <<<"$release_json")
-            [ "$target_sha" = "$RELEASE_SHA" ] \
-              || { echo "release target $target_sha does not match $RELEASE_SHA"; exit 1; }
+          run_id=""
+          # API enumeration failure is never treated as absent history.
+          if ! runs=$(list_matching_runs); then
+            echo "Could not enumerate docker.yml runs; refusing to dispatch blindly."
+            exit 1
+          fi
+          run_id=$(jq -r '[.[] | select(.status == "completed" and .conclusion == "success")] | sort_by(.createdAt) | last | .databaseId // empty' <<<"$runs")
+          if [ -n "$run_id" ]; then
+            echo "docker.yml already succeeded for $tag at $RELEASE_SHA (run $run_id)."
           else
-            # Create only a pre-release here. If a later asset upload fails,
-            # the next watcher run can safely resume instead of finding an
-            # incomplete final release.
-            gh release create "$tag" \
-              --repo "$GITHUB_REPOSITORY" \
-              --target "$RELEASE_SHA" \
-              --prerelease \
-              --title "Runtime ${SPEC_VERSION} (finalizing)" \
-              --notes "Runtime finalized on chain; release assets are being attached."
+            run_id=$(jq -r '[.[] | select(.status != "completed")] | sort_by(.createdAt) | last | .databaseId // empty' <<<"$runs")
+            if [ -n "$run_id" ]; then
+              echo "docker.yml is already running for $tag (run $run_id); awaiting it instead of dispatching a duplicate."
+            fi
           fi
 
-          notes=$(gh api "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
-            -f tag_name="$tag" -f target_commitish="$RELEASE_SHA" --jq '.body' || true)
-          gh release upload "$tag" --repo "$GITHUB_REPOSITORY" --clobber "${assets[@]}"
-          gh release edit "$tag" \
-            --repo "$GITHUB_REPOSITORY" \
-            --title "Runtime ${SPEC_VERSION}" \
-            ${notes:+--notes "$notes"} \
-            --prerelease=false \
-            --latest
+          if [ -z "$run_id" ]; then
+            echo "Dispatching docker.yml at $tag."
+            gh workflow run docker.yml --repo "$GITHUB_REPOSITORY" --ref "$tag" -f tag="$tag"
+            # Dispatch acceptance does not create the run instantly; poll for
+            # the matching run before watching it.
+            deadline=$((SECONDS + 120))
+            while [ "$SECONDS" -lt "$deadline" ]; do
+              if ! runs=$(list_matching_runs); then
+                echo "Could not enumerate docker.yml runs after dispatch."
+                exit 1
+              fi
+              run_id=$(jq -r '[.[] | select(.status != "completed")] | sort_by(.createdAt) | last | .databaseId // empty' <<<"$runs")
+              [ -n "$run_id" ] && break
+              sleep 10
+            done
+            [ -n "$run_id" ] \
+              || { echo "No matching docker.yml run appeared within two minutes of dispatch."; exit 1; }
+          fi
 
-  publish-docker:
-    name: Dispatch Docker image publishing
-    needs: [check, release]
-    if: needs.check.outputs.release_needed == 'true'
-    runs-on: [self-hosted, fireactions-turbo-8]
-    permissions:
-      actions: write
-    steps:
-      # Dispatch at the release tag so both workflows check out and tag the
-      # exact released sha, even if main has moved on.
-      - name: Dispatch docker workflows at the release tag
+          gh run watch "$run_id" --repo "$GITHUB_REPOSITORY" --exit-status
+
+      - name: Record Docker publication receipt
+        if: steps.receipt.outputs.already != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.check.outputs.release_tag }}
+          RELEASE_SHA: ${{ needs.check.outputs.sha }}
+          RELEASE_CODE_HASH: ${{ needs.check.outputs.code_hash }}
         run: |
-          tag="v${{ needs.check.outputs.spec_version }}"
-          gh workflow run docker.yml \
-            --repo "$GITHUB_REPOSITORY" --ref "$tag" -f tag="$tag"
-          gh workflow run docker-localnet.yml \
-            --repo "$GITHUB_REPOSITORY" --ref "$tag" -f branch-or-tag="$tag"
+          set -euo pipefail
+          # Recorded only after the child workflow succeeded, never after
+          # dispatch acceptance.
+          python3 .github/scripts/release-publication-state.py record \
+            --tag "$RELEASE_TAG" --sha "$RELEASE_SHA" \
+            --code-hash "$RELEASE_CODE_HASH" --channel docker
+
+  publish-docker-localnet:
+    name: Dispatch localnet Docker image publishing
+    needs: check
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      needs.check.result == 'success' &&
+      needs.check.outputs.eligible == 'true'
+    timeout-minutes: 180
+    runs-on: [self-hosted, fireactions-turbo-8]
+    permissions:
+      actions: write # dispatch docker-localnet.yml and observe its run
+      contents: write # upload the publication receipt
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Re-verify release identity before dispatch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECTED_SPEC_VERSION: ${{ needs.check.outputs.spec_version }}
+          EXPECTED_SHA: ${{ needs.check.outputs.sha }}
+          EXPECTED_CODE_HASH: ${{ needs.check.outputs.code_hash }}
+        run: |
+          set -euo pipefail
+          # Runs from the trusted workflow revision on main. An approval must
+          # not dispatch image builds for an identity the chain no longer
+          # finalizes; stop and let the next scheduled run select it.
+          python3 .github/scripts/mainnet-release-state.py \
+            --mode published --output release-state.json
+          jq -e '.eligible == true' release-state.json > /dev/null \
+            || { echo "Release is no longer eligible for publication; stopping stale job."; exit 1; }
+          spec=$(jq -er '.spec_version' release-state.json)
+          sha=$(jq -er '.sha' release-state.json)
+          code_hash=$(jq -er '.code_hash' release-state.json)
+          [ "$spec" = "$EXPECTED_SPEC_VERSION" ] \
+            || { echo "Finalized spec $spec does not match selected $EXPECTED_SPEC_VERSION"; exit 1; }
+          [ "$sha" = "$EXPECTED_SHA" ] \
+            || { echo "Release commit $sha does not match selected $EXPECTED_SHA"; exit 1; }
+          [ "$code_hash" = "$EXPECTED_CODE_HASH" ] \
+            || { echo "Runtime hash $code_hash does not match selected $EXPECTED_CODE_HASH"; exit 1; }
+
+      - name: Check localnet Docker publication receipt
+        id: receipt
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.check.outputs.release_tag }}
+          RELEASE_SHA: ${{ needs.check.outputs.sha }}
+          RELEASE_CODE_HASH: ${{ needs.check.outputs.code_hash }}
+        run: |
+          set -euo pipefail
+          status=0
+          python3 .github/scripts/release-publication-state.py check \
+            --tag "$RELEASE_TAG" --sha "$RELEASE_SHA" \
+            --code-hash "$RELEASE_CODE_HASH" --channel docker-localnet || status=$?
+          case "$status" in
+            0)
+              echo "Localnet Docker images for $RELEASE_TAG are already recorded complete; skipping."
+              echo "already=true" >> "$GITHUB_OUTPUT"
+              ;;
+            1)
+              echo "No localnet Docker receipt for $RELEASE_TAG; publication remains eligible."
+              echo "already=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Localnet Docker publication receipt could not be verified (exit $status); failing visibly."
+              exit "$status"
+              ;;
+          esac
+
+      # Dispatch at the release tag so docker-localnet.yml checks out and tags
+      # the exact released sha, even if main has moved on.
+      - name: Dispatch docker-localnet.yml at the release tag
+        if: steps.receipt.outputs.already != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SPEC_VERSION: ${{ needs.check.outputs.spec_version }}
+          RELEASE_SHA: ${{ needs.check.outputs.sha }}
+        run: |
+          set -euo pipefail
+          tag="v${SPEC_VERSION}"
+
+          list_matching_runs() {
+            gh run list --repo "$GITHUB_REPOSITORY" --workflow docker-localnet.yml \
+              --event workflow_dispatch --limit 100 \
+              --json databaseId,headBranch,headSha,status,conclusion,createdAt \
+              --jq "[.[] | select(.headBranch == \"$tag\" and .headSha == \"$RELEASE_SHA\")]"
+          }
+
+          run_id=""
+          # API enumeration failure is never treated as absent history.
+          if ! runs=$(list_matching_runs); then
+            echo "Could not enumerate docker-localnet.yml runs; refusing to dispatch blindly."
+            exit 1
+          fi
+          run_id=$(jq -r '[.[] | select(.status == "completed" and .conclusion == "success")] | sort_by(.createdAt) | last | .databaseId // empty' <<<"$runs")
+          if [ -n "$run_id" ]; then
+            echo "docker-localnet.yml already succeeded for $tag at $RELEASE_SHA (run $run_id)."
+          else
+            run_id=$(jq -r '[.[] | select(.status != "completed")] | sort_by(.createdAt) | last | .databaseId // empty' <<<"$runs")
+            if [ -n "$run_id" ]; then
+              echo "docker-localnet.yml is already running for $tag (run $run_id); awaiting it instead of dispatching a duplicate."
+            fi
+          fi
+
+          if [ -z "$run_id" ]; then
+            echo "Dispatching docker-localnet.yml at $tag."
+            gh workflow run docker-localnet.yml --repo "$GITHUB_REPOSITORY" --ref "$tag" -f branch-or-tag="$tag"
+            # Dispatch acceptance does not create the run instantly; poll for
+            # the matching run before watching it.
+            deadline=$((SECONDS + 120))
+            while [ "$SECONDS" -lt "$deadline" ]; do
+              if ! runs=$(list_matching_runs); then
+                echo "Could not enumerate docker-localnet.yml runs after dispatch."
+                exit 1
+              fi
+              run_id=$(jq -r '[.[] | select(.status != "completed")] | sort_by(.createdAt) | last | .databaseId // empty' <<<"$runs")
+              [ -n "$run_id" ] && break
+              sleep 10
+            done
+            [ -n "$run_id" ] \
+              || { echo "No matching docker-localnet.yml run appeared within two minutes of dispatch."; exit 1; }
+          fi
+
+          gh run watch "$run_id" --repo "$GITHUB_REPOSITORY" --exit-status
+
+      - name: Record localnet Docker publication receipt
+        if: steps.receipt.outputs.already != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.check.outputs.release_tag }}
+          RELEASE_SHA: ${{ needs.check.outputs.sha }}
+          RELEASE_CODE_HASH: ${{ needs.check.outputs.code_hash }}
+        run: |
+          set -euo pipefail
+          # Recorded only after the child workflow succeeded, never after
+          # dispatch acceptance.
+          python3 .github/scripts/release-publication-state.py record \
+            --tag "$RELEASE_TAG" --sha "$RELEASE_SHA" \
+            --code-hash "$RELEASE_CODE_HASH" --channel docker-localnet
 
   # Full platform matrix (manylinux x86_64/aarch64, macOS arm64/x86_64,
   # sdist) at the released commit; the SDK's committed .dev0 is stamped stable.
   build-core:
     name: Build bittensor-core wheels
-    needs: check
-    if: needs.check.outputs.python_needed == 'true'
+    needs: [check, check-python]
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      needs.check.result == 'success' &&
+      needs.check.outputs.eligible == 'true' &&
+      needs.check-python.outputs.python_needed == 'true'
     uses: ./.github/workflows/build-core-wheels.yml
     with:
       ref: ${{ needs.check.outputs.sha }}
 
   publish-sdk:
     name: Publish Python packages to PyPI
-    needs: [check, release, build-core]
+    needs: [check, check-python, build-core]
     if: >-
       always() &&
-      needs.check.outputs.python_needed == 'true' &&
-      needs.build-core.result == 'success' &&
-      (needs.release.result == 'success' || needs.release.result == 'skipped')
+      github.ref == 'refs/heads/main' &&
+      needs.check.result == 'success' &&
+      needs.check.outputs.eligible == 'true' &&
+      needs.check-python.outputs.python_needed == 'true' &&
+      needs.build-core.result == 'success'
     runs-on: [self-hosted, fireactions-turbo-8]
     # PyPI trusted publishing (OIDC); publishers for `bittensor` and
     # bittensor-core are registered against this workflow + mainnet environment.
@@ -375,8 +443,40 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+
+      - name: Re-verify release identity before publishing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECTED_SPEC_VERSION: ${{ needs.check.outputs.spec_version }}
+          EXPECTED_SHA: ${{ needs.check.outputs.sha }}
+          EXPECTED_CODE_HASH: ${{ needs.check.outputs.code_hash }}
+        run: |
+          set -euo pipefail
+          # Runs from the trusted workflow revision on main, before any
+          # external publication. An old approval must not deploy old
+          # packages over a newer finalized release; stop and let the next
+          # scheduled run select the current identity.
+          python3 .github/scripts/mainnet-release-state.py \
+            --mode published --output release-state.json
+          jq -e '.eligible == true' release-state.json > /dev/null \
+            || { echo "Release is no longer eligible for publication; stopping stale job."; exit 1; }
+          spec=$(jq -er '.spec_version' release-state.json)
+          sha=$(jq -er '.sha' release-state.json)
+          code_hash=$(jq -er '.code_hash' release-state.json)
+          [ "$spec" = "$EXPECTED_SPEC_VERSION" ] \
+            || { echo "Finalized spec $spec does not match selected $EXPECTED_SPEC_VERSION"; exit 1; }
+          [ "$sha" = "$EXPECTED_SHA" ] \
+            || { echo "Release commit $sha does not match selected $EXPECTED_SHA"; exit 1; }
+          [ "$code_hash" = "$EXPECTED_CODE_HASH" ] \
+            || { echo "Runtime hash $code_hash does not match selected $EXPECTED_CODE_HASH"; exit 1; }
+
+      # Released source is checked out separately so the trusted helper
+      # scripts in .github/scripts/ (executed from the workflow revision on
+      # main) are never shadowed by the older revision being published.
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.check.outputs.sha }}
+          path: release-src
 
       # One-time v432 recovery: the deployed commit was tagged with the SDK
       # version still at its 11.0.0.dev0 placeholder, so building it as-is
@@ -386,9 +486,9 @@ jobs:
       - name: Stamp stable SDK version (v432 recovery)
         if: needs.check.outputs.spec_version == '432' && needs.check.outputs.sha == '8586e65ec279644a6837cf25b12333064c77474e'
         run: |
-          sed -i '0,/^version = ".*"/s//version = "11.0.0"/' sdk/python/pyproject.toml
-          grep -qx 'version = "11.0.0"' sdk/python/pyproject.toml \
-            || { echo "failed to stamp sdk/python/pyproject.toml"; exit 1; }
+          sed -i '0,/^version = ".*"/s//version = "11.0.0"/' release-src/sdk/python/pyproject.toml
+          grep -qx 'version = "11.0.0"' release-src/sdk/python/pyproject.toml \
+            || { echo "failed to stamp release-src/sdk/python/pyproject.toml"; exit 1; }
           echo "bittensor version stamped to 11.0.0"
 
       - name: Install uv
@@ -400,25 +500,26 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: core-dist-*
-          path: dist
+          path: release-src/dist
           merge-multiple: true
 
       - name: Prepare stable SDK distribution
-        run: python3 .github/scripts/prepare-sdk-dist.py
+        working-directory: release-src
+        run: python3 "$GITHUB_WORKSPACE/.github/scripts/prepare-sdk-dist.py"
 
       - name: Build SDK wheel and sdist
-        working-directory: sdk/python
+        working-directory: release-src/sdk/python
         run: uv build --out-dir ../../dist
 
       # Refuse to publish development or release-candidate artifacts from the
       # stable channel. Also require the complete SDK/core platform set.
       - name: Verify stable artifacts
         env:
-          EXPECTED_SDK_VERSION: ${{ needs.check.outputs.sdk_version }}
-          EXPECTED_CORE_VERSION: ${{ needs.check.outputs.core_version }}
+          EXPECTED_SDK_VERSION: ${{ needs.check-python.outputs.sdk_version }}
+          EXPECTED_CORE_VERSION: ${{ needs.check-python.outputs.core_version }}
         run: |
-          sdk_version=$(sed -n 's/^version = "\(.*\)"/\1/p' sdk/python/pyproject.toml | head -n 1)
-          core_version=$(sed -n 's/^version = "\(.*\)"/\1/p' sdk/bittensor-core-py/pyproject.toml | head -n 1)
+          sdk_version=$(sed -n 's/^version = "\(.*\)"/\1/p' release-src/sdk/python/pyproject.toml | head -n 1)
+          core_version=$(sed -n 's/^version = "\(.*\)"/\1/p' release-src/sdk/bittensor-core-py/pyproject.toml | head -n 1)
           : ${sdk_version:?could not parse stable SDK version}
           : ${core_version:?could not parse stable core version}
           [[ "$sdk_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
@@ -429,11 +530,11 @@ jobs:
             || { echo "SDK version $sdk_version != expected $EXPECTED_SDK_VERSION"; exit 1; }
           [ "$core_version" = "$EXPECTED_CORE_VERSION" ] \
             || { echo "core version $core_version != expected $EXPECTED_CORE_VERSION"; exit 1; }
-          ls -la dist
-          test -f "dist/bittensor-${sdk_version}-py3-none-any.whl"
-          test -f "dist/bittensor-${sdk_version}.tar.gz"
-          compgen -G "dist/bittensor_core-${core_version}-*.whl" >/dev/null
-          test -f "dist/bittensor_core-${core_version}.tar.gz"
+          ls -la release-src/dist
+          test -f "release-src/dist/bittensor-${sdk_version}-py3-none-any.whl"
+          test -f "release-src/dist/bittensor-${sdk_version}.tar.gz"
+          compgen -G "release-src/dist/bittensor_core-${core_version}-*.whl" >/dev/null
+          test -f "release-src/dist/bittensor_core-${core_version}.tar.gz"
 
       # PEP 740 provenance: sign every dist with this job's OIDC identity.
       # Must happen here, not in build-core-wheels.yml — PyPI only accepts
@@ -447,6 +548,7 @@ jobs:
       # already on the index are skipped instead of failing with a 400
       # duplicate (e.g. the SDK wheel landed but bittensor-core didn't).
       - name: Publish to PyPI
+        working-directory: release-src
         run: |
           ls -la dist
           uv publish --trusted-publishing always \
@@ -457,8 +559,8 @@ jobs:
       # set and the trusted-publisher attestation on every file.
       - name: Verify complete publication on PyPI
         env:
-          SDK_VERSION: ${{ needs.check.outputs.sdk_version }}
-          CORE_VERSION: ${{ needs.check.outputs.core_version }}
+          SDK_VERSION: ${{ needs.check-python.outputs.sdk_version }}
+          CORE_VERSION: ${{ needs.check-python.outputs.core_version }}
         run: |
           for attempt in $(seq 1 12); do
             status=0
@@ -479,62 +581,288 @@ jobs:
 
   publish-crates:
     name: Publish Rust crates to crates.io
-    needs: [check, release]
-    if: needs.check.outputs.release_needed == 'true'
+    needs: check
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      needs.check.result == 'success' &&
+      needs.check.outputs.eligible == 'true'
     runs-on: [self-hosted, fireactions-turbo-8]
     environment: mainnet
+    permissions:
+      contents: write # upload the publication receipt
     steps:
+      - uses: actions/checkout@v4
+
+      - name: Re-verify release identity before publishing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECTED_SPEC_VERSION: ${{ needs.check.outputs.spec_version }}
+          EXPECTED_SHA: ${{ needs.check.outputs.sha }}
+          EXPECTED_CODE_HASH: ${{ needs.check.outputs.code_hash }}
+        run: |
+          set -euo pipefail
+          # Runs from the trusted workflow revision on main, before any
+          # external publication. An old approval must not deploy old
+          # packages over a newer finalized release; stop and let the next
+          # scheduled run select the current identity.
+          python3 .github/scripts/mainnet-release-state.py \
+            --mode published --output release-state.json
+          jq -e '.eligible == true' release-state.json > /dev/null \
+            || { echo "Release is no longer eligible for publication; stopping stale job."; exit 1; }
+          spec=$(jq -er '.spec_version' release-state.json)
+          sha=$(jq -er '.sha' release-state.json)
+          code_hash=$(jq -er '.code_hash' release-state.json)
+          [ "$spec" = "$EXPECTED_SPEC_VERSION" ] \
+            || { echo "Finalized spec $spec does not match selected $EXPECTED_SPEC_VERSION"; exit 1; }
+          [ "$sha" = "$EXPECTED_SHA" ] \
+            || { echo "Release commit $sha does not match selected $EXPECTED_SHA"; exit 1; }
+          [ "$code_hash" = "$EXPECTED_CODE_HASH" ] \
+            || { echo "Runtime hash $code_hash does not match selected $EXPECTED_CODE_HASH"; exit 1; }
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.check.outputs.sha }}
+          path: release-src
 
       - uses: ./.github/actions/rust-setup
         with:
           cache-key: publish-crates
 
+      - name: Check crates publication receipt
+        id: receipt
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.check.outputs.release_tag }}
+          RELEASE_SHA: ${{ needs.check.outputs.sha }}
+          RELEASE_CODE_HASH: ${{ needs.check.outputs.code_hash }}
+        run: |
+          set -euo pipefail
+          status=0
+          python3 .github/scripts/release-publication-state.py check \
+            --tag "$RELEASE_TAG" --sha "$RELEASE_SHA" \
+            --code-hash "$RELEASE_CODE_HASH" --channel crates || status=$?
+          case "$status" in
+            0)
+              echo "Crates for $RELEASE_TAG are already recorded complete; skipping."
+              echo "already=true" >> "$GITHUB_OUTPUT"
+              ;;
+            1)
+              echo "No crates receipt for $RELEASE_TAG; publication remains eligible."
+              echo "already=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Crates publication receipt could not be verified (exit $status); failing visibly."
+              exit "$status"
+              ;;
+          esac
+
       # Workspace crates are publish = false while they depend on the
       # patched polkadot-sdk fork. Any crate that flips publish on is
-      # picked up here automatically, in dependency order.
+      # picked up here automatically, in dependency order. Registry lookups
+      # before each upload make retries safe after a partial multi-crate
+      # upload without changing which crates opt into publishing.
       - name: Publish publishable crates
+        if: steps.receipt.outputs.already != 'true'
+        working-directory: release-src
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
         run: |
-          publishable=$(cargo metadata --format-version 1 --no-deps \
-            | jq -r '.packages[] | select(.publish != []) | .name')
-          if [[ -z "$publishable" ]]; then
-            echo "No publishable crates in the workspace; skipping."
-            exit 0
-          fi
-          for crate in $publishable; do
-            echo "Publishing $crate..."
-            cargo publish -p "$crate" --locked || {
-              echo "Failed to publish $crate"
-              exit 1
-            }
-          done
+          set -euo pipefail
+          cargo metadata --format-version 1 --no-deps > /tmp/cargo-metadata.json
+          python3 - <<'PYEOF'
+          import json
+          import os
+          import subprocess
+          import sys
+          import time
+          import urllib.error
+          import urllib.request
+
+          with open("/tmp/cargo-metadata.json") as fh:
+              meta = json.load(fh)
+          packages = {p["name"]: p for p in meta["packages"]}
+          # `publish: null` means the default (crates.io); an empty list
+          # means the crate opted out of publishing.
+          publishable = sorted(
+              name for name, p in packages.items()
+              if p.get("publish") is None or len(p["publish"]) > 0
+          )
+          if not publishable:
+              print("No publishable crates in the workspace; skipping.")
+              sys.exit(0)
+
+          # Publish in dependency order using local workspace dependency
+          # edges rather than metadata list order. Normal, build, and dev
+          # dependencies must all exist on the registry before a publish.
+          edges = {name: [] for name in publishable}
+          indegree = {name: 0 for name in publishable}
+          for name in publishable:
+              for dep in packages[name].get("dependencies", []):
+                  target = dep["name"]
+                  if target in indegree and target != name:
+                      edges[target].append(name)
+                      indegree[name] += 1
+          ready = sorted(name for name in publishable if indegree[name] == 0)
+          order = []
+          while ready:
+              name = ready.pop(0)
+              order.append(name)
+              for dependent in edges[name]:
+                  indegree[dependent] -= 1
+                  if indegree[dependent] == 0:
+                      ready.append(dependent)
+                      ready.sort()
+          if len(order) != len(publishable):
+              raise SystemExit("workspace publishable crates form a dependency cycle")
+
+          headers = {"User-Agent": "subtensor-release-watcher (publication retry logic)"}
+
+          def registry_status(name, version):
+              url = f"https://crates.io/api/v1/crates/{name}/{version}"
+              request = urllib.request.Request(url, headers=headers)
+              try:
+                  with urllib.request.urlopen(request) as response:
+                      return response.status
+              except urllib.error.HTTPError as exc:
+                  if exc.code == 404:
+                      return 404
+                  raise SystemExit(
+                      f"crates.io returned HTTP {exc.code} for {name} {version}; refusing to guess"
+                  )
+              except urllib.error.URLError as exc:
+                  raise SystemExit(f"crates.io unreachable for {name} {version}: {exc}")
+
+          for name in order:
+              version = packages[name]["version"]
+              if registry_status(name, version) == 200:
+                  print(f"{name} {version} is already on crates.io; skipping.")
+                  continue
+              print(f"Publishing {name} {version}...")
+              subprocess.run(
+                  ["cargo", "publish", "-p", name, "--locked"],
+                  check=True,
+                  env=dict(os.environ),
+              )
+              # Verify propagation after each upload so the overall receipt is
+              # recorded only once every crate is actually visible.
+              for attempt in range(1, 13):
+                  if registry_status(name, version) == 200:
+                      print(f"{name} {version} visible on crates.io (attempt {attempt}).")
+                      break
+                  if attempt < 12:
+                      print(
+                          f"crates.io has not listed {name} {version} yet "
+                          f"(attempt {attempt}/12); retrying."
+                      )
+                      time.sleep(10)
+              else:
+                  raise SystemExit(f"crates.io did not list {name} {version} within two minutes")
+          print("All publishable workspace crates are on crates.io.")
+          PYEOF
+
+      - name: Record crates publication receipt
+        if: steps.receipt.outputs.already != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.check.outputs.release_tag }}
+          RELEASE_SHA: ${{ needs.check.outputs.sha }}
+          RELEASE_CODE_HASH: ${{ needs.check.outputs.code_hash }}
+        run: |
+          set -euo pipefail
+          # Recorded only after every publishable crate was confirmed visible
+          # on crates.io (or the workspace had none).
+          python3 .github/scripts/release-publication-state.py record \
+            --tag "$RELEASE_TAG" --sha "$RELEASE_SHA" \
+            --code-hash "$RELEASE_CODE_HASH" --channel crates
 
   promote-website:
     name: Deploy production website and docs
-    needs: [check, release]
-    if: needs.check.outputs.release_needed == 'true'
+    needs: check
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      needs.check.result == 'success' &&
+      needs.check.outputs.eligible == 'true'
     runs-on: [self-hosted, fireactions-turbo-8]
     environment: mainnet
+    permissions:
+      contents: write # upload the publication receipt
     steps:
+      - uses: actions/checkout@v4
+
+      - name: Re-verify release identity before publishing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECTED_SPEC_VERSION: ${{ needs.check.outputs.spec_version }}
+          EXPECTED_SHA: ${{ needs.check.outputs.sha }}
+          EXPECTED_CODE_HASH: ${{ needs.check.outputs.code_hash }}
+        run: |
+          set -euo pipefail
+          # Runs from the trusted workflow revision on main, before any
+          # external publication. An old approval must not deploy old docs
+          # over a newer finalized release; stop and let the next scheduled
+          # run select the current identity.
+          python3 .github/scripts/mainnet-release-state.py \
+            --mode published --output release-state.json
+          jq -e '.eligible == true' release-state.json > /dev/null \
+            || { echo "Release is no longer eligible for publication; stopping stale job."; exit 1; }
+          spec=$(jq -er '.spec_version' release-state.json)
+          sha=$(jq -er '.sha' release-state.json)
+          code_hash=$(jq -er '.code_hash' release-state.json)
+          [ "$spec" = "$EXPECTED_SPEC_VERSION" ] \
+            || { echo "Finalized spec $spec does not match selected $EXPECTED_SPEC_VERSION"; exit 1; }
+          [ "$sha" = "$EXPECTED_SHA" ] \
+            || { echo "Release commit $sha does not match selected $EXPECTED_SHA"; exit 1; }
+          [ "$code_hash" = "$EXPECTED_CODE_HASH" ] \
+            || { echo "Runtime hash $code_hash does not match selected $EXPECTED_CODE_HASH"; exit 1; }
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.check.outputs.sha }}
+          path: release-src
+
+      - name: Check website publication receipt
+        id: receipt
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.check.outputs.release_tag }}
+          RELEASE_SHA: ${{ needs.check.outputs.sha }}
+          RELEASE_CODE_HASH: ${{ needs.check.outputs.code_hash }}
+        run: |
+          set -euo pipefail
+          status=0
+          python3 .github/scripts/release-publication-state.py check \
+            --tag "$RELEASE_TAG" --sha "$RELEASE_SHA" \
+            --code-hash "$RELEASE_CODE_HASH" --channel website || status=$?
+          case "$status" in
+            0)
+              echo "Website for $RELEASE_TAG is already recorded complete; skipping."
+              echo "already=true" >> "$GITHUB_OUTPUT"
+              ;;
+            1)
+              echo "No website receipt for $RELEASE_TAG; publication remains eligible."
+              echo "already=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Website publication receipt could not be verified (exit $status); failing visibly."
+              exit "$status"
+              ;;
+          esac
 
       - name: Set up Node.js
+        if: steps.receipt.outputs.already != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 20
 
       - name: Enable corepack (yarn 4)
+        if: steps.receipt.outputs.already != 'true'
         run: corepack enable
 
       - name: Deploy to Vercel (production)
-        # Repo root, not website/: the Vercel root directory is resolved
-        # against the cwd (see deploy-docs.yml).
+        if: steps.receipt.outputs.already != 'true'
+        # Repo root of the released source, not website/: the Vercel root
+        # directory is resolved against the cwd (see deploy-docs.yml).
+        working-directory: release-src
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -545,3 +873,20 @@ jobs:
           # --archive=tgz: the prebuilt output exceeds Vercel's 15k-file
           # upload limit (the generated docs tree alone is >30k files).
           npx --yes vercel deploy --prebuilt --prod --archive=tgz --token "$VERCEL_TOKEN"
+
+      - name: Record website publication receipt
+        if: steps.receipt.outputs.already != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.check.outputs.release_tag }}
+          RELEASE_SHA: ${{ needs.check.outputs.sha }}
+          RELEASE_CODE_HASH: ${{ needs.check.outputs.code_hash }}
+        run: |
+          set -euo pipefail
+          # Recorded only after the production deploy command succeeded. A
+          # failure between deployment and receipt upload can repeat the
+          # deployment of the same verified release; no other source or
+          # fallback deployment is permitted.
+          python3 .github/scripts/release-publication-state.py record \
+            --tag "$RELEASE_TAG" --sha "$RELEASE_SHA" \
+            --code-hash "$RELEASE_CODE_HASH" --channel website


### PR DESCRIPTION
## Summary

- Add a trusted control-plane detector for finalized mainnet runtime identity.
- Add an independently gated reconciler that finalizes GitHub releases and updates the mainnet mirror after finalized-runtime and artifact verification.
- Remove GitHub release/mirror mutation from the approval-gated watcher while preserving PyPI, crates.io, and production website approvals.
- Make Docker, crates, and website publication independently retryable with immutable per-channel completion receipts.

## Behavior

`reconcile-mainnet-release.yml` polls on the existing ten-minute cadence and is disabled unless both conditions hold:

- the workflow ref is `refs/heads/main`; and
- `RELEASE_METADATA_AUTOMATION_ENABLED == 'true'`.

The detector validates finalized runtime bytes, the exact lightweight `v<spec>` tag and main ancestry, and trusted release-train artifact provenance. Finalization is ordered as:

1. verify the exact artifact;
2. re-read finalized identity;
3. update and read back the protected `mainnet` ref through the dedicated App token;
4. re-read finalized identity;
5. upload all five required runtime assets;
6. promote the prerelease.

Already-final matching releases are verified without rewriting. Stale finalized identities stop before mutation.

The existing watcher retains its schedule, concurrency group, `publish-sdk` environment, crates and website `mainnet` environments, PyPI trusted publishing, crates.io publication, Vercel deployment, and automatic Docker dispatch behavior. Python state is isolated from non-Python channels. Docker, crates, and website receipts are immutable release assets named `publication-<channel>.json`; failed or partial channels remain retryable.

## Verification

Offline checks run successfully:

```text
PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s .github/scripts -p 'test_mainnet_release_state.py'
Ran 4 tests ... OK

PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s .github/scripts -p 'test_release_publication_state.py'
Ran 17 tests ... OK
```

Additional checks:

- Both workflow files parse with PyYAML.
- New Python scripts compile with `py_compile`.
- `git diff --check` passes.
- An offline fake-GitHub smoke harness executed the actual extracted publication command sequence and recorded `verify -> mirror update/read-back -> asset upload -> final promotion`; the already-final retry performed zero writes.
- No live workflow, deployment, chain transaction, registry publication, or production website operation was performed.

## Preserved authorization boundaries

This PR does not remove or change PyPI, crates.io, production-site, or Docker authorization behavior. It only removes the redundant generic `mainnet` approval from GitHub metadata finalization and mirror synchronization.

## Activation contract — do not merge until ready

Provisioning and activation are intentionally not part of this PR. Before merging, a separately authorized cutover must:

1. Create and install a dedicated GitHub App named `subtensor-release-metadata` on this repository only, with Contents read/write, mandatory Metadata read, and no webhooks.
2. Add `RELEASE_METADATA_APP_ID` and `RELEASE_METADATA_APP_PRIVATE_KEY` to a new `release-metadata` environment restricted to `main`, with no reviewers or wait timer and no signing, registry, or Vercel credentials.
3. Create the active mainnet-only mirror ruleset with the existing update/creation/deletion/non-fast-forward restrictions, retaining the DeployKey bypass and adding the dedicated App Integration bypass; only then remove `mainnet` from `network-branch-mirrors (CI only)`.
4. Set `RELEASE_METADATA_AUTOMATION_ENABLED=true` only after the above controls are in place.

There is deliberately no fallback to the shared mirror key, a PAT, or an unprotected environment. Keep the variable unset and do not merge/activate this PR until the provisioning and cutover are ready.
