### PR TITLE
test: swap_basket coverage

### DIFF
--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -3533,3 +3533,146 @@ fn test_sudo_set_root_weights_cap() {
         ));
     });
 }
+
+#[test]
+fn test_sudo_set_basket_trading_enabled() {
+    new_test_ext().execute_with(|| {
+        // Launch default: trading is off.
+        assert!(!pallet_subtensor::BasketTradingEnabled::<Test>::get());
+
+        // Only root may flip the switch.
+        assert_noop!(
+            AdminUtils::sudo_set_basket_trading_enabled(
+                <<Test as Config>::RuntimeOrigin>::signed(U256::from(1)),
+                true
+            ),
+            DispatchError::BadOrigin
+        );
+        assert!(!pallet_subtensor::BasketTradingEnabled::<Test>::get());
+
+        assert_ok!(AdminUtils::sudo_set_basket_trading_enabled(
+            <<Test as Config>::RuntimeOrigin>::root(),
+            true
+        ));
+        assert!(pallet_subtensor::BasketTradingEnabled::<Test>::get());
+        frame_system::Pallet::<Test>::assert_last_event(RuntimeEvent::AdminUtils(
+            crate::Event::BasketTradingToggled { enabled: true },
+        ));
+
+        assert_ok!(AdminUtils::sudo_set_basket_trading_enabled(
+            <<Test as Config>::RuntimeOrigin>::root(),
+            false
+        ));
+        assert!(!pallet_subtensor::BasketTradingEnabled::<Test>::get());
+        frame_system::Pallet::<Test>::assert_last_event(RuntimeEvent::AdminUtils(
+            crate::Event::BasketTradingToggled { enabled: false },
+        ));
+    });
+}
+
+#[test]
+fn test_sudo_set_basket_trading_frozen() {
+    new_test_ext().execute_with(|| {
+        let hotkey = U256::from(42);
+        let other = U256::from(43);
+        assert!(!pallet_subtensor::BasketTradingFrozen::<Test>::contains_key(hotkey));
+
+        // Only root may freeze.
+        assert_noop!(
+            AdminUtils::sudo_set_basket_trading_frozen(
+                <<Test as Config>::RuntimeOrigin>::signed(U256::from(1)),
+                hotkey,
+                true
+            ),
+            DispatchError::BadOrigin
+        );
+
+        // Freeze one hotkey: only that hotkey is marked.
+        assert_ok!(AdminUtils::sudo_set_basket_trading_frozen(
+            <<Test as Config>::RuntimeOrigin>::root(),
+            hotkey,
+            true
+        ));
+        assert!(pallet_subtensor::BasketTradingFrozen::<Test>::contains_key(
+            hotkey
+        ));
+        assert!(!pallet_subtensor::BasketTradingFrozen::<Test>::contains_key(other));
+        frame_system::Pallet::<Test>::assert_last_event(RuntimeEvent::AdminUtils(
+            crate::Event::BasketTradingFrozenSet {
+                hotkey,
+                frozen: true,
+            },
+        ));
+
+        // Freezing twice is idempotent; unfreezing removes the row and emits.
+        assert_ok!(AdminUtils::sudo_set_basket_trading_frozen(
+            <<Test as Config>::RuntimeOrigin>::root(),
+            hotkey,
+            true
+        ));
+        assert_ok!(AdminUtils::sudo_set_basket_trading_frozen(
+            <<Test as Config>::RuntimeOrigin>::root(),
+            hotkey,
+            false
+        ));
+        assert!(!pallet_subtensor::BasketTradingFrozen::<Test>::contains_key(hotkey));
+        frame_system::Pallet::<Test>::assert_last_event(RuntimeEvent::AdminUtils(
+            crate::Event::BasketTradingFrozenSet {
+                hotkey,
+                frozen: false,
+            },
+        ));
+        // Unfreezing a never-frozen hotkey is a harmless no-op.
+        assert_ok!(AdminUtils::sudo_set_basket_trading_frozen(
+            <<Test as Config>::RuntimeOrigin>::root(),
+            other,
+            false
+        ));
+    });
+}
+
+#[test]
+fn test_sudo_set_basket_daily_turnover_cap() {
+    new_test_ext().execute_with(|| {
+        // Launch default: 10% of fund NAV per window.
+        assert_eq!(
+            pallet_subtensor::BasketDailyTurnoverCap::<Test>::get(),
+            pallet_subtensor::DEFAULT_BASKET_DAILY_TURNOVER_CAP
+        );
+
+        // Only root may set the cap.
+        assert_noop!(
+            AdminUtils::sudo_set_basket_daily_turnover_cap(
+                <<Test as Config>::RuntimeOrigin>::signed(U256::from(1)),
+                1000
+            ),
+            DispatchError::BadOrigin
+        );
+
+        // Zero would refuse every trade; rejected.
+        assert_noop!(
+            AdminUtils::sudo_set_basket_daily_turnover_cap(
+                <<Test as Config>::RuntimeOrigin>::root(),
+                0
+            ),
+            Error::<Test>::ValueNotInBounds
+        );
+        assert_eq!(
+            pallet_subtensor::BasketDailyTurnoverCap::<Test>::get(),
+            pallet_subtensor::DEFAULT_BASKET_DAILY_TURNOVER_CAP
+        );
+
+        // Root sets a new cap (100%) and the storage + event reflect it.
+        assert_ok!(AdminUtils::sudo_set_basket_daily_turnover_cap(
+            <<Test as Config>::RuntimeOrigin>::root(),
+            u16::MAX
+        ));
+        assert_eq!(
+            pallet_subtensor::BasketDailyTurnoverCap::<Test>::get(),
+            u16::MAX
+        );
+        frame_system::Pallet::<Test>::assert_last_event(RuntimeEvent::AdminUtils(
+            crate::Event::BasketDailyTurnoverCapSet { cap: u16::MAX },
+        ));
+    });
+}

--- a/pallets/subtensor/src/macros/events.rs
+++ b/pallets/subtensor/src/macros/events.rs
@@ -529,25 +529,6 @@ mod events {
             tao: TaoBalance,
         },
 
-        /// A validator rebalanced its beta basket: `alpha_sold` of `origin_netuid` was sold
-        /// for `tao_mid` TAO, which bought `alpha_bought` of `destination_netuid`. Fund
-        /// shares and staker entitlements are unaffected; only the fund's composition changed.
-        BasketSwapped {
-            /// Validator hotkey whose basket was rebalanced.
-            hotkey: T::AccountId,
-            /// Subnet sold out of (root = the fund's TAO slot).
-            origin_netuid: NetUid,
-            /// Subnet bought into (root = the fund's TAO slot).
-            destination_netuid: NetUid,
-            /// Alpha (or TAO when origin is root) removed from the origin holding.
-            alpha_sold: AlphaBalance,
-            /// TAO that passed through the middle of the swap; counted against the fund's
-            /// daily turnover budget.
-            tao_mid: TaoBalance,
-            /// Alpha (or TAO when destination is root) added to the destination holding.
-            alpha_bought: AlphaBalance,
-        },
-
         /// Voting power tracking has been enabled for a subnet.
         VotingPowerTrackingEnabled {
             /// The subnet ID
@@ -834,6 +815,25 @@ mod events {
             netuid: NetUid,
             /// Alpha removed from basket custody and recorded as burned.
             alpha: AlphaBalance,
+        },
+
+        /// A validator rebalanced its beta basket: `alpha_sold` of `origin_netuid` was sold
+        /// for `tao_mid` TAO, which bought `alpha_bought` of `destination_netuid`. Fund
+        /// shares and staker entitlements are unaffected; only the fund's composition changed.
+        BasketSwapped {
+            /// Validator hotkey whose basket was rebalanced.
+            hotkey: T::AccountId,
+            /// Subnet sold out of (root = the fund's TAO slot).
+            origin_netuid: NetUid,
+            /// Subnet bought into (root = the fund's TAO slot).
+            destination_netuid: NetUid,
+            /// Alpha (or TAO when origin is root) removed from the origin holding.
+            alpha_sold: AlphaBalance,
+            /// TAO that passed through the middle of the swap; counted against the fund's
+            /// daily turnover budget.
+            tao_mid: TaoBalance,
+            /// Alpha (or TAO when destination is root) added to the destination holding.
+            alpha_bought: AlphaBalance,
         },
     }
 }

--- a/pallets/subtensor/src/staking/basket_views.rs
+++ b/pallets/subtensor/src/staking/basket_views.rs
@@ -176,10 +176,13 @@ impl<T: Config> Pallet<T> {
     }
 
     /// The fund's `swap_basket` turnover window as seen at block `now`: the stored window
-    /// if still open, otherwise a fresh one starting at `now` with nothing used.
+    /// if still open and charged, otherwise a fresh one starting at `now` with nothing used.
+    /// A fund that has never traded (the `(0, 0)` default) opens its first window at its
+    /// first trade rather than at block 0, so a young chain does not hand every fund a
+    /// shared window ending at block `BASKET_TRADE_WINDOW_BLOCKS`.
     pub fn basket_trade_window_at(hotkey: &T::AccountId, now: u64) -> (u64, u64) {
         let (window_start, tao_used) = BasketTradeWindow::<T>::get(hotkey);
-        if now.saturating_sub(window_start) >= crate::BASKET_TRADE_WINDOW_BLOCKS {
+        if tao_used == 0 || now.saturating_sub(window_start) >= crate::BASKET_TRADE_WINDOW_BLOCKS {
             (now, 0)
         } else {
             (window_start, tao_used)

--- a/pallets/subtensor/src/tests/mod.rs
+++ b/pallets/subtensor/src/tests/mod.rs
@@ -37,6 +37,7 @@ mod staking2;
 mod subnet;
 mod subnet_emissions;
 mod subnet_info;
+mod swap_basket;
 mod swap_coldkey;
 mod swap_hotkey;
 mod swap_hotkey_with_subnet;

--- a/pallets/subtensor/src/tests/swap_basket.rs
+++ b/pallets/subtensor/src/tests/swap_basket.rs
@@ -15,11 +15,11 @@ use crate::tests::claim_root::{
 };
 use crate::tests::mock::*;
 use crate::{
-    BASKET_TRADE_WINDOW_BLOCKS, BasketClaimed, BasketDailyTurnoverCap, BasketRate,
+    BASKET_TRADE_WINDOW_BLOCKS, BasketClaimed, BasketDailyTurnoverCap, BasketRate, BasketShares,
     BasketTradeWindow, BasketTradingEnabled, BasketTradingFrozen, ColdkeySwapAnnouncements,
-    DEFAULT_BASKET_DAILY_TURNOVER_CAP, DefaultMinStake, Error, Event, RootWeightsCap,
-    SubnetAlphaIn, SubnetAlphaOut, SubnetMovingPrice, SubnetProtocolFlow, SubnetTAO, SubnetTaoFlow,
-    SubtokenEnabled, TotalStake, Uids,
+    DEFAULT_BASKET_DAILY_TURNOVER_CAP, DefaultMinStake, Error, Event, NetworksAdded,
+    RootWeightsCap, SubnetAlphaIn, SubnetAlphaOut, SubnetMovingPrice, SubnetProtocolFlow,
+    SubnetTAO, SubnetTaoFlow, SubtokenEnabled, TotalStake, Uids,
 };
 use codec::Encode;
 use frame_support::dispatch::DispatchResultWithPostInfo;
@@ -30,6 +30,7 @@ use sp_core::U256;
 use sp_runtime::traits::Hash;
 use substrate_fixed::types::I96F32;
 use subtensor_runtime_common::{AlphaBalance, NetUid, TaoBalance, Token};
+use subtensor_swap_interface::SwapHandler;
 
 type HashingOf<T> = <T as frame_system::Config>::Hashing;
 
@@ -988,4 +989,336 @@ fn regression_basket_swapped_event_index_is_appended() {
     .encode();
     assert_eq!(prior_tail[0], 148);
     assert_eq!(swapped[0], 149);
+}
+
+// =============================================================================
+// Documented weaknesses (calibration pass on PR #3150)
+//
+// These tests pin *current* behaviour so the weaknesses are visible in CI. Each is
+// expected to PASS today; when a fix for the referenced finding lands, the assertion it
+// names will flip and the test must be inverted or removed together with the fix.
+// Finding numbers refer to `docs/pr-3150-swap-basket-exploit-calibration.md` (§2.x, §4).
+// =============================================================================
+
+/// Deep-cash fund plus one thin subnet C (1 000 τ / 100 000 α, price 0.01, EMA = spot),
+/// with enough networks on chain for the 1/16 concentration cap to bind.
+fn setup_cash_fund_with_thin_pool() -> (Fund, NetUid) {
+    let coldkey = U256::from(1001);
+    let hotkey = U256::from(1002);
+    let staker = U256::from(1003);
+    let owner_c = U256::from(3001);
+    let hotkey_c = U256::from(3002);
+
+    let netuid_a = add_dynamic_network(&hotkey, &coldkey);
+    let netuid_c = add_dynamic_network(&hotkey_c, &owner_c);
+    remove_owner_registration_stake(netuid_a);
+    remove_owner_registration_stake(netuid_c);
+    fund_pool(netuid_a);
+    SubnetMovingPrice::<Test>::insert(netuid_a, I96F32::from_num(1));
+    // Thin pool: 1 000 τ against 100 000 α.
+    SubnetTAO::<Test>::insert(netuid_c, TaoBalance::from(THIN_POOL_TAO));
+    SubnetAlphaIn::<Test>::insert(netuid_c, AlphaBalance::from(THIN_POOL_ALPHA));
+    SubnetMovingPrice::<Test>::insert(netuid_c, I96F32::from_num(0.01));
+
+    SubtensorModule::set_tao_weight(u64::MAX);
+    zero_claim_threshold();
+    register_on_root(&hotkey, 0);
+    NetworksAdded::<Test>::insert(NetUid::ROOT, true);
+    // 16 destinations on chain so `RootWeightsCap` (1/16) is enforced.
+    for raw in 100u16..113 {
+        NetworksAdded::<Test>::insert(NetUid::from(raw), true);
+    }
+    assert!(
+        SubtensorModule::binding_root_weights_cap(
+            SubtensorModule::get_all_subnet_netuids().len() as u64
+        )
+        .is_some()
+    );
+
+    // The fund holds 100 000 τ of cash in the root slot, backed by balance on the root pot
+    // and counted in the root reserves; shares are outstanding so NAV/share is 1.
+    let escrow = SubtensorModule::get_beta_escrow_account_id();
+    let root_account = SubtensorModule::get_subnet_account_id(NetUid::ROOT).unwrap();
+    add_balance_to_coldkey_account(&root_account, TaoBalance::from(CASH_NAV));
+    SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
+        &hotkey,
+        &escrow,
+        NetUid::ROOT,
+        CASH_NAV.into(),
+    );
+    SubnetTAO::<Test>::mutate(NetUid::ROOT, |t| *t = t.saturating_add(CASH_NAV.into()));
+    SubnetAlphaOut::<Test>::mutate(NetUid::ROOT, |t| *t = t.saturating_add(CASH_NAV.into()));
+    TotalStake::<Test>::mutate(|t| *t = t.saturating_add(CASH_NAV.into()));
+    BasketShares::<Test>::insert(hotkey, CASH_NAV);
+    mock_increase_stake_for_hotkey_and_coldkey_on_subnet(
+        &hotkey,
+        &staker,
+        NetUid::ROOT,
+        2_000_000u64.into(),
+    );
+
+    BasketTradingEnabled::<Test>::put(true);
+    (
+        Fund {
+            coldkey,
+            hotkey,
+            staker,
+            netuid_a,
+            netuid_b: netuid_c,
+        },
+        netuid_c,
+    )
+}
+
+/// 100 000 τ of fund cash.
+const CASH_NAV: u64 = 100_000_000_000_000;
+/// Thin pool reserves: 1 000 τ and 100 000 α (price 0.01).
+const THIN_POOL_TAO: u64 = 1_000_000_000_000;
+const THIN_POOL_ALPHA: u64 = 100_000_000_000_000;
+/// One buy slice of 9 τ: < 1% of the thin pool's TAO, so its own price impact is < 2%.
+const SLICE: u64 = 9_000_000_000;
+
+fn spot(netuid: NetUid) -> f64 {
+    <Test as crate::Config>::SwapInterface::current_alpha_price(netuid.into()).to_num::<f64>()
+}
+
+/// A counterparty sells (fee-free) exactly enough alpha into `netuid` to bring spot back
+/// down to `target_price`, pulling the fund's TAO out of the pool.
+fn counterparty_sells_back_to(netuid: NetUid, target_price: f64) {
+    let tao = SubnetTAO::<Test>::get(netuid).to_u64() as f64;
+    let alpha_in = SubnetAlphaIn::<Test>::get(netuid).to_u64() as f64;
+    // Constant product: k = tao * alpha; at the target price alpha' = sqrt(k / p).
+    let target_alpha = (tao * alpha_in / target_price).sqrt();
+    let sell = target_alpha - alpha_in;
+    if sell < 1.0 {
+        return;
+    }
+    let out = SubtensorModule::swap_alpha_for_tao(
+        netuid,
+        AlphaBalance::from(sell as u64),
+        <Test as crate::Config>::SwapInterface::min_price::<TaoBalance>(),
+        true,
+    )
+    .expect("counterparty sale fills");
+    // The counterparty walks away with the TAO (leaves the pot).
+    assert_ok!(SubtensorModule::transfer_tao_from_subnet(
+        netuid,
+        &U256::from(9_999),
+        out.amount_paid_out.into(),
+    ));
+}
+
+/// Finding §2.1 (High): sliced buys into a thin pool, each answered by a counterparty
+/// sell-back to the EMA, pass every guardrail on every trade and drain the fund by ~8% of
+/// NAV inside one turnover window. The concentration cap never fires because it measures
+/// *realizable* value, which is bounded by the pool's TAO reserve. Documents current
+/// behaviour; flip when a liquidity-relative destination cap (§5.1) lands.
+#[test]
+fn finding_2_1_thin_pool_drain_passes_every_guardrail() {
+    new_test_ext(1).execute_with(|| {
+        let (fund, netuid_c) = setup_cash_fund_with_thin_pool();
+        let nav_before = nav(&fund.hotkey);
+        assert_eq!(nav_before, CASH_NAV);
+        let budget = SubtensorModule::basket_trade_budget_tao(nav_before);
+        let counterparty_before = SubtensorModule::get_coldkey_balance(&U256::from(9_999)).to_u64();
+
+        let mut trades = 0u32;
+        let mut spent = 0u64;
+        let refused_with = loop {
+            match swap(&fund, NetUid::ROOT, netuid_c, SLICE) {
+                Ok(_) => {
+                    trades += 1;
+                    spent += SLICE;
+                    counterparty_sells_back_to(netuid_c, 0.01);
+                }
+                Err(err) => break err.error,
+            }
+        };
+
+        // Only the turnover budget ever stops the loop, and only after it is spent.
+        assert_eq!(
+            refused_with,
+            Error::<Test>::BasketTurnoverBudgetExceeded.into()
+        );
+        assert!(trades > 500, "trades = {trades}");
+        assert!(spent > budget * 9 / 10, "spent {spent} of budget {budget}");
+
+        // The fund now holds several times the pool's whole alpha reserve, realizable for
+        // roughly the pool's TAO reserve; the counterparty walked away with ~all the TAO.
+        let holding = escrow_alpha(&fund.hotkey, netuid_c);
+        assert!(
+            holding > 5 * THIN_POOL_ALPHA,
+            "holding {holding} vs reserve {THIN_POOL_ALPHA}"
+        );
+        let realizable = SubtensorModule::realizable_tao_for_alpha(netuid_c, holding);
+        assert!(realizable <= THIN_POOL_TAO);
+        let received =
+            SubtensorModule::get_coldkey_balance(&U256::from(9_999)).to_u64() - counterparty_before;
+        assert!(
+            received > spent * 95 / 100,
+            "counterparty took {received} of {spent}"
+        );
+
+        // Loss: > 5% of NAV in one window (calibration run: 8.3%), i.e. ~90% of the TAO
+        // traded — far above the PR's stated worst case of cap × (2 × 2% + fees).
+        let nav_after = nav(&fund.hotkey);
+        let loss = nav_before - nav_after;
+        assert!(
+            loss > nav_before * 5 / 100,
+            "loss {loss} ({}%) must exceed 5% of NAV to reproduce the finding",
+            loss * 100 / nav_before
+        );
+        assert!(loss > spent * 3 / 4, "loss {loss} vs spent {spent}");
+
+        // The concentration cap passes because the destination is measured realizable.
+        let cap = SubtensorModule::binding_root_weights_cap(
+            SubtensorModule::get_all_subnet_netuids().len() as u64,
+        )
+        .expect("cap binds");
+        assert!(SubtensorModule::share_within_root_cap(
+            realizable, nav_after, cap
+        ));
+        // ...while the same holding marked at spot is several multiples of the cap share.
+        let spot_value = SubtensorModule::spot_tao_for_alpha(netuid_c, holding);
+        assert!(!SubtensorModule::share_within_root_cap(
+            spot_value, nav_after, cap
+        ));
+        assert!(spot_value > 5 * realizable);
+    });
+}
+
+/// Finding §2.2 (Medium): the turnover window is a fixed interval with a lazy reset, so a
+/// trader can spend one full budget at block `start + 7199` and another at `start + 7200`
+/// — 2× the daily cap in two adjacent blocks. Documents current behaviour; flip when a
+/// token-bucket budget (§5.2) lands.
+#[test]
+fn finding_2_2_window_boundary_lets_two_budgets_through_in_adjacent_blocks() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        BasketDailyTurnoverCap::<Test>::put(DEFAULT_BASKET_DAILY_TURNOVER_CAP);
+        let budget = SubtensorModule::basket_trade_budget_tao(nav(&fund.hotkey));
+        // Two half-budget trades fit inside one window (tao_mid trails alpha by the fee).
+        let half = budget / 2;
+
+        let start = System::block_number();
+        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, half));
+        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, half));
+        let (_, used_in_first_window) = BasketTradeWindow::<Test>::get(fund.hotkey);
+        assert!(used_in_first_window > budget * 99 / 100);
+
+        // Last block of the window: the budget is spent.
+        System::set_block_number(start + BASKET_TRADE_WINDOW_BLOCKS - 1);
+        assert_noop!(
+            swap(&fund, fund.netuid_a, fund.netuid_b, half),
+            Error::<Test>::BasketTurnoverBudgetExceeded
+        );
+
+        // Very next block: a whole new budget is available.
+        System::set_block_number(start + BASKET_TRADE_WINDOW_BLOCKS);
+        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, half));
+        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, half));
+        let (_, used_in_second_window) = BasketTradeWindow::<Test>::get(fund.hotkey);
+
+        let moved_in_two_blocks = used_in_first_window + used_in_second_window;
+        assert!(
+            moved_in_two_blocks > budget * 19 / 10,
+            "moved {moved_in_two_blocks} vs one budget {budget}"
+        );
+    });
+}
+
+/// Finding §2.3 (Low): the 2% band is per leg, not per block. With spot below the EMA,
+/// chained buy legs in one block each pass (`ceiling = 1.02 × min(EMA, spot)`) and walk
+/// the price up to 1.02 × EMA — here +20% or more in a single block. Documents current
+/// behaviour; flip if a per-block price or rate bound is added.
+#[test]
+fn finding_2_3_chained_legs_in_one_block_walk_price_to_ema_ceiling() {
+    new_test_ext(1).execute_with(|| {
+        let (fund, netuid_c) = setup_cash_fund_with_thin_pool();
+        // Spot 0.01 sits 20% below a 0.0125 EMA.
+        let ema = 0.0125f64;
+        SubnetMovingPrice::<Test>::insert(netuid_c, I96F32::from_num(ema));
+        let spot_before = spot(netuid_c);
+        let block = System::block_number();
+
+        let mut legs = 0u32;
+        let refused_with = loop {
+            match swap(&fund, NetUid::ROOT, netuid_c, SLICE) {
+                Ok(_) => legs += 1,
+                Err(err) => break err.error,
+            }
+        };
+        assert_eq!(System::block_number(), block, "all legs ran in one block");
+        assert_eq!(refused_with, Error::<Test>::SlippageTooHigh.into());
+
+        let spot_after = spot(netuid_c);
+        assert!(legs >= 10, "legs = {legs}");
+        assert!(
+            spot_after / spot_before > 1.20,
+            "price moved {spot_before} -> {spot_after} in one block"
+        );
+        // Stopped only by the EMA ceiling, not by any per-block rule.
+        assert!(spot_after <= ema * 1.02 * 1.001);
+        assert!(spot_after > ema);
+    });
+}
+
+/// Finding §4 "crash lock": once spot sits 5% below the EMA a fund cannot sell even one
+/// unit of the holding (no stop-loss), and 5% above it cannot buy. Documents current
+/// behaviour; flip when a wider sell-side tolerance (§5.3) lands.
+#[test]
+fn finding_crash_lock_blocks_selling_a_falling_holding() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        // Spot is 1.0 on both pools. A's EMA is 5% above spot: the fund holds A and cannot
+        // sell any of it — into another subnet or into cash.
+        SubnetMovingPrice::<Test>::insert(fund.netuid_a, I96F32::from_num(1.0 / 0.95));
+        assert_noop!(
+            swap(&fund, fund.netuid_a, fund.netuid_b, TRADE),
+            Error::<Test>::SlippageTooHigh
+        );
+        assert_noop!(
+            swap(&fund, fund.netuid_a, NetUid::ROOT, TRADE),
+            Error::<Test>::SlippageTooHigh
+        );
+        SubnetMovingPrice::<Test>::insert(fund.netuid_a, I96F32::from_num(1));
+
+        // B's EMA is 5% below spot: the fund cannot buy B.
+        SubnetMovingPrice::<Test>::insert(fund.netuid_b, I96F32::from_num(0.95));
+        assert_noop!(
+            swap(&fund, fund.netuid_a, fund.netuid_b, TRADE),
+            Error::<Test>::SlippageTooHigh
+        );
+    });
+}
+
+/// Finding §4 "cash slot": root is a capped destination like any subnet, so with the cap
+/// binding a fund cannot hold more than `RootWeightsCap` (1/16) of NAV as TAO — it cannot
+/// de-risk into cash. Documents current behaviour; flip when a separate cash cap (§5.4)
+/// lands.
+#[test]
+fn finding_cash_slot_is_capped_at_root_weights_cap() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        // Root + A + B + 13 placeholders = 16 destinations: the default 1/16 cap binds.
+        for raw in 100u16..113 {
+            NetworksAdded::<Test>::insert(NetUid::from(raw), true);
+        }
+        let available = SubtensorModule::get_all_subnet_netuids().len() as u64;
+        assert_eq!(available, 16);
+        assert_eq!(
+            SubtensorModule::binding_root_weights_cap(available),
+            Some(u64::from(RootWeightsCap::<Test>::get(NetUid::ROOT)))
+        );
+
+        let held = escrow_alpha(&fund.hotkey, fund.netuid_a);
+        // 10% of the fund into cash: refused.
+        assert_noop!(
+            swap(&fund, fund.netuid_a, NetUid::ROOT, held / 10),
+            Error::<Test>::RootWeightCapExceeded
+        );
+        // 6% (just under 1/16): allowed.
+        assert_ok!(swap(&fund, fund.netuid_a, NetUid::ROOT, held * 6 / 100));
+        assert!(escrow_alpha(&fund.hotkey, NetUid::ROOT) > 0);
+    });
 }

--- a/pallets/subtensor/src/tests/swap_basket.rs
+++ b/pallets/subtensor/src/tests/swap_basket.rs
@@ -1,0 +1,991 @@
+//! Beta basket: validator-directed rebalancing (`swap_basket`).
+//!
+//! Trades change only the fund's composition. Shares, the claimable rate, and every
+//! staker's watermark are untouched; NAV moves only by fees and slippage; root reserves
+//! stay in lockstep; the block author receives the AMM fee; both legs are booked as
+//! protocol flow. Every gate, guardrail, and rollback path is pinned here.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use crate::CheckColdkeySwap;
+use crate::migrations::migrate_seed_beta_basket::kickoff_seed_beta_basket_v2;
+use crate::tests::claim_root::{
+    escrow_alpha, flush_baskets, fund_pool, fund_shares, register_on_root, root_stake_of,
+    zero_claim_threshold,
+};
+use crate::tests::mock::*;
+use crate::{
+    BASKET_TRADE_WINDOW_BLOCKS, BasketClaimed, BasketDailyTurnoverCap, BasketRate,
+    BasketTradeWindow, BasketTradingEnabled, BasketTradingFrozen, ColdkeySwapAnnouncements,
+    DEFAULT_BASKET_DAILY_TURNOVER_CAP, DefaultMinStake, Error, Event, RootWeightsCap,
+    SubnetAlphaIn, SubnetAlphaOut, SubnetMovingPrice, SubnetProtocolFlow, SubnetTAO, SubnetTaoFlow,
+    SubtokenEnabled, TotalStake, Uids,
+};
+use codec::Encode;
+use frame_support::dispatch::DispatchResultWithPostInfo;
+use frame_support::traits::{ExtendedDispatchable, Get};
+use frame_support::weights::Weight;
+use frame_support::{assert_noop, assert_ok};
+use sp_core::U256;
+use sp_runtime::traits::Hash;
+use substrate_fixed::types::I96F32;
+use subtensor_runtime_common::{AlphaBalance, NetUid, TaoBalance, Token};
+
+type HashingOf<T> = <T as frame_system::Config>::Hashing;
+
+/// Economic bound: a trade may only cost AMM fees and slippage, so NAV must stay within
+/// this percentage of its pre-trade value on deep pools.
+const FEE_TOLERANCE_PCT: u64 = 5;
+
+/// Dividend credited to the fund in the standard playground (alpha on subnet A, price ~1).
+const DIVIDEND: u64 = 100_000_000;
+
+/// A trade comfortably above `DefaultMinStake` (2 TAO in the mock) and well inside the
+/// default 10% turnover budget of a `DIVIDEND`-sized fund.
+const TRADE: u64 = 4_000_000;
+
+struct Fund {
+    /// Owns `hotkey`; the account that signs trades.
+    coldkey: U256,
+    /// Root-registered validator whose basket is traded.
+    hotkey: U256,
+    /// Root staker entitled to the fund's dividends.
+    staker: U256,
+    /// Dividend origin; the fund's initial holding lives here.
+    netuid_a: NetUid,
+    /// Second deep pool to trade into.
+    netuid_b: NetUid,
+}
+
+/// A root validator whose fund holds `DIVIDEND` alpha on subnet A, a second deep pool B,
+/// EMA prices pinned at 1.0, trading enabled, and the turnover budget lifted to 100% so
+/// happy-path tests can move whole holdings. Guardrail tests tighten what they need.
+fn setup_fund() -> Fund {
+    let coldkey = U256::from(1001);
+    let hotkey = U256::from(1002);
+    let staker = U256::from(1003);
+    let owner_b = U256::from(2001);
+    let hotkey_b = U256::from(2002);
+
+    let netuid_a = add_dynamic_network(&hotkey, &coldkey);
+    let netuid_b = add_dynamic_network(&hotkey_b, &owner_b);
+    remove_owner_registration_stake(netuid_a);
+    fund_pool(netuid_a);
+    fund_pool(netuid_b);
+    SubnetMovingPrice::<Test>::insert(netuid_a, I96F32::from_num(1));
+    SubnetMovingPrice::<Test>::insert(netuid_b, I96F32::from_num(1));
+
+    SubtensorModule::set_tao_weight(u64::MAX);
+    zero_claim_threshold();
+
+    mock_increase_stake_for_hotkey_and_coldkey_on_subnet(
+        &hotkey,
+        &staker,
+        NetUid::ROOT,
+        2_000_000u64.into(),
+    );
+    mock_increase_stake_for_hotkey_and_coldkey_on_subnet(
+        &hotkey,
+        &coldkey,
+        netuid_a,
+        10_000_000u64.into(),
+    );
+    register_on_root(&hotkey, 0);
+
+    SubtensorModule::distribute_emission(
+        netuid_a,
+        AlphaBalance::ZERO,
+        AlphaBalance::ZERO,
+        DIVIDEND.into(),
+        AlphaBalance::ZERO,
+    );
+    flush_baskets();
+    assert!(escrow_alpha(&hotkey, netuid_a) > 0);
+    assert!(fund_shares(&hotkey) > 0);
+
+    BasketTradingEnabled::<Test>::put(true);
+    BasketDailyTurnoverCap::<Test>::put(u16::MAX);
+
+    Fund {
+        coldkey,
+        hotkey,
+        staker,
+        netuid_a,
+        netuid_b,
+    }
+}
+
+fn swap(fund: &Fund, origin: NetUid, dest: NetUid, amount: u64) -> DispatchResultWithPostInfo {
+    SubtensorModule::swap_basket(
+        RuntimeOrigin::signed(fund.coldkey),
+        fund.hotkey,
+        origin,
+        dest,
+        amount.into(),
+    )
+}
+
+fn nav(hotkey: &U256) -> u64 {
+    SubtensorModule::get_validator_basket_nav_tao(hotkey).to_u64()
+}
+
+fn author_balance() -> u64 {
+    SubtensorModule::get_coldkey_balance(&U256::from(MOCK_BLOCK_BUILDER)).to_u64()
+}
+
+/// Forget the fund's turnover window so consecutive whole-holding trades in one test are
+/// not limited by the budget (budget behaviour has its own tests).
+fn reset_turnover_window(hotkey: &U256) {
+    BasketTradeWindow::<Test>::remove(hotkey);
+}
+
+/// `(alpha_sold, tao_mid, alpha_bought)` of the most recent `BasketSwapped` event.
+fn last_swap_event() -> (u64, u64, u64) {
+    System::events()
+        .iter()
+        .rev()
+        .find_map(|record| match &record.event {
+            RuntimeEvent::SubtensorModule(Event::BasketSwapped {
+                alpha_sold,
+                tao_mid,
+                alpha_bought,
+                ..
+            }) => Some((alpha_sold.to_u64(), tao_mid.to_u64(), alpha_bought.to_u64())),
+            _ => None,
+        })
+        .expect("a BasketSwapped event was emitted")
+}
+
+/// Snapshot of everything a trade must leave untouched.
+#[derive(PartialEq, Debug)]
+struct Entitlements {
+    shares: u64,
+    rate: I96F32,
+    claimed: i128,
+    owed: u64,
+    root_stake: u64,
+}
+
+fn entitlements(fund: &Fund) -> Entitlements {
+    Entitlements {
+        shares: fund_shares(&fund.hotkey),
+        rate: BasketRate::<Test>::get(fund.hotkey),
+        claimed: BasketClaimed::<Test>::get(fund.hotkey, fund.staker),
+        owed: SubtensorModule::get_basket_owed_shares(&fund.hotkey, &fund.staker),
+        root_stake: root_stake_of(&fund.hotkey, &fund.staker),
+    }
+}
+
+fn assert_nav_within_fees(before: u64, after: u64) {
+    assert!(
+        after <= before,
+        "a trade cannot create value: {before} -> {after}"
+    );
+    assert!(
+        after >= before * (100 - FEE_TOLERANCE_PCT) / 100,
+        "a trade may only cost fees and slippage: {before} -> {after}"
+    );
+}
+
+// =============================================================================
+// Happy paths
+// =============================================================================
+
+/// Alpha -> alpha: the holding moves, entitlements are untouched, NAV moves only by fees,
+/// TotalStake drops by exactly the block author's fee, the event names both legs.
+#[test]
+fn test_swap_basket_alpha_to_alpha_is_composition_only() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        let held = escrow_alpha(&fund.hotkey, fund.netuid_a);
+        let before = entitlements(&fund);
+        let nav_before = nav(&fund.hotkey);
+        let ts_before = TotalStake::<Test>::get().to_u64();
+        let author_before = author_balance();
+
+        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, TRADE));
+
+        let (alpha_sold, tao_mid, alpha_bought) = last_swap_event();
+        assert_eq!(alpha_sold, TRADE);
+        assert!(tao_mid > 0 && tao_mid <= TRADE, "tao_mid = {tao_mid}");
+        assert_eq!(escrow_alpha(&fund.hotkey, fund.netuid_a), held - TRADE);
+        assert_eq!(escrow_alpha(&fund.hotkey, fund.netuid_b), alpha_bought);
+        assert!(alpha_bought > 0);
+
+        assert_eq!(entitlements(&fund), before);
+        assert_nav_within_fees(nav_before, nav(&fund.hotkey));
+
+        // The block author is paid on both legs. Only the sell leg's fee (alpha sold
+        // fee-free for TAO that leaves the pool) reduces `TotalStake`; the buy leg's fee is
+        // TAO already counted in by `swap_tao_for_alpha` and merely moves pot -> author,
+        // exactly as in `stake_into_subnet`. The sell-leg fee is what the origin pool
+        // booked as protocol outflow beyond `tao_mid`.
+        let author_fee = author_balance() - author_before;
+        assert!(
+            author_fee > 0,
+            "the block author must receive the swap fees"
+        );
+        let sell_fee_outflow = (-SubnetProtocolFlow::<Test>::get(fund.netuid_a)) as u64 - tao_mid;
+        assert!(sell_fee_outflow > 0 && sell_fee_outflow < author_fee);
+        assert_eq!(
+            TotalStake::<Test>::get().to_u64(),
+            ts_before - sell_fee_outflow
+        );
+    });
+}
+
+/// Alpha -> TAO (destination 0): the proceeds become root cash 1:1, the root reserves are
+/// credited by exactly `tao_mid`, and the cash slot is worth exactly its face value.
+#[test]
+fn test_swap_basket_alpha_to_root_credits_reserves_in_lockstep() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        let held = escrow_alpha(&fund.hotkey, fund.netuid_a);
+        let root_tao_before = SubnetTAO::<Test>::get(NetUid::ROOT).to_u64();
+        let root_alpha_out_before = SubnetAlphaOut::<Test>::get(NetUid::ROOT).to_u64();
+        let nav_before = nav(&fund.hotkey);
+        let before = entitlements(&fund);
+
+        // The whole holding.
+        assert_ok!(swap(&fund, fund.netuid_a, NetUid::ROOT, held));
+
+        let (alpha_sold, tao_mid, alpha_bought) = last_swap_event();
+        assert_eq!(alpha_sold, held);
+        assert_eq!(alpha_bought, tao_mid, "root cash is TAO 1:1");
+        assert_eq!(escrow_alpha(&fund.hotkey, fund.netuid_a), 0);
+        assert_eq!(escrow_alpha(&fund.hotkey, NetUid::ROOT), tao_mid);
+        assert_eq!(
+            SubnetTAO::<Test>::get(NetUid::ROOT).to_u64(),
+            root_tao_before + tao_mid
+        );
+        assert_eq!(
+            SubnetAlphaOut::<Test>::get(NetUid::ROOT).to_u64(),
+            root_alpha_out_before + tao_mid
+        );
+        assert_eq!(nav(&fund.hotkey), tao_mid, "cash values at face");
+        assert_eq!(entitlements(&fund), before);
+        assert_nav_within_fees(nav_before, nav(&fund.hotkey));
+    });
+}
+
+/// TAO -> alpha (origin 0): the cash slot is debited, the root reserves unwind exactly to
+/// where they started, and no block-author fee is taken on the root leg.
+#[test]
+fn test_swap_basket_root_to_alpha_debits_reserves_in_lockstep() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        let root_tao_start = SubnetTAO::<Test>::get(NetUid::ROOT).to_u64();
+        let root_alpha_out_start = SubnetAlphaOut::<Test>::get(NetUid::ROOT).to_u64();
+        assert_ok!(swap(
+            &fund,
+            fund.netuid_a,
+            NetUid::ROOT,
+            escrow_alpha(&fund.hotkey, fund.netuid_a)
+        ));
+        let cash = escrow_alpha(&fund.hotkey, NetUid::ROOT);
+        assert!(cash > 0);
+        reset_turnover_window(&fund.hotkey);
+
+        let before = entitlements(&fund);
+        let nav_before = nav(&fund.hotkey);
+        let ts_before = TotalStake::<Test>::get().to_u64();
+        let author_before = author_balance();
+
+        assert_ok!(swap(&fund, NetUid::ROOT, fund.netuid_b, cash));
+
+        let (alpha_sold, tao_mid, alpha_bought) = last_swap_event();
+        assert_eq!(alpha_sold, cash);
+        assert_eq!(tao_mid, cash, "selling cash is TAO 1:1 with no fee");
+        assert_eq!(escrow_alpha(&fund.hotkey, NetUid::ROOT), 0);
+        assert_eq!(escrow_alpha(&fund.hotkey, fund.netuid_b), alpha_bought);
+        assert!(alpha_bought > 0);
+        assert_eq!(
+            SubnetTAO::<Test>::get(NetUid::ROOT).to_u64(),
+            root_tao_start
+        );
+        assert_eq!(
+            SubnetAlphaOut::<Test>::get(NetUid::ROOT).to_u64(),
+            root_alpha_out_start
+        );
+        // Root leg is fee-free and the buy leg's fee stays inside `TotalStake` accounting
+        // (it is TAO moved from the pot to the author, already counted as staked).
+        assert_eq!(TotalStake::<Test>::get().to_u64(), ts_before);
+        assert!(
+            author_balance() > author_before,
+            "buy-leg fee goes to the author"
+        );
+        assert_eq!(entitlements(&fund), before);
+        assert_nav_within_fees(nav_before, nav(&fund.hotkey));
+    });
+}
+
+/// Both legs are booked as protocol flow, never user flow: the sell leg is an outflow of
+/// `tao_mid` plus the author fee, the buy leg an inflow bounded by `tao_mid`.
+#[test]
+fn test_swap_basket_books_protocol_flow_not_user_flow() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        assert_eq!(SubnetProtocolFlow::<Test>::get(fund.netuid_a), 0);
+        assert_eq!(SubnetProtocolFlow::<Test>::get(fund.netuid_b), 0);
+        let user_a = SubnetTaoFlow::<Test>::get(fund.netuid_a);
+        let user_b = SubnetTaoFlow::<Test>::get(fund.netuid_b);
+        let author_before = author_balance();
+
+        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, TRADE));
+
+        let (_, tao_mid, _) = last_swap_event();
+        let author_fee = (author_balance() - author_before) as i64;
+        let flow_a = SubnetProtocolFlow::<Test>::get(fund.netuid_a);
+        let flow_b = SubnetProtocolFlow::<Test>::get(fund.netuid_b);
+        // Sell leg: outflow of the TAO through the middle plus the author's fee share.
+        let sell_fee_outflow = -flow_a - tao_mid as i64;
+        assert!(
+            sell_fee_outflow > 0,
+            "sell outflow must include the author fee: {flow_a}"
+        );
+        assert!(
+            sell_fee_outflow < author_fee,
+            "author is also paid on the buy leg"
+        );
+        // Buy leg: inflow is what entered the pool, fee excluded.
+        assert!(
+            flow_b > 0 && flow_b < tao_mid as i64,
+            "buy inflow = {flow_b}"
+        );
+        assert!(tao_mid as i64 - flow_b < author_fee);
+
+        assert_eq!(SubnetTaoFlow::<Test>::get(fund.netuid_a), user_a);
+        assert_eq!(SubnetTaoFlow::<Test>::get(fund.netuid_b), user_b);
+    });
+}
+
+/// After a rebalance the staker still redeems ~the same value: composition is not
+/// entitlement.
+#[test]
+fn test_swap_basket_then_claim_pays_the_same_value() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        let nav_before = nav(&fund.hotkey);
+        let owed_before = SubtensorModule::get_basket_owed_shares(&fund.hotkey, &fund.staker);
+
+        assert_ok!(swap(
+            &fund,
+            fund.netuid_a,
+            fund.netuid_b,
+            escrow_alpha(&fund.hotkey, fund.netuid_a)
+        ));
+        assert_eq!(
+            SubtensorModule::get_basket_owed_shares(&fund.hotkey, &fund.staker),
+            owed_before
+        );
+
+        let root_before = root_stake_of(&fund.hotkey, &fund.staker);
+        assert_ok!(SubtensorModule::claim_root_with_hotkey(
+            RuntimeOrigin::signed(fund.staker),
+            fund.hotkey
+        ));
+        let gain = root_stake_of(&fund.hotkey, &fund.staker) - root_before;
+        assert_nav_within_fees(nav_before, gain);
+    });
+}
+
+/// The actual weight scales with the fund's holding count and never exceeds the declared
+/// 256-row cap.
+#[test]
+fn test_swap_basket_post_dispatch_weight_is_bounded() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        let post = swap(&fund, fund.netuid_a, fund.netuid_b, TRADE).expect("trade succeeds");
+        let actual = post.actual_weight.expect("trade reports its actual weight");
+        // Two rows after the trade (A remainder + B).
+        assert_eq!(actual, SubtensorModule::swap_basket_weight(2));
+        assert!(actual.all_lt(SubtensorModule::swap_basket_weight(256)));
+    });
+}
+
+// =============================================================================
+// Gates and errors
+// =============================================================================
+
+#[test]
+fn test_swap_basket_rejects_when_trading_disabled() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        BasketTradingEnabled::<Test>::put(false);
+        assert_noop!(
+            swap(&fund, fund.netuid_a, fund.netuid_b, TRADE),
+            Error::<Test>::BasketTradingDisabled
+        );
+    });
+}
+
+#[test]
+fn test_swap_basket_rejects_when_frozen() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        BasketTradingFrozen::<Test>::insert(fund.hotkey, ());
+        assert_noop!(
+            swap(&fund, fund.netuid_a, fund.netuid_b, TRADE),
+            Error::<Test>::BasketTradingFrozen
+        );
+        BasketTradingFrozen::<Test>::remove(fund.hotkey);
+        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, TRADE));
+    });
+}
+
+#[test]
+fn test_swap_basket_rejects_same_subnet() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        assert_noop!(
+            swap(&fund, fund.netuid_a, fund.netuid_a, TRADE),
+            Error::<Test>::BasketSameSubnet
+        );
+        assert_noop!(
+            swap(&fund, NetUid::ROOT, NetUid::ROOT, TRADE),
+            Error::<Test>::BasketSameSubnet
+        );
+    });
+}
+
+#[test]
+fn test_swap_basket_rejects_non_owner_coldkey() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        let stranger = U256::from(777);
+        assert_noop!(
+            SubtensorModule::swap_basket(
+                RuntimeOrigin::signed(stranger),
+                fund.hotkey,
+                fund.netuid_a,
+                fund.netuid_b,
+                TRADE.into(),
+            ),
+            Error::<Test>::NonAssociatedColdKey
+        );
+        // A hotkey with no account at all is also "not owned".
+        assert_noop!(
+            SubtensorModule::swap_basket(
+                RuntimeOrigin::signed(fund.coldkey),
+                U256::from(778),
+                fund.netuid_a,
+                fund.netuid_b,
+                TRADE.into(),
+            ),
+            Error::<Test>::NonAssociatedColdKey
+        );
+    });
+}
+
+#[test]
+fn test_swap_basket_rejects_hotkey_not_on_root() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        Uids::<Test>::remove(NetUid::ROOT, fund.hotkey);
+        assert_noop!(
+            swap(&fund, fund.netuid_a, fund.netuid_b, TRADE),
+            Error::<Test>::HotKeyNotRegisteredInSubNet
+        );
+    });
+}
+
+#[test]
+fn test_swap_basket_rejects_while_seed_migration_in_progress() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        kickoff_seed_beta_basket_v2::<Test>();
+        assert_noop!(
+            swap(&fund, fund.netuid_a, fund.netuid_b, TRADE),
+            Error::<Test>::BetaBasketSeedInProgress
+        );
+    });
+}
+
+/// The `CheckColdkeySwap` dispatch extension refuses the trade while the signing coldkey
+/// has a swap announced (the same guard every other signed call gets).
+#[test]
+fn test_swap_basket_rejects_while_coldkey_swap_announced() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        let call = RuntimeCall::SubtensorModule(crate::Call::swap_basket {
+            hotkey: fund.hotkey,
+            origin_netuid: fund.netuid_a,
+            destination_netuid: fund.netuid_b,
+            amount: TRADE.into(),
+        });
+        let dispatch = |call: RuntimeCall| {
+            <CheckColdkeySwap<Test> as ExtendedDispatchable<RuntimeCall>>::dispatch_with_extension(
+                RuntimeOrigin::signed(fund.coldkey),
+                call,
+            )
+        };
+
+        let hash = HashingOf::<Test>::hash_of(&U256::from(42));
+        ColdkeySwapAnnouncements::<Test>::insert(fund.coldkey, (System::block_number(), hash));
+        let held = escrow_alpha(&fund.hotkey, fund.netuid_a);
+        assert_eq!(
+            dispatch(call.clone()).unwrap_err().error,
+            Error::<Test>::ColdkeySwapAnnounced.into()
+        );
+        assert_eq!(escrow_alpha(&fund.hotkey, fund.netuid_a), held);
+
+        ColdkeySwapAnnouncements::<Test>::remove(fund.coldkey);
+        assert_ok!(dispatch(call));
+        assert_eq!(escrow_alpha(&fund.hotkey, fund.netuid_a), held - TRADE);
+    });
+}
+
+#[test]
+fn test_swap_basket_rejects_nonexistent_subnets() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        let missing = NetUid::from(99u16);
+        assert_noop!(
+            swap(&fund, fund.netuid_a, missing, TRADE),
+            Error::<Test>::SubnetNotExists
+        );
+        assert_noop!(
+            swap(&fund, missing, fund.netuid_a, TRADE),
+            Error::<Test>::SubnetNotExists
+        );
+    });
+}
+
+#[test]
+fn test_swap_basket_rejects_subtoken_disabled_destination() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        SubtokenEnabled::<Test>::insert(fund.netuid_b, false);
+        assert_noop!(
+            swap(&fund, fund.netuid_a, fund.netuid_b, TRADE),
+            Error::<Test>::SubtokenDisabled
+        );
+    });
+}
+
+#[test]
+fn test_swap_basket_rejects_zero_and_dust_amounts() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        assert_noop!(
+            swap(&fund, fund.netuid_a, fund.netuid_b, 0),
+            Error::<Test>::AmountTooLow
+        );
+        // Positive, but the TAO through the middle lands below `DefaultMinStake`.
+        let dust = DefaultMinStake::<Test>::get().to_u64() / 2;
+        assert_noop!(
+            swap(&fund, fund.netuid_a, fund.netuid_b, dust),
+            Error::<Test>::AmountTooLow
+        );
+    });
+}
+
+#[test]
+fn test_swap_basket_rejects_more_than_held() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        let held = escrow_alpha(&fund.hotkey, fund.netuid_a);
+        assert_noop!(
+            swap(&fund, fund.netuid_a, fund.netuid_b, held + 1),
+            Error::<Test>::NotEnoughStakeToWithdraw
+        );
+        // An empty origin (no cash yet) fails the same way.
+        assert_noop!(
+            swap(&fund, NetUid::ROOT, fund.netuid_b, TRADE),
+            Error::<Test>::NotEnoughStakeToWithdraw
+        );
+    });
+}
+
+// =============================================================================
+// Guardrail: per-leg slippage band
+// =============================================================================
+
+/// Buy leg, EMA anchor: a pre-trade pump (spot above the moving price by more than 2%)
+/// is refused before any leg runs.
+#[test]
+fn test_swap_basket_buy_refused_when_spot_above_ema_band() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        // Spot is 1.0; a moving price of 0.9 puts the ceiling at 0.918.
+        SubnetMovingPrice::<Test>::insert(fund.netuid_b, I96F32::from_num(0.9));
+        assert_noop!(
+            swap(&fund, fund.netuid_a, fund.netuid_b, TRADE),
+            Error::<Test>::SlippageTooHigh
+        );
+    });
+}
+
+/// Sell leg, EMA anchor: a pre-trade dump (spot below the moving price by more than 2%)
+/// is refused.
+#[test]
+fn test_swap_basket_sell_refused_when_spot_below_ema_band() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        // Spot is 1.0; a moving price of 1.1 puts the floor at 1.078.
+        SubnetMovingPrice::<Test>::insert(fund.netuid_a, I96F32::from_num(1.1));
+        assert_noop!(
+            swap(&fund, fund.netuid_a, fund.netuid_b, TRADE),
+            Error::<Test>::SlippageTooHigh
+        );
+    });
+}
+
+/// A subnet with no moving price yet cannot be traded on either leg.
+#[test]
+fn test_swap_basket_refused_without_moving_price() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        SubnetMovingPrice::<Test>::insert(fund.netuid_b, I96F32::from_num(0));
+        assert_noop!(
+            swap(&fund, fund.netuid_a, fund.netuid_b, TRADE),
+            Error::<Test>::SlippageTooHigh
+        );
+        SubnetMovingPrice::<Test>::insert(fund.netuid_b, I96F32::from_num(1));
+        SubnetMovingPrice::<Test>::insert(fund.netuid_a, I96F32::from_num(0));
+        assert_noop!(
+            swap(&fund, fund.netuid_a, fund.netuid_b, TRADE),
+            Error::<Test>::SlippageTooHigh
+        );
+    });
+}
+
+/// Buy leg, spot anchor: on a thin destination pool the trade's own price impact would
+/// exceed 2%, so the leg cannot fill fully within the ceiling and the trade is refused.
+#[test]
+fn test_swap_basket_buy_refused_when_own_impact_exceeds_band() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        // 10 TAO / 10 alpha: a 4 TAO buy would move the price ~96%.
+        SubnetTAO::<Test>::insert(fund.netuid_b, TaoBalance::from(10_000_000u64));
+        SubnetAlphaIn::<Test>::insert(fund.netuid_b, AlphaBalance::from(10_000_000u64));
+        assert_noop!(
+            swap(&fund, fund.netuid_a, fund.netuid_b, TRADE),
+            Error::<Test>::SlippageTooHigh
+        );
+    });
+}
+
+/// Sell leg, spot anchor: on a thin origin pool the sale's own impact exceeds 2%.
+#[test]
+fn test_swap_basket_sell_refused_when_own_impact_exceeds_band() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        SubnetTAO::<Test>::insert(fund.netuid_a, TaoBalance::from(10_000_000u64));
+        SubnetAlphaIn::<Test>::insert(fund.netuid_a, AlphaBalance::from(10_000_000u64));
+        assert_noop!(
+            swap(&fund, fund.netuid_a, fund.netuid_b, TRADE),
+            Error::<Test>::SlippageTooHigh
+        );
+    });
+}
+
+/// Fills that sit just inside the band on both legs pass: spot 1% away from the moving
+/// price on each side, and a trade small enough to leave less than 1% of impact.
+#[test]
+fn test_swap_basket_fills_just_inside_band() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        // Sell floor = max(1.01, 1.0) * 0.98 = 0.9898 < spot; buy ceiling = min(0.99, 1.0)
+        // * 1.02 = 1.0098 > spot.
+        SubnetMovingPrice::<Test>::insert(fund.netuid_a, I96F32::from_num(1.01));
+        SubnetMovingPrice::<Test>::insert(fund.netuid_b, I96F32::from_num(0.99));
+        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, TRADE));
+        let (alpha_sold, tao_mid, alpha_bought) = last_swap_event();
+        assert_eq!(alpha_sold, TRADE);
+        assert!(tao_mid > 0 && alpha_bought > 0);
+    });
+}
+
+/// A `swap_basket` refusal after the sell leg has already executed rolls the whole trade
+/// back: holdings, reserves, TotalStake, author fee, and the turnover window are untouched.
+#[test]
+fn test_swap_basket_failed_second_leg_leaves_no_partial_state() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        // The sell leg on A is fine; the buy leg on a thin B fails.
+        SubnetTAO::<Test>::insert(fund.netuid_b, TaoBalance::from(10_000_000u64));
+        SubnetAlphaIn::<Test>::insert(fund.netuid_b, AlphaBalance::from(10_000_000u64));
+
+        let held = escrow_alpha(&fund.hotkey, fund.netuid_a);
+        let tao_a = SubnetTAO::<Test>::get(fund.netuid_a);
+        let alpha_in_a = SubnetAlphaIn::<Test>::get(fund.netuid_a);
+        let ts = TotalStake::<Test>::get();
+        let author = author_balance();
+        let window = BasketTradeWindow::<Test>::get(fund.hotkey);
+        let flow_a = SubnetProtocolFlow::<Test>::get(fund.netuid_a);
+        let before = entitlements(&fund);
+
+        assert!(swap(&fund, fund.netuid_a, fund.netuid_b, TRADE).is_err());
+
+        assert_eq!(escrow_alpha(&fund.hotkey, fund.netuid_a), held);
+        assert_eq!(escrow_alpha(&fund.hotkey, fund.netuid_b), 0);
+        assert_eq!(SubnetTAO::<Test>::get(fund.netuid_a), tao_a);
+        assert_eq!(SubnetAlphaIn::<Test>::get(fund.netuid_a), alpha_in_a);
+        assert_eq!(TotalStake::<Test>::get(), ts);
+        assert_eq!(
+            author_balance(),
+            author,
+            "rolled-back fee must not reach the author"
+        );
+        assert_eq!(BasketTradeWindow::<Test>::get(fund.hotkey), window);
+        assert_eq!(SubnetProtocolFlow::<Test>::get(fund.netuid_a), flow_a);
+        assert_eq!(entitlements(&fund), before);
+        assert!(!System::events().iter().any(|e| matches!(
+            e.event,
+            RuntimeEvent::SubtensorModule(Event::BasketSwapped { .. })
+        )));
+    });
+}
+
+// =============================================================================
+// Guardrail: turnover budget
+// =============================================================================
+
+/// The TAO through the middle accumulates in the window, refuses at the cap, and the
+/// window rolls after `BASKET_TRADE_WINDOW_BLOCKS`.
+#[test]
+fn test_swap_basket_turnover_budget_accumulates_refuses_and_rolls() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        BasketDailyTurnoverCap::<Test>::put(DEFAULT_BASKET_DAILY_TURNOVER_CAP);
+        let budget = SubtensorModule::basket_trade_budget_tao(nav(&fund.hotkey));
+        // 10% of a ~100 TAO fund: two 4 TAO trades fit, a third does not.
+        assert!(
+            budget > 2 * TRADE && budget < 3 * TRADE,
+            "budget = {budget}"
+        );
+        let start = System::block_number();
+        assert!(
+            start > 0,
+            "the first trade must open the window at the current block"
+        );
+        assert_eq!(BasketTradeWindow::<Test>::get(fund.hotkey), (0, 0));
+        assert_eq!(
+            SubtensorModule::get_basket_trading_status(&fund.hotkey).window_start_block,
+            start
+        );
+
+        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, TRADE));
+        let (_, mid_1, _) = last_swap_event();
+        assert_eq!(BasketTradeWindow::<Test>::get(fund.hotkey), (start, mid_1));
+
+        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, TRADE));
+        let (_, mid_2, _) = last_swap_event();
+        assert_eq!(
+            BasketTradeWindow::<Test>::get(fund.hotkey),
+            (start, mid_1 + mid_2),
+            "tao_used is the sum of tao_mid across the window"
+        );
+
+        assert_noop!(
+            swap(&fund, fund.netuid_a, fund.netuid_b, TRADE),
+            Error::<Test>::BasketTurnoverBudgetExceeded
+        );
+        // The view agrees with what a trade would be charged against.
+        let status = SubtensorModule::get_basket_trading_status(&fund.hotkey);
+        assert_eq!(status.window_start_block, start);
+        assert_eq!(status.tao_used.to_u64(), mid_1 + mid_2);
+        assert!(status.enabled && !status.frozen);
+
+        // One block short of the roll: still refused.
+        System::set_block_number(start + BASKET_TRADE_WINDOW_BLOCKS - 1);
+        assert_noop!(
+            swap(&fund, fund.netuid_a, fund.netuid_b, TRADE),
+            Error::<Test>::BasketTurnoverBudgetExceeded
+        );
+
+        // At the roll a fresh window opens, charged only with this trade.
+        let rolled = start + BASKET_TRADE_WINDOW_BLOCKS;
+        System::set_block_number(rolled);
+        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, TRADE));
+        let (_, mid_3, _) = last_swap_event();
+        assert_eq!(BasketTradeWindow::<Test>::get(fund.hotkey), (rolled, mid_3));
+    });
+}
+
+/// Root cash is TAO 1:1, so a root-origin trade charges exactly its amount.
+#[test]
+fn test_swap_basket_turnover_charges_root_origin_at_face() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        assert_ok!(swap(&fund, fund.netuid_a, NetUid::ROOT, 3 * TRADE));
+        let start = System::block_number();
+        BasketTradeWindow::<Test>::remove(fund.hotkey);
+
+        assert_ok!(swap(&fund, NetUid::ROOT, fund.netuid_b, TRADE));
+        assert_eq!(BasketTradeWindow::<Test>::get(fund.hotkey), (start, TRADE));
+    });
+}
+
+// =============================================================================
+// Guardrail: concentration cap
+// =============================================================================
+
+/// With enough destinations on chain (root + A + B = 3, cap 1/2) the destination holding
+/// may not end above the cap share of NAV; smaller trades pass.
+#[test]
+fn test_swap_basket_refuses_destination_over_concentration_cap() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        assert_eq!(SubtensorModule::get_all_subnet_netuids().len(), 3);
+        RootWeightsCap::<Test>::insert(NetUid::ROOT, u16::MAX / 2);
+        let held = escrow_alpha(&fund.hotkey, fund.netuid_a);
+
+        // 60% of the fund into B: over the cap.
+        assert_noop!(
+            swap(&fund, fund.netuid_a, fund.netuid_b, held * 6 / 10),
+            Error::<Test>::RootWeightCapExceeded
+        );
+        // 40% is fine.
+        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, held * 4 / 10));
+        // Topping B up past the cap is refused even though this trade alone is small.
+        assert_noop!(
+            swap(&fund, fund.netuid_a, fund.netuid_b, held * 2 / 10),
+            Error::<Test>::RootWeightCapExceeded
+        );
+        // The cash slot is a destination like any other.
+        assert_noop!(
+            swap(&fund, fund.netuid_a, NetUid::ROOT, held * 6 / 10),
+            Error::<Test>::RootWeightCapExceeded
+        );
+    });
+}
+
+/// Selling out of a holding that is already over the cap is always allowed; only the
+/// destination is checked.
+#[test]
+fn test_swap_basket_allows_selling_out_of_over_cap_position() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        // Build the over-cap position while the cap is not binding (default 1/16 needs 16
+        // destinations), then make it binding.
+        assert_ok!(swap(
+            &fund,
+            fund.netuid_a,
+            fund.netuid_b,
+            escrow_alpha(&fund.hotkey, fund.netuid_a)
+        ));
+        assert_eq!(escrow_alpha(&fund.hotkey, fund.netuid_a), 0);
+        reset_turnover_window(&fund.hotkey);
+        RootWeightsCap::<Test>::insert(NetUid::ROOT, u16::MAX / 2);
+        let held_b = escrow_alpha(&fund.hotkey, fund.netuid_b);
+
+        // B holds 100% (> 50%): selling 30% of it back into A is allowed ...
+        assert_ok!(swap(&fund, fund.netuid_b, fund.netuid_a, held_b * 3 / 10));
+        // ... but moving 60% would put A over the cap.
+        assert_noop!(
+            swap(&fund, fund.netuid_b, fund.netuid_a, held_b * 6 / 10),
+            Error::<Test>::RootWeightCapExceeded
+        );
+    });
+}
+
+/// Young-chain softening: with fewer destinations than the cap demands (3 < 16 at the
+/// default 1/16), the concentration rule is skipped and a whole holding can move.
+#[test]
+fn test_swap_basket_concentration_cap_skipped_on_young_chain() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        assert!(
+            SubtensorModule::binding_root_weights_cap(
+                SubtensorModule::get_all_subnet_netuids().len() as u64
+            )
+            .is_none()
+        );
+        let held = escrow_alpha(&fund.hotkey, fund.netuid_a);
+        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, held));
+        assert_eq!(escrow_alpha(&fund.hotkey, fund.netuid_a), 0);
+    });
+}
+
+// =============================================================================
+// Guardrails follow the fund on hotkey swap
+// =============================================================================
+
+#[test]
+fn test_swap_basket_freeze_and_window_follow_hotkey_swap() {
+    new_test_ext(1).execute_with(|| {
+        let fund = setup_fund();
+        let new_hotkey = U256::from(10030);
+        // The swap target must be a hotkey the same coldkey owns (a subnet-scoped swap does
+        // not create ownership).
+        let _ = SubtensorModule::create_account_if_non_existent(&fund.coldkey, &new_hotkey);
+
+        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, TRADE));
+        let window = BasketTradeWindow::<Test>::get(fund.hotkey);
+        assert!(window.1 > 0);
+        BasketTradingFrozen::<Test>::insert(fund.hotkey, ());
+
+        let mut weight = Weight::zero();
+        assert_ok!(SubtensorModule::perform_hotkey_swap_on_one_subnet(
+            &fund.hotkey,
+            &new_hotkey,
+            &mut weight,
+            NetUid::ROOT,
+            false,
+        ));
+
+        // The freeze is copied (the old key stays frozen too), the window moves.
+        assert!(BasketTradingFrozen::<Test>::contains_key(new_hotkey));
+        assert!(BasketTradingFrozen::<Test>::contains_key(fund.hotkey));
+        assert_eq!(BasketTradeWindow::<Test>::get(new_hotkey), window);
+        assert_eq!(BasketTradeWindow::<Test>::get(fund.hotkey), (0, 0));
+
+        // `register_on_root` only writes `Uids` (no `Keys` row), so the subnet-scoped swap
+        // above cannot carry the root seat over; give the new hotkey its seat directly.
+        register_on_root(&new_hotkey, 0);
+
+        // The new hotkey is frozen: no trades until governance lifts it.
+        let new_fund = Fund {
+            hotkey: new_hotkey,
+            ..fund
+        };
+        assert_noop!(
+            swap(&new_fund, new_fund.netuid_b, new_fund.netuid_a, TRADE),
+            Error::<Test>::BasketTradingFrozen
+        );
+        BasketTradingFrozen::<Test>::remove(new_hotkey);
+        // And the moved window is what the next trade is charged against.
+        BasketDailyTurnoverCap::<Test>::put(DEFAULT_BASKET_DAILY_TURNOVER_CAP);
+        let held_b = escrow_alpha(&new_hotkey, new_fund.netuid_b);
+        assert_ok!(swap(
+            &new_fund,
+            new_fund.netuid_b,
+            new_fund.netuid_a,
+            held_b
+        ));
+        let (_, mid, _) = last_swap_event();
+        assert_eq!(
+            BasketTradeWindow::<Test>::get(new_hotkey),
+            (window.0, window.1 + mid)
+        );
+    });
+}
+
+// =============================================================================
+// Event index stability
+// =============================================================================
+
+/// `BasketSwapped` must be appended after the last pre-existing event so historical
+/// event indices stay stable for decoders.
+#[test]
+fn regression_basket_swapped_event_index_is_appended() {
+    let prior_tail = Event::<Test>::BasketAlphaWrittenOff {
+        hotkey: U256::from(1),
+        netuid: NetUid::from(1),
+        alpha: AlphaBalance::from(1),
+    }
+    .encode();
+    let swapped = Event::<Test>::BasketSwapped {
+        hotkey: U256::from(1),
+        origin_netuid: NetUid::from(1),
+        destination_netuid: NetUid::from(2),
+        alpha_sold: AlphaBalance::from(1),
+        tao_mid: TaoBalance::from(1),
+        alpha_bought: AlphaBalance::from(1),
+    }
+    .encode();
+    assert_eq!(prior_tail[0], 148);
+    assert_eq!(swapped[0], 149);
+}

--- a/pallets/subtensor/src/tests/swap_basket.rs
+++ b/pallets/subtensor/src/tests/swap_basket.rs
@@ -5,7 +5,12 @@
 //! stay in lockstep; the block author receives the AMM fee; both legs are booked as
 //! protocol flow. Every gate, guardrail, and rollback path is pinned here.
 
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(
+    clippy::arithmetic_side_effects,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::unwrap_used
+)]
 
 use crate::CheckColdkeySwap;
 use crate::migrations::migrate_seed_beta_basket::kickoff_seed_beta_basket_v2;

--- a/pallets/subtensor/src/tests/swap_basket.rs
+++ b/pallets/subtensor/src/tests/swap_basket.rs
@@ -1195,34 +1195,48 @@ fn finding_2_1_thin_pool_drain_passes_every_guardrail() {
 fn finding_2_2_window_boundary_lets_two_budgets_through_in_adjacent_blocks() {
     new_test_ext(1).execute_with(|| {
         let fund = setup_fund();
-        BasketDailyTurnoverCap::<Test>::put(DEFAULT_BASKET_DAILY_TURNOVER_CAP);
+        // The window mechanics do not depend on the cap value; a 50% cap keeps the
+        // window-opening trade (which must clear `DefaultMinStake`) small next to the budget.
+        BasketDailyTurnoverCap::<Test>::put(u16::MAX / 2);
         let budget = SubtensorModule::basket_trade_budget_tao(nav(&fund.hotkey));
-        // Two half-budget trades fit inside one window (tao_mid trails alpha by the fee).
-        let half = budget / 2;
 
+        // Open the window with one minimal trade at `start`; it is not part of the burst.
         let start = System::block_number();
-        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, half));
-        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, half));
-        let (_, used_in_first_window) = BasketTradeWindow::<Test>::get(fund.hotkey);
-        assert!(used_in_first_window > budget * 99 / 100);
+        let opener = DefaultMinStake::<Test>::get().to_u64() * 101 / 100;
+        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, opener));
+        let (_, opening) = BasketTradeWindow::<Test>::get(fund.hotkey);
+        assert!(opening > 0 && opening < budget / 10);
 
-        // Last block of the window: the budget is spent.
+        // Penultimate block of the window: spend everything that is left of the budget.
+        // Two slices sized from the remaining budget fit (tao_mid trails alpha by the fee).
         System::set_block_number(start + BASKET_TRADE_WINDOW_BLOCKS - 1);
+        let remaining = budget - opening;
+        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, remaining / 2));
+        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, remaining / 2));
+        let (_, used_first) = BasketTradeWindow::<Test>::get(fund.hotkey);
+        assert!(
+            used_first > budget * 99 / 100,
+            "first window used {used_first} of {budget}"
+        );
         assert_noop!(
-            swap(&fund, fund.netuid_a, fund.netuid_b, half),
+            swap(&fund, fund.netuid_a, fund.netuid_b, TRADE),
             Error::<Test>::BasketTurnoverBudgetExceeded
         );
+        let burst_first_block = used_first - opening;
 
-        // Very next block: a whole new budget is available.
+        // Very next block: the window rolls and a whole new budget is available.
         System::set_block_number(start + BASKET_TRADE_WINDOW_BLOCKS);
-        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, half));
-        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, half));
-        let (_, used_in_second_window) = BasketTradeWindow::<Test>::get(fund.hotkey);
+        let budget_2 = SubtensorModule::basket_trade_budget_tao(nav(&fund.hotkey));
+        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, budget_2 / 2));
+        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, budget_2 / 2));
+        let (_, burst_second_block) = BasketTradeWindow::<Test>::get(fund.hotkey);
+        assert!(burst_second_block > budget_2 * 99 / 100);
 
-        let moved_in_two_blocks = used_in_first_window + used_in_second_window;
+        // Two adjacent blocks moved ~2x the daily cap.
+        let moved_in_two_adjacent_blocks = burst_first_block + burst_second_block;
         assert!(
-            moved_in_two_blocks > budget * 19 / 10,
-            "moved {moved_in_two_blocks} vs one budget {budget}"
+            moved_in_two_adjacent_blocks > budget * 19 / 10,
+            "moved {moved_in_two_adjacent_blocks} across the boundary vs one budget {budget}"
         );
     });
 }

--- a/runtime/src/proxy_filters/mod.rs
+++ b/runtime/src/proxy_filters/mod.rs
@@ -773,11 +773,9 @@ mod tests {
             );
         }
 
-        // Broad proxies: `Any`, `NonTransfer`, and `NonCritical` may trade; `NonFungible`
-        // (no value movement) may not.
+        // `Any` may trade; `NonFungible` (no value movement) may not. The broad
+        // `NonTransfer` / `NonCritical` grants are pinned separately below.
         assert!(proxy_type_filter(&ProxyType::Any, &swap_basket));
-        assert!(proxy_type_filter(&ProxyType::NonTransfer, &swap_basket));
-        assert!(proxy_type_filter(&ProxyType::NonCritical, &swap_basket));
         assert!(!proxy_type_filter(&ProxyType::NonFungible, &swap_basket));
 
         // Superset relation: only `Any` and `NonTransfer` cover the trading grant.
@@ -795,6 +793,28 @@ mod tests {
             .into_iter()
             .collect::<BTreeSet<_>>()
         );
+    }
+
+    /// Documents current behaviour (PR #3150 calibration pass, §3 / §5.6): every existing
+    /// `NonTransfer` and `NonCritical` delegate gains `swap_basket` at upgrade without
+    /// opting in, because `BasketTradingCalls` is included in both allow lists. Expected to
+    /// pass today; flip this test when `swap_basket` is restricted to the explicit
+    /// `BasketTrading` grant.
+    #[test]
+    fn broad_proxies_currently_admit_swap_basket_without_opt_in() {
+        use pallet_subtensor::Call as SubtensorCall;
+        use subtensor_runtime_common::{AccountId, AlphaBalance, NetUid};
+
+        let swap_basket = RuntimeCall::SubtensorModule(SubtensorCall::swap_basket {
+            hotkey: AccountId::new([7u8; 32]),
+            origin_netuid: NetUid::from(1),
+            destination_netuid: NetUid::from(2),
+            amount: AlphaBalance::from(1),
+        });
+        assert!(proxy_type_filter(&ProxyType::NonTransfer, &swap_basket));
+        assert!(proxy_type_filter(&ProxyType::NonCritical, &swap_basket));
+        assert!(allowed_calls(ProxyType::NonTransfer).contains("SubtensorModule::swap_basket"));
+        assert!(allowed_calls(ProxyType::NonCritical).contains("SubtensorModule::swap_basket"));
     }
 
     #[test]

--- a/runtime/src/proxy_filters/mod.rs
+++ b/runtime/src/proxy_filters/mod.rs
@@ -720,6 +720,83 @@ mod tests {
         ));
     }
 
+    /// `BasketTrading` is a single-call grant: it admits `swap_basket` and nothing else,
+    /// no other narrow proxy admits `swap_basket`, and the broad proxies include it only
+    /// where value-moving stake calls are allowed.
+    #[test]
+    fn basket_trading_proxy_grants_exactly_swap_basket() {
+        use frame_system::Call as SystemCall;
+        use pallet_subtensor::Call as SubtensorCall;
+        use subtensor_runtime_common::{AccountId, AlphaBalance, NetUid, TaoBalance};
+
+        let hotkey = AccountId::new([7u8; 32]);
+        let swap_basket = RuntimeCall::SubtensorModule(SubtensorCall::swap_basket {
+            hotkey: hotkey.clone(),
+            origin_netuid: NetUid::from(1),
+            destination_netuid: NetUid::from(2),
+            amount: AlphaBalance::from(1),
+        });
+        let stake_into_basket = RuntimeCall::SubtensorModule(SubtensorCall::stake_into_basket {
+            hotkey: hotkey.clone(),
+            amount_staked: TaoBalance::from(1),
+        });
+        let set_root_weights = RuntimeCall::SubtensorModule(SubtensorCall::set_root_weights {
+            dests: vec![1],
+            weights: vec![1],
+        });
+        let claim = RuntimeCall::SubtensorModule(SubtensorCall::claim_root_with_hotkey { hotkey });
+        let remark = RuntimeCall::System(SystemCall::remark { remark: vec![] });
+
+        // The trading proxy admits the trade and nothing adjacent to it.
+        assert!(proxy_type_filter(&ProxyType::BasketTrading, &swap_basket));
+        for denied in [&stake_into_basket, &set_root_weights, &claim, &remark] {
+            assert!(!proxy_type_filter(&ProxyType::BasketTrading, denied));
+        }
+
+        // No other narrow proxy can be used to trade the basket.
+        for narrow in [
+            ProxyType::Owner,
+            ProxyType::Staking,
+            ProxyType::Registration,
+            ProxyType::Transfer,
+            ProxyType::SmallTransfer,
+            ProxyType::RootClaim,
+            ProxyType::ChildKeys,
+            ProxyType::SwapHotkey,
+            ProxyType::SubnetLeaseBeneficiary,
+            ProxyType::SudoUncheckedSetCode,
+            ProxyType::RootWeights,
+        ] {
+            assert!(
+                !proxy_type_filter(&narrow, &swap_basket),
+                "{narrow:?} must not admit swap_basket"
+            );
+        }
+
+        // Broad proxies: `Any`, `NonTransfer`, and `NonCritical` may trade; `NonFungible`
+        // (no value movement) may not.
+        assert!(proxy_type_filter(&ProxyType::Any, &swap_basket));
+        assert!(proxy_type_filter(&ProxyType::NonTransfer, &swap_basket));
+        assert!(proxy_type_filter(&ProxyType::NonCritical, &swap_basket));
+        assert!(!proxy_type_filter(&ProxyType::NonFungible, &swap_basket));
+
+        // Superset relation: only `Any` and `NonTransfer` cover the trading grant.
+        let supersets = all_proxy_types()
+            .into_iter()
+            .filter(|proxy_type| proxy_type.is_superset(&ProxyType::BasketTrading))
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            supersets,
+            [
+                ProxyType::Any,
+                ProxyType::NonTransfer,
+                ProxyType::BasketTrading
+            ]
+            .into_iter()
+            .collect::<BTreeSet<_>>()
+        );
+    }
+
     #[test]
     fn sudo_unchecked_set_code_only_matches_set_code() {
         use alloc::boxed::Box;

--- a/runtime/src/proxy_filters/mod.rs
+++ b/runtime/src/proxy_filters/mod.rs
@@ -49,14 +49,14 @@ type SubnetLeaseAllowed = (
     SubnetManagementCalls,
 );
 
-/// `NonTransfer`: excludes liquid value movement, coldkey swaps, and EVM,
-/// Contracts, and Crowdloan calls that can move value indirectly.
+/// `NonTransfer`: excludes liquid value movement, coldkey swaps, EVM,
+/// Contracts, and Crowdloan calls that can move value indirectly, and basket
+/// trading (which needs the explicit `BasketTrading` grant).
 type NonTransferAllowed = (
     InfraCommonCalls,
     AdminAll,
     SudoCalls,
     StakeManagementCalls,
-    BasketTradingCalls,
     PowRegistrationCalls,
     BurnedRegistrationCalls,
     FaucetCalls,
@@ -86,7 +86,8 @@ type NonFungibleAllowed = (
 );
 
 /// `NonCritical`: day-to-day operations including value movement, but no sudo,
-/// network dissolution, root/burned registration, or coldkey swaps.
+/// network dissolution, root/burned registration, coldkey swaps, or basket
+/// trading (which needs the explicit `BasketTrading` grant).
 type NonCriticalAllowed = (
     InfraCommonCalls,
     EvmCalls,
@@ -96,7 +97,6 @@ type NonCriticalAllowed = (
     BalanceTransferCalls,
     BalanceMaintenanceCalls,
     StakeManagementCalls,
-    BasketTradingCalls,
     StakeTransferCalls,
     PowRegistrationCalls,
     FaucetCalls,
@@ -159,8 +159,7 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
                 | ProxyType::SudoUncheckedSetCode
                 | ProxyType::SwapHotkey
                 | ProxyType::SubnetLeaseBeneficiary
-                | ProxyType::RootClaim
-                | ProxyType::BasketTrading,
+                | ProxyType::RootClaim,
             ) => true,
             (ProxyType::Transfer, ProxyType::SmallTransfer) => true,
             _ => false,
@@ -316,6 +315,7 @@ mod tests {
             | &group_calls::<BalanceMaintenanceCalls>())
             | &(&group_calls::<StakeTransferCalls>() | &group_calls::<ColdkeySwapCalls>());
         let denied = &denied | &group_calls::<(EvmCalls, ContractsCalls, CrowdloanCalls)>();
+        let denied = &denied | &group_calls::<BasketTradingCalls>();
         assert_eq!(
             allowed_calls(ProxyType::NonTransfer),
             &all_runtime_calls() - &denied
@@ -343,6 +343,7 @@ mod tests {
         let denied = &(&(&group_calls::<SudoCalls>() | &group_calls::<BurnedRegistrationCalls>())
             | &(&group_calls::<RootRegistrationCalls>() | &group_calls::<CriticalNetworkCalls>()))
             | &group_calls::<ColdkeySwapCalls>();
+        let denied = &denied | &group_calls::<BasketTradingCalls>();
         assert_eq!(
             allowed_calls(ProxyType::NonCritical),
             &all_runtime_calls() - &denied
@@ -486,7 +487,6 @@ mod tests {
             ProxyType::SwapHotkey,
             ProxyType::SubnetLeaseBeneficiary,
             ProxyType::RootClaim,
-            ProxyType::BasketTrading,
         ]
         .into_iter()
         .collect::<BTreeSet<_>>();
@@ -773,35 +773,29 @@ mod tests {
             );
         }
 
-        // `Any` may trade; `NonFungible` (no value movement) may not. The broad
-        // `NonTransfer` / `NonCritical` grants are pinned separately below.
+        // Only `Any` may trade among the broad proxies; `NonFungible` (no value movement)
+        // may not. `NonTransfer` / `NonCritical` are pinned separately below.
         assert!(proxy_type_filter(&ProxyType::Any, &swap_basket));
         assert!(!proxy_type_filter(&ProxyType::NonFungible, &swap_basket));
 
-        // Superset relation: only `Any` and `NonTransfer` cover the trading grant.
+        // Superset relation: only `Any` covers the trading grant.
         let supersets = all_proxy_types()
             .into_iter()
             .filter(|proxy_type| proxy_type.is_superset(&ProxyType::BasketTrading))
             .collect::<BTreeSet<_>>();
         assert_eq!(
             supersets,
-            [
-                ProxyType::Any,
-                ProxyType::NonTransfer,
-                ProxyType::BasketTrading
-            ]
-            .into_iter()
-            .collect::<BTreeSet<_>>()
+            [ProxyType::Any, ProxyType::BasketTrading]
+                .into_iter()
+                .collect::<BTreeSet<_>>()
         );
     }
 
-    /// Documents current behaviour (PR #3150 calibration pass, §3 / §5.6): every existing
-    /// `NonTransfer` and `NonCritical` delegate gains `swap_basket` at upgrade without
-    /// opting in, because `BasketTradingCalls` is included in both allow lists. Expected to
-    /// pass today; flip this test when `swap_basket` is restricted to the explicit
-    /// `BasketTrading` grant.
+    /// `swap_basket` needs the explicit `BasketTrading` grant: the broad `NonTransfer`
+    /// and `NonCritical` delegations do not admit it (PR #3150 calibration pass §5.6),
+    /// so an existing delegate does not gain trading power at upgrade without opting in.
     #[test]
-    fn broad_proxies_currently_admit_swap_basket_without_opt_in() {
+    fn broad_proxies_do_not_admit_swap_basket_without_explicit_grant() {
         use pallet_subtensor::Call as SubtensorCall;
         use subtensor_runtime_common::{AccountId, AlphaBalance, NetUid};
 
@@ -811,10 +805,14 @@ mod tests {
             destination_netuid: NetUid::from(2),
             amount: AlphaBalance::from(1),
         });
-        assert!(proxy_type_filter(&ProxyType::NonTransfer, &swap_basket));
-        assert!(proxy_type_filter(&ProxyType::NonCritical, &swap_basket));
-        assert!(allowed_calls(ProxyType::NonTransfer).contains("SubtensorModule::swap_basket"));
-        assert!(allowed_calls(ProxyType::NonCritical).contains("SubtensorModule::swap_basket"));
+        for broad in [ProxyType::NonTransfer, ProxyType::NonCritical] {
+            assert!(
+                !proxy_type_filter(&broad, &swap_basket),
+                "{broad:?} must not admit swap_basket"
+            );
+            assert!(!allowed_calls(broad).contains("SubtensorModule::swap_basket"));
+        }
+        assert!(proxy_type_filter(&ProxyType::BasketTrading, &swap_basket));
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Stacked on #3150 (`feat/basket-trading-swap-basket`). Adds the pallet, AdminUtils, and proxy-filter tests for `swap_basket` that the feature PR shipped without (its tests were temporary and removed), plus behaviour-documenting tests for the weaknesses found in the calibration pass.

Commits, in order:

1. **`fix(swap_basket)`** — two non-test changes the tests exposed (kept separate on purpose):
   - `pallets/subtensor/src/macros/events.rs`: `BasketSwapped` was inserted mid-enum (before `VotingPowerTrackingEnabled`), renumbering every later event and failing `tests::epoch::regression_liquid_alpha_event_indices_are_append_only` (this is the `cargo test` failure on #3150's CI). Moved to the tail (index 149).
   - `pallets/subtensor/src/staking/basket_views.rs::basket_trade_window_at`: the `(0, 0)` storage default was treated as an open window starting at block 0, so on a young chain every fund shared a first window ending at block 7200 regardless of when it first traded. An uncharged window now opens at the current block. (Never bites on mainnet where `now ≫ 7200`; matters for localnet/tests and the `basket_trading_status` view.)
2. **`test: swap_basket coverage`** — `pallets/subtensor/src/tests/swap_basket.rs` (31 tests), `pallets/admin-utils/src/tests/mod.rs` (+3), `runtime/src/proxy_filters/mod.rs` (+1).
3. **`test: pin the swap_basket weaknesses`** — 5 pallet tests + 1 proxy test that document the findings in `docs/pr-3150-swap-basket-exploit-calibration.md`; each carries a comment naming the finding so it flips when the corresponding fix lands. **No guardrail logic was changed.**
4. **`fix(proxy): swap_basket requires BasketTrading proxy`** — `BasketTradingCalls` removed from the `NonTransfer` and `NonCritical` allow lists (`runtime/src/proxy_filters/mod.rs`); `BasketTrading` is the only proxy type that admits `swap_basket` (`Any` aside), `Staking` stays without it, and `NonTransfer` is no longer a superset of `BasketTrading`. The pinned broad-proxy test now asserts the denial (§5.6 of the calibration report).

### Covered

- **Happy paths**: alpha→alpha, alpha→TAO (dest 0), TAO→alpha (origin 0), whole-holding amounts; composition-only (shares, `BasketRate`, watermark, owed, root stake unchanged; NAV within fees); root reserve lockstep (`SubnetTAO[ROOT]`, `SubnetAlphaOut[ROOT]` credited/debited by exactly `tao_mid`); `TotalStake` drops by exactly the sell-leg author fee; block author paid on both legs; protocol flow (sell outflow = `tao_mid` + author fee, buy inflow fee-excluded, user flow untouched); `BasketSwapped` payload; claim after rebalance pays the same value; post-dispatch weight = `swap_basket_weight(rows)` < declared cap.
- **Gates/errors**: `BasketTradingDisabled`, `BasketTradingFrozen` (and unfreeze), `BasketSameSubnet`, `NonAssociatedColdKey` (stranger and non-existent hotkey), `HotKeyNotRegisteredInSubNet`, `BetaBasketSeedInProgress`, `ColdkeySwapAnnounced` via the `CheckColdkeySwap` dispatch extension, `SubnetNotExists` (both sides), `SubtokenDisabled`, `AmountTooLow` (zero and sub-`DefaultMinStake`), `NotEnoughStakeToWithdraw` (over-held and empty origin).
- **Slippage band**: EMA-anchored refusal on buy and sell, spot-anchored (own-impact) refusal on buy and sell, missing EMA on either side, a fill just inside the band on both legs.
- **Turnover budget**: accumulates `tao_mid` across trades, refuses at the cap, refuses at `start + 7199`, rolls at `start + 7200` with a fresh window, root origin charged at face, `basket_trading_status` agrees. (These tests and `basket_trade_window_at` will be reworked in #3153, which replaces the fixed window with a token bucket and stacks on this branch.)
- **Concentration cap**: refuses over cap (including topping up and the cash slot), allows selling out of an over-cap position, young-chain softening.
- **Hotkey swap**: freeze copied to the new hotkey, window moved and charged against by the next trade.
- **Rollback**: a failing second leg leaves holdings, pool reserves, `TotalStake`, author balance, turnover window, protocol flow, and events untouched.
- **AdminUtils**: `sudo_set_basket_trading_enabled`, `sudo_set_basket_trading_frozen`, `sudo_set_basket_daily_turnover_cap` — `BadOrigin` for signed, `ValueNotInBounds` for a zero cap, storage effect, events.
- **Proxy filters**: `BasketTrading` admits exactly `swap_basket` and denies adjacent calls; no other narrow proxy admits `swap_basket`; `NonTransfer`, `NonCritical`, and `NonFungible` deny it; superset relation is `{Any}` only.
- **Event index**: `BasketSwapped` pinned at 149 after `BasketAlphaWrittenOff` (148); the existing append-only regression test passes again.

### Weaknesses pinned (pass today, must flip with a fix)

| Test | Finding |
|---|---|
| `finding_2_1_thin_pool_drain_passes_every_guardrail` | §2.1 sliced buys + counterparty sell-back: >500 trades all pass, >5% of NAV lost in one window (~90% of TAO traded); cap passes on realizable value while spot value is >5× realizable |
| `finding_2_2_window_boundary_lets_two_budgets_through_in_adjacent_blocks` | §2.2 >1.9× the daily budget moved in two adjacent blocks (`start + 7199`, `start + 7200`) |
| `finding_2_3_chained_legs_in_one_block_walk_price_to_ema_ceiling` | §2.3 ≥10 legs in one block, price +20% up to 1.02×EMA |
| `finding_crash_lock_blocks_selling_a_falling_holding` | §4 sell refused 5% below EMA (into subnet or cash), buy refused 5% above |
| `finding_cash_slot_is_capped_at_root_weights_cap` | §4 with the cap binding, 10% into cash refused, 6% allowed |
| ~~`broad_proxies_currently_admit_swap_basket_without_opt_in`~~ | §3/§5.6 — **fixed in commit 4**; now `broad_proxies_do_not_admit_swap_basket_without_explicit_grant` asserts the denial |

### Bugs the tests exposed

1. `BasketSwapped` event index shift (breaks #3150 CI) — fixed in commit 1.
2. First turnover window anchored at block 0 on young chains — fixed in commit 1.
3. `NonTransfer` / `NonCritical` delegates gained `swap_basket` without opting in — fixed in commit 4.
4. (Pre-existing, not fixed, asserted as-is) `TotalStake` keeps the buy-leg author fee counted as stake — inherited from `stake_into_subnet`; the happy-path test asserts the exact current relation (`TotalStake` drops only by the sell-leg fee).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other: test coverage

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] `./scripts/fix_rust.sh` (creates a commit; ran `cargo fmt --check --all` instead)
- [ ] Documentation changes: none needed
- [x] My changes generate no new warnings (`cargo clippy -p pallet-subtensor --all-targets -D warnings` clean)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`cargo test -p pallet-subtensor swap_basket`: 36 passed; `cargo test -p pallet-admin-utils basket`: 3 passed; `cargo test -p node-subtensor-runtime proxy_filters`: 17 passed; `regression_liquid_alpha_event_indices_are_append_only`: passes)
- [ ] Dependent changes: none

## Additional Notes

Per `AGENTS.md`: no `spec_version` change, no labels, no benchmarks. `cargo fmt --check --all` and `git diff --check` clean. Runtime tests were run with `SKIP_WASM_BUILD=1` and `CXX=g++ CC=gcc LIBRARY_PATH=/usr/lib/gcc/x86_64-linux-gnu/13` (this VM's default `cc` is clang without libstdc++ on the link path).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c12261c-f25f-5e0e-8438-fa3e890e5c25?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c12261c-f25f-5e0e-8438-fa3e890e5c25&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

