### PR TITLE
fix(swap_basket): liquidity-relative destination cap, token-bucket turnover, flush weight

### DIFF
--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -165,7 +165,7 @@ pub mod pallet {
 
         /// The basket daily turnover budget (`BasketDailyTurnoverCap`) was set.
         BasketDailyTurnoverCapSet {
-            /// Max u16-normalized share of fund NAV a fund may trade per window
+            /// Turnover bucket capacity as a u16-normalized share of fund NAV
             /// (`u16::MAX` = 100%).
             cap: u16,
         },
@@ -2570,11 +2570,10 @@ pub mod pallet {
         }
 
         /// Sets the basket daily turnover budget ([`pallet_subtensor::BasketDailyTurnoverCap`]):
-        /// the largest u16-normalized share of fund NAV (`u16::MAX` = 100%) a fund may push
-        /// through `swap_basket` per 7200-block window. With each leg bounded to 2% of both
-        /// the moving and the spot price, the worst-case daily value a rogue trader can move
-        /// against the fund is `cap × (2 × 2% + fees)` of NAV. Root-only. One
-        /// storage write; reuses the `sudo_set_root_weights_cap` weight.
+        /// the capacity of each fund's `swap_basket` turnover bucket as a u16-normalized share
+        /// of fund NAV (`u16::MAX` = 100%). The bucket refills over 7200 blocks, so at most one
+        /// capacity can be traded at any instant and about one per day sustained. Root-only.
+        /// One storage write; reuses the `sudo_set_root_weights_cap` weight.
         #[pallet::call_index(108)]
         #[pallet::weight(<T as pallet::Config>::WeightInfo::sudo_set_root_weights_cap())]
         pub fn sudo_set_basket_daily_turnover_cap(

--- a/pallets/admin-utils/src/lib.rs
+++ b/pallets/admin-utils/src/lib.rs
@@ -169,6 +169,13 @@ pub mod pallet {
             /// (`u16::MAX` = 100%).
             cap: u16,
         },
+
+        /// The basket liquidity cap (`BasketLiquidityCap`) was set.
+        BasketLiquidityCapSet {
+            /// Max u16-normalized share of a subnet's alpha reserve a fund may hold on that
+            /// subnet after a `swap_basket` buy (`u16::MAX` = 100%).
+            cap: u16,
+        },
     }
 
     // Errors inform users that something went wrong.
@@ -2579,6 +2586,23 @@ pub mod pallet {
             pallet_subtensor::BasketDailyTurnoverCap::<T>::put(cap);
             Self::deposit_event(Event::BasketDailyTurnoverCapSet { cap });
             log::debug!("BasketDailyTurnoverCapSet( cap: {cap:?} )");
+            Ok(())
+        }
+
+        /// Sets the basket liquidity cap ([`pallet_subtensor::BasketLiquidityCap`]): the
+        /// largest u16-normalized share of a subnet's alpha reserve (`u16::MAX` = 100%) a fund
+        /// may hold on that subnet after a `swap_basket` buy. Bounds the fund's exposure to
+        /// any one pool's liquidity: with cap `L` the value at risk on a pool with TAO
+        /// reserve `R` is about `R × L² / (1 + L)`. Root-only. One storage write; reuses the
+        /// `sudo_set_root_weights_cap` weight.
+        #[pallet::call_index(109)]
+        #[pallet::weight(<T as pallet::Config>::WeightInfo::sudo_set_root_weights_cap())]
+        pub fn sudo_set_basket_liquidity_cap(origin: OriginFor<T>, cap: u16) -> DispatchResult {
+            ensure_root(origin)?;
+            ensure!(cap > 0, Error::<T>::ValueNotInBounds);
+            pallet_subtensor::BasketLiquidityCap::<T>::put(cap);
+            Self::deposit_event(Event::BasketLiquidityCapSet { cap });
+            log::debug!("BasketLiquidityCapSet( cap: {cap:?} )");
             Ok(())
         }
 

--- a/pallets/admin-utils/src/tests/mod.rs
+++ b/pallets/admin-utils/src/tests/mod.rs
@@ -18,6 +18,7 @@ use sp_runtime::PerU16;
 use substrate_fixed::types::I96F32;
 use subtensor_runtime_common::{MechId, NetUid, TaoBalance, Token};
 pub mod mock;
+mod swap_basket_liquidity_cap;
 use mock::*;
 
 #[test]

--- a/pallets/admin-utils/src/tests/swap_basket_liquidity_cap.rs
+++ b/pallets/admin-utils/src/tests/swap_basket_liquidity_cap.rs
@@ -1,0 +1,46 @@
+//! `sudo_set_basket_liquidity_cap`: governance setter for the `swap_basket` liquidity cap.
+
+use super::mock::*;
+use crate::Error;
+use frame_support::{assert_noop, assert_ok, sp_runtime::DispatchError};
+use frame_system::Config;
+use sp_core::U256;
+
+#[test]
+fn test_sudo_set_basket_liquidity_cap() {
+    new_test_ext().execute_with(|| {
+        // Launch default: 10% of the destination pool's alpha reserve.
+        assert_eq!(
+            pallet_subtensor::BasketLiquidityCap::<Test>::get(),
+            pallet_subtensor::DEFAULT_BASKET_LIQUIDITY_CAP
+        );
+
+        // Only root may set the cap.
+        assert_noop!(
+            AdminUtils::sudo_set_basket_liquidity_cap(
+                <<Test as Config>::RuntimeOrigin>::signed(U256::from(1)),
+                u16::MAX / 4
+            ),
+            DispatchError::BadOrigin
+        );
+
+        // Zero would refuse every buy.
+        assert_noop!(
+            AdminUtils::sudo_set_basket_liquidity_cap(<<Test as Config>::RuntimeOrigin>::root(), 0),
+            Error::<Test>::ValueNotInBounds
+        );
+
+        // Root sets a looser cap (25%) and the storage + event reflect it.
+        assert_ok!(AdminUtils::sudo_set_basket_liquidity_cap(
+            <<Test as Config>::RuntimeOrigin>::root(),
+            u16::MAX / 4
+        ));
+        assert_eq!(
+            pallet_subtensor::BasketLiquidityCap::<Test>::get(),
+            u16::MAX / 4
+        );
+        frame_system::Pallet::<Test>::assert_last_event(RuntimeEvent::AdminUtils(
+            crate::Event::BasketLiquidityCapSet { cap: u16::MAX / 4 },
+        ));
+    });
+}

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -91,6 +91,10 @@ pub const DEFAULT_BASKET_DAILY_TURNOVER_CAP: u16 = u16::MAX / 10;
 /// Length of one `swap_basket` turnover window in blocks (one day at 12s blocks).
 pub const BASKET_TRADE_WINDOW_BLOCKS: u64 = 7200;
 
+/// Default [`BasketLiquidityCap`]: a fund's holding on a subnet may not exceed 10% of that
+/// subnet's alpha reserve after a `swap_basket` buy (u16-normalized).
+pub const DEFAULT_BASKET_LIQUIDITY_CAP: u16 = u16::MAX / 10;
+
 /// Max deviation of a `swap_basket` leg's execution price from its reference, in basis
 /// points (2%). The reference is the *stricter* of the subnet's moving (EMA) price and its
 /// spot price: the EMA anchor defeats a pre-trade pump, the spot anchor caps the trade's own
@@ -2980,6 +2984,26 @@ pub mod pallet {
     #[pallet::storage]
     pub type BasketDailyTurnoverCap<T: Config> =
         StorageValue<_, u16, ValueQuery, DefaultBasketDailyTurnoverCap<T>>;
+
+    #[pallet::type_value]
+    /// Default liquidity cap for basket trading: a holding may not exceed 10% of the
+    /// destination pool's alpha reserve (u16-normalized; 6553/65535).
+    pub fn DefaultBasketLiquidityCap<T: Config>() -> u16 {
+        crate::DEFAULT_BASKET_LIQUIDITY_CAP
+    }
+
+    /// --- ITEM --> max share of a subnet's alpha reserve (`SubnetAlphaIn`) a fund may hold
+    /// on that subnet after a `swap_basket` buy (u16-normalized, `u16::MAX` = 100%).
+    ///
+    /// The concentration cap ([`RootWeightsCap`]) marks holdings at realizable value, which
+    /// is bounded by the pool's TAO reserve, so on a thin pool a fund could keep buying while
+    /// counterparties sell back into its own price support and the realizable share never
+    /// grows. This cap bounds the fund's exposure to any one pool's liquidity instead: with
+    /// cap `L` the value at risk on a pool with TAO reserve `R` is about `R × L² / (1 + L)`
+    /// (≈ 1% of `R` at 10%). Set via `AdminUtils::sudo_set_basket_liquidity_cap`.
+    #[pallet::storage]
+    pub type BasketLiquidityCap<T: Config> =
+        StorageValue<_, u16, ValueQuery, DefaultBasketLiquidityCap<T>>;
 
     /// --- MAP ( validator_hotkey ) --> `(window_start_block, tao_used)` for the fund's current
     /// basket-trade turnover window. A window is [`crate::BASKET_TRADE_WINDOW_BLOCKS`] long

--- a/pallets/subtensor/src/lib.rs
+++ b/pallets/subtensor/src/lib.rs
@@ -85,11 +85,14 @@ pub const MIN_ROOT_BASKET_WEIGHTS: u16 = 8;
 /// admits a 16-way equal split, so a fund must curate at least 16 destinations.
 pub const DEFAULT_ROOT_WEIGHTS_CAP: u16 = u16::MAX / 16 + 1;
 
-/// Default [`BasketDailyTurnoverCap`]: 10% of fund NAV per trade window (u16-normalized).
+/// Default [`BasketDailyTurnoverCap`]: the `swap_basket` turnover bucket holds 10% of fund
+/// NAV (u16-normalized).
 pub const DEFAULT_BASKET_DAILY_TURNOVER_CAP: u16 = u16::MAX / 10;
 
-/// Length of one `swap_basket` turnover window in blocks (one day at 12s blocks).
-pub const BASKET_TRADE_WINDOW_BLOCKS: u64 = 7200;
+/// Blocks for an empty `swap_basket` turnover bucket to refill completely (one day at 12s
+/// blocks). The bucket refills continuously at `budget / BASKET_TRADE_REFILL_BLOCKS` per
+/// block, so at any instant at most one full budget can be spent.
+pub const BASKET_TRADE_REFILL_BLOCKS: u64 = 7200;
 
 /// Default [`BasketLiquidityCap`]: a fund's holding on a subnet may not exceed 10% of that
 /// subnet's alpha reserve after a `swap_basket` buy (u16-normalized).
@@ -2968,19 +2971,18 @@ pub mod pallet {
         StorageMap<_, Blake2_128Concat, T::AccountId, (), OptionQuery>;
 
     #[pallet::type_value]
-    /// Default daily turnover budget for basket trading: 10% of fund NAV per window
-    /// (u16-normalized; 6553/65535).
+    /// Default daily turnover budget for basket trading: a bucket of 10% of fund NAV that
+    /// refills over one day (u16-normalized; 6553/65535).
     pub fn DefaultBasketDailyTurnoverCap<T: Config>() -> u16 {
         crate::DEFAULT_BASKET_DAILY_TURNOVER_CAP
     }
 
-    /// --- ITEM --> max TAO a fund may push through `swap_basket` per
-    /// [`crate::BASKET_TRADE_WINDOW_BLOCKS`], as a u16-normalized share of the fund's NAV
-    /// (`u16::MAX` = 100%). Each leg is also bounded to
-    /// [`crate::BASKET_TRADE_MAX_SLIPPAGE_BPS`] of *both* the moving price and the spot
-    /// price, so the worst-case daily value a rogue trader can move against the fund is
-    /// `cap × (2 × slippage + fees)` of NAV. Set via
-    /// `AdminUtils::sudo_set_basket_daily_turnover_cap`.
+    /// --- ITEM --> capacity of a fund's `swap_basket` turnover bucket as a u16-normalized
+    /// share of the fund's NAV (`u16::MAX` = 100%). The bucket refills at
+    /// `capacity / BASKET_TRADE_REFILL_BLOCKS` per block, so at most one capacity can be
+    /// pushed through the fund at any instant and about one per day sustained. Each leg is
+    /// also bounded to [`crate::BASKET_TRADE_MAX_SLIPPAGE_BPS`] of *both* the moving price
+    /// and the spot price. Set via `AdminUtils::sudo_set_basket_daily_turnover_cap`.
     #[pallet::storage]
     pub type BasketDailyTurnoverCap<T: Config> =
         StorageValue<_, u16, ValueQuery, DefaultBasketDailyTurnoverCap<T>>;
@@ -3005,14 +3007,15 @@ pub mod pallet {
     pub type BasketLiquidityCap<T: Config> =
         StorageValue<_, u16, ValueQuery, DefaultBasketLiquidityCap<T>>;
 
-    /// --- MAP ( validator_hotkey ) --> `(window_start_block, tao_used)` for the fund's current
-    /// basket-trade turnover window. A window is [`crate::BASKET_TRADE_WINDOW_BLOCKS`] long
-    /// and resets lazily on the first trade after it expires. `tao_used` is the TAO that
-    /// passed through the middle of each swap (sell leg out / buy leg in). Follows the fund
-    /// on hotkey swap.
+    /// --- MAP ( validator_hotkey ) --> `(tao_available, last_refill_block)` of the fund's
+    /// `swap_basket` turnover bucket. A missing row is a full bucket (a new fund starts full).
+    /// On each trade the bucket is refilled for the blocks elapsed since `last_refill_block`
+    /// at `budget / BASKET_TRADE_REFILL_BLOCKS` per block, clamped to one budget (NAV at
+    /// that moment), then the TAO through the middle of the swap is taken out. Follows the
+    /// fund on hotkey swap (lower level, later refill block).
     #[pallet::storage]
-    pub type BasketTradeWindow<T: Config> =
-        StorageMap<_, Blake2_128Concat, T::AccountId, (u64, u64), ValueQuery>;
+    pub type BasketTradeBucket<T: Config> =
+        StorageMap<_, Blake2_128Concat, T::AccountId, (u64, u64), OptionQuery>;
 
     #[pallet::type_value]
     /// Default share cap for a single root basket destination: 1/16 of the vector

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2110,10 +2110,11 @@ mod dispatches {
         /// * `BasketLiquidityCapExceeded`: The destination holding would exceed the liquidity cap.
         /// * `RootWeightCapExceeded`: The destination would exceed the concentration cap.
         #[pallet::call_index(150)]
-        // Declared weight is a cap sized for 256 holdings (three NAV sim-swap sweeps plus
-        // two AMM legs); the actual weight is computed in `do_swap_basket` from the real
-        // holding count and refunded post-dispatch, mirroring `stake_into_basket`.
-        #[pallet::weight((Pallet::<T>::swap_basket_weight(256), DispatchClass::Normal, Pays::Yes))]
+        // Declared weight is a cap sized for 256 holdings (two NAV sim-swap sweeps plus two
+        // AMM legs) plus the pending-deposit flush the hotkey's queue implies; the actual
+        // weight is computed in `do_swap_basket` from the real holding count and flush work
+        // and refunded post-dispatch, mirroring `stake_into_basket` / `claim_root`.
+        #[pallet::weight((Pallet::<T>::swap_basket_declared_weight(hotkey), DispatchClass::Normal, Pays::Yes))]
         pub fn swap_basket(
             origin: OriginFor<T>,
             hotkey: T::AccountId,

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2085,8 +2085,9 @@ mod dispatches {
         /// Guardrails: each AMM leg must fill fully within 2% of the subnet's moving price;
         /// the TAO through the middle is charged against the fund's daily turnover budget
         /// (`BasketDailyTurnoverCap` of NAV per 7200 blocks); the destination holding may not
-        /// end above `RootWeightsCap` of NAV. Trading must be enabled network-wide and not
-        /// frozen for the hotkey by governance.
+        /// end above `BasketLiquidityCap` of the destination pool's alpha reserve, nor above
+        /// `RootWeightsCap` of NAV. Trading must be enabled network-wide and not frozen for
+        /// the hotkey by governance.
         ///
         /// # Arguments
         /// * `origin`: Signed by the coldkey that owns `hotkey` (or its `BasketTrading` proxy).
@@ -2106,6 +2107,7 @@ mod dispatches {
         /// * `NotEnoughStakeToWithdraw`: The fund holds less than `amount` on origin.
         /// * `SlippageTooHigh`: A leg could not fill within 2% of the moving price.
         /// * `BasketTurnoverBudgetExceeded`: The trade exceeds the fund's daily budget.
+        /// * `BasketLiquidityCapExceeded`: The destination holding would exceed the liquidity cap.
         /// * `RootWeightCapExceeded`: The destination would exceed the concentration cap.
         #[pallet::call_index(150)]
         // Declared weight is a cap sized for 256 holdings (three NAV sim-swap sweeps plus

--- a/pallets/subtensor/src/macros/dispatches.rs
+++ b/pallets/subtensor/src/macros/dispatches.rs
@@ -2083,8 +2083,8 @@ mod dispatches {
         /// entitlements are unchanged; only the fund's composition moves.
         ///
         /// Guardrails: each AMM leg must fill fully within 2% of the subnet's moving price;
-        /// the TAO through the middle is charged against the fund's daily turnover budget
-        /// (`BasketDailyTurnoverCap` of NAV per 7200 blocks); the destination holding may not
+        /// the TAO through the middle is taken from the fund's turnover bucket
+        /// (`BasketDailyTurnoverCap` of NAV, refilling over 7200 blocks); the destination holding may not
         /// end above `BasketLiquidityCap` of the destination pool's alpha reserve, nor above
         /// `RootWeightsCap` of NAV. Trading must be enabled network-wide and not frozen for
         /// the hotkey by governance.
@@ -2106,7 +2106,7 @@ mod dispatches {
         /// * `HotKeyNotRegisteredInSubNet`: `hotkey` is not on root.
         /// * `NotEnoughStakeToWithdraw`: The fund holds less than `amount` on origin.
         /// * `SlippageTooHigh`: A leg could not fill within 2% of the moving price.
-        /// * `BasketTurnoverBudgetExceeded`: The trade exceeds the fund's daily budget.
+        /// * `BasketTurnoverBudgetExceeded`: The trade exceeds what the fund's turnover bucket holds.
         /// * `BasketLiquidityCapExceeded`: The destination holding would exceed the liquidity cap.
         /// * `RootWeightCapExceeded`: The destination would exceed the concentration cap.
         #[pallet::call_index(150)]

--- a/pallets/subtensor/src/macros/errors.rs
+++ b/pallets/subtensor/src/macros/errors.rs
@@ -386,5 +386,9 @@ mod errors {
         BasketTurnoverBudgetExceeded,
         /// `swap_basket` origin and destination are the same subnet.
         BasketSameSubnet,
+        /// The trade would leave the fund holding more of the destination subnet than
+        /// [`crate::BasketLiquidityCap`] allows as a share of that subnet's alpha reserve.
+        /// Trade a smaller amount or pick a deeper pool.
+        BasketLiquidityCapExceeded,
     }
 }

--- a/pallets/subtensor/src/macros/errors.rs
+++ b/pallets/subtensor/src/macros/errors.rs
@@ -380,9 +380,10 @@ mod errors {
         /// Basket trading is frozen for this validator hotkey by governance
         /// ([`crate::BasketTradingFrozen`]).
         BasketTradingFrozen,
-        /// The trade would push more TAO through the fund in the current window than
-        /// [`crate::BasketDailyTurnoverCap`] allows (as a share of fund NAV). Wait for the
-        /// window to roll or trade a smaller amount.
+        /// The trade would push more TAO through the fund than its turnover bucket holds
+        /// ([`crate::BasketDailyTurnoverCap`] of fund NAV, refilling over
+        /// [`crate::BASKET_TRADE_REFILL_BLOCKS`]). Wait for the bucket to refill or trade
+        /// a smaller amount.
         BasketTurnoverBudgetExceeded,
         /// `swap_basket` origin and destination are the same subnet.
         BasketSameSubnet,

--- a/pallets/subtensor/src/rpc_info/basket_info.rs
+++ b/pallets/subtensor/src/rpc_info/basket_info.rs
@@ -279,20 +279,22 @@ impl<T: Config> Pallet<T> {
 }
 
 /// One fund's `swap_basket` trading status as a trade at the current block would see it.
-/// `enabled` is the network-wide gate, `frozen` the per-hotkey governance freeze. The window
-/// is the one a trade now would be charged to (already rolled if the stored one expired);
-/// `budget_tao` is that window's full allowance at current NAV.
-#[freeze_struct("89f0b89d928a6ac1")]
+/// `enabled` is the network-wide gate, `frozen` the per-hotkey governance freeze. The
+/// turnover budget is a token bucket: `tao_available` is what a trade now could push
+/// through the fund, `budget_tao` the bucket's capacity at current NAV, and it refills at
+/// `budget_tao / refill_blocks` per block.
+#[freeze_struct("9ae6f8b94367d627")]
 #[derive(Decode, Encode, PartialEq, Eq, Clone, Debug, TypeInfo)]
 pub struct BasketTradingStatus {
     /// `BasketTradingEnabled`: the network-wide gate.
     pub enabled: bool,
     /// `BasketTradingFrozen[hotkey]`: governance froze this fund's trading.
     pub frozen: bool,
-    /// First block of the turnover window a trade now would be charged to.
-    pub window_start_block: u64,
-    /// TAO already pushed through the fund in that window.
-    pub tao_used: TaoBalance,
-    /// The window's full allowance: `BasketDailyTurnoverCap` share of current NAV.
+    /// Blocks for an empty bucket to refill completely (`BASKET_TRADE_REFILL_BLOCKS`); the
+    /// refill rate is `budget_tao / refill_blocks` per block.
+    pub refill_blocks: u64,
+    /// TAO the bucket holds right now: the most a trade at this block could push through.
+    pub tao_available: TaoBalance,
+    /// The bucket's capacity: `BasketDailyTurnoverCap` share of current NAV.
     pub budget_tao: TaoBalance,
 }

--- a/pallets/subtensor/src/staking/basket_trade.rs
+++ b/pallets/subtensor/src/staking/basket_trade.rs
@@ -95,8 +95,9 @@ impl<T: Config> Pallet<T> {
         ensure!(amount > 0, Error::<T>::AmountTooLow);
 
         // Settle queued dividend credits first so the budget and the cap are measured
-        // against the fund's full, current NAV.
-        Self::flush_basket_deposits_for_hotkey(&hotkey);
+        // against the fund's full, current NAV. The flush work is priced into the
+        // post-dispatch weight.
+        let (flush_work, _, _) = Self::flush_basket_deposits_for_hotkey(&hotkey);
 
         let escrow = Self::get_beta_escrow_account_id();
         let held =
@@ -121,7 +122,8 @@ impl<T: Config> Pallet<T> {
             alpha_bought: outcome.alpha_bought.into(),
         });
 
-        Ok(Self::swap_basket_weight(outcome.holdings))
+        Ok(Self::swap_basket_weight(outcome.holdings)
+            .saturating_add(Self::basket_flush_weight(flush_work)))
     }
 
     /// Transactional body of [`Self::do_swap_basket`]; any error rolls the whole trade back.
@@ -331,5 +333,37 @@ impl<T: Config> Pallet<T> {
         Weight::from_parts(60_000_000, 8000)
             .saturating_add(T::DbWeight::get().reads_writes(24_u64, 16_u64))
             .saturating_add(Self::basket_nav_sweep_weight(num_holdings).saturating_mul(2))
+    }
+
+    /// Weight of settling `flush_work` units of queued dividend credits ahead of a trade.
+    /// `flush_basket_deposits_for_hotkey` reports its work in quote units (one sim-swap
+    /// valuation each), so they are priced like NAV-sweep rows, as `claim_root` does. Zero
+    /// when nothing was queued.
+    pub(crate) fn basket_flush_weight(flush_work: u64) -> Weight {
+        if flush_work == 0 {
+            Weight::zero()
+        } else {
+            Self::basket_nav_sweep_weight(flush_work)
+        }
+    }
+
+    /// Pre-dispatch weight of `swap_basket` for `hotkey`: the 256-holding trade cap plus the
+    /// flush work its pending-deposit queue implies. Refunded to actual post-dispatch.
+    pub(crate) fn swap_basket_declared_weight(hotkey: &T::AccountId) -> Weight {
+        Self::swap_basket_weight(256).saturating_add(Self::basket_flush_weight(
+            Self::swap_basket_flush_estimate(hotkey),
+        ))
+    }
+
+    /// Upper estimate of the flush work a trade will do: nothing when the queue is empty,
+    /// else one unit per queued credit plus the deposit's own sweeps (`holdings × 3 +
+    /// destinations`, both bounded by the 256-row cap the trade weight already assumes).
+    fn swap_basket_flush_estimate(hotkey: &T::AccountId) -> u64 {
+        let credits = PendingBasketDeposits::<T>::iter_prefix(hotkey).count() as u64;
+        if credits == 0 {
+            0
+        } else {
+            credits.saturating_add(4 * 256)
+        }
     }
 }

--- a/pallets/subtensor/src/staking/basket_trade.rs
+++ b/pallets/subtensor/src/staking/basket_trade.rs
@@ -47,6 +47,8 @@ impl<T: Config> Pallet<T> {
     /// * each AMM leg must fill fully within [`crate::BASKET_TRADE_MAX_SLIPPAGE_BPS`] of
     ///   both the subnet's moving (EMA) price and its spot price;
     /// * the TAO through the middle is charged against the fund's per-window turnover budget;
+    /// * the destination holding may not end above [`crate::BasketLiquidityCap`] of the
+    ///   destination pool's alpha reserve;
     /// * the destination holding may not end above [`crate::RootWeightsCap`] of fund NAV.
     ///
     /// AMM fees are charged like any user swap; the block-author fee is settled through the
@@ -165,6 +167,10 @@ impl<T: Config> Pallet<T> {
             alpha_bought,
         );
 
+        // --- 4b. Liquidity rule: the fund may not hold more of the destination than
+        // `BasketLiquidityCap` of the pool's alpha reserve.
+        Self::ensure_within_liquidity_cap(hotkey, escrow, destination_netuid)?;
+
         // --- 5. Shape rule on the post-trade fund: one valuation sweep gives the NAV, the
         // destination's value, and the row count.
         let after = Self::try_valued_basket_holdings(hotkey)?;
@@ -278,6 +284,30 @@ impl<T: Config> Pallet<T> {
             .ok_or(Error::<T>::BasketTurnoverBudgetExceeded)?;
         ensure!(new_used <= budget, Error::<T>::BasketTurnoverBudgetExceeded);
         BasketTradeWindow::<T>::insert(hotkey, (window_start, new_used));
+        Ok(())
+    }
+
+    /// Post-buy liquidity check: the fund's holding on `netuid` may not exceed
+    /// [`crate::BasketLiquidityCap`] of the pool's alpha reserve. Root is the fund's cash
+    /// slot with no pool and is exempt. Realizable value (the concentration cap's measure)
+    /// is bounded by the pool's TAO reserve, so it cannot see a fund accumulating a thin
+    /// pool's supply while counterparties sell into its price support; this rule can.
+    fn ensure_within_liquidity_cap(
+        hotkey: &T::AccountId,
+        escrow: &T::AccountId,
+        netuid: NetUid,
+    ) -> DispatchResult {
+        if netuid.is_root() {
+            return Ok(());
+        }
+        let held =
+            Self::get_stake_for_hotkey_and_coldkey_on_subnet(hotkey, escrow, netuid).to_u64();
+        let reserve = SubnetAlphaIn::<T>::get(netuid).to_u64();
+        let cap = BasketLiquidityCap::<T>::get() as u64;
+        ensure!(
+            Self::share_within_root_cap(held, reserve, cap),
+            Error::<T>::BasketLiquidityCapExceeded
+        );
         Ok(())
     }
 

--- a/pallets/subtensor/src/staking/basket_trade.rs
+++ b/pallets/subtensor/src/staking/basket_trade.rs
@@ -46,7 +46,7 @@ impl<T: Config> Pallet<T> {
     /// Guardrails (see the storage docs on [`crate::BasketDailyTurnoverCap`]):
     /// * each AMM leg must fill fully within [`crate::BASKET_TRADE_MAX_SLIPPAGE_BPS`] of
     ///   both the subnet's moving (EMA) price and its spot price;
-    /// * the TAO through the middle is charged against the fund's per-window turnover budget;
+    /// * the TAO through the middle is taken from the fund's turnover bucket;
     /// * the destination holding may not end above [`crate::BasketLiquidityCap`] of the
     ///   destination pool's alpha reserve;
     /// * the destination holding may not end above [`crate::RootWeightsCap`] of fund NAV.
@@ -270,22 +270,21 @@ impl<T: Config> Pallet<T> {
         Ok(limit.saturating_to_num::<u64>().into())
     }
 
-    /// Charge `tao_mid` against the fund's per-window turnover budget
-    /// (`nav_before × BasketDailyTurnoverCap / u16::MAX`), rolling the window when
-    /// [`crate::BASKET_TRADE_WINDOW_BLOCKS`] have passed since it opened.
+    /// Take `tao_mid` out of the fund's turnover bucket after refilling it for the blocks
+    /// elapsed (capacity `nav_before × BasketDailyTurnoverCap / u16::MAX`, full refill over
+    /// [`crate::BASKET_TRADE_REFILL_BLOCKS`]).
     fn consume_basket_trade_budget(
         hotkey: &T::AccountId,
         nav_before: u64,
         tao_mid: u64,
     ) -> DispatchResult {
         let now = Self::get_current_block_as_u64();
-        let (window_start, tao_used) = Self::basket_trade_window_at(hotkey, now);
         let budget = Self::basket_trade_budget_tao(nav_before);
-        let new_used = tao_used
-            .checked_add(tao_mid)
+        let available = Self::basket_trade_bucket_at(hotkey, now, budget);
+        let remaining = available
+            .checked_sub(tao_mid)
             .ok_or(Error::<T>::BasketTurnoverBudgetExceeded)?;
-        ensure!(new_used <= budget, Error::<T>::BasketTurnoverBudgetExceeded);
-        BasketTradeWindow::<T>::insert(hotkey, (window_start, new_used));
+        BasketTradeBucket::<T>::insert(hotkey, (remaining, now));
         Ok(())
     }
 

--- a/pallets/subtensor/src/staking/basket_views.rs
+++ b/pallets/subtensor/src/staking/basket_views.rs
@@ -175,21 +175,23 @@ impl<T: Config> Pallet<T> {
             .collect()
     }
 
-    /// The fund's `swap_basket` turnover window as seen at block `now`: the stored window
-    /// if still open and charged, otherwise a fresh one starting at `now` with nothing used.
-    /// A fund that has never traded (the `(0, 0)` default) opens its first window at its
-    /// first trade rather than at block 0, so a young chain does not hand every fund a
-    /// shared window ending at block `BASKET_TRADE_WINDOW_BLOCKS`.
-    pub fn basket_trade_window_at(hotkey: &T::AccountId, now: u64) -> (u64, u64) {
-        let (window_start, tao_used) = BasketTradeWindow::<T>::get(hotkey);
-        if tao_used == 0 || now.saturating_sub(window_start) >= crate::BASKET_TRADE_WINDOW_BLOCKS {
-            (now, 0)
-        } else {
-            (window_start, tao_used)
+    /// TAO the fund's `swap_basket` turnover bucket holds at block `now` given a bucket
+    /// capacity of `budget`: the stored level plus `budget / BASKET_TRADE_REFILL_BLOCKS` per
+    /// block elapsed since the last refill, clamped to `budget`. A fund with no stored
+    /// bucket (never traded) is full. Clamping also absorbs a NAV drop: the level can never
+    /// exceed one current budget.
+    pub fn basket_trade_bucket_at(hotkey: &T::AccountId, now: u64, budget: u64) -> u64 {
+        match BasketTradeBucket::<T>::get(hotkey) {
+            None => budget,
+            Some((level, last_refill_block)) => {
+                let elapsed = now.saturating_sub(last_refill_block);
+                let refill = Self::mul_div_u64(budget, elapsed, crate::BASKET_TRADE_REFILL_BLOCKS);
+                level.saturating_add(refill).min(budget)
+            }
         }
     }
 
-    /// TAO a fund with `nav` may push through `swap_basket` per window
+    /// Capacity of a fund's `swap_basket` turnover bucket at `nav`
     /// (`nav × BasketDailyTurnoverCap / u16::MAX`).
     pub fn basket_trade_budget_tao(nav: u64) -> u64 {
         Self::mul_div_u64(
@@ -203,14 +205,14 @@ impl<T: Config> Pallet<T> {
     /// block would see it.
     pub fn get_basket_trading_status(hotkey: &T::AccountId) -> BasketTradingStatus {
         let now = Self::get_current_block_as_u64();
-        let (window_start_block, tao_used) = Self::basket_trade_window_at(hotkey, now);
         let nav = Self::get_validator_basket_nav_tao(hotkey).to_u64();
+        let budget = Self::basket_trade_budget_tao(nav);
         BasketTradingStatus {
             enabled: BasketTradingEnabled::<T>::get(),
             frozen: BasketTradingFrozen::<T>::contains_key(hotkey),
-            window_start_block,
-            tao_used: tao_used.into(),
-            budget_tao: Self::basket_trade_budget_tao(nav).into(),
+            refill_blocks: crate::BASKET_TRADE_REFILL_BLOCKS,
+            tao_available: Self::basket_trade_bucket_at(hotkey, now, budget).into(),
+            budget_tao: budget.into(),
         }
     }
 

--- a/pallets/subtensor/src/staking/claim_root.rs
+++ b/pallets/subtensor/src/staking/claim_root.rs
@@ -1194,17 +1194,20 @@ impl<T: Config> Pallet<T> {
         }
 
         // Trading guardrails follow the fund so a hotkey swap can neither escape a
-        // governance freeze nor reset the turnover window. The freeze is copied, not
-        // moved: a later swap back onto the old hotkey must still find it frozen.
+        // governance freeze nor refill the turnover bucket. The freeze is copied, not
+        // moved: a later swap back onto the old hotkey must still find it frozen. The
+        // bucket is carried conservatively: the lower level and the later refill block.
         if BasketTradingFrozen::<T>::contains_key(old_hotkey) {
             BasketTradingFrozen::<T>::insert(new_hotkey, ());
         }
-        let (window_start, tao_used) = BasketTradeWindow::<T>::take(old_hotkey);
-        if tao_used != 0 {
-            BasketTradeWindow::<T>::mutate(new_hotkey, |(start, used)| {
-                *start = (*start).max(window_start);
-                *used = used.saturating_add(tao_used);
-            });
+        if let Some((old_level, old_block)) = BasketTradeBucket::<T>::take(old_hotkey) {
+            let carried = match BasketTradeBucket::<T>::get(new_hotkey) {
+                Some((new_level, new_block)) => {
+                    (old_level.min(new_level), old_block.max(new_block))
+                }
+                None => (old_level, old_block),
+            };
+            BasketTradeBucket::<T>::insert(new_hotkey, carried);
         }
 
         moved_rows

--- a/pallets/subtensor/src/tests/mod.rs
+++ b/pallets/subtensor/src/tests/mod.rs
@@ -38,6 +38,7 @@ mod subnet;
 mod subnet_emissions;
 mod subnet_info;
 mod swap_basket;
+mod swap_basket_liquidity_cap;
 mod swap_coldkey;
 mod swap_hotkey;
 mod swap_hotkey_with_subnet;

--- a/pallets/subtensor/src/tests/swap_basket.rs
+++ b/pallets/subtensor/src/tests/swap_basket.rs
@@ -20,8 +20,8 @@ use crate::tests::claim_root::{
 };
 use crate::tests::mock::*;
 use crate::{
-    BASKET_TRADE_WINDOW_BLOCKS, BasketClaimed, BasketDailyTurnoverCap, BasketLiquidityCap,
-    BasketRate, BasketShares, BasketTradeWindow, BasketTradingEnabled, BasketTradingFrozen,
+    BASKET_TRADE_REFILL_BLOCKS, BasketClaimed, BasketDailyTurnoverCap, BasketLiquidityCap,
+    BasketRate, BasketShares, BasketTradeBucket, BasketTradingEnabled, BasketTradingFrozen,
     ColdkeySwapAnnouncements, DEFAULT_BASKET_DAILY_TURNOVER_CAP, DefaultMinStake, Error, Event,
     NetworksAdded, RootWeightsCap, SubnetAlphaIn, SubnetAlphaOut, SubnetMovingPrice,
     SubnetProtocolFlow, SubnetTAO, SubnetTaoFlow, SubtokenEnabled, TotalStake, Uids,
@@ -139,10 +139,10 @@ fn author_balance() -> u64 {
     SubtensorModule::get_coldkey_balance(&U256::from(MOCK_BLOCK_BUILDER)).to_u64()
 }
 
-/// Forget the fund's turnover window so consecutive whole-holding trades in one test are
+/// Refill the fund's turnover bucket so consecutive whole-holding trades in one test are
 /// not limited by the budget (budget behaviour has its own tests).
-fn reset_turnover_window(hotkey: &U256) {
-    BasketTradeWindow::<Test>::remove(hotkey);
+fn refill_turnover_bucket(hotkey: &U256) {
+    BasketTradeBucket::<Test>::remove(hotkey);
 }
 
 /// `(alpha_sold, tao_mid, alpha_bought)` of the most recent `BasketSwapped` event.
@@ -290,7 +290,7 @@ fn test_swap_basket_root_to_alpha_debits_reserves_in_lockstep() {
         ));
         let cash = escrow_alpha(&fund.hotkey, NetUid::ROOT);
         assert!(cash > 0);
-        reset_turnover_window(&fund.hotkey);
+        refill_turnover_bucket(&fund.hotkey);
 
         let before = entitlements(&fund);
         let nav_before = nav(&fund.hotkey);
@@ -704,7 +704,7 @@ fn test_swap_basket_fills_just_inside_band() {
 }
 
 /// A `swap_basket` refusal after the sell leg has already executed rolls the whole trade
-/// back: holdings, reserves, TotalStake, author fee, and the turnover window are untouched.
+/// back: holdings, reserves, TotalStake, author fee, and the turnover bucket are untouched.
 #[test]
 fn test_swap_basket_failed_second_leg_leaves_no_partial_state() {
     new_test_ext(1).execute_with(|| {
@@ -718,7 +718,7 @@ fn test_swap_basket_failed_second_leg_leaves_no_partial_state() {
         let alpha_in_a = SubnetAlphaIn::<Test>::get(fund.netuid_a);
         let ts = TotalStake::<Test>::get();
         let author = author_balance();
-        let window = BasketTradeWindow::<Test>::get(fund.hotkey);
+        let bucket = BasketTradeBucket::<Test>::get(fund.hotkey);
         let flow_a = SubnetProtocolFlow::<Test>::get(fund.netuid_a);
         let before = entitlements(&fund);
 
@@ -734,7 +734,7 @@ fn test_swap_basket_failed_second_leg_leaves_no_partial_state() {
             author,
             "rolled-back fee must not reach the author"
         );
-        assert_eq!(BasketTradeWindow::<Test>::get(fund.hotkey), window);
+        assert_eq!(BasketTradeBucket::<Test>::get(fund.hotkey), bucket);
         assert_eq!(SubnetProtocolFlow::<Test>::get(fund.netuid_a), flow_a);
         assert_eq!(entitlements(&fund), before);
         assert!(!System::events().iter().any(|e| matches!(
@@ -748,10 +748,11 @@ fn test_swap_basket_failed_second_leg_leaves_no_partial_state() {
 // Guardrail: turnover budget
 // =============================================================================
 
-/// The TAO through the middle accumulates in the window, refuses at the cap, and the
-/// window rolls after `BASKET_TRADE_WINDOW_BLOCKS`.
+/// The TAO through the middle drains the turnover bucket, refuses when the bucket cannot
+/// cover a trade, refills continuously at `budget / BASKET_TRADE_REFILL_BLOCKS` per block,
+/// and clamps at one full budget.
 #[test]
-fn test_swap_basket_turnover_budget_accumulates_refuses_and_rolls() {
+fn test_swap_basket_turnover_bucket_drains_refuses_and_refills() {
     new_test_ext(1).execute_with(|| {
         let fund = setup_fund();
         BasketDailyTurnoverCap::<Test>::put(DEFAULT_BASKET_DAILY_TURNOVER_CAP);
@@ -762,51 +763,69 @@ fn test_swap_basket_turnover_budget_accumulates_refuses_and_rolls() {
             "budget = {budget}"
         );
         let start = System::block_number();
-        assert!(
-            start > 0,
-            "the first trade must open the window at the current block"
-        );
-        assert_eq!(BasketTradeWindow::<Test>::get(fund.hotkey), (0, 0));
-        assert_eq!(
-            SubtensorModule::get_basket_trading_status(&fund.hotkey).window_start_block,
-            start
-        );
+
+        // A fund that has never traded has a full bucket and no stored row.
+        assert_eq!(BasketTradeBucket::<Test>::get(fund.hotkey), None);
+        let status = SubtensorModule::get_basket_trading_status(&fund.hotkey);
+        assert_eq!(status.tao_available.to_u64(), budget);
+        assert_eq!(status.budget_tao.to_u64(), budget);
+        assert_eq!(status.refill_blocks, BASKET_TRADE_REFILL_BLOCKS);
 
         assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, TRADE));
         let (_, mid_1, _) = last_swap_event();
-        assert_eq!(BasketTradeWindow::<Test>::get(fund.hotkey), (start, mid_1));
+        assert_eq!(
+            BasketTradeBucket::<Test>::get(fund.hotkey),
+            Some((budget - mid_1, start))
+        );
 
         assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, TRADE));
         let (_, mid_2, _) = last_swap_event();
         assert_eq!(
-            BasketTradeWindow::<Test>::get(fund.hotkey),
-            (start, mid_1 + mid_2),
-            "tao_used is the sum of tao_mid across the window"
+            BasketTradeBucket::<Test>::get(fund.hotkey),
+            Some((budget - mid_1 - mid_2, start)),
+            "each trade takes its tao_mid out of the bucket"
         );
 
         assert_noop!(
             swap(&fund, fund.netuid_a, fund.netuid_b, TRADE),
             Error::<Test>::BasketTurnoverBudgetExceeded
         );
-        // The view agrees with what a trade would be charged against.
+        // The view agrees with what a trade would be allowed right now.
         let status = SubtensorModule::get_basket_trading_status(&fund.hotkey);
-        assert_eq!(status.window_start_block, start);
-        assert_eq!(status.tao_used.to_u64(), mid_1 + mid_2);
+        assert_eq!(status.tao_available.to_u64(), budget - mid_1 - mid_2);
         assert!(status.enabled && !status.frozen);
 
-        // One block short of the roll: still refused.
-        System::set_block_number(start + BASKET_TRADE_WINDOW_BLOCKS - 1);
+        // Half a refill period later the bucket has gained ~half a budget: one more trade
+        // fits, the next does not.
+        System::set_block_number(start + BASKET_TRADE_REFILL_BLOCKS / 2);
+        let status = SubtensorModule::get_basket_trading_status(&fund.hotkey);
+        let expected = budget - mid_1 - mid_2 + budget / 2;
+        assert!(
+            status.tao_available.to_u64().abs_diff(expected) <= budget / 1_000,
+            "available {} vs expected {expected}",
+            status.tao_available
+        );
+        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, TRADE));
         assert_noop!(
             swap(&fund, fund.netuid_a, fund.netuid_b, TRADE),
             Error::<Test>::BasketTurnoverBudgetExceeded
         );
 
-        // At the roll a fresh window opens, charged only with this trade.
-        let rolled = start + BASKET_TRADE_WINDOW_BLOCKS;
-        System::set_block_number(rolled);
-        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, TRADE));
-        let (_, mid_3, _) = last_swap_event();
-        assert_eq!(BasketTradeWindow::<Test>::get(fund.hotkey), (rolled, mid_3));
+        // A full refill period after the last trade the bucket is full again — and no
+        // fuller: the level clamps at one budget.
+        System::set_block_number(
+            start + BASKET_TRADE_REFILL_BLOCKS / 2 + BASKET_TRADE_REFILL_BLOCKS,
+        );
+        let budget_now = SubtensorModule::basket_trade_budget_tao(nav(&fund.hotkey));
+        let status = SubtensorModule::get_basket_trading_status(&fund.hotkey);
+        assert_eq!(status.tao_available.to_u64(), budget_now);
+        System::set_block_number(start + 10 * BASKET_TRADE_REFILL_BLOCKS);
+        let status = SubtensorModule::get_basket_trading_status(&fund.hotkey);
+        assert_eq!(
+            status.tao_available.to_u64(),
+            budget_now,
+            "clamped at one budget"
+        );
     });
 }
 
@@ -817,10 +836,14 @@ fn test_swap_basket_turnover_charges_root_origin_at_face() {
         let fund = setup_fund();
         assert_ok!(swap(&fund, fund.netuid_a, NetUid::ROOT, 3 * TRADE));
         let start = System::block_number();
-        BasketTradeWindow::<Test>::remove(fund.hotkey);
+        refill_turnover_bucket(&fund.hotkey);
+        let budget = SubtensorModule::basket_trade_budget_tao(nav(&fund.hotkey));
 
         assert_ok!(swap(&fund, NetUid::ROOT, fund.netuid_b, TRADE));
-        assert_eq!(BasketTradeWindow::<Test>::get(fund.hotkey), (start, TRADE));
+        assert_eq!(
+            BasketTradeBucket::<Test>::get(fund.hotkey),
+            Some((budget - TRADE, start))
+        );
     });
 }
 
@@ -873,7 +896,7 @@ fn test_swap_basket_allows_selling_out_of_over_cap_position() {
             escrow_alpha(&fund.hotkey, fund.netuid_a)
         ));
         assert_eq!(escrow_alpha(&fund.hotkey, fund.netuid_a), 0);
-        reset_turnover_window(&fund.hotkey);
+        refill_turnover_bucket(&fund.hotkey);
         RootWeightsCap::<Test>::insert(NetUid::ROOT, u16::MAX / 2);
         let held_b = escrow_alpha(&fund.hotkey, fund.netuid_b);
 
@@ -910,7 +933,7 @@ fn test_swap_basket_concentration_cap_skipped_on_young_chain() {
 // =============================================================================
 
 #[test]
-fn test_swap_basket_freeze_and_window_follow_hotkey_swap() {
+fn test_swap_basket_freeze_and_bucket_follow_hotkey_swap() {
     new_test_ext(1).execute_with(|| {
         let fund = setup_fund();
         let new_hotkey = U256::from(10030);
@@ -919,8 +942,7 @@ fn test_swap_basket_freeze_and_window_follow_hotkey_swap() {
         let _ = SubtensorModule::create_account_if_non_existent(&fund.coldkey, &new_hotkey);
 
         assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, TRADE));
-        let window = BasketTradeWindow::<Test>::get(fund.hotkey);
-        assert!(window.1 > 0);
+        let bucket = BasketTradeBucket::<Test>::get(fund.hotkey).expect("trade stores the bucket");
         BasketTradingFrozen::<Test>::insert(fund.hotkey, ());
 
         let mut weight = Weight::zero();
@@ -932,11 +954,11 @@ fn test_swap_basket_freeze_and_window_follow_hotkey_swap() {
             false,
         ));
 
-        // The freeze is copied (the old key stays frozen too), the window moves.
+        // The freeze is copied (the old key stays frozen too), the bucket moves.
         assert!(BasketTradingFrozen::<Test>::contains_key(new_hotkey));
         assert!(BasketTradingFrozen::<Test>::contains_key(fund.hotkey));
-        assert_eq!(BasketTradeWindow::<Test>::get(new_hotkey), window);
-        assert_eq!(BasketTradeWindow::<Test>::get(fund.hotkey), (0, 0));
+        assert_eq!(BasketTradeBucket::<Test>::get(new_hotkey), Some(bucket));
+        assert_eq!(BasketTradeBucket::<Test>::get(fund.hotkey), None);
 
         // `register_on_root` only writes `Uids` (no `Keys` row), so the subnet-scoped swap
         // above cannot carry the root seat over; give the new hotkey its seat directly.
@@ -952,8 +974,14 @@ fn test_swap_basket_freeze_and_window_follow_hotkey_swap() {
             Error::<Test>::BasketTradingFrozen
         );
         BasketTradingFrozen::<Test>::remove(new_hotkey);
-        // And the moved window is what the next trade is charged against.
+        // And the moved bucket is what the next trade draws from: tightening the cap clamps
+        // the carried level to the new (smaller) budget, then the trade takes its tao_mid.
         BasketDailyTurnoverCap::<Test>::put(DEFAULT_BASKET_DAILY_TURNOVER_CAP);
+        let budget = SubtensorModule::basket_trade_budget_tao(nav(&new_hotkey));
+        assert!(
+            bucket.0 > budget,
+            "carried level exceeds the tightened budget"
+        );
         let held_b = escrow_alpha(&new_hotkey, new_fund.netuid_b);
         assert_ok!(swap(
             &new_fund,
@@ -963,8 +991,8 @@ fn test_swap_basket_freeze_and_window_follow_hotkey_swap() {
         ));
         let (_, mid, _) = last_swap_event();
         assert_eq!(
-            BasketTradeWindow::<Test>::get(new_hotkey),
-            (window.0, window.1 + mid)
+            BasketTradeBucket::<Test>::get(new_hotkey),
+            Some((budget - mid, System::block_number()))
         );
     });
 }
@@ -1169,57 +1197,65 @@ fn finding_2_1_thin_pool_drain_is_stopped_by_liquidity_cap() {
     });
 }
 
-/// Finding §2.2 (Medium): the turnover window is a fixed interval with a lazy reset, so a
-/// trader can spend one full budget at block `start + 7199` and another at `start + 7200`
-/// — 2× the daily cap in two adjacent blocks. Documents current behaviour; flip when a
-/// token-bucket budget (§5.2) lands.
+/// Finding §2.2 (Medium), fixed by the token bucket (§5.2): a fixed window with a lazy
+/// reset let a trader spend one full budget at block `start + 7199` and another at
+/// `start + 7200`. With the bucket, spending the budget empties it, the very next block
+/// refills only `budget / 7200`, and two adjacent blocks can never move more than one
+/// budget (plus one block of refill).
 #[test]
-fn finding_2_2_window_boundary_lets_two_budgets_through_in_adjacent_blocks() {
+fn finding_2_2_bucket_denies_a_second_budget_in_the_adjacent_block() {
     new_test_ext(1).execute_with(|| {
         let fund = setup_fund();
-        // The window mechanics do not depend on the cap value; a 50% cap keeps the
-        // window-opening trade (which must clear `DefaultMinStake`) small next to the budget.
         BasketDailyTurnoverCap::<Test>::put(u16::MAX / 2);
         let budget = SubtensorModule::basket_trade_budget_tao(nav(&fund.hotkey));
-
-        // Open the window with one minimal trade at `start`; it is not part of the burst.
         let start = System::block_number();
-        let opener = DefaultMinStake::<Test>::get().to_u64() * 101 / 100;
-        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, opener));
-        let (_, opening) = BasketTradeWindow::<Test>::get(fund.hotkey);
-        assert!(opening > 0 && opening < budget / 10);
 
-        // Penultimate block of the window: spend everything that is left of the budget.
-        // Two slices sized from the remaining budget fit (tao_mid trails alpha by the fee).
-        System::set_block_number(start + BASKET_TRADE_WINDOW_BLOCKS - 1);
-        let remaining = budget - opening;
-        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, remaining / 2));
-        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, remaining / 2));
-        let (_, used_first) = BasketTradeWindow::<Test>::get(fund.hotkey);
+        // Spend the whole bucket in this block (two slices; tao_mid trails alpha by the fee).
+        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, budget / 2));
+        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, budget / 2));
+        let (level, block) = BasketTradeBucket::<Test>::get(fund.hotkey).expect("bucket stored");
+        assert_eq!(block, start);
         assert!(
-            used_first > budget * 99 / 100,
-            "first window used {used_first} of {budget}"
+            level < budget / 100,
+            "bucket nearly empty: {level} of {budget}"
         );
         assert_noop!(
             swap(&fund, fund.netuid_a, fund.netuid_b, TRADE),
             Error::<Test>::BasketTurnoverBudgetExceeded
         );
-        let burst_first_block = used_first - opening;
+        let moved_first_block = budget - level;
 
-        // Very next block: the window rolls and a whole new budget is available.
-        System::set_block_number(start + BASKET_TRADE_WINDOW_BLOCKS);
-        let budget_2 = SubtensorModule::basket_trade_budget_tao(nav(&fund.hotkey));
-        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, budget_2 / 2));
-        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, budget_2 / 2));
-        let (_, burst_second_block) = BasketTradeWindow::<Test>::get(fund.hotkey);
-        assert!(burst_second_block > budget_2 * 99 / 100);
-
-        // Two adjacent blocks moved ~2x the daily cap.
-        let moved_in_two_adjacent_blocks = burst_first_block + burst_second_block;
-        assert!(
-            moved_in_two_adjacent_blocks > budget * 19 / 10,
-            "moved {moved_in_two_adjacent_blocks} across the boundary vs one budget {budget}"
+        // Very next block: only one block's refill is available, far below a second budget.
+        System::set_block_number(start + 1);
+        let per_block = budget / BASKET_TRADE_REFILL_BLOCKS;
+        let status = SubtensorModule::get_basket_trading_status(&fund.hotkey);
+        assert!(status.tao_available.to_u64() <= level + per_block + 1);
+        assert_noop!(
+            swap(&fund, fund.netuid_a, fund.netuid_b, budget / 2),
+            Error::<Test>::BasketTurnoverBudgetExceeded
         );
+        assert_noop!(
+            swap(&fund, fund.netuid_a, fund.netuid_b, TRADE),
+            Error::<Test>::BasketTurnoverBudgetExceeded
+        );
+
+        // Across the two adjacent blocks at most one budget (+ one refill step) moved.
+        assert!(moved_first_block <= budget);
+        assert!(
+            status.tao_available.to_u64() + moved_first_block <= budget + per_block + 1,
+            "two adjacent blocks must not exceed one budget"
+        );
+
+        // A full refill period later the bucket is whole again.
+        System::set_block_number(start + BASKET_TRADE_REFILL_BLOCKS);
+        let budget_now = SubtensorModule::basket_trade_budget_tao(nav(&fund.hotkey));
+        assert_eq!(
+            SubtensorModule::get_basket_trading_status(&fund.hotkey)
+                .tao_available
+                .to_u64(),
+            budget_now
+        );
+        assert_ok!(swap(&fund, fund.netuid_a, fund.netuid_b, budget_now / 2));
     });
 }
 

--- a/pallets/subtensor/src/tests/swap_basket.rs
+++ b/pallets/subtensor/src/tests/swap_basket.rs
@@ -20,11 +20,11 @@ use crate::tests::claim_root::{
 };
 use crate::tests::mock::*;
 use crate::{
-    BASKET_TRADE_WINDOW_BLOCKS, BasketClaimed, BasketDailyTurnoverCap, BasketRate, BasketShares,
-    BasketTradeWindow, BasketTradingEnabled, BasketTradingFrozen, ColdkeySwapAnnouncements,
-    DEFAULT_BASKET_DAILY_TURNOVER_CAP, DefaultMinStake, Error, Event, NetworksAdded,
-    RootWeightsCap, SubnetAlphaIn, SubnetAlphaOut, SubnetMovingPrice, SubnetProtocolFlow,
-    SubnetTAO, SubnetTaoFlow, SubtokenEnabled, TotalStake, Uids,
+    BASKET_TRADE_WINDOW_BLOCKS, BasketClaimed, BasketDailyTurnoverCap, BasketLiquidityCap,
+    BasketRate, BasketShares, BasketTradeWindow, BasketTradingEnabled, BasketTradingFrozen,
+    ColdkeySwapAnnouncements, DEFAULT_BASKET_DAILY_TURNOVER_CAP, DefaultMinStake, Error, Event,
+    NetworksAdded, RootWeightsCap, SubnetAlphaIn, SubnetAlphaOut, SubnetMovingPrice,
+    SubnetProtocolFlow, SubnetTAO, SubnetTaoFlow, SubtokenEnabled, TotalStake, Uids,
 };
 use codec::Encode;
 use frame_support::dispatch::DispatchResultWithPostInfo;
@@ -1113,19 +1113,19 @@ fn counterparty_sells_back_to(netuid: NetUid, target_price: f64) {
     ));
 }
 
-/// Finding §2.1 (High): sliced buys into a thin pool, each answered by a counterparty
-/// sell-back to the EMA, pass every guardrail on every trade and drain the fund by ~8% of
-/// NAV inside one turnover window. The concentration cap never fires because it measures
-/// *realizable* value, which is bounded by the pool's TAO reserve. Documents current
-/// behaviour; flip when a liquidity-relative destination cap (§5.1) lands.
+/// Finding §2.1 (High), fixed by the liquidity-relative destination cap (§5.1): sliced buys
+/// into a thin pool, each answered by a counterparty sell-back to the EMA, used to pass
+/// every guardrail and drain ~8% of NAV inside one turnover window, because the
+/// concentration cap measures *realizable* value (bounded by the pool's TAO reserve). Now
+/// the loop stops as soon as the fund holds `BasketLiquidityCap` of the pool's alpha
+/// reserve, long before the turnover budget, and the loss is a sliver of the pool.
 #[test]
-fn finding_2_1_thin_pool_drain_passes_every_guardrail() {
+fn finding_2_1_thin_pool_drain_is_stopped_by_liquidity_cap() {
     new_test_ext(1).execute_with(|| {
         let (fund, netuid_c) = setup_cash_fund_with_thin_pool();
         let nav_before = nav(&fund.hotkey);
         assert_eq!(nav_before, CASH_NAV);
         let budget = SubtensorModule::basket_trade_budget_tao(nav_before);
-        let counterparty_before = SubtensorModule::get_coldkey_balance(&U256::from(9_999)).to_u64();
 
         let mut trades = 0u32;
         let mut spent = 0u64;
@@ -1140,55 +1140,32 @@ fn finding_2_1_thin_pool_drain_passes_every_guardrail() {
             }
         };
 
-        // Only the turnover budget ever stops the loop, and only after it is spent.
+        // The liquidity cap, not the turnover budget, stops the loop — early.
         assert_eq!(
             refused_with,
-            Error::<Test>::BasketTurnoverBudgetExceeded.into()
+            Error::<Test>::BasketLiquidityCapExceeded.into()
         );
-        assert!(trades > 500, "trades = {trades}");
-        assert!(spent > budget * 9 / 10, "spent {spent} of budget {budget}");
+        assert!(trades < 50, "trades = {trades}");
+        assert!(spent < budget / 5, "spent {spent} of budget {budget}");
 
-        // The fund now holds several times the pool's whole alpha reserve, realizable for
-        // roughly the pool's TAO reserve; the counterparty walked away with ~all the TAO.
+        // The fund holds at most the cap's share of the pool's alpha reserve.
         let holding = escrow_alpha(&fund.hotkey, netuid_c);
-        assert!(
-            holding > 5 * THIN_POOL_ALPHA,
-            "holding {holding} vs reserve {THIN_POOL_ALPHA}"
-        );
-        let realizable = SubtensorModule::realizable_tao_for_alpha(netuid_c, holding);
-        assert!(realizable <= THIN_POOL_TAO);
-        let received =
-            SubtensorModule::get_coldkey_balance(&U256::from(9_999)).to_u64() - counterparty_before;
-        assert!(
-            received > spent * 95 / 100,
-            "counterparty took {received} of {spent}"
-        );
+        let reserve = SubnetAlphaIn::<Test>::get(netuid_c).to_u64();
+        assert!(SubtensorModule::share_within_root_cap(
+            holding,
+            reserve,
+            BasketLiquidityCap::<Test>::get() as u64
+        ));
 
-        // Loss: > 5% of NAV in one window (calibration run: 8.3%), i.e. ~90% of the TAO
-        // traded — far above the PR's stated worst case of cap × (2 × 2% + fees).
+        // Loss is bounded by ~R × L² / (1 + L) of the pool's TAO reserve (≈ 1% at 10%),
+        // plus fees — not by the turnover budget.
         let nav_after = nav(&fund.hotkey);
         let loss = nav_before - nav_after;
         assert!(
-            loss > nav_before * 5 / 100,
-            "loss {loss} ({}%) must exceed 5% of NAV to reproduce the finding",
-            loss * 100 / nav_before
+            loss < THIN_POOL_TAO * 3 / 100,
+            "loss {loss} must be a sliver of the {THIN_POOL_TAO} pool"
         );
-        assert!(loss > spent * 3 / 4, "loss {loss} vs spent {spent}");
-
-        // The concentration cap passes because the destination is measured realizable.
-        let cap = SubtensorModule::binding_root_weights_cap(
-            SubtensorModule::get_all_subnet_netuids().len() as u64,
-        )
-        .expect("cap binds");
-        assert!(SubtensorModule::share_within_root_cap(
-            realizable, nav_after, cap
-        ));
-        // ...while the same holding marked at spot is several multiples of the cap share.
-        let spot_value = SubtensorModule::spot_tao_for_alpha(netuid_c, holding);
-        assert!(!SubtensorModule::share_within_root_cap(
-            spot_value, nav_after, cap
-        ));
-        assert!(spot_value > 5 * realizable);
+        assert!(loss < nav_before / 1_000, "loss {loss} vs NAV {nav_before}");
     });
 }
 
@@ -1254,6 +1231,9 @@ fn finding_2_2_window_boundary_lets_two_budgets_through_in_adjacent_blocks() {
 fn finding_2_3_chained_legs_in_one_block_walk_price_to_ema_ceiling() {
     new_test_ext(1).execute_with(|| {
         let (fund, netuid_c) = setup_cash_fund_with_thin_pool();
+        // Isolate the band: the walk accumulates well over 10% of the thin pool's alpha
+        // reserve, which the liquidity cap would otherwise stop first.
+        BasketLiquidityCap::<Test>::put(u16::MAX);
         // Spot 0.01 sits 20% below a 0.0125 EMA.
         let ema = 0.0125f64;
         SubnetMovingPrice::<Test>::insert(netuid_c, I96F32::from_num(ema));

--- a/pallets/subtensor/src/tests/swap_basket_liquidity_cap.rs
+++ b/pallets/subtensor/src/tests/swap_basket_liquidity_cap.rs
@@ -1,0 +1,261 @@
+//! `swap_basket` liquidity cap ([`BasketLiquidityCap`]): a fund may not hold more than the
+//! cap's share of a destination pool's alpha reserve after a buy.
+//!
+//! Motivation: the concentration cap marks holdings at realizable value, which is bounded by
+//! the pool's TAO reserve. On a thin pool a stolen key can buy in 2%-band slices while a
+//! counterparty sells alpha back to the EMA between slices; every slice passes the slippage,
+//! turnover, and concentration rules, yet the fund's realizable NAV collapses by roughly the
+//! turnover it spent. The liquidity cap stops that accumulation.
+#![allow(clippy::arithmetic_side_effects, clippy::unwrap_used)]
+
+use crate::tests::claim_root::{escrow_alpha, register_on_root};
+use crate::tests::mock::*;
+use crate::{
+    BasketDailyTurnoverCap, BasketLiquidityCap, BasketTradingEnabled, Error, Owner, SubnetAlphaIn,
+    SubnetAlphaOut, SubnetMovingPrice, SubnetTAO, TotalStake,
+};
+use frame_support::{assert_noop, assert_ok};
+use sp_core::U256;
+use sp_runtime::Saturating;
+use substrate_fixed::types::I96F32;
+use subtensor_runtime_common::{AlphaBalance, NetUid, TaoBalance, Token};
+use subtensor_swap_interface::SwapHandler;
+
+const TAO: u64 = 1_000_000_000;
+
+fn escrow() -> U256 {
+    SubtensorModule::get_beta_escrow_account_id()
+}
+
+/// A dynamic subnet with a pool of `tao` TAO against `alpha` alpha and its moving price
+/// pinned to spot, so the slippage band never intervenes.
+fn make_pool(hotkey: &U256, coldkey: &U256, tao: u64, alpha: u64) -> NetUid {
+    let netuid = add_dynamic_network(hotkey, coldkey);
+    remove_owner_registration_stake(netuid);
+    SubnetTAO::<Test>::insert(netuid, TaoBalance::from(tao));
+    SubnetAlphaIn::<Test>::insert(netuid, AlphaBalance::from(alpha));
+    let subnet_account = SubtensorModule::get_subnet_account_id(netuid).unwrap();
+    add_balance_to_coldkey_account(&subnet_account, TaoBalance::from(tao));
+    SubnetMovingPrice::<Test>::insert(netuid, I96F32::from_num(tao as f64 / alpha as f64));
+    netuid
+}
+
+/// A root-registered validator whose fund holds `tao` TAO in its root (cash) slot, with
+/// the root reserves credited the way `credit_root_reserves` does.
+fn make_fund_with_cash(coldkey: U256, hotkey: U256, tao: u64) {
+    register_on_root(&hotkey, 0);
+    Owner::<Test>::insert(hotkey, coldkey);
+    SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
+        &hotkey,
+        &escrow(),
+        NetUid::ROOT,
+        tao.into(),
+    );
+    SubnetTAO::<Test>::mutate(NetUid::ROOT, |t| *t = t.saturating_add(tao.into()));
+    SubnetAlphaOut::<Test>::mutate(NetUid::ROOT, |t| *t = t.saturating_add(tao.into()));
+    TotalStake::<Test>::mutate(|t| *t = t.saturating_add(tao.into()));
+    let root_account = SubtensorModule::get_subnet_account_id(NetUid::ROOT).unwrap();
+    add_balance_to_coldkey_account(&root_account, TaoBalance::from(tao));
+}
+
+fn nav(hotkey: &U256) -> u64 {
+    SubtensorModule::get_validator_basket_nav_tao(hotkey).to_u64()
+}
+
+/// The counterparty sells alpha until spot is back at the moving price (constant product:
+/// `A' = sqrt(k / p)`), so the fund's next slice sees an un-moved reference.
+fn sell_back_to_ema(netuid: NetUid) {
+    let r = SubnetTAO::<Test>::get(netuid).to_u64() as f64;
+    let a = SubnetAlphaIn::<Test>::get(netuid).to_u64() as f64;
+    let target = SubnetMovingPrice::<Test>::get(netuid).to_num::<f64>();
+    let to_sell = (((r * a / target).sqrt() - a).max(0.0) * 1.003) as u64;
+    if to_sell > 0 {
+        assert_ok!(SubtensorModule::swap_alpha_for_tao(
+            netuid,
+            to_sell.into(),
+            <Test as crate::Config>::SwapInterface::min_price::<TaoBalance>(),
+            false,
+        ));
+    }
+}
+
+/// The thin-pool drain: 9 τ slices (< 1% of the reserve, so < 2% marginal move) into a
+/// 1,000 τ pool with a counterparty selling back to the EMA between slices. Without the
+/// liquidity cap this runs until the turnover budget is spent and loses ~90% of what it
+/// spends; with the cap it stops once the fund holds 10% of the pool's alpha reserve, and
+/// the fund's realizable NAV loss is bounded to a sliver of the pool's TAO reserve.
+#[test]
+fn test_liquidity_cap_stops_thin_pool_drain() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        BasketTradingEnabled::<Test>::put(true);
+        SubtensorModule::set_tao_weight(u64::MAX);
+        let thin = make_pool(&U256::from(4), &U256::from(3), 1_000 * TAO, 100_000 * TAO);
+        make_fund_with_cash(coldkey, hotkey, 100_000 * TAO);
+
+        let nav_before = nav(&hotkey);
+        let budget = SubtensorModule::basket_trade_budget_tao(nav_before);
+        let slice = 9 * TAO;
+        let mut spent = 0u64;
+        let mut refused = None;
+        for _ in 0..2_000 {
+            match SubtensorModule::do_swap_basket(coldkey, hotkey, NetUid::ROOT, thin, slice) {
+                Ok(_) => spent += slice,
+                Err(err) => {
+                    refused = Some(err);
+                    break;
+                }
+            }
+            sell_back_to_ema(thin);
+        }
+
+        assert_eq!(
+            refused,
+            Some(Error::<Test>::BasketLiquidityCapExceeded.into()),
+            "drain must be stopped by the liquidity cap"
+        );
+        // Far short of the turnover budget the drain used to exhaust.
+        assert!(spent < budget / 5, "spent {spent} of budget {budget}");
+
+        // The fund holds at most the cap's share of the pool's alpha reserve.
+        let held = escrow_alpha(&hotkey, thin);
+        let reserve = SubnetAlphaIn::<Test>::get(thin).to_u64();
+        assert!(
+            u128::from(held) * u128::from(u16::MAX)
+                <= u128::from(BasketLiquidityCap::<Test>::get()) * u128::from(reserve),
+            "held {held} exceeds cap share of reserve {reserve}"
+        );
+
+        // Loss is bounded by roughly `R × L² / (1 + L)` ≈ 1% of the pool's TAO reserve
+        // (plus fees), not by the turnover budget.
+        let loss = nav_before.saturating_sub(nav(&hotkey));
+        assert!(
+            loss < 20 * TAO,
+            "loss {loss} rao should be a sliver of the 1,000 τ pool"
+        );
+    });
+}
+
+/// The fund's holding on `netuid` as a share of the pool's alpha reserve, in basis points.
+fn held_share_bps(hotkey: &U256, netuid: NetUid) -> u64 {
+    let held = escrow_alpha(hotkey, netuid);
+    let reserve = SubnetAlphaIn::<Test>::get(netuid).to_u64();
+    (u128::from(held) * 10_000 / u128::from(reserve.max(1))) as u64
+}
+
+/// Build a position the way a manager must on a real pool: slices of ~0.9% of the TAO
+/// reserve (< 2% marginal move), letting the moving price catch up to spot between slices.
+/// Returns the slice that was refused and the error.
+fn buy_slices_until_refused(
+    coldkey: U256,
+    hotkey: U256,
+    netuid: NetUid,
+) -> (u64, sp_runtime::DispatchError) {
+    for _ in 0..200 {
+        let spot = <Test as crate::Config>::SwapInterface::current_alpha_price(netuid);
+        SubnetMovingPrice::<Test>::insert(netuid, I96F32::from_num(spot.to_num::<f64>()));
+        let slice = SubnetTAO::<Test>::get(netuid).to_u64() * 9 / 1000;
+        if let Err(err) =
+            SubtensorModule::do_swap_basket(coldkey, hotkey, NetUid::ROOT, netuid, slice)
+        {
+            return (slice, err);
+        }
+    }
+    panic!("position never hit the cap");
+}
+
+/// Happy path up to the boundary: band-sized slices succeed until the holding sits just
+/// under the cap; the slice that would cross it fails and rolls back, leaving the holding
+/// and the cash slot unchanged. Selling out is never capped.
+#[test]
+fn test_liquidity_cap_boundary() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        BasketTradingEnabled::<Test>::put(true);
+        BasketDailyTurnoverCap::<Test>::put(u16::MAX); // isolate the liquidity rule
+        SubtensorModule::set_tao_weight(u64::MAX);
+        // Deep pool at price 1.0: 1,000,000 τ against 1,000,000 α.
+        let sn = make_pool(
+            &U256::from(4),
+            &U256::from(3),
+            1_000_000 * TAO,
+            1_000_000 * TAO,
+        );
+        make_fund_with_cash(coldkey, hotkey, 1_000_000 * TAO);
+
+        let (slice, err) = buy_slices_until_refused(coldkey, hotkey, sn);
+        assert_eq!(err, Error::<Test>::BasketLiquidityCapExceeded.into());
+
+        // Just under the cap: within one slice (~0.9% of the reserve) of 10%.
+        let held = escrow_alpha(&hotkey, sn);
+        let share = held_share_bps(&hotkey, sn);
+        assert!(held > 0);
+        assert!((900..=1_000).contains(&share), "share {share} bps");
+
+        // The refused slice rolled back: nothing moved.
+        let cash_before = escrow_alpha(&hotkey, NetUid::ROOT);
+        assert_noop!(
+            SubtensorModule::do_swap_basket(coldkey, hotkey, NetUid::ROOT, sn, slice),
+            Error::<Test>::BasketLiquidityCapExceeded
+        );
+        assert_eq!(escrow_alpha(&hotkey, sn), held);
+        assert_eq!(escrow_alpha(&hotkey, NetUid::ROOT), cash_before);
+
+        // Selling out of the position is not subject to the cap, and root (the cash slot)
+        // is never a capped destination. One band-sized slice of alpha.
+        let sell = SubnetAlphaIn::<Test>::get(sn).to_u64() * 9 / 1000;
+        assert_ok!(SubtensorModule::do_swap_basket(
+            coldkey,
+            hotkey,
+            sn,
+            NetUid::ROOT,
+            sell
+        ));
+        assert_eq!(escrow_alpha(&hotkey, sn), held - sell);
+    });
+}
+
+/// The cap is governance-tunable: raising `BasketLiquidityCap` admits the trade the default
+/// refused.
+#[test]
+fn test_liquidity_cap_follows_storage() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        BasketTradingEnabled::<Test>::put(true);
+        BasketDailyTurnoverCap::<Test>::put(u16::MAX);
+        SubtensorModule::set_tao_weight(u64::MAX);
+        let sn = make_pool(
+            &U256::from(4),
+            &U256::from(3),
+            1_000_000 * TAO,
+            1_000_000 * TAO,
+        );
+        make_fund_with_cash(coldkey, hotkey, 1_000_000 * TAO);
+
+        assert_eq!(
+            BasketLiquidityCap::<Test>::get(),
+            crate::DEFAULT_BASKET_LIQUIDITY_CAP
+        );
+        let (slice, err) = buy_slices_until_refused(coldkey, hotkey, sn);
+        assert_eq!(err, Error::<Test>::BasketLiquidityCapExceeded.into());
+        assert!(held_share_bps(&hotkey, sn) <= 1_000);
+
+        // Governance loosens the cap to 25%: the same slice is now admitted, and the
+        // position can keep growing past 10%.
+        BasketLiquidityCap::<Test>::put(u16::MAX / 4);
+        assert_ok!(SubtensorModule::do_swap_basket(
+            coldkey,
+            hotkey,
+            NetUid::ROOT,
+            sn,
+            slice
+        ));
+        let (_, err) = buy_slices_until_refused(coldkey, hotkey, sn);
+        assert_eq!(err, Error::<Test>::BasketLiquidityCapExceeded.into());
+        let share = held_share_bps(&hotkey, sn);
+        assert!((2_350..=2_500).contains(&share), "share {share} bps");
+    });
+}

--- a/pallets/subtensor/src/tests/swap_basket_liquidity_cap.rs
+++ b/pallets/subtensor/src/tests/swap_basket_liquidity_cap.rs
@@ -8,11 +8,14 @@
 //! turnover it spent. The liquidity cap stops that accumulation.
 #![allow(clippy::arithmetic_side_effects, clippy::unwrap_used)]
 
-use crate::tests::claim_root::{escrow_alpha, register_on_root};
+use crate::tests::claim_root::{
+    escrow_alpha, flush_baskets, register_on_root, set_root_weights_direct, zero_claim_threshold,
+};
 use crate::tests::mock::*;
 use crate::{
-    BasketDailyTurnoverCap, BasketLiquidityCap, BasketTradingEnabled, Error, Owner, SubnetAlphaIn,
-    SubnetAlphaOut, SubnetMovingPrice, SubnetTAO, TotalStake,
+    BasketDailyTurnoverCap, BasketLiquidityCap, BasketTradingEnabled, Error, Owner,
+    RootClaimableThreshold, RootWeightsCap, SubnetAlphaIn, SubnetAlphaOut, SubnetMovingPrice,
+    SubnetTAO, TotalStake,
 };
 use frame_support::{assert_noop, assert_ok};
 use sp_core::U256;
@@ -257,5 +260,367 @@ fn test_liquidity_cap_follows_storage() {
         assert_eq!(err, Error::<Test>::BasketLiquidityCapExceeded.into());
         let share = held_share_bps(&hotkey, sn);
         assert!((2_350..=2_500).contains(&share), "share {share} bps");
+    });
+}
+
+// ---------------------------------------------------------------------------------------
+// Winners must be allowed to run: a holding that grows past either cap through price
+// appreciation is never sold, swept, penalized, or used to block trades elsewhere. Only
+// further buys into that subnet are refused.
+// ---------------------------------------------------------------------------------------
+
+/// Give the fund `alpha` of `netuid` directly (as if bought earlier at a lower price).
+fn hold(hotkey: &U256, netuid: NetUid, alpha: u64) {
+    SubtensorModule::increase_stake_for_hotkey_and_coldkey_on_subnet(
+        hotkey,
+        &escrow(),
+        netuid,
+        alpha.into(),
+    );
+}
+
+/// Appreciate `netuid` by moving the pool along its constant-product curve: TAO reserve
+/// × `num`, alpha reserve ÷ `num` (price × `num²`). The moving price is pinned to the new
+/// spot so the band is not what decides the outcome. The subnet account is topped up so
+/// sells can physically pay out.
+fn appreciate(netuid: NetUid, num: u64) {
+    let tao = SubnetTAO::<Test>::get(netuid).to_u64() * num;
+    let alpha = SubnetAlphaIn::<Test>::get(netuid).to_u64() / num;
+    SubnetTAO::<Test>::insert(netuid, TaoBalance::from(tao));
+    SubnetAlphaIn::<Test>::insert(netuid, AlphaBalance::from(alpha));
+    let subnet_account = SubtensorModule::get_subnet_account_id(netuid).unwrap();
+    add_balance_to_coldkey_account(&subnet_account, TaoBalance::from(tao));
+    pin_ema_to_spot(netuid);
+}
+
+fn pin_ema_to_spot(netuid: NetUid) {
+    let spot = <Test as crate::Config>::SwapInterface::current_alpha_price(netuid);
+    SubnetMovingPrice::<Test>::insert(netuid, I96F32::from_num(spot.to_num::<f64>()));
+}
+
+/// Realizable share of the fund a holding represents, in basis points.
+fn nav_share_bps(hotkey: &U256, netuid: NetUid) -> u64 {
+    let value = SubtensorModule::realizable_tao_for_alpha(netuid, escrow_alpha(hotkey, netuid));
+    (u128::from(value) * 10_000 / u128::from(nav(hotkey).max(1))) as u64
+}
+
+/// Fund with cash plus equal positions in two deep subnets; the concentration cap is set
+/// to 1/2 so it binds with root + two subnets (mainnet's 1/16 needs sixteen).
+fn winner_env(coldkey: U256, hotkey: U256) -> (NetUid, NetUid) {
+    BasketTradingEnabled::<Test>::put(true);
+    BasketDailyTurnoverCap::<Test>::put(u16::MAX);
+    RootWeightsCap::<Test>::insert(NetUid::ROOT, u16::MAX / 2 + 1);
+    SubtensorModule::set_tao_weight(u64::MAX);
+    let a = make_pool(
+        &U256::from(11),
+        &U256::from(10),
+        1_000_000 * TAO,
+        1_000_000 * TAO,
+    );
+    // B is the validator's own subnet (registered there), so root dividends paid out of B
+    // reach this hotkey in the dividend tests.
+    let b = make_pool(&hotkey, &coldkey, 1_000_000 * TAO, 1_000_000 * TAO);
+    mock_increase_stake_for_hotkey_and_coldkey_on_subnet(
+        &hotkey,
+        &coldkey,
+        b,
+        (10_000 * TAO).into(),
+    );
+    make_fund_with_cash(coldkey, hotkey, 100 * TAO);
+    hold(&hotkey, a, 1_000 * TAO);
+    hold(&hotkey, b, 1_000 * TAO);
+    (a, b)
+}
+
+/// A holding that appreciated past the concentration cap: only buys into it are refused.
+/// Partial sells (to cash or to another subnet) and every trade between other holdings
+/// proceed, and the winner is left exactly where the manager put it.
+#[test]
+fn test_over_cap_winner_only_blocks_further_buys() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let (a, b) = winner_env(coldkey, hotkey);
+        assert!(nav_share_bps(&hotkey, a) < 5_000);
+
+        // A quadruples in price: ~78% of NAV, far over the 50% cap.
+        appreciate(a, 2);
+        let share = nav_share_bps(&hotkey, a);
+        assert!(share > 7_000, "share {share} bps");
+        let winner = escrow_alpha(&hotkey, a);
+
+        // Refused: topping up the winner.
+        assert_noop!(
+            SubtensorModule::do_swap_basket(coldkey, hotkey, NetUid::ROOT, a, 10 * TAO),
+            Error::<Test>::RootWeightCapExceeded
+        );
+        assert_noop!(
+            SubtensorModule::do_swap_basket(coldkey, hotkey, b, a, 10 * TAO),
+            Error::<Test>::RootWeightCapExceeded
+        );
+        assert_eq!(escrow_alpha(&hotkey, a), winner);
+
+        // Allowed: take profit into another subnet, and into cash.
+        assert_ok!(SubtensorModule::do_swap_basket(
+            coldkey,
+            hotkey,
+            a,
+            b,
+            100 * TAO
+        ));
+        assert_ok!(SubtensorModule::do_swap_basket(
+            coldkey,
+            hotkey,
+            a,
+            NetUid::ROOT,
+            100 * TAO
+        ));
+        assert_eq!(escrow_alpha(&hotkey, a), winner - 200 * TAO);
+        assert!(nav_share_bps(&hotkey, a) > 5_000, "still over cap");
+
+        // Allowed: trades that do not touch the winner, in both directions.
+        pin_ema_to_spot(b);
+        assert_ok!(SubtensorModule::do_swap_basket(
+            coldkey,
+            hotkey,
+            NetUid::ROOT,
+            b,
+            50 * TAO
+        ));
+        pin_ema_to_spot(b);
+        assert_ok!(SubtensorModule::do_swap_basket(
+            coldkey,
+            hotkey,
+            b,
+            NetUid::ROOT,
+            10 * TAO
+        ));
+        assert_eq!(escrow_alpha(&hotkey, a), winner - 200 * TAO);
+    });
+}
+
+/// The non-trade paths never consult a cap: curated dividend deployment keeps buying the
+/// over-cap winner per the weight vector, dust consolidation leaves it alone (curated or
+/// not), a claim redeems it strictly pro-rata with every other holding, and a hotkey swap
+/// moves it by value.
+#[test]
+fn test_over_cap_winner_untouched_by_dividends_dust_claims_and_hotkey_swap() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let alice = U256::from(3);
+        let (a, b) = winner_env(coldkey, hotkey);
+        set_root_weights_direct(&hotkey, 0, &[(a, u16::MAX / 2), (b, u16::MAX / 2)]);
+        zero_claim_threshold();
+        // A real staker so dividends have a claimant base.
+        mock_increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey,
+            &alice,
+            NetUid::ROOT,
+            (2 * TAO).into(),
+        );
+        appreciate(a, 2);
+        assert!(nav_share_bps(&hotkey, a) > 7_000);
+        let winner = escrow_alpha(&hotkey, a);
+
+        // Dividends (origin B) are sold and redeployed per weights: half lands in A even
+        // though A is over the cap.
+        SubtensorModule::distribute_emission(
+            b,
+            AlphaBalance::ZERO,
+            AlphaBalance::ZERO,
+            (10 * TAO).into(),
+            AlphaBalance::ZERO,
+        );
+        flush_baskets();
+        let after_dividend = escrow_alpha(&hotkey, a);
+        assert!(
+            after_dividend > winner,
+            "dividends must keep flowing into the winner"
+        );
+
+        // Dust consolidation: with A orphaned from the weight vector and a live threshold,
+        // an above-threshold holding is not swept.
+        set_root_weights_direct(&hotkey, 0, &[(b, u16::MAX)]);
+        RootClaimableThreshold::<Test>::insert(NetUid::ROOT, I96F32::from_num(TAO));
+        assert_eq!(
+            SubtensorModule::consolidate_dust_basket_holdings(&hotkey),
+            0
+        );
+        assert_eq!(escrow_alpha(&hotkey, a), after_dividend);
+        zero_claim_threshold();
+        set_root_weights_direct(&hotkey, 0, &[(a, u16::MAX / 2), (b, u16::MAX / 2)]);
+
+        // A claim redeems pro-rata: A and B shrink by the same fraction (±1%).
+        let a_before = escrow_alpha(&hotkey, a);
+        let b_before = escrow_alpha(&hotkey, b);
+        assert!(SubtensorModule::get_basket_owed_shares(&hotkey, &alice) > 0);
+        assert_ok!(SubtensorModule::claim_root_with_hotkey(
+            RuntimeOrigin::signed(alice),
+            hotkey
+        ));
+        let a_frac = (a_before - escrow_alpha(&hotkey, a)) * 10_000 / a_before;
+        let b_frac = (b_before - escrow_alpha(&hotkey, b)) * 10_000 / b_before;
+        assert!(a_frac > 0, "claim must take from the winner too");
+        assert!(
+            a_frac.abs_diff(b_frac) <= 100,
+            "pro-rata: A took {a_frac} bps, B took {b_frac} bps"
+        );
+
+        // Hotkey swap moves the holding by value, no cap consulted.
+        let new_hotkey = U256::from(4);
+        let a_now = escrow_alpha(&hotkey, a);
+        SubtensorModule::transfer_basket_for_new_hotkey(&hotkey, &new_hotkey);
+        assert_eq!(escrow_alpha(&new_hotkey, a), a_now);
+        assert_eq!(escrow_alpha(&hotkey, a), 0);
+    });
+}
+
+/// Same for the liquidity cap: after a run-up shrinks the pool's alpha reserve, a fund that
+/// now holds more than the cap's share of it can still sell, trade elsewhere, and receive
+/// dividends; only buys into that subnet are refused.
+#[test]
+fn test_over_liquidity_cap_winner_only_blocks_further_buys() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let alice = U256::from(3);
+        BasketTradingEnabled::<Test>::put(true);
+        BasketDailyTurnoverCap::<Test>::put(u16::MAX);
+        SubtensorModule::set_tao_weight(u64::MAX);
+        zero_claim_threshold();
+        // Thin pool: 10,000 τ against 1,000,000 α. The fund holds 9% of the reserve.
+        let thin = make_pool(
+            &U256::from(11),
+            &U256::from(10),
+            10_000 * TAO,
+            1_000_000 * TAO,
+        );
+        let deep = make_pool(&hotkey, &coldkey, 1_000_000 * TAO, 1_000_000 * TAO);
+        mock_increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey,
+            &coldkey,
+            deep,
+            (10_000 * TAO).into(),
+        );
+        make_fund_with_cash(coldkey, hotkey, 10_000 * TAO);
+        hold(&hotkey, thin, 90_000 * TAO);
+        hold(&hotkey, deep, 1_000 * TAO);
+        mock_increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey,
+            &alice,
+            NetUid::ROOT,
+            (2 * TAO).into(),
+        );
+        assert!(held_share_bps(&hotkey, thin) < 1_000);
+
+        // Run-up: alpha leaves the pool, the fund's 90k α is now 22.5% of the reserve.
+        appreciate(thin, 2);
+        // (`appreciate` halves the reserve: 500k α; buy-side pressure in the mock only.)
+        SubnetAlphaIn::<Test>::insert(thin, AlphaBalance::from(400_000 * TAO));
+        pin_ema_to_spot(thin);
+        let share = held_share_bps(&hotkey, thin);
+        assert!(share > 2_000, "share {share} bps");
+        let winner = escrow_alpha(&hotkey, thin);
+
+        // Refused: any further buy, even a tiny one.
+        assert_noop!(
+            SubtensorModule::do_swap_basket(coldkey, hotkey, NetUid::ROOT, thin, TAO),
+            Error::<Test>::BasketLiquidityCapExceeded
+        );
+        assert_noop!(
+            SubtensorModule::do_swap_basket(coldkey, hotkey, deep, thin, TAO),
+            Error::<Test>::BasketLiquidityCapExceeded
+        );
+
+        // Allowed: take profit (one band-sized slice) and trade the other holdings.
+        let slice = SubnetAlphaIn::<Test>::get(thin).to_u64() * 9 / 1000;
+        assert_ok!(SubtensorModule::do_swap_basket(
+            coldkey,
+            hotkey,
+            thin,
+            NetUid::ROOT,
+            slice
+        ));
+        assert_eq!(escrow_alpha(&hotkey, thin), winner - slice);
+        assert!(held_share_bps(&hotkey, thin) > 1_000, "still over the cap");
+        assert_ok!(SubtensorModule::do_swap_basket(
+            coldkey,
+            hotkey,
+            NetUid::ROOT,
+            deep,
+            100 * TAO
+        ));
+
+        // Allowed: dividends deployed into it by the weight vector.
+        set_root_weights_direct(&hotkey, 0, &[(thin, u16::MAX)]);
+        let before = escrow_alpha(&hotkey, thin);
+        SubtensorModule::distribute_emission(
+            deep,
+            AlphaBalance::ZERO,
+            AlphaBalance::ZERO,
+            (10 * TAO).into(),
+            AlphaBalance::ZERO,
+        );
+        flush_baskets();
+        assert!(escrow_alpha(&hotkey, thin) > before);
+    });
+}
+
+/// Profit-taking after a sharp run-up is not blocked by the band. The sell floor is
+/// `0.98 × max(EMA, spot)`, so with spot far above a stale EMA the first slice fills at
+/// 0.98 × spot, and chained slices may walk the price down to 0.98 × EMA. Only a sale that
+/// would push spot below that (a drawdown relative to the EMA) waits for the EMA.
+#[test]
+fn test_profit_taking_after_run_up_is_not_blocked_by_band() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        BasketTradingEnabled::<Test>::put(true);
+        BasketDailyTurnoverCap::<Test>::put(u16::MAX);
+        SubtensorModule::set_tao_weight(u64::MAX);
+        let a = make_pool(
+            &U256::from(11),
+            &U256::from(10),
+            1_000_000 * TAO,
+            1_000_000 * TAO,
+        );
+        make_fund_with_cash(coldkey, hotkey, 100 * TAO);
+        hold(&hotkey, a, 1_000_000 * TAO);
+        // Run-up ×4 with the EMA left where it was (price 1.0): spot is 4× EMA.
+        appreciate(a, 2);
+        SubnetMovingPrice::<Test>::insert(a, I96F32::from_num(1.0));
+        let p0 = <Test as crate::Config>::SwapInterface::current_alpha_price(a).to_num::<f64>();
+        assert!(p0 > 3.9);
+
+        // Buying the runaway subnet is refused by the band (spot > 1.02 × EMA).
+        assert_noop!(
+            SubtensorModule::do_swap_basket(coldkey, hotkey, NetUid::ROOT, a, TAO),
+            Error::<Test>::SlippageTooHigh
+        );
+
+        // Selling is not: band-sized slices fill until spot reaches 0.98 × EMA.
+        let mut legs = 0;
+        let mut sold = 0u64;
+        loop {
+            let slice = SubnetAlphaIn::<Test>::get(a).to_u64() * 9 / 1000;
+            match SubtensorModule::do_swap_basket(coldkey, hotkey, a, NetUid::ROOT, slice) {
+                Ok(_) => {
+                    legs += 1;
+                    sold += slice;
+                }
+                Err(err) => {
+                    assert_eq!(err, Error::<Test>::SlippageTooHigh.into());
+                    break;
+                }
+            }
+            assert!(legs < 200);
+        }
+        let p1 = <Test as crate::Config>::SwapInterface::current_alpha_price(a).to_num::<f64>();
+        assert!(legs >= 30, "only {legs} legs");
+        assert!(sold > 200_000 * TAO, "sold {sold}");
+        // Stopped at the EMA floor, not at the run-up price.
+        assert!(p1 < 1.02 && p1 >= 0.97, "price {p1}");
+        assert!(escrow_alpha(&hotkey, NetUid::ROOT) > 100 * TAO);
     });
 }

--- a/pallets/subtensor/src/tests/swap_basket_liquidity_cap.rs
+++ b/pallets/subtensor/src/tests/swap_basket_liquidity_cap.rs
@@ -13,9 +13,9 @@ use crate::tests::claim_root::{
 };
 use crate::tests::mock::*;
 use crate::{
-    BasketDailyTurnoverCap, BasketLiquidityCap, BasketTradingEnabled, Error, Owner,
-    PendingBasketDeposits, RootClaimableThreshold, RootWeightsCap, SubnetAlphaIn, SubnetAlphaOut,
-    SubnetMovingPrice, SubnetTAO, TotalStake,
+    BASKET_TRADE_REFILL_BLOCKS, BasketDailyTurnoverCap, BasketLiquidityCap, BasketTradeBucket,
+    BasketTradingEnabled, Error, Owner, PendingBasketDeposits, RootClaimableThreshold,
+    RootWeightsCap, SubnetAlphaIn, SubnetAlphaOut, SubnetMovingPrice, SubnetTAO, TotalStake,
 };
 use frame_support::dispatch::GetDispatchInfo;
 use frame_support::pallet_prelude::Weight;
@@ -622,7 +622,7 @@ fn test_profit_taking_after_run_up_is_not_blocked_by_band() {
         assert!(legs >= 30, "only {legs} legs");
         assert!(sold > 200_000 * TAO, "sold {sold}");
         // Stopped at the EMA floor, not at the run-up price.
-        assert!(p1 < 1.02 && p1 >= 0.97, "price {p1}");
+        assert!((0.97..1.02).contains(&p1), "price {p1}");
         assert!(escrow_alpha(&hotkey, NetUid::ROOT) > 100 * TAO);
     });
 }
@@ -716,5 +716,67 @@ fn test_swap_basket_weight_charges_pending_deposit_flush() {
             actual.all_lt(declared_two),
             "actual must refund below declared"
         );
+    });
+}
+
+// ---------------------------------------------------------------------------------------
+// Turnover bucket: clamping and the hotkey-swap carry.
+// ---------------------------------------------------------------------------------------
+
+/// The bucket level is clamped to one *current* budget, so a NAV drop cannot leave a fund
+/// with more spendable turnover than its shrunken budget; a hotkey swap onto a hotkey that
+/// already has a bucket keeps the lower level and the later refill block.
+#[test]
+fn test_turnover_bucket_clamps_to_current_budget_and_carries_conservatively() {
+    new_test_ext(1).execute_with(|| {
+        let hotkey = U256::from(2);
+        let other = U256::from(4);
+        let now = 1_000u64;
+
+        // Never traded: full, whatever the budget.
+        assert_eq!(
+            SubtensorModule::basket_trade_bucket_at(&hotkey, now, 500),
+            500
+        );
+
+        // Stored level above a (shrunken) budget clamps; refill accrues pro rata and clamps.
+        BasketTradeBucket::<Test>::insert(hotkey, (800u64, now));
+        assert_eq!(
+            SubtensorModule::basket_trade_bucket_at(&hotkey, now, 500),
+            500
+        );
+        BasketTradeBucket::<Test>::insert(hotkey, (100u64, now));
+        let quarter = BASKET_TRADE_REFILL_BLOCKS / 4;
+        assert_eq!(
+            SubtensorModule::basket_trade_bucket_at(&hotkey, now + quarter, 1_000),
+            100 + 250
+        );
+        assert_eq!(
+            SubtensorModule::basket_trade_bucket_at(
+                &hotkey,
+                now + BASKET_TRADE_REFILL_BLOCKS,
+                1_000
+            ),
+            1_000
+        );
+        assert_eq!(
+            SubtensorModule::basket_trade_bucket_at(
+                &hotkey,
+                now + 10 * BASKET_TRADE_REFILL_BLOCKS,
+                1_000
+            ),
+            1_000
+        );
+
+        // Carry on hotkey swap: min level, max refill block; the old row is removed.
+        BasketTradeBucket::<Test>::insert(hotkey, (100u64, now + 50));
+        BasketTradeBucket::<Test>::insert(other, (40u64, now + 10));
+        SubtensorModule::transfer_basket_for_new_hotkey(&hotkey, &other);
+        assert_eq!(BasketTradeBucket::<Test>::get(other), Some((40, now + 50)));
+        assert_eq!(BasketTradeBucket::<Test>::get(hotkey), None);
+
+        // A full (unstored) source leaves the destination's bucket as it is.
+        SubtensorModule::transfer_basket_for_new_hotkey(&hotkey, &other);
+        assert_eq!(BasketTradeBucket::<Test>::get(other), Some((40, now + 50)));
     });
 }

--- a/pallets/subtensor/src/tests/swap_basket_liquidity_cap.rs
+++ b/pallets/subtensor/src/tests/swap_basket_liquidity_cap.rs
@@ -14,9 +14,11 @@ use crate::tests::claim_root::{
 use crate::tests::mock::*;
 use crate::{
     BasketDailyTurnoverCap, BasketLiquidityCap, BasketTradingEnabled, Error, Owner,
-    RootClaimableThreshold, RootWeightsCap, SubnetAlphaIn, SubnetAlphaOut, SubnetMovingPrice,
-    SubnetTAO, TotalStake,
+    PendingBasketDeposits, RootClaimableThreshold, RootWeightsCap, SubnetAlphaIn, SubnetAlphaOut,
+    SubnetMovingPrice, SubnetTAO, TotalStake,
 };
+use frame_support::dispatch::GetDispatchInfo;
+use frame_support::pallet_prelude::Weight;
 use frame_support::{assert_noop, assert_ok};
 use sp_core::U256;
 use sp_runtime::Saturating;
@@ -622,5 +624,97 @@ fn test_profit_taking_after_run_up_is_not_blocked_by_band() {
         // Stopped at the EMA floor, not at the run-up price.
         assert!(p1 < 1.02 && p1 >= 0.97, "price {p1}");
         assert!(escrow_alpha(&hotkey, NetUid::ROOT) > 100 * TAO);
+    });
+}
+
+// ---------------------------------------------------------------------------------------
+// Weight: the pending-deposit flush a trade performs is charged, not free.
+// ---------------------------------------------------------------------------------------
+
+fn declared_swap_weight(
+    coldkey: U256,
+    hotkey: U256,
+    from: NetUid,
+    to: NetUid,
+    amount: u64,
+) -> Weight {
+    let _ = coldkey;
+    RuntimeCall::SubtensorModule(crate::Call::swap_basket {
+        hotkey,
+        origin_netuid: from,
+        destination_netuid: to,
+        amount: amount.into(),
+    })
+    .get_dispatch_info()
+    .call_weight
+}
+
+/// The declared weight grows with the number of queued dividend credits, the actual weight
+/// includes the flush work actually done, and it refunds below the declared cap. With an
+/// empty queue the trade costs exactly its holding-count weight.
+#[test]
+fn test_swap_basket_weight_charges_pending_deposit_flush() {
+    new_test_ext(1).execute_with(|| {
+        let coldkey = U256::from(1);
+        let hotkey = U256::from(2);
+        let alice = U256::from(3);
+        let (a, b) = winner_env(coldkey, hotkey);
+        set_root_weights_direct(&hotkey, 0, &[(a, u16::MAX / 2), (b, u16::MAX / 2)]);
+        zero_claim_threshold();
+        mock_increase_stake_for_hotkey_and_coldkey_on_subnet(
+            &hotkey,
+            &alice,
+            NetUid::ROOT,
+            (2 * TAO).into(),
+        );
+        pin_ema_to_spot(a);
+        pin_ema_to_spot(b);
+
+        // Empty queue: declared is the bare 256-row cap (plus whatever fixed extension
+        // weight the runtime adds to every call), actual is the bare row weight.
+        let bare_declared = declared_swap_weight(coldkey, hotkey, a, b, TAO);
+        assert!(bare_declared.all_gte(SubtensorModule::swap_basket_weight(256)));
+        let bare_actual = SubtensorModule::do_swap_basket(coldkey, hotkey, a, b, TAO).unwrap();
+        assert_eq!(bare_actual, SubtensorModule::swap_basket_weight(3));
+
+        // One queued origin raises the declared weight by the flush estimate; a second
+        // origin raises it by one more unit.
+        SubtensorModule::enqueue_basket_deposit(&hotkey, b, (5 * TAO).into());
+        let declared_one = declared_swap_weight(coldkey, hotkey, a, b, TAO);
+        assert_eq!(
+            declared_one.saturating_sub(bare_declared),
+            SubtensorModule::basket_flush_weight(1 + 4 * 256)
+        );
+        SubtensorModule::enqueue_basket_deposit(&hotkey, a, (5 * TAO).into());
+        let declared_two = declared_swap_weight(coldkey, hotkey, a, b, TAO);
+        assert_eq!(
+            declared_two.saturating_sub(declared_one),
+            SubtensorModule::basket_flush_weight(1)
+        );
+
+        // Learn the flush work this exact queue implies, then restore the queue: the trade
+        // must charge precisely that on top of its row weight, and refund below declared.
+        let (flush_work, _, _) = SubtensorModule::flush_basket_deposits_for_hotkey(&hotkey);
+        assert!(flush_work > 0);
+        SubtensorModule::enqueue_basket_deposit(&hotkey, b, (5 * TAO).into());
+        SubtensorModule::enqueue_basket_deposit(&hotkey, a, (5 * TAO).into());
+        pin_ema_to_spot(a);
+        pin_ema_to_spot(b);
+        let actual = SubtensorModule::do_swap_basket(coldkey, hotkey, a, b, TAO).unwrap();
+        assert!(
+            PendingBasketDeposits::<Test>::iter_prefix(hotkey)
+                .next()
+                .is_none()
+        );
+        assert_eq!(
+            actual,
+            SubtensorModule::swap_basket_weight(3)
+                .saturating_add(SubtensorModule::basket_flush_weight(flush_work))
+        );
+        assert!(actual.all_gt(bare_actual), "flush work must be charged");
+        assert!(
+            actual.all_lt(declared_two),
+            "actual must refund below declared"
+        );
     });
 }

--- a/runtime/src/proxy_filters/call_groups.rs
+++ b/runtime/src/proxy_filters/call_groups.rs
@@ -603,6 +603,7 @@ call_filter_group!(
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_basket_trading_enabled),
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_basket_trading_frozen),
         RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_basket_daily_turnover_cap),
+        RuntimeCall::AdminUtils(AdminUtilsCall::sudo_set_basket_liquidity_cap),
     ]
 );
 

--- a/sdk/python/bittensor/cli/commands/root_trade.py
+++ b/sdk/python/bittensor/cli/commands/root_trade.py
@@ -44,8 +44,9 @@ def _trade_review(
     if status is not None:
         rows.append(
             (
-                "daily budget",
-                f"{status['remaining_tao']} of {status['budget_tao']} left this window",
+                "turnover budget",
+                f"{status['remaining_tao']} of {status['budget_tao']} available "
+                f"(refills {status['refill_per_block_tao']} per block)",
             )
         )
         if not status["enabled"]:

--- a/sdk/python/bittensor/error_descriptions/subtensor.py
+++ b/sdk/python/bittensor/error_descriptions/subtensor.py
@@ -117,11 +117,12 @@ DESCRIPTIONS: dict[str, str] = {
         "`AdminUtils.sudo_set_basket_trading_frozen(hotkey, false)`."
     ),
     "BasketTurnoverBudgetExceeded": (
-        "The trade would push more TAO through the fund than its daily turnover budget "
-        "allows: `BasketDailyTurnoverCap` (u16-normalized share of fund NAV, default 10%) "
-        "per 7200-block window, counted on the TAO through the middle of each swap. Query "
-        "`basket_trading_status` for the window's start block, TAO already used, and full "
-        "budget; trade a smaller amount or wait for the window to roll."
+        "The trade would push more TAO through the fund than its turnover bucket holds. "
+        "The bucket's capacity is `BasketDailyTurnoverCap` (u16-normalized share of fund "
+        "NAV, default 10%); it refills continuously over 7200 blocks and each swap takes "
+        "the TAO through its middle out of it, so at most one capacity can be traded at "
+        "any instant. Query `basket_trading_status` for the remaining budget, the capacity, "
+        "and the refill rate; trade a smaller amount or wait for the bucket to refill."
     ),
     "BetaBasketSeedInProgress": (
         "The `migrate_seed_beta_basket_v2` seed has not completed (it normally finishes "

--- a/sdk/python/bittensor/error_descriptions/subtensor.py
+++ b/sdk/python/bittensor/error_descriptions/subtensor.py
@@ -93,6 +93,13 @@ DESCRIPTIONS: dict[str, str] = {
         "coldkey-wide claim by validator where that fits, and investigate or consolidate an "
         "individually oversized basket."
     ),
+    "BasketLiquidityCapExceeded": (
+        "The trade would leave the fund holding more of the destination subnet than "
+        "`BasketLiquidityCap` allows as a share of that subnet's alpha reserve "
+        "(u16-normalized, default 10%). This bounds the fund's exposure to any one pool's "
+        "liquidity. Trade a smaller amount, or pick a deeper pool; query `validator_basket` "
+        "for the current holding and `subnet` for the pool's alpha reserve."
+    ),
     "BasketSameSubnet": (
         "`swap_basket` was called with the same origin and destination netuid. A basket "
         "trade sells one holding to buy another; pick two different subnets (netuid 0 is "

--- a/sdk/python/bittensor/error_map.py
+++ b/sdk/python/bittensor/error_map.py
@@ -224,6 +224,7 @@ NAME_TO_CODE: dict[str, ErrorCode] = {
     "BasketTradingFrozen": _C.DISABLED,
     "BasketTurnoverBudgetExceeded": _C.RATE_LIMITED,
     "BasketSameSubnet": _C.INVALID_ARGUMENT,
+    "BasketLiquidityCapExceeded": _C.LIMIT_EXCEEDED,
     "RootStakeLocked": _C.TOO_EARLY,
     "TooManyUIDsPerMechanism": _C.LIMIT_EXCEEDED,
     "VotingPowerTrackingNotEnabled": _C.DISABLED,

--- a/sdk/python/bittensor/intents/staking.py
+++ b/sdk/python/bittensor/intents/staking.py
@@ -1714,7 +1714,8 @@ class SwapBasket(Intent):
 
     Guardrails enforced on chain: each AMM leg must fill fully within 2% of
     the subnet's moving price (``SlippageTooHigh`` otherwise); the TAO through
-    the middle is charged against the fund's daily turnover budget
+    the middle is taken from the fund's turnover bucket, which holds
+    ``BasketDailyTurnoverCap`` of NAV and refills over 7200 blocks
     (``BasketTurnoverBudgetExceeded``); the destination holding may not end
     above the ``BasketLiquidityCap`` share of the destination pool's alpha
     reserve (``BasketLiquidityCapExceeded``) nor above the ``RootWeightsCap``

--- a/sdk/python/bittensor/intents/staking.py
+++ b/sdk/python/bittensor/intents/staking.py
@@ -1715,8 +1715,10 @@ class SwapBasket(Intent):
     Guardrails enforced on chain: each AMM leg must fill fully within 2% of
     the subnet's moving price (``SlippageTooHigh`` otherwise); the TAO through
     the middle is charged against the fund's daily turnover budget
-    (``BasketTurnoverBudgetExceeded``); the destination may not end above the
-    ``RootWeightsCap`` share of fund NAV (``RootWeightCapExceeded``). Trading
+    (``BasketTurnoverBudgetExceeded``); the destination holding may not end
+    above the ``BasketLiquidityCap`` share of the destination pool's alpha
+    reserve (``BasketLiquidityCapExceeded``) nor above the ``RootWeightsCap``
+    share of fund NAV (``RootWeightCapExceeded``). Trading
     must be enabled network-wide and not frozen for the hotkey. Query
     ``basket_trading_status`` for the remaining budget and
     ``validator_basket`` for current holdings before trading. Pass ``all``

--- a/sdk/python/bittensor/namespaces.pyi
+++ b/sdk/python/bittensor/namespaces.pyi
@@ -428,14 +428,14 @@ class Staking(_ReadNamespace):
         """
 
     async def basket_trading_status(self, hotkey_ss58: str, *, block: Optional[int] = None) -> dict:
-        """A validator's `swap_basket` trading status: gates and the daily turnover budget.
+        """A validator's `swap_basket` trading status: gates and the turnover bucket.
 
         `enabled` is the network-wide gate, `frozen` the per-hotkey governance freeze.
-        The window is the one a trade at the current block would be charged to
-        (7200 blocks; already rolled if the stored one expired). `budget_tao` is the
-        window's full allowance at current NAV (`BasketDailyTurnoverCap` share of
-        NAV), `used_tao` what this window has already consumed, and
-        `remaining_tao` the difference.
+        The turnover budget is a token bucket: `budget_tao` is its capacity at current
+        NAV (`BasketDailyTurnoverCap` share of NAV), `remaining_tao` what a trade right
+        now could push through the fund, `used_tao` the difference, and the bucket
+        refills by `refill_per_block_tao` every block (`budget_tao / refill_blocks`,
+        a full refill over `refill_blocks` = 7200 blocks).
         """
 
     async def root_basket_owed(self, coldkey_ss58: str, *, block: Optional[int] = None) -> Balance:

--- a/sdk/python/bittensor/reads/root.py
+++ b/sdk/python/bittensor/reads/root.py
@@ -403,25 +403,28 @@ async def validator_basket_nav(view, hotkey_ss58: str) -> Balance:
     param_docs={"hotkey_ss58": "Validator hotkey whose basket trading status to read."},
 )
 async def basket_trading_status(view, hotkey_ss58: str) -> dict:
-    """A validator's `swap_basket` trading status: gates and the daily turnover budget.
+    """A validator's `swap_basket` trading status: gates and the turnover bucket.
 
     `enabled` is the network-wide gate, `frozen` the per-hotkey governance freeze.
-    The window is the one a trade at the current block would be charged to
-    (7200 blocks; already rolled if the stored one expired). `budget_tao` is the
-    window's full allowance at current NAV (`BasketDailyTurnoverCap` share of
-    NAV), `used_tao` what this window has already consumed, and
-    `remaining_tao` the difference.
+    The turnover budget is a token bucket: `budget_tao` is its capacity at current
+    NAV (`BasketDailyTurnoverCap` share of NAV), `remaining_tao` what a trade right
+    now could push through the fund, `used_tao` the difference, and the bucket
+    refills by `refill_per_block_tao` every block (`budget_tao / refill_blocks`,
+    a full refill over `refill_blocks` = 7200 blocks).
     """
     row = await view.runtime(_GET_BASKET_TRADING_STATUS, [hotkey_ss58]) or {}
-    used_rao = int(row.get("tao_used") or 0)
+    available_rao = int(row.get("tao_available") or 0)
     budget_rao = int(row.get("budget_tao") or 0)
+    refill_blocks = int(row.get("refill_blocks") or 0)
+    per_block_rao = budget_rao // refill_blocks if refill_blocks else 0
     return {
         "enabled": bool(row.get("enabled", False)),
         "frozen": bool(row.get("frozen", False)),
-        "window_start_block": int(row.get("window_start_block") or 0),
-        "used_tao": view.balance(used_rao, _ROOT_NETUID),
+        "refill_blocks": refill_blocks,
+        "refill_per_block_tao": view.balance(per_block_rao, _ROOT_NETUID),
+        "used_tao": view.balance(max(budget_rao - available_rao, 0), _ROOT_NETUID),
         "budget_tao": view.balance(budget_rao, _ROOT_NETUID),
-        "remaining_tao": view.balance(max(budget_rao - used_rao, 0), _ROOT_NETUID),
+        "remaining_tao": view.balance(min(available_rao, budget_rao), _ROOT_NETUID),
     }
 
 

--- a/sdk/python/codegen/check.py
+++ b/sdk/python/codegen/check.py
@@ -264,6 +264,7 @@ RAW_ONLY: dict[str, set[str]] = {
         "sudo_set_basket_trading_enabled",
         "sudo_set_basket_trading_frozen",
         "sudo_set_basket_daily_turnover_cap",
+        "sudo_set_basket_liquidity_cap",
         "sudo_set_sn_owner_hotkey",
         "sudo_set_stake_threshold",
         "sudo_set_start_call_delay",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Stacked on #3150 ← #3152 (base is `test/swap-basket-coverage` at `60982234e`). Four commits, each self-contained:

### 1. `fix(swap_basket): liquidity-relative destination cap`

**The exploit.** A stolen trader key buys a thin subnet with fund cash in 2%-band slices while a counterparty (a colluding subnet owner, or plain arbitrageurs) sells alpha back to the EMA between slices; every slice passes the slippage, turnover, and concentration rules. Reproduced against #3150: the fund lost 8.3% of NAV in one turnover window (≈90% of the TAO it spent), because the concentration cap marks holdings at *realizable* value, which is bounded by the pool's TAO reserve and never grows no matter how much of the pool's supply the fund accumulates (it held 9× the pool's alpha reserve and passed the 1/16 cap at 0.98%).

**The fix.** After the buy leg, `swap_basket` refuses a trade that would leave the fund holding more than `BasketLiquidityCap` of the destination subnet's alpha reserve (`SubnetAlphaIn`). Root (the cash slot) has no pool and is exempt. Selling is never capped.

**The bound.** With cap `L` and a destination pool with TAO reserve `R`, a drain can extract about `R × L² / (1 + L)` from that pool — ≈1% of `R` at the 10% default (≈10 τ on a 1,000 τ pool, vs. the whole turnover budget before). Today's largest funds (~12.5k τ) are barely constrained: 10% of a median mainnet pool (~2.4M α ≈ 7k τ) is ≈700 τ, about the fund's 1/16 slice.

**Default and tuning.** `BasketLiquidityCap` is u16-normalized, default `u16::MAX / 10` (10%). `AdminUtils::sudo_set_basket_liquidity_cap(cap)` (call index 109, root-only, zero rejected); e.g. `16383` = 25%. Global, not per subnet.

Also flips #3152's §2.1 pin (`finding_2_1_thin_pool_drain_is_stopped_by_liquidity_cap`) and isolates its §2.3 pin from the new cap.

### 2. `test(swap_basket): winners over either cap are never clipped`

Appreciation via direct pool state. A holding over `RootWeightsCap` or `BasketLiquidityCap` only refuses further **buys into that subnet**. Partial sells to cash or another subnet, trades between other holdings, curated dividend redeploy, dust consolidation, pro-rata claims and hotkey swap all leave the winner alone. Profit-taking after a run-up is not blocked by the EMA band (sell floor anchors to spot when spot > EMA; chained slices may walk price down to 0.98 × EMA).

### 3. `fix(swap_basket): charge pending-deposit flush work`

`do_swap_basket` flushes queued dividend credits before trading but did not price that work. Declared weight now comes from the pending-deposit count (`swap_basket_declared_weight(hotkey)`: the 256-row cap plus one unit per queued credit plus `4 × 256` for the deposit's own sweeps), refunded post-dispatch to the flush work actually reported, priced per quote unit like `claim_root`. An empty queue costs nothing extra, so the existing weight pin is unchanged.

### 4. `feat(swap_basket): token-bucket turnover budget`

Replaces the fixed 7200-block window. Per hotkey `BasketTradeBucket = (tao_available, last_refill_block)`; a missing row is a full bucket. On each trade: refill `blocks_elapsed × budget / BASKET_TRADE_REFILL_BLOCKS`, clamp to one budget (NAV at that moment), require `tao_available ≥ tao_mid`, subtract. Empty → `BasketTurnoverBudgetExceeded`. Hotkey swap carries the bucket conservatively (min level, max refill block). **Bound: at most 1× the budget at any instant** and ≈1× per day sustained; the §2.2 two-blocks-two-budgets burst is gone (pin flipped: `finding_2_2_bucket_denies_a_second_budget_in_the_adjacent_block`). `BasketTradeWindow` is removed (never on a live chain; no migration).

`BasketTradingStatus` keeps its SCALE encoding, so no runtime API bump: the `u64` slot is now `refill_blocks` (7200) and `tao_used` is now `tao_available`; refill rate = `budget_tao / refill_blocks`. `freeze_struct` hash updated. SDK `basket_trading_status` returns `remaining_tao`, `budget_tao`, `used_tao`, `refill_blocks`, `refill_per_block_tao`; CLI text updated.

## Related Issue(s)

- Follows up #3150 (`swap_basket`) and #3152 (coverage); see the exploitation/calibration review §2.1, §2.2, §3.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (token-bucket turnover budget)

## Breaking Change

None on chain (new storage with defaults; error/event appended; the removed window storage never shipped). Clients decoding `BasketTradingStatus` by field name must switch `window_start_block`/`tao_used` → `refill_blocks`/`tao_available` (encoding unchanged; the SDK read is updated here).

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `./scripts/fix_rust.sh` (ran `cargo fmt --check --all` and `cargo clippy -p pallet-subtensor -p pallet-admin-utils --tests -- -D warnings` instead; both clean)
- [ ] I have made corresponding changes to the documentation (SDK registries/docstrings updated; generated docs need a regeneration run, see notes)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional Notes

**Tests run (final stack)**
- `cargo test -p pallet-subtensor -- swap_basket claim_root stake_into_basket basket_flush swap_hotkey staking::` — 347 passed (includes #3152's `swap_basket.rs` with the rewritten bucket tests and both flipped pins, and the 9 tests in `swap_basket_liquidity_cap.rs`).
- `cargo test -p pallet-admin-utils -- basket root_weights_cap` — 5 passed.
- Runtime `proxy_filters` — 15 passed (before the restack; unchanged files).
- `cargo fmt --check --all`, `git diff --check`, `cargo clippy --tests -D warnings` on both pallets: clean.

**Not in this PR (per AGENTS.md)**
- `sudo_set_basket_liquidity_cap` reuses the measured `sudo_set_root_weights_cap` weight; a benchmark/`WeightInfo` entry is still owed for it and for the four #3150 dispatchables. `swap_basket` keeps the hand formula + refund pattern.
- No `spec_version` change or labels.
- Generated docs (`docs/errors/chain/*`, `docs/hyperparameters/index.mdx`, `docs/query/basket-trading-status.mdx`) not regenerated here (no `uv` environment); the SDK registries and docstrings they derive from are updated.
- `sdk/python/bittensor/_generated/` still needs regeneration against a node running this runtime.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1091c0f3-73f1-582a-88a0-056c714c9232?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1091c0f3-73f1-582a-88a0-056c714c9232&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

